### PR TITLE
tapcfg: update default testnet universe port

### DIFF
--- a/tapcfg/config.go
+++ b/tapcfg/config.go
@@ -53,7 +53,7 @@ const (
 
 	defaultAcceptRemoteProofs = false
 
-	defaultTestnetFederationServer = "testnet.universe.lightning.finance:12010"
+	defaultTestnetFederationServer = "testnet.universe.lightning.finance:10029"
 
 	// DefaultAutogenValidity is the default validity of a self-signed
 	// certificate. The value corresponds to 14 months


### PR DESCRIPTION
Updates the port in the default testnet universe federation server address. The server will support both ports for a while until this change has been released with a proper version for a while.