### PR TITLE
cmd/tapcli: use proper default tapd directory

### DIFF
--- a/cmd/tapcli/main.go
+++ b/cmd/tapcli/main.go
@@ -45,7 +45,7 @@ const (
 )
 
 var (
-	defaultTapdDir     = btcutil.AppDataDir("tap", false)
+	defaultTapdDir     = btcutil.AppDataDir("tapd", false)
 	defaultTLSCertPath = filepath.Join(defaultTapdDir, defaultTLSCertFilename)
 
 	// maxMsgRecvSize is the largest message our client will receive. We


### PR DESCRIPTION
Fixes https://github.com/lightninglabs/taproot-assets/issues/277