### PR TITLE
itest: support multiple proof courier service types

### DIFF
--- a/itest/integration_test.go
+++ b/itest/integration_test.go
@@ -41,14 +41,6 @@ func TestTaprootAssetsDaemon(t *testing.T) {
 
 	lndHarness.SetupStandbyNodes()
 
-	// Start aperture service and attach to test harness.
-	//
-	// TODO(ffranr): Each test case should have access to its own
-	// 		 independent aperture service. Remove this global
-	//   	         instance.
-	apertureHarness := setupApertureHarness(ht.t)
-	ht.apertureHarness = &apertureHarness
-
 	t.Logf("Running %v integration tests", len(testCases))
 	for _, testCase := range testCases {
 		logLine := fmt.Sprintf("STARTING ============ %v ============\n",
@@ -58,9 +50,11 @@ func TestTaprootAssetsDaemon(t *testing.T) {
 			// The universe server and tapd client are both freshly
 			// created and later discarded for each test run to
 			// assure no state is taken over between runs.
-			tapdHarness, universeServer := setupHarnesses(
-				t1, ht, lndHarness, testCase.enableHashMail,
-			)
+			tapdHarness, universeServer, proofCourier :=
+				setupHarnesses(
+					t1, ht, lndHarness,
+					testCase.proofCourierType,
+				)
 			lndHarness.EnsureConnected(
 				lndHarness.Alice, lndHarness.Bob,
 			)
@@ -70,6 +64,7 @@ func TestTaprootAssetsDaemon(t *testing.T) {
 
 			ht := ht.newHarnessTest(
 				t1, lndHarness, universeServer, tapdHarness,
+				proofCourier,
 			)
 
 			// Now we have everything to run the test case.

--- a/itest/send_test.go
+++ b/itest/send_test.go
@@ -81,7 +81,6 @@ func testBasicSend(t *harnessTest) {
 	secondTapd := setupTapdHarness(
 		t.t, t, t.lndHarness.Bob, t.universeServer,
 		func(params *tapdHarnessParams) {
-			params.enableHashMail = true
 			params.startupSyncNode = t.tapd
 			params.startupSyncNumAssets = len(rpcAssets)
 		},
@@ -163,7 +162,6 @@ func testBasicSendPassiveAsset(t *harnessTest) {
 	recvTapd := setupTapdHarness(
 		t.t, t, t.lndHarness.Bob, t.universeServer,
 		func(params *tapdHarnessParams) {
-			params.enableHashMail = true
 			params.startupSyncNode = t.tapd
 			params.startupSyncNumAssets = len(rpcAssets)
 		},
@@ -257,7 +255,6 @@ func testReattemptFailedAssetSend(t *harnessTest) {
 	sendTapd := setupTapdHarness(
 		t.t, t, t.lndHarness.Bob, t.universeServer,
 		func(params *tapdHarnessParams) {
-			params.enableHashMail = true
 			params.expectErrExit = true
 		},
 	)
@@ -356,7 +353,6 @@ func testOfflineReceiverEventuallyReceives(t *harnessTest) {
 	sendTapd := setupTapdHarness(
 		t.t, t, t.lndHarness.Bob, t.universeServer,
 		func(params *tapdHarnessParams) {
-			params.enableHashMail = true
 			params.expectErrExit = true
 			params.proofSendBackoffCfg = &proof.BackoffCfg{
 				BackoffResetWait: 1 * time.Microsecond,

--- a/itest/test_list_on_test.go
+++ b/itest/test_list_on_test.go
@@ -3,6 +3,10 @@
 
 package itest
 
+import (
+	"github.com/lightninglabs/taproot-assets/proof"
+)
+
 var testCases = []*testCase{
 	{
 		name: "mint assets",
@@ -21,23 +25,24 @@ var testCases = []*testCase{
 		test: testMultiAddress,
 	},
 	{
-		name:           "basic send",
-		test:           testBasicSend,
-		enableHashMail: true,
+		name:             "basic send",
+		test:             testBasicSend,
+		proofCourierType: proof.ApertureCourier,
 	},
 	{
-		name:           "reattempt failed asset send",
-		test:           testReattemptFailedAssetSend,
-		enableHashMail: true,
+		name:             "reattempt failed asset send",
+		test:             testReattemptFailedAssetSend,
+		proofCourierType: proof.ApertureCourier,
 	},
 	{
-		name:           "offline receiver eventually receives",
-		test:           testOfflineReceiverEventuallyReceives,
-		enableHashMail: true,
+		name:             "offline receiver eventually receives",
+		test:             testOfflineReceiverEventuallyReceives,
+		proofCourierType: proof.ApertureCourier,
 	},
 	{
-		name: "basic send passive asset",
-		test: testBasicSendPassiveAsset,
+		name:             "basic send passive asset",
+		test:             testBasicSendPassiveAsset,
+		proofCourierType: proof.ApertureCourier,
 	},
 	{
 		name: "multi input send non-interactive single ID",

--- a/proof/courier.go
+++ b/proof/courier.go
@@ -19,6 +19,30 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+// CourierType is an enum that represents the different types of proof courier
+// services.
+type CourierType int64
+
+const (
+	// DisabledCourier is the default courier type that is used when no
+	// courier is specified.
+	DisabledCourier CourierType = iota
+
+	// ApertureCourier is a courier that uses the hashmail protocol to
+	// deliver proofs.
+	ApertureCourier
+)
+
+// CourierHarness interface is an integration testing harness for a proof
+// courier service.
+type CourierHarness interface {
+	// Start starts the proof courier service.
+	Start(chan error) error
+
+	// Stop stops the proof courier service.
+	Stop() error
+}
+
 // Courier abstracts away from the final proof retrival/delivery process as
 // part of the non-interactive send flow. A sender can use this given the
 // abstracted Addr/source type to send a proof to the receiver. Conversely, a
@@ -198,7 +222,7 @@ func (h *HashMailBox) ReadProof(ctx context.Context,
 var ackMsg = []byte("ack")
 
 // AckProof sends an ACK from the receiver to the sender that a proof has been
-// recevied.
+// received.
 func (h *HashMailBox) AckProof(ctx context.Context, sid streamID) error {
 	writeStream, err := h.client.SendStream(ctx)
 	if err != nil {

--- a/proof/courier.go
+++ b/proof/courier.go
@@ -43,7 +43,7 @@ type CourierHarness interface {
 	Stop() error
 }
 
-// Courier abstracts away from the final proof retrival/delivery process as
+// Courier abstracts away from the final proof retrieval/delivery process as
 // part of the non-interactive send flow. A sender can use this given the
 // abstracted Addr/source type to send a proof to the receiver. Conversely, a
 // receiver can use this to fetch a proof from the sender.
@@ -63,7 +63,7 @@ type Courier[Addr any] interface {
 	SetSubscribers(map[uint64]*chanutils.EventReceiver[chanutils.Event])
 }
 
-// ProofMailbox represents an abstract store-and-forward maillbox that can be
+// ProofMailbox represents an abstract store-and-forward mailbox that can be
 // used to send/receive proofs.
 type ProofMailbox interface {
 	// Init creates a mailbox given the specified stream ID.
@@ -76,13 +76,13 @@ type ProofMailbox interface {
 	ReadProof(ctx context.Context, sid streamID) (Blob, error)
 
 	// AckProof sends an ACK from the receiver to the sender that a proof
-	// has been recevied.
+	// has been received.
 	AckProof(ctx context.Context, sid streamID) error
 
 	// RecvAck waits for the sender to receive the ack from the receiver.
 	RecvAck(ctx context.Context, sid streamID) error
 
-	// CleanUp atempts to tear down the mailbox as specified by the passed
+	// CleanUp attempts to tear down the mailbox as specified by the passed
 	// sid.
 	CleanUp(ctx context.Context, sid streamID) error
 }


### PR DESCRIPTION
This commit adds a new proof courier harness interface which will allow the integration tests to support multiple different proof courier service types. It also ensures that each test case has its own proof courier service instance.

This commit also removes the need to specify a proof courier when starting a new taro node during a test case. By default, the test harness will be inspected for an existing proof courier.