### PR TITLE
cmd/tarocli: fix help fall through for assets send

### DIFF
--- a/cmd/tarocli/assets.go
+++ b/cmd/tarocli/assets.go
@@ -224,7 +224,7 @@ func sendAssets(ctx *cli.Context) error {
 
 	switch {
 	case ctx.String(addrName) == "":
-		_ = cli.ShowCommandHelp(ctx, "sent")
+		_ = cli.ShowCommandHelp(ctx, "send")
 		return nil
 	}
 


### PR DESCRIPTION
Before this commit, if you didn't provide the correct args, nothing would print out since it was trying to print the help for the `sent` command. We fix this to instead properly try to print the help for the `send` command instead.