### PR TITLE
scripts: use sed to work around sqlc LEFT JOIN issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,5 +18,8 @@ tarod-debug
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
+# Sed backup files.
+*.bak
+
 # Dependency directories (remove the comment below to include it)
 # vendor/

--- a/scripts/gen_sqlc_docker.sh
+++ b/scripts/gen_sqlc_docker.sh
@@ -17,3 +17,12 @@ docker run \
   -v "$DIR/../:/build" \
   -w /build \
   kjconroy/sqlc:1.14.0 generate
+
+# Until https://github.com/kyleconroy/sqlc/issues/1334 is fixed, we need to
+# manually modify some types so LEFT JOIN queries compile properly.
+echo "Fixing LEFT JOIN issue..."
+sed -i.bak -E 's/FamKeyFamily([[:space:]])+int32/FamKeyFamily\1sql.NullInt32/g' tarodb/sqlite/assets.sql.go
+sed -i.bak -E 's/FamKeyIndex([[:space:]])+int32/FamKeyIndex\1sql.NullInt32/g' tarodb/sqlite/assets.sql.go
+
+echo "Reformatting modified files.."
+go fmt tarodb/sqlite/assets.sql.go


### PR DESCRIPTION
In this commit, we modify the main script that we use to run the `sqlc`
code generation to also replace the two fields that need to be
`sql.NullInt32` for the LEFT JOIN compilation to work.

Can be removed once this issue is fixed:
https://github.com/kyleconroy/sqlc/issues/1334