### PR TITLE
universe: RPC fixes

### DIFF
--- a/itest/assertions.go
+++ b/itest/assertions.go
@@ -479,6 +479,22 @@ func assertAddr(t *testing.T, expected *taprpc.Asset, actual *taprpc.Addr) {
 	require.NotEqual(t, expected.ScriptKey, actual.ScriptKey)
 }
 
+// assertEqualAsset asserts that two taprpc.Asset objects are equal, ignoring
+// node-specific fields like if script keys are local, if the asset is spent,
+// or if the anchor information is populated.
+func assertAsset(t *testing.T, expected, actual *taprpc.Asset) {
+	require.Equal(t, expected.Version, actual.Version)
+	require.Equal(t, expected.AssetGenesis, actual.AssetGenesis)
+	require.Equal(t, expected.AssetType, actual.AssetType)
+	require.Equal(t, expected.Amount, actual.Amount)
+	require.Equal(t, expected.LockTime, actual.LockTime)
+	require.Equal(t, expected.RelativeLockTime, actual.RelativeLockTime)
+	require.Equal(t, expected.ScriptVersion, actual.ScriptVersion)
+	require.Equal(t, expected.ScriptKey, actual.ScriptKey)
+	require.Equal(t, expected.AssetGroup, actual.AssetGroup)
+	require.Equal(t, expected.PrevWitnesses, actual.PrevWitnesses)
+}
+
 // assertBalanceByID asserts that the balance of a single asset,
 // specified by ID, on the given daemon is correct.
 func assertBalanceByID(t *testing.T, tapd *tapdHarness, id []byte,
@@ -778,15 +794,15 @@ func assertUniverseStats(t *testing.T, node *tapdHarness,
 		}
 
 		if numProofs != int(uniStats.NumTotalProofs) {
-			return fmt.Errorf("expected %v, got %v",
+			return fmt.Errorf("expected %v proofs, got %v",
 				numProofs, uniStats.NumTotalProofs)
 		}
 		if numSyncs != int(uniStats.NumTotalSyncs) {
-			return fmt.Errorf("expected %v, got %v",
+			return fmt.Errorf("expected %v syncs, got %v",
 				numSyncs, uniStats.NumTotalSyncs)
 		}
 		if numAssets != int(uniStats.NumTotalAssets) {
-			return fmt.Errorf("expected %v, got %v",
+			return fmt.Errorf("expected %v assets, got %v",
 				numAssets, uniStats.NumTotalAssets)
 		}
 

--- a/tapdb/universe_federation.go
+++ b/tapdb/universe_federation.go
@@ -3,7 +3,6 @@ package tapdb
 import (
 	"context"
 	"errors"
-	"fmt"
 	"time"
 
 	"github.com/lightninglabs/taproot-assets/fn"
@@ -121,8 +120,7 @@ func (u *UniverseFederationDB) AddServers(ctx context.Context,
 		// Add context to unique constraint errors.
 		var uniqueConstraintErr *ErrSqlUniqueConstraintViolation
 		if errors.As(err, &uniqueConstraintErr) {
-			return fmt.Errorf("universe name is already added: %w",
-				err)
+			return universe.ErrDuplicateUniverse
 		}
 
 		return err

--- a/tapdb/universe_federation_test.go
+++ b/tapdb/universe_federation_test.go
@@ -57,7 +57,7 @@ func TestUniverseFederationCRUD(t *testing.T) {
 	// If we try to insert them all again, then we should get an error as
 	// we ensure the host names are unique.
 	err = fedDB.AddServers(ctx, addrs...)
-	require.ErrorContains(t, err, "universe name is already added")
+	require.ErrorIs(t, err, universe.ErrDuplicateUniverse)
 
 	// Next, we should be able to fetch all the active hosts.
 	dbAddrs, err := fedDB.UniverseServers(ctx)

--- a/universe/auto_syncer.go
+++ b/universe/auto_syncer.go
@@ -2,6 +2,7 @@ package universe
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -108,7 +109,10 @@ func (f *FederationEnvoy) Start() error {
 			return NewServerAddrFromStr(a)
 		})
 		err := f.AddServer(serverAddrs...)
-		if err != nil {
+		// On restart, we'll get an error for universe servers already
+		// inserted in our DB, since we can't store duplicates.
+		// We can safely ignore that error.
+		if !errors.Is(err, ErrDuplicateUniverse) {
 			log.Warnf("unable to add universe servers: %v", err)
 		}
 

--- a/universe/interface.go
+++ b/universe/interface.go
@@ -23,6 +23,10 @@ var (
 	// ErrNoUniverseServers is returned when no active Universe servers are
 	// found in the DB.
 	ErrNoUniverseServers = fmt.Errorf("no active federation servers")
+
+	// ErrDuplicateUniverse is returned when the Universe server being added
+	// to the DB already exists.
+	ErrDuplicateUniverse = fmt.Errorf("universe server already added")
 )
 
 // Identifier is the identifier for a root/base universe.


### PR DESCRIPTION
Display 33-byte script keys instead of 32 bytes. We should audit the current structs are parsing to make it internally consistent, so that copy & paste works on the CLI.