### PR TITLE
address: Address type and encoding

### DIFF
--- a/address/address.go
+++ b/address/address.go
@@ -1,0 +1,258 @@
+package address
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"strings"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcutil/bech32"
+	"github.com/lightninglabs/taro/asset"
+	"github.com/lightningnetwork/lnd/tlv"
+)
+
+var (
+	// ErrUnsupportedHRP is an error returned when we attempt to encode a Taro
+	// address with an HRP for a network without Taro support.
+	ErrUnsupportedHRP = errors.New(
+		"address: unsupported HRP value",
+	)
+
+	// ErrMistmatchedHRP is an error returned when we attempt to decode a Taro
+	// address with an HRP that does not match the expected network.
+	ErrMismatchedHRP = errors.New(
+		"address: network mismatch",
+	)
+
+	// ErrInvalidBech32m is an error returned when we attempt to decode
+	// a Taro address from a string that is not a valid bech32m string.
+	ErrInvalidBech32m = errors.New(
+		"address: invalid bech32m string",
+	)
+
+	// ErrInvalidAmountCollectible is an error returned when we attempt to
+	// create a Taro address for a Collectible asset with an amount not
+	// equal to one.
+	ErrInvalidAmountCollectible = errors.New(
+		"address: collectible asset amount not one",
+	)
+
+	// ErrInvalidAmountNormal is an error returned when we attempt to create
+	// a Taro address for a Normal asset with an amount of zero.
+	ErrInvalidAmountNormal = errors.New(
+		"address: normal asset amount of zero",
+	)
+
+	// ErrUnsupportedAssetType is an error returned when we attempt to create
+	// a Taro address for a non-standard asset type.
+	ErrUnsupportedAssetType = errors.New(
+		"address: unsupported asset type",
+	)
+)
+
+// Highest version of Taro script supported.
+const (
+	TaroScriptVersion uint8 = 0
+)
+
+// AddressTaro represents a Taro address. Taro addresses specify an asset,
+// pubkey, and amount.
+type AddressTaro struct {
+	// HRP is the human-readable part for Bech32m encoded Taro addresses.
+	Hrp string
+
+	// Version is the Taro version of the asset.
+	Version asset.Version
+
+	// ID is the hash that uniquely identifies
+	// the asset requested by the receiver.
+	ID asset.ID
+
+	// FamilyKey is the tweaked public key that is used to associate assets
+	// together across distinct asset IDs, allowing further issuance of the
+	// asset to be made possible.
+	FamilyKey *btcec.PublicKey
+
+	// ScriptKey represents a tweaked Taproot output key encumbering the
+	// different ways an asset can be spent.
+	ScriptKey btcec.PublicKey
+
+	// InternalKey is the BIP-340/341 public key of the receiver.
+	InternalKey btcec.PublicKey
+
+	// Amount is the number of asset units being requested by the receiver.
+	Amount uint64
+
+	// Type uniquely identifies the type of Taro asset.
+	Type asset.Type
+}
+
+// New creates an address for receiving a Taro asset.
+func New(id asset.ID, familyKey *btcec.PublicKey, scriptKey btcec.PublicKey,
+	internalKey btcec.PublicKey, amt uint64,
+	assetType asset.Type, net *ChainParams,
+) (*AddressTaro, error) {
+
+	// Check for invalid combinations of asset type and amount.
+	// Collectible assets must have an amount of 1, and Normal assets
+	// must have a non-zero amount. We also reject invalid asset types.
+	switch assetType {
+	case asset.Collectible:
+		if amt != 1 {
+			return nil, ErrInvalidAmountCollectible
+		}
+	case asset.Normal:
+		if amt == 0 {
+			return nil, ErrInvalidAmountNormal
+		}
+	default:
+		return nil, ErrUnsupportedAssetType
+	}
+
+	if !IsBech32MTaroPrefix(net.TaroHRP + "1") {
+		return nil, ErrUnsupportedHRP
+	}
+
+	payload := AddressTaro{
+		Hrp:         net.TaroHRP,
+		Version:     asset.V0,
+		ID:          id,
+		FamilyKey:   familyKey,
+		ScriptKey:   scriptKey,
+		InternalKey: internalKey,
+		Amount:      amt,
+		Type:        assetType,
+	}
+	return &payload, nil
+}
+
+// Copy returns a deep copy of an Address.
+func (a AddressTaro) Copy() *AddressTaro {
+	addressCopy := a
+
+	if a.FamilyKey != nil {
+		famKey := *a.FamilyKey
+		addressCopy.FamilyKey = &famKey
+	}
+
+	return &addressCopy
+}
+
+// EncodeRecords determines the non-nil records to include when encoding an
+// address at runtime.
+func (a AddressTaro) EncodeRecords() []tlv.Record {
+	records := make([]tlv.Record, 0, 7)
+	records = append(records, NewAddressVersionRecord(&a.Version))
+	records = append(records, NewAddressIDRecord(&a.ID))
+	if a.FamilyKey != nil {
+		records = append(records, NewAddressFamilyKeyRecord(&a.FamilyKey))
+	}
+	records = append(records, NewAddressScriptKeyRecord(&a.ScriptKey))
+	records = append(records, NewAddressInternalKeyRecord(&a.InternalKey))
+	records = append(records, NewAddressAmountRecord(&a.Amount))
+	if a.Type != asset.Normal {
+		records = append(records, NewAddressTypeRecord(&a.Type))
+	}
+	return records
+}
+
+// DecodeRecords provides all records known for an address for proper
+// decoding.
+func (a *AddressTaro) DecodeRecords() []tlv.Record {
+	return []tlv.Record{
+		NewAddressVersionRecord(&a.Version),
+		NewAddressIDRecord(&a.ID),
+		NewAddressFamilyKeyRecord(&a.FamilyKey),
+		NewAddressScriptKeyRecord(&a.ScriptKey),
+		NewAddressInternalKeyRecord(&a.InternalKey),
+		NewAddressAmountRecord(&a.Amount),
+		NewAddressTypeRecord(&a.Type),
+	}
+}
+
+// Encode encodes an address into a TLV stream.
+func (a AddressTaro) Encode(w io.Writer) error {
+	stream, err := tlv.NewStream(a.EncodeRecords()...)
+	if err != nil {
+		return err
+	}
+	return stream.Encode(w)
+}
+
+// Decode decodes an address from a TLV stream.
+func (a *AddressTaro) Decode(r io.Reader) error {
+	stream, err := tlv.NewStream(a.DecodeRecords()...)
+	if err != nil {
+		return err
+	}
+	return stream.Decode(r)
+}
+
+// EncodeAddress returns a bech32m string encoding of a Taro address.
+func (a AddressTaro) EncodeAddress() (string, error) {
+	var buf bytes.Buffer
+	if err := a.Encode(&buf); err != nil {
+		return "", err
+	}
+	// Group the address bytes into 5 bit groups, as this is what is used to
+	// encode each character in the address string.
+	converted, err := bech32.ConvertBits(buf.Bytes(), 8, 5, true)
+	if err != nil {
+		return "", err
+	}
+
+	// Check that our address is targeting a supported network.
+	if IsBech32MTaroPrefix(a.Hrp + "1") {
+		bech, err := bech32.EncodeM(a.Hrp, converted)
+		if err != nil {
+			return "", err
+		}
+		return bech, nil
+	}
+	return "", ErrUnsupportedHRP
+}
+
+// DecodeAddress parses a bech32m encoded Taro address string and
+// returns the HRP and address TLV.
+func DecodeAddress(addr string, net *ChainParams) (*AddressTaro, error) {
+	// Bech32m encoded Taro addresses start with a human-readable part
+	// (hrp) followed by '1'. For Bitcoin mainnet the hrp is "taro", and for
+	// testnet it is "tarot". If the address string has a prefix that matches
+	// one of the prefixes for the known networks, we try to decode it as
+	// a Taro address.
+	oneIndex := strings.LastIndexByte(addr, '1')
+	if oneIndex > 1 {
+		prefix := addr[:oneIndex+1]
+		if !IsBech32MTaroPrefix(prefix) {
+			return nil, ErrUnsupportedHRP
+		}
+		if IsForNet(prefix, net) {
+			_, data, err := bech32.DecodeNoLimit(addr)
+			if err != nil {
+				return nil, err
+			}
+
+			// The remaining characters of the address returned are grouped into
+			// words of 5 bits. In order to restore the original address TLV
+			// bytes, we'll need to regroup into 8 bit words.
+			converted, err := bech32.ConvertBits(data, 5, 8, false)
+			if err != nil {
+				return nil, err
+			}
+
+			// The HRP is everything before the found '1'.
+			hrp := prefix[:len(prefix)-1]
+
+			buf := bytes.NewBuffer(converted)
+			var a AddressTaro
+			if err := a.Decode(buf); err != nil {
+				return nil, err
+			}
+			a.Hrp = hrp
+			return &a, nil
+		}
+		return nil, ErrMismatchedHRP
+	}
+	return nil, ErrInvalidBech32m
+}

--- a/address/address_test.go
+++ b/address/address_test.go
@@ -1,0 +1,262 @@
+package address
+
+import (
+	"bytes"
+	"encoding/hex"
+	"math/rand"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/lightninglabs/taro/asset"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	hashBytes1     = [32]byte{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}
+	invalidHrp     = "bc"
+	invalidNet     = ChainParams{&chaincfg.MainNetParams, invalidHrp}
+	pubKeyBytes, _ = hex.DecodeString(
+		"a0afeb165f0ec36880b68e0baabd9ad9c62fd1a69aa998bc30e9a346202e078f",
+	)
+	pubKey, _ = schnorr.ParsePubKey(pubKeyBytes)
+)
+
+func randAddress(t *testing.T, net *ChainParams, famkey bool,
+	amt *uint64, assetType asset.Type) (*AddressTaro, error) {
+
+	t.Helper()
+
+	var amount uint64
+	amount = 1
+	if amt != nil {
+		amount = *amt
+	}
+
+	if amt == nil && assetType == asset.Normal {
+		amount = rand.Uint64()
+	}
+
+	var familyKey *btcec.PublicKey
+	if famkey {
+		familyKey = pubKey
+	}
+
+	pubKeyCopy1 := *pubKey
+	pubKeyCopy2 := *pubKey
+
+	return New(hashBytes1, familyKey, pubKeyCopy1,
+		pubKeyCopy2, amount, assetType, net)
+}
+
+// TODO: Use network
+func randEncodedAddress(t *testing.T, net *ChainParams, famkey bool,
+	assetType asset.Type) (*AddressTaro, string, error) {
+
+	t.Helper()
+
+	var amount uint64
+	if assetType == asset.Normal {
+		amount = rand.Uint64()
+	}
+
+	var familyKey *btcec.PublicKey
+	if famkey {
+		familyKey = pubKey
+	}
+
+	pubKeyCopy1 := *pubKey
+	pubKeyCopy2 := *pubKey
+
+	newAddr := AddressTaro{net.TaroHRP, asset.Version(TaroScriptVersion),
+		hashBytes1, familyKey, pubKeyCopy1, pubKeyCopy2,
+		amount, asset.Normal}
+
+	encodedAddr, err := newAddr.EncodeAddress()
+
+	return &newAddr, encodedAddr, err
+}
+
+func assertAddressEqual(t *testing.T, a, b *AddressTaro) {
+	t.Helper()
+
+	require.Equal(t, a.Version, b.Version)
+	require.Equal(t, a.ID, b.ID)
+	require.Equal(t, a.FamilyKey, b.FamilyKey)
+	require.Equal(t, a.ScriptKey, b.ScriptKey)
+	require.Equal(t, a.InternalKey, b.InternalKey)
+	require.Equal(t, a.Amount, b.Amount)
+	require.Equal(t, a.Type, b.Type)
+}
+
+func TestNewAddress(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name string
+		f    func() (*AddressTaro, error)
+		err  error
+	}{
+		{
+			name: "normal address",
+			f: func() (*AddressTaro, error) {
+				return randAddress(
+					t, &TestNet3Taro, false, nil, asset.Normal,
+				)
+			},
+			err: nil,
+		},
+		{
+			name: "collectible address with family key",
+			f: func() (*AddressTaro, error) {
+				return randAddress(
+					t, &MainNetTaro, true, nil, asset.Collectible,
+				)
+			},
+			err: nil,
+		},
+		{
+			name: "invalid normal asset value",
+			f: func() (*AddressTaro, error) {
+				zeroAmt := uint64(0)
+				return randAddress(
+					t, &TestNet3Taro, false, &zeroAmt, asset.Normal,
+				)
+			},
+			err: ErrInvalidAmountNormal,
+		},
+		{
+			name: "invalid collectible asset value",
+			f: func() (*AddressTaro, error) {
+				badAmt := uint64(2)
+				return randAddress(
+					t, &TestNet3Taro, false, &badAmt, asset.Collectible,
+				)
+			},
+			err: ErrInvalidAmountCollectible,
+		},
+		{
+			name: "invalid hrp",
+			f: func() (*AddressTaro, error) {
+				return randAddress(
+					t, &invalidNet, false, nil, asset.Normal,
+				)
+			},
+			err: ErrUnsupportedHRP,
+		},
+		{
+			name: "invalid asset type",
+			f: func() (*AddressTaro, error) {
+				pubKeyCopy1 := *pubKey
+				pubKeyCopy2 := *pubKey
+				return New(
+					hashBytes1, nil, pubKeyCopy1, pubKeyCopy2,
+					rand.Uint64(), 2, &MainNetTaro,
+				)
+			},
+			err: ErrUnsupportedAssetType,
+		},
+	}
+
+	for _, testCase := range testCases {
+		success := t.Run(testCase.name, func(t *testing.T) {
+			address, err := testCase.f()
+			require.Equal(t, testCase.err, err)
+
+			if testCase.err == nil {
+				require.NotNil(t, address)
+			} else {
+				require.Nil(t, address)
+			}
+		})
+		if !success {
+			return
+		}
+	}
+}
+
+func TestAddressEncoding(t *testing.T) {
+	t.Parallel()
+
+	assetAddressEncoding := func(a *AddressTaro) {
+		t.Helper()
+
+		assertAddressEqual(t, a, a.Copy())
+		var buf bytes.Buffer
+		require.NoError(t, a.Encode(&buf))
+		var b AddressTaro
+		require.NoError(t, b.Decode(&buf))
+		assertAddressEqual(t, a, &b)
+	}
+
+	testCases := []struct {
+		name string
+		f    func() (*AddressTaro, string, error)
+		err  error
+	}{
+		{
+			name: "valid address",
+			f: func() (*AddressTaro, string, error) {
+				return randEncodedAddress(
+					t, &TestNet3Taro, false, asset.Normal,
+				)
+			},
+			err: nil,
+		},
+		{
+			name: "family collectible",
+			f: func() (*AddressTaro, string, error) {
+				return randEncodedAddress(
+					t, &MainNetTaro, true, asset.Collectible,
+				)
+			},
+			err: nil,
+		},
+		{
+			name: "unsupported hrp",
+			f: func() (*AddressTaro, string, error) {
+				return randEncodedAddress(
+					t, &invalidNet, true, asset.Collectible,
+				)
+			},
+			err: ErrUnsupportedHRP,
+		},
+		{
+			name: "mismatched hrp",
+			f: func() (*AddressTaro, string, error) {
+				newAddr, encodedAddr, _ := randEncodedAddress(
+					t, &TestNet3Taro, true, asset.Collectible,
+				)
+				_, err := DecodeAddress(encodedAddr, &MainNetTaro)
+				return newAddr, "", err
+			},
+			err: ErrMismatchedHRP,
+		},
+		{
+			name: "missing hrp",
+			f: func() (*AddressTaro, string, error) {
+				newAddr, encodedAddr, _ := randEncodedAddress(
+					t, &TestNet3Taro, true, asset.Collectible,
+				)
+				encodedAddr = encodedAddr[4:]
+				_, err := DecodeAddress(encodedAddr[4:], &TestNet3Taro)
+				return newAddr, "", err
+			},
+			err: ErrInvalidBech32m,
+		},
+	}
+
+	for _, testCase := range testCases {
+		success := t.Run(testCase.name, func(t *testing.T) {
+			addr, _, err := testCase.f()
+			require.Equal(t, testCase.err, err)
+			if testCase.err == nil {
+				assetAddressEncoding(addr)
+			}
+		})
+		if !success {
+			return
+		}
+	}
+}

--- a/address/encoding.go
+++ b/address/encoding.go
@@ -1,0 +1,43 @@
+package address
+
+import (
+	"io"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/lightningnetwork/lnd/tlv"
+)
+
+func schnorrPubKeyEncoder(w io.Writer, val any, buf *[8]byte) error {
+	if t, ok := val.(*btcec.PublicKey); ok {
+		var keyBytes [schnorr.PubKeyBytesLen]byte
+		copy(keyBytes[:], schnorr.SerializePubKey(t))
+		return tlv.EBytes32(w, &keyBytes, buf)
+	}
+	return tlv.NewTypeForEncodingErr(val, "*btcec.PublicKey")
+}
+
+func schnorrPubKeyDecoder(r io.Reader, val any, buf *[8]byte, l uint64) error {
+	if typ, ok := val.(*btcec.PublicKey); ok {
+		var keyBytes [schnorr.PubKeyBytesLen]byte
+		err := tlv.DBytes32(r, &keyBytes, buf, schnorr.PubKeyBytesLen)
+		if err != nil {
+			return err
+		}
+		var key *btcec.PublicKey
+		// Handle empty key, which is not on the curve.
+		if keyBytes == [32]byte{} {
+			key = &btcec.PublicKey{}
+		} else {
+			key, err = schnorr.ParsePubKey(keyBytes[:])
+			if err != nil {
+				return err
+			}
+		}
+		*typ = *key
+		return nil
+	}
+	return tlv.NewTypeForDecodingErr(
+		val, "*btcec.PublicKey", l, schnorr.PubKeyBytesLen,
+	)
+}

--- a/address/params.go
+++ b/address/params.go
@@ -1,0 +1,64 @@
+package address
+
+import (
+	"strings"
+
+	"github.com/btcsuite/btcd/chaincfg"
+)
+
+// Human-readable prefixes for bech32m encoded addresses for each network.
+const (
+	Bech32HRPTaroMainnet = "taro"
+	Bech32HRPTaroTestnet = "tarot"
+)
+
+// ChainParams defines a Taro-supporting network by its parameters. These
+// parameters include those specified by chaincfg.Params, as well as a
+// Taro-specific HRP used for Taro addresses. These parameters may be
+// used by Taro applications to differentiate networks as well as addresses
+// and keys for one network from those intended for use on another network.
+type ChainParams struct {
+	*chaincfg.Params
+	TaroHRP string
+}
+
+// TODO(jhb): Resolve duplicate networks?
+func Register(params *ChainParams) error {
+	err := chaincfg.Register(params.Params)
+	if err != nil {
+		return err
+	}
+
+	bech32TaroPrefixes[params.TaroHRP+"1"] = struct{}{}
+	return nil
+}
+
+var (
+	// Set of all supported prefixes for bech32m encoded addresses.
+	bech32TaroPrefixes = make(map[string]struct{})
+
+	// Default Taro-supportng networks.
+	MainNetTaro  = ChainParams{&chaincfg.MainNetParams, Bech32HRPTaroMainnet}
+	TestNet3Taro = ChainParams{&chaincfg.TestNet3Params, Bech32HRPTaroTestnet}
+)
+
+// IsBech32MTaroPrefix returns whether the prefix is a known prefix for Taro
+// addresses on any supported network.  This is used when creating an address,
+// encoding an address to a string, or decoding an address string into a TLV.
+func IsBech32MTaroPrefix(prefix string) bool {
+	prefix = strings.ToLower(prefix)
+	_, ok := bech32TaroPrefixes[prefix]
+	return ok
+}
+
+// IsForNet returns whether or not the HRP is associated with the
+// passed network.
+func IsForNet(hrp string, net *ChainParams) bool {
+	return hrp == net.TaroHRP
+}
+
+func init() {
+	// Register all default networks when the package is initialized.
+	bech32TaroPrefixes[MainNetTaro.TaroHRP+"1"] = struct{}{}
+	bech32TaroPrefixes[TestNet3Taro.TaroHRP+"1"] = struct{}{}
+}

--- a/address/records.go
+++ b/address/records.go
@@ -1,0 +1,72 @@
+package address
+
+import (
+	"crypto/sha256"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/lightninglabs/taro/asset"
+	"github.com/lightningnetwork/lnd/tlv"
+)
+
+// AddressTlvType represents the different TLV types for Address TLV records.
+type AddressTLVType = tlv.Type
+
+const (
+	AddressVersion     AddressTLVType = 0
+	AddressID          AddressTLVType = 2
+	AddressFamilyKey   AddressTLVType = 3
+	AddressScriptKey   AddressTLVType = 4
+	AddressInternalKey AddressTLVType = 6
+	AddressAmount      AddressTLVType = 8
+	AddressType        AddressTLVType = 9
+)
+
+func NewAddressVersionRecord(version *asset.Version) tlv.Record {
+	return tlv.MakeStaticRecord(
+		AddressVersion, version, 1, asset.VersionEncoder, asset.VersionDecoder,
+	)
+}
+
+func NewAddressIDRecord(id *asset.ID) tlv.Record {
+	return tlv.MakeStaticRecord(
+		AddressID, id, sha256.Size, asset.IDEncoder, asset.IDDecoder,
+	)
+}
+
+func NewAddressFamilyKeyRecord(familyKey **btcec.PublicKey) tlv.Record {
+	return tlv.MakeStaticRecord(
+		AddressFamilyKey, familyKey, schnorr.PubKeyBytesLen,
+		asset.SchnorrPubKeyEncoder, asset.SchnorrPubKeyDecoder,
+	)
+}
+
+func NewAddressScriptKeyRecord(scriptKey *btcec.PublicKey) tlv.Record {
+	return tlv.MakeStaticRecord(
+		AddressScriptKey, scriptKey, schnorr.PubKeyBytesLen,
+		schnorrPubKeyEncoder, schnorrPubKeyDecoder,
+	)
+}
+
+func NewAddressInternalKeyRecord(internalKey *btcec.PublicKey) tlv.Record {
+	return tlv.MakeStaticRecord(
+		AddressInternalKey, internalKey, schnorr.PubKeyBytesLen,
+		schnorrPubKeyEncoder, schnorrPubKeyDecoder,
+	)
+}
+
+func NewAddressAmountRecord(amount *uint64) tlv.Record {
+	recordSize := func() uint64 {
+		return tlv.VarIntSize(*amount)
+	}
+	return tlv.MakeDynamicRecord(
+		AddressAmount, amount, recordSize,
+		asset.VarIntEncoder, asset.VarIntDecoder,
+	)
+}
+
+func NewAddressTypeRecord(assetType *asset.Type) tlv.Record {
+	return tlv.MakeStaticRecord(
+		AddressType, assetType, 1, asset.TypeEncoder, asset.TypeDecoder,
+	)
+}


### PR DESCRIPTION
Split from #43. Adds tests.

Currently have a test failure for the TLV encode + decode round trip, with the ScriptKey and InternalKey fields. I think it's related to those fields being pubkey values and not pointers, but not sure.

```
=== CONT  TestAddressEncoding
    /home/jhb/taro/taro/address/address_test.go:226:
                Error Trace:    address_test.go:78
                                                        address_test.go:172
                                                        address_test.go:226
                Error:          Not equal:
                                expected: secp256k1.PublicKey{x:secp256k1.FieldVal{n:[10]uint32{0x30571be, 0x1322145, 0x1d0fa14, 0x7d489a, 0x946188, 0x239116, 0x3bd77a4, 0x13588c5, 0x2d52456, 0x2d6238}}, y:secp256k1.FieldVal{n:[10]uint32{0x2eb9e12, 0xa5e12e, 0x6c6750, 0x3e06e8e, 0x5e90f7, 0x3306d49, 0x369c176, 0x25d7b1, 0x21c75d3, 0x23ce57}}}
                                actual  : secp256k1.PublicKey{x:secp256k1.FieldVal{n:[10]uint32{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}}, y:secp256k1.FieldVal{n:[10]uint32{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}}}

                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -3,12 +3,12 @@
                                   n: ([10]uint32) (len=10) {
                                -   (uint32) 50688446,
                                -   (uint32) 20062533,
                                -   (uint32) 30472724,
                                -   (uint32) 8210586,
                                -   (uint32) 9724296,
                                -   (uint32) 2330902,
                                -   (uint32) 62748580,
                                -   (uint32) 20285637,
                                -   (uint32) 47522902,
                                -   (uint32) 2974264
                                +   (uint32) 0,
                                +   (uint32) 0,
                                +   (uint32) 0,
                                +   (uint32) 0,
                                +   (uint32) 0,
                                +   (uint32) 0,
                                +   (uint32) 0,
                                +   (uint32) 0,
                                +   (uint32) 0,
                                +   (uint32) 0
                                   }
                                @@ -17,12 +17,12 @@
                                   n: ([10]uint32) (len=10) {
                                -   (uint32) 48995858,
                                -   (uint32) 10871086,
                                -   (uint32) 7104336,
                                -   (uint32) 65040014,
                                -   (uint32) 6197495,
                                -   (uint32) 53505353,
                                -   (uint32) 57262454,
                                -   (uint32) 2480049,
                                -   (uint32) 35419603,
                                -   (uint32) 2346583
                                +   (uint32) 0,
                                +   (uint32) 0,
                                +   (uint32) 0,
                                +   (uint32) 0,
                                +   (uint32) 0,
                                +   (uint32) 0,
                                +   (uint32) 0,
                                +   (uint32) 0,
                                +   (uint32) 0,
                                +   (uint32) 0
                                   }
                Test:           TestAddressEncoding
```

Fixes https://github.com/lightninglabs/taro/issues/15