### PR TITLE
mssmt: Add MS-SMT implementation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,11 @@
+module github.com/lightninglabs/taro
+
+go 1.18
+
+require github.com/stretchr/testify v1.7.1
+
+require (
+	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,11 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/mssmt/bench_test.go
+++ b/mssmt/bench_test.go
@@ -1,0 +1,100 @@
+package mssmt
+
+import (
+	"fmt"
+	"testing"
+)
+
+func randElem[K comparable, V any](elems map[K]V) (K, V) {
+	for k, v := range elems {
+		return k, v
+	}
+	panic("unreachable")
+}
+
+func benchmarkInsert(b *testing.B, tree *Tree, leaves map[[32]byte]*LeafNode,
+	_ map[[32]byte]*Proof) {
+
+	for i := 0; i < b.N; i++ {
+		key, leaf := randElem(leaves)
+		_ = tree.Insert(key, leaf)
+	}
+}
+
+func benchmarkGet(b *testing.B, tree *Tree, leaves map[[32]byte]*LeafNode,
+	_ map[[32]byte]*Proof) {
+
+	for i := 0; i < b.N; i++ {
+		key, _ := randElem(leaves)
+		_ = tree.Get(key)
+	}
+}
+
+func benchmarkMerkleProof(b *testing.B, tree *Tree, _ map[[32]byte]*LeafNode,
+	proofs map[[32]byte]*Proof) {
+
+	for i := 0; i < b.N; i++ {
+		key, _ := randElem(proofs)
+		_ = tree.MerkleProof(key)
+	}
+}
+
+func benchmarkVerifyMerkleProof(b *testing.B, tree *Tree,
+	_ map[[32]byte]*LeafNode, proofs map[[32]byte]*Proof) {
+
+	for i := 0; i < b.N; i++ {
+		key, proof := randElem(proofs)
+		_ = VerifyMerkleProof(key, proof, tree.Root())
+	}
+}
+
+func benchmarkMerkleProofCompress(b *testing.B, _ *Tree,
+	_ map[[32]byte]*LeafNode, proofs map[[32]byte]*Proof) {
+
+	for i := 0; i < b.N; i++ {
+		_, proof := randElem(proofs)
+		_ = proof.Compress().Decompress()
+	}
+}
+
+type benchmarkFunc = func(*testing.B, *Tree, map[[32]byte]*LeafNode,
+	map[[32]byte]*Proof)
+
+type benchmark struct {
+	name string
+	f    benchmarkFunc
+}
+
+func newBenchmark(name string, f benchmarkFunc) benchmark {
+	return benchmark{name: name, f: f}
+}
+
+var benchmarks = []benchmark{
+	newBenchmark("Insert", benchmarkInsert),
+	newBenchmark("Get", benchmarkGet),
+	newBenchmark("MerkleProof", benchmarkMerkleProof),
+	newBenchmark("VerifyMerkleProof", benchmarkVerifyMerkleProof),
+	newBenchmark("MerkleProofCompress", benchmarkMerkleProofCompress),
+}
+
+func BenchmarkTree(b *testing.B) {
+	for _, numLeaves := range []int{10, 1_000, 100_000} {
+		tree, leaves := randTree(numLeaves)
+		proofs := make(map[[32]byte]*Proof, numLeaves)
+		for key := range leaves {
+			proofs[key] = tree.MerkleProof(key)
+		}
+
+		for _, benchmark := range benchmarks {
+			name := fmt.Sprintf("%v-%v", benchmark.name, numLeaves)
+			success := b.Run(name, func(b *testing.B) {
+				b.ResetTimer()
+				b.ReportAllocs()
+				benchmark.f(b, tree, leaves, proofs)
+			})
+			if !success {
+				break
+			}
+		}
+	}
+}

--- a/mssmt/node.go
+++ b/mssmt/node.go
@@ -1,0 +1,154 @@
+package mssmt
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+)
+
+const (
+	// hashSize is the size of hashes used in the MS-SMT.
+	hashSize = sha256.Size
+)
+
+var (
+	// EmptyLeafNode represents an empty leaf in a MS-SMT, one with a nil
+	// value and 0 sum.
+	EmptyLeafNode = NewLeafNode(nil, 0)
+)
+
+// NodeKey represents the key of a MS-SMT node.
+type NodeKey [hashSize]byte
+
+// String returns a NodeKey as a hex-encoded string.
+func (k NodeKey) String() string {
+	return hex.EncodeToString(k[:])
+}
+
+// Node represents a MS-SMT node. A node can either be a leaf or a branch.
+type Node interface {
+	// NodeKey returns the unique identifier for a MS-SMT node. It
+	// represents the hash of the node committing to its internal data.
+	NodeKey() NodeKey
+
+	// NodeSum returns the sum commitment of the node.
+	NodeSum() uint64
+
+	// Equal determines whether a node is equal to another.
+	Equal(Node) bool
+}
+
+// LeafNode represents a leaf node within a MS-SMT. Leaf nodes commit to a value
+// and some integer value (the sum) associated with the value.
+type LeafNode struct {
+	// Cached nodeKey instance to prevent redundant computations.
+	nodeKey *NodeKey
+
+	Value []byte
+	sum   uint64
+}
+
+// NewLeafNode constructs a new leaf node.
+func NewLeafNode(value []byte, sum uint64) *LeafNode {
+	return &LeafNode{
+		Value: value,
+		sum:   sum,
+	}
+}
+
+// NodeKey returns the unique identifier for a MS-SMT node. It represents the
+// hash of the leaf committing to its internal data.
+func (n *LeafNode) NodeKey() NodeKey {
+	if n.nodeKey != nil {
+		return *n.nodeKey
+	}
+
+	h := sha256.New()
+	h.Write(n.Value)
+	binary.Write(h, binary.BigEndian, n.sum)
+	n.nodeKey = (*NodeKey)(h.Sum(nil))
+	return *n.nodeKey
+}
+
+// NodeSum returns the sum commitment of the leaf node.
+func (n *LeafNode) NodeSum() uint64 {
+	return n.sum
+}
+
+// Equal determines whether a leaf node is equal to another.
+func (n *LeafNode) Equal(other Node) bool {
+	switch leaf := other.(type) {
+	case *LeafNode:
+		return bytes.Equal(n.Value, leaf.Value) && n.sum == leaf.sum
+	default:
+		return false
+	}
+}
+
+// IsEmpty returns whether this is an empty leaf.
+func (n *LeafNode) IsEmpty() bool {
+	return len(n.Value) == 0 && n.sum == 0
+}
+
+// BranchNode represents an intermediate or root node within a MS-SMT. It
+// commits to its left and right children, along with their respective sum
+// values.
+type BranchNode struct {
+	// Cached instances to prevent redundant computations.
+	nodeKey *NodeKey
+	sum     *uint64
+
+	Left  Node
+	Right Node
+}
+
+// NewBranch constructs a new branch backed by its left and right children.
+func NewBranch(left, right Node) *BranchNode {
+	return &BranchNode{
+		Left:  left,
+		Right: right,
+	}
+}
+
+// NodeKey returns the unique identifier for a MS-SMT node. It represents the
+// hash of the branch committing to its internal data.
+func (n *BranchNode) NodeKey() NodeKey {
+	if n.nodeKey != nil {
+		return *n.nodeKey
+	}
+
+	left := n.Left.NodeKey()
+	right := n.Right.NodeKey()
+
+	h := sha256.New()
+	h.Write(left[:])
+	h.Write(right[:])
+	binary.Write(h, binary.BigEndian, n.NodeSum())
+	n.nodeKey = (*NodeKey)(h.Sum(nil))
+	return *n.nodeKey
+}
+
+// NodeSum returns the sum commitment of the branch's left and right children.
+func (n *BranchNode) NodeSum() uint64 {
+	if n.sum != nil {
+		return *n.sum
+	}
+
+	sum := n.Left.NodeSum() + n.Right.NodeSum()
+	n.sum = &sum
+	return sum
+}
+
+// Equal determines whether a branch node is equal to another.
+func (n *BranchNode) Equal(other Node) bool {
+	switch branch := other.(type) {
+	case *BranchNode:
+		return n.Left.NodeKey() == branch.Left.NodeKey() &&
+			n.Left.NodeSum() == branch.Left.NodeSum() &&
+			n.Right.NodeKey() == branch.Right.NodeKey() &&
+			n.Right.NodeSum() == branch.Right.NodeSum()
+	default:
+		return false
+	}
+}

--- a/mssmt/proof.go
+++ b/mssmt/proof.go
@@ -1,0 +1,113 @@
+package mssmt
+
+// Proof represents a merkle proof for a MS-SMT.
+type Proof struct {
+	// Leaf is the leaf node the proof is valid for. If the leaf is empty,
+	// then this should be considered a non-inclusion proof.
+	Leaf LeafNode
+
+	// Nodes represents the siblings that should be hashed with the leaf and
+	// its parents to arrive at the root of the MS-SMT.
+	Nodes []Node
+}
+
+// CompressedProof represents a compressed MS-SMT merkle proof. Since merkle
+// proofs for a MS-SMT are always constant size (255 nodes), we replace its
+// empty nodes by a bit vector.
+type CompressedProof struct {
+	// Leaf is the leaf node the compressed proof is valid for. If the leaf
+	// is empty, then this should be considered a non-inclusion proof.
+	Leaf LeafNode
+
+	// Bits determines whether a sibling node within a proof is part of the
+	// empty tree. This allows us to efficiently compress proofs by not
+	// including any pre-computed nodes.
+	Bits []bool
+
+	// Nodes represents the non-empty siblings that should be hashed with
+	// the leaf and its parents to arrive at the root of the MS-SMT.
+	Nodes []Node
+
+	// nextNodeIdx is the index of the next node to include in a
+	// decompressed proof.
+	nextNodeIdx int
+}
+
+// NewProof initializes a new merkle proof for the given leaf node.
+func NewProof(leaf LeafNode, nodes []Node) *Proof {
+	return &Proof{
+		Leaf:  leaf,
+		Nodes: nodes,
+	}
+}
+
+// Root returns the root node obtained by walking up the tree.
+func (p Proof) Root(key [32]byte) *BranchNode {
+	return walkUp(&key, &p.Leaf, p.Nodes, nil)
+}
+
+// ProvesInclusion returns whether the proof proves the leaf is included or not
+// in the tree. Note that this does not refer to the validity of the proof
+// itself, `VerifyMerkleTree` should be used for that instead.
+func (p Proof) ProvesInclusion() bool {
+	return !p.Leaf.IsEmpty()
+}
+
+// Compress compresses a merkle proof by replacing its empty nodes with a bit
+// vector.
+func (p Proof) Compress() *CompressedProof {
+	var (
+		bits  = make([]bool, len(p.Nodes))
+		nodes []Node
+	)
+	for i, node := range p.Nodes {
+		// The proof nodes start at the leaf, while the EmptyTree starts
+		// at the root.
+		if node.NodeKey() == EmptyTree[maxTreeLevels-i].NodeKey() {
+			bits[i] = true
+		} else {
+			nodes = append(nodes, node)
+		}
+	}
+	return &CompressedProof{
+		Leaf:  p.Leaf,
+		Bits:  bits,
+		Nodes: nodes,
+	}
+}
+
+// ProvesInclusion returns whether the proof proves the leaf is included or not
+// in the tree. Note that this does not refer to the validity of the proof
+// itself, `VerifyMerkleTree` should be used for that instead.
+func (p CompressedProof) ProvesInclusion() bool {
+	return !p.Leaf.IsEmpty()
+}
+
+// resetNodeIdx resets the node index back to the start.
+func (p *CompressedProof) resetNodeIdx() {
+	p.nextNodeIdx = 0
+}
+
+// nextNode pops the next node from the proof stack.
+func (p *CompressedProof) nextNode() Node {
+	nextNode := p.Nodes[p.nextNodeIdx]
+	p.nextNodeIdx++
+	return nextNode
+}
+
+// Decompress decompresses a compressed merkle proof by replacing its bit vector
+// with the empty nodes it represents.
+func (p *CompressedProof) Decompress() *Proof {
+	p.resetNodeIdx()
+	nodes := make([]Node, len(p.Bits))
+	for i, bitSet := range p.Bits {
+		if bitSet {
+			// The proof nodes start at the leaf, while the
+			// EmptyTree starts at the root.
+			nodes[i] = EmptyTree[maxTreeLevels-i]
+		} else {
+			nodes[i] = p.nextNode()
+		}
+	}
+	return NewProof(p.Leaf, nodes)
+}

--- a/mssmt/store.go
+++ b/mssmt/store.go
@@ -1,0 +1,84 @@
+package mssmt
+
+import "fmt"
+
+// Store represents a generic key-value store to back the storage of non-empty
+// leaf and branch nodes in a MS-SMT.
+type Store interface {
+	// InsertBranch stores a new branch keyed by its NodeKey.
+	InsertBranch(*BranchNode)
+
+	// InsertLeaf stores a new leaf keyed by its NodeKey (not the insertion
+	// key).
+	InsertLeaf(*LeafNode)
+
+	// DeleteBranch deletes the branch node keyed by the given NodeKey.
+	DeleteBranch(NodeKey)
+
+	// DeleteLeaf deletes the leaf node keyed by the given NodeKey.
+	DeleteLeaf(NodeKey)
+
+	// GetChildren returns the left and right child of the node keyed by the
+	// given NodeKey.
+	GetChildren(uint8, NodeKey) (Node, Node)
+}
+
+// DefaultStore is an in-memory implementation of the Store interface.
+type DefaultStore struct {
+	branches map[NodeKey]*BranchNode
+	leaves   map[NodeKey]*LeafNode
+}
+
+var _ Store = (*DefaultStore)(nil)
+
+// NewDefaultStore initializes a new DefaultStore.
+func NewDefaultStore() *DefaultStore {
+	return &DefaultStore{
+		branches: make(map[NodeKey]*BranchNode),
+		leaves:   make(map[NodeKey]*LeafNode),
+	}
+}
+
+// InsertBranch stores a new branch keyed by its NodeKey.
+func (c *DefaultStore) InsertBranch(branch *BranchNode) {
+	c.branches[branch.NodeKey()] = branch
+}
+
+// InsertLeaf stores a new leaf keyed by its NodeKey.
+func (c *DefaultStore) InsertLeaf(leaf *LeafNode) {
+	c.leaves[leaf.NodeKey()] = leaf
+}
+
+// DeleteBranch deletes the branch node keyed by the given NodeKey.
+func (c *DefaultStore) DeleteBranch(key NodeKey) {
+	delete(c.branches, key)
+}
+
+// DeleteLeaf deletes the leaf node keyed by the given NodeKey.
+func (c *DefaultStore) DeleteLeaf(key NodeKey) {
+	delete(c.leaves, key)
+}
+
+// GetChildren returns the left and right child of the node keyed by the given
+// NodeKey.
+func (c *DefaultStore) GetChildren(height uint8, key NodeKey) (Node, Node) {
+	getNode := func(height uint, key NodeKey) Node {
+		if key == EmptyTree[height].NodeKey() {
+			return EmptyTree[height]
+		}
+		if branch, ok := c.branches[key]; ok {
+			return branch
+		}
+		return c.leaves[key]
+	}
+
+	node := getNode(uint(height), key)
+	switch node := node.(type) {
+	case *BranchNode:
+		return getNode(uint(height)+1, node.Left.NodeKey()),
+			getNode(uint(height)+1, node.Right.NodeKey())
+	default:
+		panic(fmt.Sprintf("unexpected node type %T with key %v", node,
+			key))
+	}
+}

--- a/mssmt/tree.go
+++ b/mssmt/tree.go
@@ -1,0 +1,173 @@
+package mssmt
+
+const (
+	// maxTreeLevels represents the depth of the MS-SMT.
+	maxTreeLevels = hashSize * 8
+
+	// lastBitIndex represents the index of the last bit for MS-SMT keys.
+	lastBitIndex = maxTreeLevels - 1
+)
+
+var (
+	// EmptyTree stores a copy of all nodes up to the root in a MS-SMT in
+	// which all the leaves are empty.
+	EmptyTree []Node
+)
+
+func init() {
+	// Initialize the empty MS-SMT by starting from an empty leaf and
+	// hashing all the way up to the root.
+	EmptyTree = make([]Node, maxTreeLevels+1)
+	EmptyTree[maxTreeLevels] = EmptyLeafNode
+	for i := lastBitIndex; i >= 0; i-- {
+		EmptyTree[i] = NewBranch(EmptyTree[i+1], EmptyTree[i+1])
+	}
+}
+
+// Tree represents a Merkle-Sum Sparse Merkle Tree (MS-SMT). A MS-SMT is an
+// augmented version of a sparse merkle tree that includes a sum value, which is
+// combined during the internal branch hashing operation. Such trees permit
+// efficient proofs of non-inclusion, while also supporting efficient fault
+// proofs of invalid merkle sum commitments.
+type Tree struct {
+	root  Node
+	store Store
+}
+
+// NewTree initializes an empty MS-SMT backed by `store`. As a result, `store`
+// will only maintain non-empty relevant nodes, i.e., stale parents are deleted
+// and empty nodes are never stored.
+func NewTree(store Store) *Tree {
+	return &Tree{
+		root:  EmptyTree[0],
+		store: store,
+	}
+}
+
+// Root returns the root node of the MS-SMT.
+func (t Tree) Root() *BranchNode {
+	return t.root.(*BranchNode)
+}
+
+// bitIndex returns the bit found at `idx` for a NodeKey.
+func bitIndex(idx uint8, key *[hashSize]byte) byte {
+	byteVal := key[idx/8]
+	return (byteVal >> (idx % 8)) & 1
+}
+
+// Type alias for closures to be invoked at every iteration of walking through a
+// tree.
+type iterFunc = func(height uint8, current, sibling, parent Node)
+
+// walkDown walks down the tree from the root node to the leaf indexed by `key`.
+// The leaf node found is returned.
+func (t Tree) walkDown(key *[hashSize]byte, iter iterFunc) *LeafNode {
+	current := t.root
+	for i := 0; i <= lastBitIndex; i++ {
+		left, right := t.store.GetChildren(uint8(i), current.NodeKey())
+		var next, sibling Node
+		if bitIndex(uint8(i), key) == 0 {
+			next, sibling = left, right
+		} else {
+			next, sibling = right, left
+		}
+		if iter != nil {
+			iter(uint8(i), next, sibling, current)
+		}
+		current = next
+	}
+	return current.(*LeafNode)
+}
+
+// walkUp walks up from the `start` leaf node up to the root with the help of
+// `siblings`. The root branch node computed is returned.
+func walkUp(key *[hashSize]byte, start *LeafNode, siblings []Node,
+	iter iterFunc) *BranchNode {
+
+	var current Node = start
+	for i := lastBitIndex; i >= 0; i-- {
+		sibling := siblings[lastBitIndex-i]
+		var parent Node
+		if bitIndex(uint8(i), key) == 0 {
+			parent = NewBranch(current, sibling)
+		} else {
+			parent = NewBranch(sibling, current)
+		}
+		if iter != nil {
+			iter(uint8(i), current, sibling, parent)
+		}
+		current = parent
+	}
+	return current.(*BranchNode)
+}
+
+// insert inserts a leaf node at the given key within the MS-SMT.
+func (t *Tree) insert(key *[hashSize]byte, leaf *LeafNode) *Tree {
+	// As we walk down to the leaf node, we'll keep track of the sibling and
+	// parent for each node we visit.
+	prevParents := make([]NodeKey, maxTreeLevels)
+	siblings := make([]Node, maxTreeLevels)
+	_ = t.walkDown(key, func(i uint8, _, sibling, parent Node) {
+		prevParents[maxTreeLevels-1-i] = parent.NodeKey()
+		siblings[maxTreeLevels-1-i] = sibling
+	})
+
+	// Now that we've arrived at the leaf node, we'll need to work our way
+	// back up to the root, updating any stale and new intermediate branch
+	// nodes.
+	root := walkUp(key, leaf, siblings, func(i uint8, _, _, parent Node) {
+		// Replace the old parent with the new one. Our store should
+		// never track empty branches.
+		prevParent := prevParents[maxTreeLevels-1-i]
+		if prevParent != EmptyTree[i].NodeKey() {
+			t.store.DeleteBranch(prevParent)
+		}
+		if parent.NodeKey() != EmptyTree[i].NodeKey() {
+			t.store.InsertBranch(parent.(*BranchNode))
+		}
+	})
+
+	// With our new root updated, we can update the leaf node within the
+	// store. If we've inserted an empty leaf, then the leaf node found at
+	// the given key is being deleted, otherise it's being inserted.
+	if leaf.IsEmpty() {
+		t.store.DeleteLeaf(*key)
+	} else {
+		t.store.InsertLeaf(leaf)
+	}
+	t.root = root
+	return t
+}
+
+// Insert inserts a leaf node at the given key within the MS-SMT.
+func (t *Tree) Insert(key [hashSize]byte, leaf *LeafNode) *Tree {
+	return t.insert(&key, leaf)
+}
+
+// Delete deletes the leaf node found at the given key within the MS-SMT.
+func (t *Tree) Delete(key [hashSize]byte) *Tree {
+	return t.insert(&key, EmptyLeafNode)
+}
+
+// Get returns the leaf node found at the given key within the MS-SMT.
+func (t Tree) Get(key [hashSize]byte) *LeafNode {
+	return t.walkDown(&key, nil)
+}
+
+// MerkleProof generates a merkle proof for the leaf node found at the given key
+// within the MS-SMT. If a leaf node does not exist at the given key, then the
+// proof should be considered a non-inclusion proof. This is noted by the
+// returned `Proof` containing an empty leaf.
+func (t Tree) MerkleProof(key [hashSize]byte) *Proof {
+	proof := make([]Node, maxTreeLevels)
+	leaf := t.walkDown(&key, func(i uint8, _, sibling, _ Node) {
+		proof[maxTreeLevels-1-i] = sibling
+	})
+	return NewProof(*leaf, proof)
+}
+
+// VerifyMerkleProof determines whether a merkle proof for the leaf found at the
+// given key is valid.
+func VerifyMerkleProof(key [hashSize]byte, proof *Proof, root *BranchNode) bool {
+	return proof.Root(key).Equal(root)
+}

--- a/mssmt/tree_test.go
+++ b/mssmt/tree_test.go
@@ -1,0 +1,133 @@
+package mssmt
+
+import (
+	"math"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}
+
+func randKey() [hashSize]byte {
+	var key [hashSize]byte
+	_, _ = rand.Read(key[:])
+	return key
+}
+
+func randLeaf() *LeafNode {
+	valueLen := rand.Intn(math.MaxUint8) + 1
+	value := make([]byte, valueLen)
+	_, _ = rand.Read(value[:])
+	sum := rand.Uint64()
+	return NewLeafNode(value, sum)
+}
+
+func randTree(numLeaves int) (*Tree, map[[hashSize]byte]*LeafNode) {
+	tree := NewTree(NewDefaultStore())
+	leaves := make(map[[hashSize]byte]*LeafNode, numLeaves)
+	for i := 0; i < numLeaves; i++ {
+		key := randKey()
+		leaf := randLeaf()
+		tree.Insert(key, leaf)
+		leaves[key] = leaf
+	}
+	return tree, leaves
+}
+
+// TestInsertion asserts that we can insert N leaves and retrieve them by their
+// insertion key. Keys that do not exist within the tree should return an empty
+// leaf.
+func TestInsertion(t *testing.T) {
+	t.Parallel()
+
+	tree, leaves := randTree(10000)
+	for key, leaf := range leaves {
+		_ = tree.Insert(key, leaf)
+		leafCopy := tree.Get(key)
+		require.Equal(t, leaf, leafCopy)
+	}
+
+	emptyLeaf := tree.Get(randKey())
+	require.True(t, emptyLeaf.IsEmpty())
+}
+
+// TestDeletion asserts that deleting all inserted leaves of a tree results in
+// an empty tree.
+func TestDeletion(t *testing.T) {
+	t.Parallel()
+
+	tree, leaves := randTree(10000)
+	require.NotEqual(t, EmptyTree[0], tree.Root())
+	for key := range leaves {
+		_ = tree.Delete(key)
+		emptyLeaf := tree.Get(key)
+		require.True(t, emptyLeaf.IsEmpty())
+	}
+	require.Equal(t, EmptyTree[0], tree.Root())
+}
+
+// TestMerkleProof asserts that merkle proofs (inclusion and non-inclusion) for
+// leaf nodes are constructed, compressed, decompressed, and verified properly.
+func TestMerkleProof(t *testing.T) {
+	t.Parallel()
+
+	assertEqualAfterCompression := func(proof *Proof) {
+		t.Helper()
+
+		// Compressed proofs should never have empty nodes.
+		compressedProof := proof.Compress()
+		for _, node := range compressedProof.Nodes {
+			for _, emptyNode := range EmptyTree {
+				require.NotEqual(
+					t, node.NodeKey(), emptyNode.NodeKey(),
+				)
+			}
+		}
+		require.Equal(t, proof, compressedProof.Decompress())
+	}
+
+	// Create a random tree and verify each leaf's merkle proof.
+	tree, leaves := randTree(1337)
+	for key, leaf := range leaves {
+		proof := tree.MerkleProof(key)
+		assertEqualAfterCompression(proof)
+		require.True(t, leaf.Equal(&proof.Leaf))
+		require.True(t, VerifyMerkleProof(key, proof, tree.Root()))
+	}
+
+	// Compute the proof for the first leaf and test some negative cases.
+	for key := range leaves {
+		proof := tree.MerkleProof(key)
+		require.True(t, VerifyMerkleProof(key, proof, tree.Root()))
+
+		// If we alter the proof's leaf sum, then the proof should no
+		// longer be valid.
+		proof.Leaf.sum++
+		require.False(t, VerifyMerkleProof(key, proof, tree.Root()))
+		proof.Leaf.sum--
+
+		// If we delete the proof's leaf node from the tree, then it
+		// should also no longer be valid.
+		_ = tree.Delete(key)
+		require.False(t, VerifyMerkleProof(key, proof, tree.Root()))
+	}
+
+	// Create a new leaf that will not be inserted in the tree. Computing
+	// its proof should result in a non-inclusion proof (an empty leaf
+	// exists at said key).
+	nonExistentKey := randKey()
+	nonExistentLeaf := randLeaf()
+	proof := tree.MerkleProof(nonExistentKey)
+	assertEqualAfterCompression(proof)
+	require.False(t, proof.ProvesInclusion())
+	invalidProof := NewProof(*nonExistentLeaf, proof.Nodes)
+	require.False(t, VerifyMerkleProof(
+		nonExistentKey, invalidProof, tree.Root()),
+	)
+	require.True(t, VerifyMerkleProof(nonExistentKey, proof, tree.Root()))
+}


### PR DESCRIPTION
This commit introduces a trivial implementation of the Merkle-Sum Sparse Merkle Tree (MS-SMT) data structure as outlined in the set of Taro BIPs.

It supports the following operations:

* Leaf insertion
* Leaf deletion
* Leaf retrieval
* Leaf merkle proof computation
* Leaf merkle proof verification
* Leaf merkle proof compression