### PR TITLE
commitment: fix pointer comparison of family keys

### DIFF
--- a/asset/asset.go
+++ b/asset/asset.go
@@ -259,6 +259,42 @@ type FamilyKey struct {
 	Sig schnorr.Signature
 }
 
+// IsEqual returns true if this family key is equivalent to the passed other
+// family key.
+func (f *FamilyKey) IsEqual(otherFamilyKey *FamilyKey) bool {
+	// If this key is nil, the other must be nil too.
+	if f == nil {
+		return otherFamilyKey == nil
+	}
+
+	// This key is non nil, other must be non nil too.
+	if otherFamilyKey == nil {
+		return false
+	}
+
+	// Make sure the RawKey keylocators are equivalent.
+	if f.RawKey.KeyLocator != otherFamilyKey.RawKey.KeyLocator {
+		return false
+	}
+
+	if f.RawKey.PubKey != nil && otherFamilyKey.RawKey.PubKey == nil {
+		return false
+	}
+
+	if f.RawKey.PubKey == nil && otherFamilyKey.RawKey.PubKey != nil {
+		return false
+	}
+
+	// At this point either both RawKey pubkeys are nil or they should be
+	// equivalent.
+	rawKeyPubEqual := f.RawKey.PubKey == otherFamilyKey.RawKey.PubKey ||
+		f.RawKey.PubKey.IsEqual(otherFamilyKey.RawKey.PubKey)
+
+	return rawKeyPubEqual &&
+		f.FamKey.IsEqual(&otherFamilyKey.FamKey) &&
+		f.Sig.IsEqual(&otherFamilyKey.Sig)
+}
+
 // GenesisSigner is used to sign the assetID using the family key public key
 // for a given asset.
 type GenesisSigner interface {

--- a/asset/asset_test.go
+++ b/asset/asset_test.go
@@ -60,6 +60,134 @@ func assertAssetEqual(t *testing.T, a, b *Asset) {
 	require.Equal(t, a.FamilyKey, b.FamilyKey)
 }
 
+// TestFamilyKeyIsEqual tests that FamilyKey.IsEqual is correct.
+func TestFamilyKeyIsEqual(t *testing.T) {
+	t.Parallel()
+
+	testKey := &FamilyKey{
+		RawKey: keychain.KeyDescriptor{
+			// Fill in some non-defaults.
+			KeyLocator: keychain.KeyLocator{
+				Family: keychain.KeyFamilyMultiSig,
+				Index:  1,
+			},
+			PubKey: pubKey,
+		},
+		FamKey: *pubKey,
+		Sig:    *sig,
+	}
+
+	pubKeyCopy := *pubKey
+
+	tests := []struct {
+		a, b  *FamilyKey
+		equal bool
+	}{
+		{
+			a:     nil,
+			b:     nil,
+			equal: true,
+		},
+		{
+			a:     &FamilyKey{},
+			b:     &FamilyKey{},
+			equal: true,
+		},
+		{
+			a:     nil,
+			b:     &FamilyKey{},
+			equal: false,
+		},
+		{
+			a: testKey,
+			b: &FamilyKey{
+				FamKey: *pubKey,
+			},
+			equal: false,
+		},
+		{
+			a: testKey,
+			b: &FamilyKey{
+				FamKey: testKey.FamKey,
+				Sig:    testKey.Sig,
+			},
+			equal: false,
+		},
+		{
+			a: testKey,
+			b: &FamilyKey{
+				RawKey: keychain.KeyDescriptor{
+					KeyLocator: testKey.RawKey.KeyLocator,
+					PubKey:     nil,
+				},
+
+				FamKey: testKey.FamKey,
+				Sig:    testKey.Sig,
+			},
+			equal: false,
+		},
+		{
+			a: testKey,
+			b: &FamilyKey{
+				RawKey: keychain.KeyDescriptor{
+					PubKey: &pubKeyCopy,
+				},
+
+				FamKey: testKey.FamKey,
+				Sig:    testKey.Sig,
+			},
+			equal: false,
+		},
+		{
+			a: testKey,
+			b: &FamilyKey{
+				RawKey: keychain.KeyDescriptor{
+					KeyLocator: testKey.RawKey.KeyLocator,
+					PubKey:     &pubKeyCopy,
+				},
+
+				FamKey: testKey.FamKey,
+				Sig:    testKey.Sig,
+			},
+			equal: true,
+		},
+		{
+			a: &FamilyKey{
+				FamKey: testKey.FamKey,
+				Sig:    testKey.Sig,
+			},
+			b: &FamilyKey{
+				FamKey: testKey.FamKey,
+				Sig:    testKey.Sig,
+			},
+			equal: true,
+		},
+		{
+			a: &FamilyKey{
+				RawKey: keychain.KeyDescriptor{
+					KeyLocator: testKey.RawKey.KeyLocator,
+				},
+				FamKey: testKey.FamKey,
+				Sig:    testKey.Sig,
+			},
+			b: &FamilyKey{
+				RawKey: keychain.KeyDescriptor{
+					KeyLocator: testKey.RawKey.KeyLocator,
+				},
+				FamKey: testKey.FamKey,
+				Sig:    testKey.Sig,
+			},
+			equal: true,
+		},
+	}
+
+	for _, testCase := range tests {
+		testCase := testCase
+		require.Equal(t, testCase.equal, testCase.a.IsEqual(testCase.b))
+		require.Equal(t, testCase.equal, testCase.b.IsEqual(testCase.a))
+	}
+}
+
 // TestAssetEncoding asserts that we can properly encode and decode assets
 // through their TLV serialization.
 func TestAssetEncoding(t *testing.T) {

--- a/commitment/asset.go
+++ b/commitment/asset.go
@@ -81,7 +81,7 @@ func parseCommon(assets ...*asset.Asset) (*AssetCommitment, error) {
 	assetFamilyKey := assets[0].FamilyKey
 	assetsMap := make(map[[32]byte]*asset.Asset, len(assets))
 	for _, asset := range assets {
-		if assetFamilyKey != asset.FamilyKey {
+		if !assetFamilyKey.IsEqual(asset.FamilyKey) {
 			return nil, ErrAssetFamilyKeyMismatch
 		}
 		if assetFamilyKey == nil && assetGenesis != asset.Genesis.ID() {

--- a/commitment/commitment_test.go
+++ b/commitment/commitment_test.go
@@ -99,6 +99,11 @@ func TestNewAssetCommitment(t *testing.T) {
 	genesis2 := randGenesis(t)
 	familyKey1 := randFamilyKey(t, genesis1)
 	familyKey2 := randFamilyKey(t, genesis2)
+	copyOfFamilyKey1 := &asset.FamilyKey{
+		RawKey: familyKey1.RawKey,
+		FamKey: familyKey1.FamKey,
+		Sig:    familyKey1.Sig,
+	}
 
 	testCases := []struct {
 		name string
@@ -150,7 +155,7 @@ func TestNewAssetCommitment(t *testing.T) {
 			f: func() []*asset.Asset {
 				return []*asset.Asset{
 					randAsset(t, genesis1, familyKey1, asset.Normal),
-					randAsset(t, genesis1, familyKey1, asset.Collectible),
+					randAsset(t, genesis1, copyOfFamilyKey1, asset.Collectible),
 				}
 			},
 			err: nil,


### PR DESCRIPTION
This PR fixes a bug where we compared pointers of family keys instead of their equivalency when creating asset commitments.