### PR TITLE
add Signer interface for Taro virtual transactions

### DIFF
--- a/taroscript/interface.go
+++ b/taroscript/interface.go
@@ -1,6 +1,9 @@
 package taroscript
 
 import (
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/lndclient"
 	"github.com/lightninglabs/taro/asset"
 	"github.com/lightninglabs/taro/commitment"
 )
@@ -12,4 +15,15 @@ type TxValidator interface {
 	// an asset transfer, including the attached witnesses.
 	Execute(newAsset *asset.Asset, splitAsset *commitment.SplitAsset,
 		prevAssets commitment.InputSet) error
+}
+
+// Signer is the interface used to compute the witness for a Taro virtual TX.
+type Signer interface {
+	// SignVirtualTx generates a signature according to the passed signing
+	// descriptor and TX.
+
+	// NOTE: We currently assume the signature requested is for the
+	// BIP 86 spending type.
+	SignVirtualTx(signDesc *lndclient.SignDescriptor, tx *wire.MsgTx,
+		prevOut *wire.TxOut) (*schnorr.Signature, error)
 }

--- a/taroscript/mock.go
+++ b/taroscript/mock.go
@@ -1,0 +1,131 @@
+package taroscript
+
+import (
+	"fmt"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/lndclient"
+	"github.com/lightningnetwork/lnd/input"
+)
+
+type MockSigner struct {
+	PrivKey *btcec.PrivateKey
+}
+
+func NewMockSigner(privKey *btcec.PrivateKey) *MockSigner {
+	return &MockSigner{
+		PrivKey: privKey,
+	}
+}
+
+// Taken from lnd/lnwallet/btcwallet/signer:L344, SignOutputRaw
+func (m *MockSigner) SignOutputRaw(tx *wire.MsgTx,
+	signDesc *input.SignDescriptor) (*schnorr.Signature, error) {
+
+	witnessScript := signDesc.WitnessScript
+
+	privKey := m.PrivKey
+	var maybeTweakPrivKey *btcec.PrivateKey
+
+	switch {
+	case signDesc.SingleTweak != nil:
+		maybeTweakPrivKey = input.TweakPrivKey(privKey,
+			signDesc.SingleTweak)
+
+	case signDesc.DoubleTweak != nil:
+		maybeTweakPrivKey = input.DeriveRevocationPrivKey(privKey,
+			signDesc.DoubleTweak)
+
+	default:
+		maybeTweakPrivKey = privKey
+	}
+
+	privKey = maybeTweakPrivKey
+
+	// In case of a taproot output any signature is always a Schnorr
+	// signature, based on the new tapscript sighash algorithm.
+	if !txscript.IsPayToTaproot(signDesc.Output.PkScript) {
+		return nil, fmt.Errorf("mock signer: output script not taproot")
+	}
+
+	sigHashes := txscript.NewTxSigHashes(
+		tx, signDesc.PrevOutputFetcher,
+	)
+
+	// Are we spending a script path or the key path? The API is
+	// slightly different, so we need to account for that to get the
+	// raw signature.
+	var rawSig []byte
+	var err error
+	switch signDesc.SignMethod {
+	case input.TaprootKeySpendBIP0086SignMethod,
+		input.TaprootKeySpendSignMethod:
+
+		// This function tweaks the private key using the tap
+		// root key supplied as the tweak.
+		rawSig, err = txscript.RawTxInTaprootSignature(
+			tx, sigHashes, signDesc.InputIndex,
+			signDesc.Output.Value, signDesc.Output.PkScript,
+			signDesc.TapTweak, signDesc.HashType,
+			privKey,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+	case input.TaprootScriptSpendSignMethod:
+		leaf := txscript.TapLeaf{
+			LeafVersion: txscript.BaseLeafVersion,
+			Script:      witnessScript,
+		}
+		rawSig, err = txscript.RawTxInTapscriptSignature(
+			tx, sigHashes, signDesc.InputIndex,
+			signDesc.Output.Value, signDesc.Output.PkScript,
+			leaf, signDesc.HashType, privKey,
+		)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	sig, err := schnorr.ParseSignature(rawSig)
+	if err != nil {
+		return nil, err
+	}
+
+	return sig, nil
+}
+
+func (m MockSigner) SignVirtualTx(signDesc *lndclient.SignDescriptor,
+	tx *wire.MsgTx, prevOut *wire.TxOut) (*schnorr.Signature, error) {
+
+	prevOutFetcher := txscript.NewCannedPrevOutputFetcher(
+		prevOut.PkScript, prevOut.Value,
+	)
+
+	sigHashes := txscript.NewTxSigHashes(tx, prevOutFetcher)
+
+	fullSignDesc := input.SignDescriptor{
+		KeyDesc:           signDesc.KeyDesc,
+		SingleTweak:       signDesc.SingleTweak,
+		DoubleTweak:       signDesc.DoubleTweak,
+		TapTweak:          signDesc.TapTweak,
+		WitnessScript:     signDesc.WitnessScript,
+		SignMethod:        signDesc.SignMethod,
+		Output:            signDesc.Output,
+		HashType:          signDesc.HashType,
+		SigHashes:         sigHashes,
+		PrevOutputFetcher: prevOutFetcher,
+		InputIndex:        signDesc.InputIndex,
+	}
+
+	sig, err := m.SignOutputRaw(tx, &fullSignDesc)
+	if err != nil {
+		return nil, err
+	}
+
+	return sig, nil
+}

--- a/taroscript/send_test.go
+++ b/taroscript/send_test.go
@@ -57,6 +57,7 @@ type spendData struct {
 	asset1CollectFamilyTaroTree    commitment.TaroCommitment
 	asset2TaroTree                 commitment.TaroCommitment
 	validator                      taroscript.TxValidator
+	signer                         taroscript.MockSigner
 }
 
 var (
@@ -174,6 +175,9 @@ func initSpendScenario(t *testing.T) spendData {
 
 	// Validator instance needed to call the Taro VM.
 	state.validator = &taro.ValidatorV0{}
+
+	// Signer needed to generate a witness for the spend.
+	state.signer = *taroscript.NewMockSigner(&state.spenderPrivKey)
 
 	return state
 }
@@ -740,8 +744,8 @@ var completeAssetSpendTestCases = []completeAssetSpendTestCase{
 			spendPrepared.InputAssets[state.asset1PrevID].
 				Genesis = state.genesis1collect
 			_, err := taroscript.CompleteAssetSpend(
-				state.spenderPrivKey, state.asset1PrevID,
-				*spendPrepared, state.validator,
+				state.spenderPubKey, state.asset1PrevID,
+				*spendPrepared, state.signer, state.validator,
 			)
 			spendPrepared.InputAssets[state.asset1PrevID].
 				Genesis = state.genesis1
@@ -759,11 +763,11 @@ var completeAssetSpendTestCases = []completeAssetSpendTestCase{
 			spendPrepared := taroscript.PrepareAssetCompleteSpend(
 				state.address1, state.asset1PrevID, spend,
 			)
-			spendPrepared.NewAsset.PrevWitnesses[0].PrevID =
-				&asset.PrevID{}
+			spendPrepared.NewAsset.PrevWitnesses[0].
+				PrevID.OutPoint.Index = 1337
 			_, err := taroscript.CompleteAssetSpend(
-				state.spenderPrivKey, state.asset1PrevID,
-				*spendPrepared, state.validator,
+				state.spenderPubKey, state.asset1PrevID,
+				*spendPrepared, state.signer, state.validator,
 			)
 			return err
 		},
@@ -783,8 +787,8 @@ var completeAssetSpendTestCases = []completeAssetSpendTestCase{
 				spendPrepared.InputAssets, state.asset1PrevID,
 			)
 			_, err := taroscript.CompleteAssetSpend(
-				state.spenderPrivKey, state.asset1PrevID,
-				*spendPrepared, state.validator,
+				state.spenderPubKey, state.asset1PrevID,
+				*spendPrepared, state.signer, state.validator,
 			)
 			return err
 		},
@@ -804,9 +808,9 @@ var completeAssetSpendTestCases = []completeAssetSpendTestCase{
 			)
 			unvalidatedAsset := spendPrepared.NewAsset
 			spendCompleted, err := taroscript.CompleteAssetSpend(
-				state.spenderPrivKey,
+				state.spenderPubKey,
 				state.asset1CollectFamilyPrevID,
-				*spendPrepared, state.validator,
+				*spendPrepared, state.signer, state.validator,
 			)
 			require.NoError(t, err)
 
@@ -830,8 +834,8 @@ var completeAssetSpendTestCases = []completeAssetSpendTestCase{
 			)
 			unvalidatedAsset := spendPrepared.NewAsset
 			spendCompleted, err := taroscript.CompleteAssetSpend(
-				state.spenderPrivKey, state.asset1PrevID,
-				*spendPrepared, state.validator,
+				state.spenderPubKey, state.asset1PrevID,
+				*spendPrepared, state.signer, state.validator,
 			)
 			require.NoError(t, err)
 
@@ -857,8 +861,8 @@ var completeAssetSpendTestCases = []completeAssetSpendTestCase{
 
 			unvalidatedAsset := spendPrepared.NewAsset
 			spendCompleted, err := taroscript.CompleteAssetSpend(
-				state.spenderPrivKey, state.asset2PrevID,
-				*spendPrepared, state.validator,
+				state.spenderPubKey, state.asset2PrevID,
+				*spendPrepared, state.signer, state.validator,
 			)
 			require.NoError(t, err)
 
@@ -905,8 +909,8 @@ var createSpendCommitmentsTestCases = []createSpendCommitmentsTestCase{
 				state.address1, state.asset1PrevID, spend,
 			)
 			spendCompleted, err := taroscript.CompleteAssetSpend(
-				state.spenderPrivKey, state.asset1PrevID,
-				*spendPrepared, state.validator,
+				state.spenderPubKey, state.asset1PrevID,
+				*spendPrepared, state.signer, state.validator,
 			)
 			require.NoError(t, err)
 
@@ -942,8 +946,8 @@ var createSpendCommitmentsTestCases = []createSpendCommitmentsTestCase{
 				state.address1, state.asset1PrevID, spend,
 			)
 			spendCompleted, err := taroscript.CompleteAssetSpend(
-				state.spenderPrivKey, state.asset1PrevID,
-				*spendPrepared, state.validator,
+				state.spenderPubKey, state.asset1PrevID,
+				*spendPrepared, state.signer, state.validator,
 			)
 			require.NoError(t, err)
 
@@ -985,8 +989,8 @@ var createSpendCommitmentsTestCases = []createSpendCommitmentsTestCase{
 			require.NoError(t, err)
 
 			spendCompleted, err := taroscript.CompleteAssetSpend(
-				state.spenderPrivKey, state.asset2PrevID,
-				*spendPrepared, state.validator,
+				state.spenderPubKey, state.asset2PrevID,
+				*spendPrepared, state.signer, state.validator,
 			)
 			require.NoError(t, err)
 
@@ -1021,9 +1025,9 @@ var createSpendCommitmentsTestCases = []createSpendCommitmentsTestCase{
 				state.asset1CollectFamilyPrevID, spend,
 			)
 			spendCompleted, err := taroscript.CompleteAssetSpend(
-				state.spenderPrivKey,
+				state.spenderPubKey,
 				state.asset1CollectFamilyPrevID,
-				*spendPrepared, state.validator,
+				*spendPrepared, state.signer, state.validator,
 			)
 			require.NoError(t, err)
 
@@ -1061,8 +1065,8 @@ var createSpendCommitmentsTestCases = []createSpendCommitmentsTestCase{
 				state.address1, state.asset1PrevID, spend,
 			)
 			spendCompleted, err := taroscript.CompleteAssetSpend(
-				state.spenderPrivKey, state.asset1PrevID,
-				*spendPrepared, state.validator,
+				state.spenderPubKey, state.asset1PrevID,
+				*spendPrepared, state.signer, state.validator,
 			)
 			require.NoError(t, err)
 
@@ -1101,8 +1105,8 @@ var createSpendCommitmentsTestCases = []createSpendCommitmentsTestCase{
 			require.NoError(t, err)
 
 			spendCompleted, err := taroscript.CompleteAssetSpend(
-				state.spenderPrivKey, state.asset2PrevID,
-				*spendPrepared, state.validator,
+				state.spenderPubKey, state.asset2PrevID,
+				*spendPrepared, state.signer, state.validator,
 			)
 			require.NoError(t, err)
 
@@ -1163,8 +1167,8 @@ var createSpendOutputsTestCases = []createSpendOutputsTestCase{
 				state.address1, state.asset1PrevID, spend,
 			)
 			spendCompleted, err := taroscript.CompleteAssetSpend(
-				state.spenderPrivKey, state.asset1PrevID,
-				*spendPrepared, state.validator,
+				state.spenderPubKey, state.asset1PrevID,
+				*spendPrepared, state.signer, state.validator,
 			)
 			require.NoError(t, err)
 
@@ -1200,8 +1204,8 @@ var createSpendOutputsTestCases = []createSpendOutputsTestCase{
 				state.address1, state.asset1PrevID, spend,
 			)
 			spendCompleted, err := taroscript.CompleteAssetSpend(
-				state.spenderPrivKey, state.asset1PrevID,
-				*spendPrepared, state.validator,
+				state.spenderPubKey, state.asset1PrevID,
+				*spendPrepared, state.signer, state.validator,
 			)
 			require.NoError(t, err)
 
@@ -1236,9 +1240,9 @@ var createSpendOutputsTestCases = []createSpendOutputsTestCase{
 				state.asset1CollectFamilyPrevID, spend,
 			)
 			spendCompleted, err := taroscript.CompleteAssetSpend(
-				state.spenderPrivKey,
+				state.spenderPubKey,
 				state.asset1CollectFamilyPrevID,
-				*spendPrepared, state.validator,
+				*spendPrepared, state.signer, state.validator,
 			)
 			require.NoError(t, err)
 
@@ -1297,8 +1301,8 @@ var createSpendOutputsTestCases = []createSpendOutputsTestCase{
 				state.address1, state.asset1PrevID, spend,
 			)
 			spendCompleted, err := taroscript.CompleteAssetSpend(
-				state.spenderPrivKey, state.asset1PrevID,
-				*spendPrepared, state.validator,
+				state.spenderPubKey, state.asset1PrevID,
+				*spendPrepared, state.signer, state.validator,
 			)
 			require.NoError(t, err)
 
@@ -1357,8 +1361,8 @@ var createSpendOutputsTestCases = []createSpendOutputsTestCase{
 			require.NoError(t, err)
 
 			spendCompleted, err := taroscript.CompleteAssetSpend(
-				state.spenderPrivKey, state.asset2PrevID,
-				*spendPrepared, state.validator,
+				state.spenderPubKey, state.asset2PrevID,
+				*spendPrepared, state.signer, state.validator,
 			)
 			require.NoError(t, err)
 

--- a/virtual_tx_signer.go
+++ b/virtual_tx_signer.go
@@ -1,0 +1,54 @@
+package taro
+
+import (
+	"context"
+
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/lndclient"
+	"github.com/lightninglabs/taro/taroscript"
+)
+
+// LndRpcVirtualTxSigner is an implementation of the taroscript.Signer
+// interface backed by an active lnd node.
+type LndRpcVirtualTxSigner struct {
+	lnd *lndclient.LndServices
+}
+
+// NewLndRpcVirtualTxSigner returns a new tx signer instance backed by the
+// passed connection to a remote lnd node.
+func NewLndRpcVirtualTxSigner(lnd *lndclient.LndServices) *LndRpcVirtualTxSigner {
+	return &LndRpcVirtualTxSigner{
+		lnd: lnd,
+	}
+}
+
+// SignVirtualTx generates a signature according to the passed signing
+// descriptor and virtual TX.
+
+// NOTE: We currently assume the signature requested is for the BIP 86
+// spending type, and that the passed key is the internal key.
+func (l *LndRpcVirtualTxSigner) SignVirtualTx(signDesc *lndclient.SignDescriptor,
+	tx *wire.MsgTx, prevOut *wire.TxOut) (*schnorr.Signature, error) {
+
+	sigs, err := l.lnd.Signer.SignOutputRaw(
+		context.Background(), tx,
+		[]*lndclient.SignDescriptor{signDesc}, []*wire.TxOut{prevOut},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// Our signer should only ever produce one signature or fail before this
+	// point, so accessing the signature directly is safe.
+	virtualTxSig, err := schnorr.ParseSignature(sigs[0])
+	if err != nil {
+		return nil, err
+	}
+
+	return virtualTxSig, nil
+}
+
+// A compile time assertion to ensure LndRpcVirtualTxSigner meets the
+// taroscript.Signer interface.
+var _ taroscript.Signer = (*LndRpcVirtualTxSigner)(nil)

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -207,10 +207,7 @@ func (vm *Engine) validateWitnessV0(virtualTx *wire.MsgTx, inputIdx uint32,
 		virtualTx, prevAsset, inputIdx, witness.TxWitness,
 	)
 
-	prevOutFetcher, err := taroscript.InputPrevOutFetcher(
-		prevAsset.ScriptVersion, prevAsset.ScriptKey.PubKey,
-		prevAsset.Amount,
-	)
+	prevOutFetcher, err := taroscript.InputPrevOutFetcher(*prevAsset)
 	if err != nil {
 		if errors.Is(err, taroscript.ErrInvalidScriptVersion) {
 			return ErrInvalidScriptVersion

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -79,6 +79,25 @@ func randAsset(t *testing.T, assetType asset.Type,
 	return a
 }
 
+func genTaprootKeySpend(t *testing.T, privKey btcec.PrivateKey,
+	virtualTx *wire.MsgTx, input *asset.Asset, idx uint32) wire.TxWitness {
+
+	t.Helper()
+	virtualTxCopy := taroscript.VirtualTxWithInput(
+		virtualTx, input, idx, nil,
+	)
+	sigHash, err := taroscript.InputKeySpendSigHash(
+		virtualTxCopy, input, idx,
+	)
+	require.NoError(t, err)
+
+	taprootPrivKey := txscript.TweakTaprootPrivKey(&privKey, nil)
+	sig, err := schnorr.Sign(taprootPrivKey, sigHash)
+	require.NoError(t, err)
+
+	return wire.TxWitness{sig.Serialize()}
+}
+
 func genTaprootScriptSpend(t *testing.T, privKey btcec.PrivateKey,
 	virtualTx *wire.MsgTx, input *asset.Asset, idx uint32,
 	tapTree *txscript.IndexedTapScriptTree,
@@ -156,11 +175,11 @@ func collectibleStateTransition(t *testing.T) (*asset.Asset,
 	inputs := commitment.InputSet{*prevID: genesisAsset}
 	virtualTx, _, err := taroscript.VirtualTx(newAsset, inputs)
 	require.NoError(t, err)
-	newWitness, err := taroscript.SignTaprootKeySpend(
-		*privKey, virtualTx, genesisAsset, 0,
+	newWitness := genTaprootKeySpend(
+		t, *privKey, virtualTx, genesisAsset, 0,
 	)
 	require.NoError(t, err)
-	newAsset.PrevWitnesses[0].TxWitness = *newWitness
+	newAsset.PrevWitnesses[0].TxWitness = newWitness
 
 	return newAsset, nil, inputs
 }
@@ -223,11 +242,11 @@ func normalStateTransition(t *testing.T) (*asset.Asset, commitment.SplitSet,
 	}
 	virtualTx, _, err := taroscript.VirtualTx(newAsset, inputs)
 	require.NoError(t, err)
-	newWitness, err := taroscript.SignTaprootKeySpend(
-		*privKey1, virtualTx, genesisAsset1, 0,
+	newWitness := genTaprootKeySpend(
+		t, *privKey1, virtualTx, genesisAsset1, 0,
 	)
 	require.NoError(t, err)
-	newAsset.PrevWitnesses[0].TxWitness = *newWitness
+	newAsset.PrevWitnesses[0].TxWitness = newWitness
 	newAsset.PrevWitnesses[1].TxWitness = genTaprootScriptSpend(
 		t, *privKey2, virtualTx, genesisAsset2, 1, tapTree, &tapLeaf,
 	)
@@ -273,11 +292,11 @@ func splitStateTransition(t *testing.T) (*asset.Asset, commitment.SplitSet,
 		splitCommitment.RootAsset, splitCommitment.PrevAssets,
 	)
 	require.NoError(t, err)
-	newWitness, err := taroscript.SignTaprootKeySpend(
-		*privKey, virtualTx, genesisAsset, 0,
+	newWitness := genTaprootKeySpend(
+		t, *privKey, virtualTx, genesisAsset, 0,
 	)
 	require.NoError(t, err)
-	splitCommitment.RootAsset.PrevWitnesses[0].TxWitness = *newWitness
+	splitCommitment.RootAsset.PrevWitnesses[0].TxWitness = newWitness
 
 	return splitCommitment.RootAsset, splitCommitment.SplitAssets,
 		splitCommitment.PrevAssets


### PR DESCRIPTION
Spun off from send state machine, builds on #115, only last commit is new.

In this PR, we introduce a `Signer` interface responsible for signing over Taro virtual TXs. This is needed to connect the sending state machine to a backing lnd client, and not require direct access to private keys.

I've added an equality check between the mock Signer and the old 'direct' signing method, and the existing unit tests pass, so AFAICT this interface + mock logic works. Requesting feedback to make sure that isn't a fluke + general improvements.

Outstanding tasks before pulling out of draft:

- [x] Update VM tests to sign with Signer interface
- [x] Fully remove 'direct' signing method
- [x] Remove equality check in CompleteAssetSpend
- [x] Clarify constraints and limitations (BIP86 only , 1-in 1-out only, etc.) where needed