### PR TITLE
make: fix package name for build env variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,10 +37,10 @@ DEV_TAGS := $(if ${tags},$(DEV_TAGS) ${tags},$(DEV_TAGS))
 # We only return the part inside the double quote here to avoid escape issues
 # when calling the external release script. The second parameter can be used to
 # add additional ldflags if needed (currently only used for the release).
-make_ldflags = $(2) -X $(PKG)/build.Commit=$(COMMIT) \
-	-X $(PKG)/build.CommitHash=$(COMMIT_HASH) \
-	-X $(PKG)/build.GoVersion=$(GOVERSION) \
-	-X $(PKG)/build.RawTags=$(shell echo $(1) | sed -e 's/ /,/g')
+make_ldflags = $(2) -X $(PKG).Commit=$(COMMIT) \
+	-X $(PKG).CommitHash=$(COMMIT_HASH) \
+	-X $(PKG).GoVersion=$(GOVERSION) \
+	-X $(PKG).RawTags=$(shell echo $(1) | sed -e 's/ /,/g')
 
 make_lnd_ldflags = -X $(LND_PKG)/build.RawTags=$(shell echo $(1) | sed -e 's/ /,/g')
 DEV_GCFLAGS := -gcflags "all=-N -l"


### PR DESCRIPTION
We moved the `version.go` file from the `build` package to the main package in a previous PR. To set the build variables like commit name, commit hash and Golang version, we need to modify the ldflags build parameter.