### PR TITLE
commitment: type commitment stores, expose equally

### DIFF
--- a/commitment/commitment_test.go
+++ b/commitment/commitment_test.go
@@ -818,7 +818,9 @@ func TestUpdateAssetCommitment(t *testing.T) {
 				case 1:
 					assets := familyAssetCommitment.Assets()
 					require.Equal(t, len(assets), testCase.numAssets)
-					assertAssetEqual(t, assets[0], asset)
+					assertAssetEqual(
+						t, assets[asset.AssetCommitmentKey()], asset,
+					)
 
 				// insertion of collectible with family key.
 				case 2:


### PR DESCRIPTION
Expose the map of assets backing an AssetCommitment, and add a type for the maps backing AssetCommitments and TaroCommmitments to document the keys used.