### PR TITLE
asset+commitment: add new genesis signer interface, use KeyDescriptors everywhere

### DIFF
--- a/asset/asset.go
+++ b/asset/asset.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"encoding/binary"
+	"fmt"
 	"io"
 
 	"github.com/btcsuite/btcd/btcec/v2"
@@ -11,6 +12,7 @@ import (
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/taro/mssmt"
+	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/lightningnetwork/lnd/tlv"
 )
 
@@ -50,6 +52,9 @@ type Genesis struct {
 	// OutputIndex is the index of the output that carries the unique Taro
 	// commitment in the genesis transaction.
 	OutputIndex uint32
+
+	// TODO(roasbeef): add asset type, have it be part of the assetID
+	// calculation
 }
 
 // TagHash computes the SHA-256 hash of the asset's tag.
@@ -240,39 +245,95 @@ const (
 // across distinct asset IDs, allowing further issuance of the asset to be made
 // possible.
 type FamilyKey struct {
-	// Key is the tweaked public key that is used to associate assets
+	// RawKey is the raw family key before the tweak with the genesis point
+	// has been applied.
+	RawKey keychain.KeyDescriptor
+
+	// FamKey is the tweaked public key that is used to associate assets
 	// together across distinct asset IDs, allowing further issuance of the
 	// asset to be made possible. The tweaked public key is the result of:
 	//   familyInternalKey + sha256(familyInternalKey || genesisOutPoint) * G
-	Key btcec.PublicKey
+	FamKey btcec.PublicKey
 
 	// Sig is a signature over an asset's ID by `Key`.
 	Sig schnorr.Signature
 }
 
-// DeriveFamilyKey derives an asset's family key based on some internal private
-// key and an asset genesis.
-func DeriveFamilyKey(internalPrivKey *btcec.PrivateKey,
-	genesis *Genesis) (*FamilyKey, error) {
+// GenesisSigner is used to sign the assetID using the family key public key
+// for a given asset.
+type GenesisSigner interface {
+	// SignGenesis signs the passed Genesis description using the public
+	// key identified by the passed key descriptor. The final tweaked
+	// public key and the signature are returned.
+	//
+	// TODO(roasbeef): need to create schnorr message signer?
+	SignGenesis(keychain.KeyDescriptor, Genesis) (*btcec.PublicKey, *schnorr.Signature, error)
+}
+
+// RawKeyGenesisSigner implements the GenesisSigner interface using a raw
+// private key.
+type RawKeyGenesisSigner struct {
+	privKey *btcec.PrivateKey
+}
+
+// NewRawKeyGenesisSigner creates a new RawKeyGenesisSigner instance given the
+// passed public key.
+func NewRawKeyGenesisSigner(priv *btcec.PrivateKey) *RawKeyGenesisSigner {
+	return &RawKeyGenesisSigner{
+		privKey: priv,
+	}
+}
+
+// SignGenesis signs the passed Genesis description using the public key
+// identified by the passed key descriptor. The final tweaked public key and
+// the signature are returned.
+func (r *RawKeyGenesisSigner) SignGenesis(keyDesc keychain.KeyDescriptor,
+	gen Genesis) (*btcec.PublicKey, *schnorr.Signature, error) {
+
+	if !keyDesc.PubKey.IsEqual(r.privKey.PubKey()) {
+		return nil, nil, fmt.Errorf("cannot sign with key")
+	}
 
 	var genesisPrevOut bytes.Buffer
-	err := wire.WriteOutPoint(&genesisPrevOut, 0, 0, &genesis.FirstPrevOut)
+	err := wire.WriteOutPoint(&genesisPrevOut, 0, 0, &gen.FirstPrevOut)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
+
+	// TODO(roasbeef): can use the musig2 API for this?? w/ a single signer
 	tweakedPrivKey := txscript.TweakTaprootPrivKey(
-		internalPrivKey, genesisPrevOut.Bytes(),
+		r.privKey, genesisPrevOut.Bytes(),
 	)
 
-	id := genesis.ID()
+	// TODO(roasbeef): this actually needs to sign the digest of the asset
+	// itself
+	id := gen.ID()
 	sig, err := schnorr.Sign(tweakedPrivKey, id[:])
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return tweakedPrivKey.PubKey(), sig, nil
+}
+
+// A compile time assertion to ensure RawKeyGenesisSigner meets the
+// GenesisSigner interface.
+var _ GenesisSigner = (*RawKeyGenesisSigner)(nil)
+
+// DeriveFamilyKey derives an asset's family key based on an internal public
+// key descriptor key and an asset genesis.
+func DeriveFamilyKey(genSigner GenesisSigner, rawKey keychain.KeyDescriptor,
+	genesis *Genesis) (*FamilyKey, error) {
+
+	famKey, sig, err := genSigner.SignGenesis(rawKey, *genesis)
 	if err != nil {
 		return nil, err
 	}
 
 	return &FamilyKey{
-		Key: *tweakedPrivKey.PubKey(),
-		Sig: *sig,
+		RawKey: rawKey,
+		FamKey: *famKey,
+		Sig:    *sig,
 	}, nil
 }
 
@@ -316,7 +377,10 @@ type Asset struct {
 
 	// ScriptKey represents a tweaked Taproot output key encumbering the
 	// different ways an asset can be spent.
-	ScriptKey btcec.PublicKey
+	//
+	// We store a full key descriptor here for wallet purposes, but will
+	// only encode the raw key for the normal script leaf TLV encoding.
+	ScriptKey keychain.KeyDescriptor
 
 	// FamilyKey is the tweaked public key that is used to associate assets
 	// together across distinct asset IDs, allowing further issuance of the
@@ -327,7 +391,7 @@ type Asset struct {
 // New instantiates a new fungible asset of type `Normal` with a genesis asset
 // witness.
 func New(genesis *Genesis, amount, locktime, relativeLocktime uint64,
-	scriptKey btcec.PublicKey, familyKey *FamilyKey) *Asset {
+	scriptKey keychain.KeyDescriptor, familyKey *FamilyKey) *Asset {
 
 	return &Asset{
 		Version:          V0,
@@ -351,7 +415,7 @@ func New(genesis *Genesis, amount, locktime, relativeLocktime uint64,
 
 // NewCollectible instantiates a new `Collectible` asset.
 func NewCollectible(genesis *Genesis, locktime, relativeLocktime uint64,
-	scriptKey btcec.PublicKey, familyKey *FamilyKey) *Asset {
+	scriptKey keychain.KeyDescriptor, familyKey *FamilyKey) *Asset {
 
 	return &Asset{
 		Version:          V0,
@@ -379,19 +443,19 @@ func (a Asset) TaroCommitmentKey() [32]byte {
 	if a.FamilyKey == nil {
 		return [32]byte(a.Genesis.ID())
 	}
-	return sha256.Sum256(schnorr.SerializePubKey(&a.FamilyKey.Key))
+	return sha256.Sum256(schnorr.SerializePubKey(&a.FamilyKey.FamKey))
 }
 
 // AssetCommitmentKey is the key that maps to a specific owner of an asset
 // within a Taro AssetCommitment.
 func (a Asset) AssetCommitmentKey() [32]byte {
 	if a.FamilyKey == nil {
-		return sha256.Sum256(schnorr.SerializePubKey(&a.ScriptKey))
+		return sha256.Sum256(schnorr.SerializePubKey(a.ScriptKey.PubKey))
 	}
 	assetID := a.Genesis.ID()
 	h := sha256.New()
 	_, _ = h.Write(assetID[:])
-	_, _ = h.Write(schnorr.SerializePubKey(&a.ScriptKey))
+	_, _ = h.Write(schnorr.SerializePubKey(a.ScriptKey.PubKey))
 	return *(*[32]byte)(h.Sum(nil))
 }
 
@@ -444,8 +508,9 @@ func (a Asset) Copy() *Asset {
 
 	if a.FamilyKey != nil {
 		assetCopy.FamilyKey = &FamilyKey{
-			Key: a.FamilyKey.Key,
-			Sig: a.FamilyKey.Sig,
+			RawKey: a.FamilyKey.RawKey,
+			FamKey: a.FamilyKey.FamKey,
+			Sig:    a.FamilyKey.Sig,
 		}
 	}
 
@@ -479,7 +544,7 @@ func (a Asset) EncodeRecords() []tlv.Record {
 		))
 	}
 	records = append(records, NewLeafScriptVersionRecord(&a.ScriptVersion))
-	records = append(records, NewLeafScriptKeyRecord(&a.ScriptKey))
+	records = append(records, NewLeafScriptKeyRecord(&a.ScriptKey.PubKey))
 	if a.FamilyKey != nil {
 		records = append(records, NewLeafFamilyKeyRecord(&a.FamilyKey))
 	}
@@ -499,7 +564,7 @@ func (a *Asset) DecodeRecords() []tlv.Record {
 		NewLeafPrevWitnessRecord(&a.PrevWitnesses),
 		NewLeafSplitCommitmentRootRecord(&a.SplitCommitmentRoot),
 		NewLeafScriptVersionRecord(&a.ScriptVersion),
-		NewLeafScriptKeyRecord(&a.ScriptKey),
+		NewLeafScriptKeyRecord(&a.ScriptKey.PubKey),
 		NewLeafFamilyKeyRecord(&a.FamilyKey),
 	}
 }

--- a/asset/asset_test.go
+++ b/asset/asset_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/taro/mssmt"
+	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/stretchr/testify/require"
 )
 
@@ -104,8 +105,13 @@ func TestAssetEncoding(t *testing.T) {
 		}},
 		SplitCommitmentRoot: nil,
 		ScriptVersion:       1,
-		ScriptKey:           *pubKey,
-		FamilyKey:           &FamilyKey{Key: *pubKey, Sig: *sig},
+		ScriptKey: keychain.KeyDescriptor{
+			PubKey: pubKey,
+		},
+		FamilyKey: &FamilyKey{
+			FamKey: *pubKey,
+			Sig:    *sig,
+		},
 	}
 	root := &Asset{
 		Version:          1,
@@ -128,8 +134,13 @@ func TestAssetEncoding(t *testing.T) {
 		}},
 		SplitCommitmentRoot: mssmt.NewComputedNode(hashBytes1, 1337),
 		ScriptVersion:       1,
-		ScriptKey:           *pubKey,
-		FamilyKey:           &FamilyKey{Key: *pubKey, Sig: *sig},
+		ScriptKey: keychain.KeyDescriptor{
+			PubKey: pubKey,
+		},
+		FamilyKey: &FamilyKey{
+			FamKey: *pubKey,
+			Sig:    *sig,
+		},
 	}
 	split.PrevWitnesses[0].SplitCommitment = &SplitCommitment{
 		Proof:     *mssmt.NewProof(mssmt.EmptyTree[:mssmt.MaxTreeLevels]),
@@ -174,7 +185,9 @@ func TestAssetEncoding(t *testing.T) {
 		}},
 		SplitCommitmentRoot: nil,
 		ScriptVersion:       2,
-		ScriptKey:           *pubKey,
-		FamilyKey:           nil,
+		ScriptKey: keychain.KeyDescriptor{
+			PubKey: pubKey,
+		},
+		FamilyKey: nil,
 	})
 }

--- a/asset/records.go
+++ b/asset/records.go
@@ -135,7 +135,7 @@ func NewLeafScriptVersionRecord(version *ScriptVersion) tlv.Record {
 	)
 }
 
-func NewLeafScriptKeyRecord(scriptKey *btcec.PublicKey) tlv.Record {
+func NewLeafScriptKeyRecord(scriptKey **btcec.PublicKey) tlv.Record {
 	return tlv.MakeStaticRecord(
 		LeafScriptKey, scriptKey, schnorr.PubKeyBytesLen,
 		SchnorrPubKeyEncoder, SchnorrPubKeyDecoder,

--- a/commitment/asset.go
+++ b/commitment/asset.go
@@ -102,7 +102,7 @@ func parseCommon(assets ...*asset.Asset) (*AssetCommitment, error) {
 		assetID = [32]byte(assetID)
 	} else {
 		assetID = sha256.Sum256(
-			schnorr.SerializePubKey(&assetFamilyKey.Key),
+			schnorr.SerializePubKey(&assetFamilyKey.FamKey),
 		)
 	}
 
@@ -177,4 +177,14 @@ func (c AssetCommitment) AssetProof(key [32]byte) (*asset.Asset, *mssmt.Proof) {
 		panic("missing tree to compute proofs")
 	}
 	return c.assets[key], c.tree.MerkleProof(key)
+}
+
+// Assets returns the set of assets committed to in the asset commitment.
+func (c AssetCommitment) Assets() []*asset.Asset {
+	assets := make([]*asset.Asset, 0, len(c.assets))
+	for _, asset := range c.assets {
+		assets = append(assets, asset)
+	}
+
+	return assets
 }

--- a/commitment/mint.go
+++ b/commitment/mint.go
@@ -4,8 +4,8 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/lightninglabs/taro/asset"
+	"github.com/lightningnetwork/lnd/keychain"
 )
 
 // AssetDetails contains all of the configurable parameters of an Asset to
@@ -15,7 +15,7 @@ type AssetDetails struct {
 	Type asset.Type
 
 	// ScriptKey is the Taproot key with ownership of the asset.
-	ScriptKey btcec.PublicKey
+	ScriptKey keychain.KeyDescriptor
 
 	// Amount is the amount of assets that should be minted for `ScriptKey`.
 	// NOTE: This should be nil when minting `Collectible` assets.

--- a/commitment/split.go
+++ b/commitment/split.go
@@ -10,6 +10,7 @@ import (
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/taro/asset"
 	"github.com/lightninglabs/taro/mssmt"
+	"github.com/lightningnetwork/lnd/keychain"
 )
 
 var (
@@ -120,7 +121,7 @@ func NewSplitCommitment(input *asset.Asset, outPoint wire.OutPoint,
 	prevID := &asset.PrevID{
 		OutPoint:  outPoint,
 		ID:        input.Genesis.ID(),
-		ScriptKey: input.ScriptKey,
+		ScriptKey: *input.ScriptKey.PubKey,
 	}
 	if input.Type != asset.Normal {
 		return nil, ErrInvalidInputType
@@ -154,7 +155,10 @@ func NewSplitCommitment(input *asset.Asset, outPoint wire.OutPoint,
 
 		assetSplit := input.Copy()
 		assetSplit.Amount = locator.Amount
-		assetSplit.ScriptKey = locator.ScriptKey
+		assetSplit.ScriptKey = keychain.KeyDescriptor{
+			// TODO(roasbeef): other info not needed here?
+			PubKey: &locator.ScriptKey,
+		}
 		assetSplit.PrevWitnesses = []asset.Witness{{
 			PrevID:          prevID,
 			TxWitness:       nil,

--- a/commitment/taro.go
+++ b/commitment/taro.go
@@ -158,6 +158,17 @@ func (c TaroCommitment) Proof(taroCommitmentKey,
 	return asset, proof
 }
 
+// CommittedAssets returns the set of assets committed to in the taro
+// commitment.
+func (c TaroCommitment) CommittedAssets() []*asset.Asset {
+	var assets []*asset.Asset
+	for _, commitment := range c.assetCommitments {
+		assets = append(assets, commitment.Assets()...)
+	}
+
+	return assets
+}
+
 // tapBranchHash takes the tap hashes of the left and right nodes and hashes
 // them into a branch.
 func tapBranchHash(l, r chainhash.Hash) chainhash.Hash {


### PR DESCRIPTION
Split off from #46. 

Two main changes:
  * A new interface so we can sign for a key family w/o having to manipulate the raw private key.
  * Use `keychain.KeyDescriptor` everywhere so we have the information need to do signing for the given key. 