### PR TITLE
Address send utils

### DIFF
--- a/address/params.go
+++ b/address/params.go
@@ -118,14 +118,19 @@ func Net(hrp string) (*ChainParams, error) {
 	switch hrp {
 	case MainNetTaro.TaroHRP:
 		return &MainNetTaro, nil
+
 	case TestNet3Taro.TaroHRP:
 		return &TestNet3Taro, nil
+
 	case RegressionNetTaro.TaroHRP:
 		return &RegressionNetTaro, nil
+
 	case SigNetTaro.TaroHRP:
 		return &SigNetTaro, nil
+
 	case SimNetTaro.TaroHRP:
 		return &SimNetTaro, nil
+
 	default:
 		return nil, ErrUnsupportedHRP
 	}


### PR DESCRIPTION
Requires #56, split from #43.

Includes first step of sending, validating the sender input Taro tree against a receiver Taro address. I imagine most errors on sending should get caught at this step.

Would like feedback on how to test P2TR script creation and signVirtualKeySpend, if possible or necessary.