### PR TITLE
tarodb+tarofreighter: properly handle case when send can't succeed

### DIFF
--- a/tarodb/assets_store.go
+++ b/tarodb/assets_store.go
@@ -1067,6 +1067,10 @@ func (a *AssetStore) SelectCommitment(
 			return err
 		}
 
+		if len(matchingAssets) == 0 {
+			return tarofreighter.ErrNoPossibleAssetInputs
+		}
+
 		// At this point, we have the set of assets that match our
 		// filter query, but we also need to be able to construct the
 		// full Taro commitment for each asset so it can be used as an

--- a/tarodb/assets_store_test.go
+++ b/tarodb/assets_store_test.go
@@ -578,6 +578,8 @@ func TestSelectCommitment(t *testing.T) {
 		constraints tarofreighter.CommitmentConstraints
 
 		numAssets int
+
+		err error
 	}{
 		// Only one asset that matches the constraints, should be the
 		// only one returned.
@@ -619,6 +621,7 @@ func TestSelectCommitment(t *testing.T) {
 				MinAmt: 10,
 			},
 			numAssets: 0,
+			err:       tarofreighter.ErrNoPossibleAssetInputs,
 		},
 
 		// Asset ID not found on disk, no matches should be returned.
@@ -639,6 +642,7 @@ func TestSelectCommitment(t *testing.T) {
 				MinAmt: 10,
 			},
 			numAssets: 0,
+			err:       tarofreighter.ErrNoPossibleAssetInputs,
 		},
 	}
 
@@ -658,7 +662,7 @@ func TestSelectCommitment(t *testing.T) {
 			selectedAssets, err := assetsStore.SelectCommitment(
 				ctx, test.constraints,
 			)
-			require.NoError(t, err)
+			require.ErrorIs(t, test.err, err)
 
 			// The number of selected assets should match up
 			// properly.

--- a/tarofreighter/chain_porter.go
+++ b/tarofreighter/chain_porter.go
@@ -437,8 +437,6 @@ func (p *ChainPorter) advanceStateUntil(currentPkg *sendPackage,
 
 		updatedPkg, err := p.stateStep(*currentPkg)
 		if err != nil {
-			// return fmt.Errorf("unable to advance "+
-			// 	"state machine: %w", err)
 			return nil, err
 		}
 

--- a/tarofreighter/interface.go
+++ b/tarofreighter/interface.go
@@ -2,6 +2,7 @@ package tarofreighter
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcutil"
@@ -65,12 +66,22 @@ type AnchoredCommitment struct {
 	Asset *asset.Asset
 }
 
+var (
+	// ErrNoPossibleAssetInputs is returned when an instance of a
+	// CommitmentSelector cannot satisfy the coin selection constraints.
+	ErrNoPossibleAssetInputs = fmt.Errorf("unable to satisfy coin " +
+		"selection constraints")
+)
+
 // CommitmentSelector attracts over the coin selection process needed to be
 // able to execute moving taro assets on chain.
 type CommitmentSelector interface {
 	// SelectCommitment takes the set of commitment constraints and returns
 	// an AnchoredCommitment that returns all the information needed to use
 	// the commitment as an input to an on chain taro transaction.
+	//
+	// If coin selection cannot be completed, then ErrNoPossibleAssetInputs
+	// should be returned.
 	SelectCommitment(context.Context,
 		CommitmentConstraints) ([]*AnchoredCommitment, error)
 }


### PR DESCRIPTION
In this commit, we add a new error that'll be returned from the coin selection interface if the set of constraints specified can't be met. This error will now properly be propagated up to the RPC interface and thru the command line instead of crashing due to a OOB access (returned slice has no asset inputs).