### PR TITLE
tapdb: use the serializable isolation by default for postgres

### DIFF
--- a/tapdb/interfaces.go
+++ b/tapdb/interfaces.go
@@ -139,7 +139,8 @@ type BaseDB struct {
 // struct.
 func (s *BaseDB) BeginTx(ctx context.Context, opts TxOptions) (*sql.Tx, error) {
 	sqlOptions := sql.TxOptions{
-		ReadOnly: opts.ReadOnly(),
+		ReadOnly:  opts.ReadOnly(),
+		Isolation: sql.LevelSerializable,
 	}
 	return s.DB.BeginTx(ctx, &sqlOptions)
 }


### PR DESCRIPTION
In this commit, we start to use the serializable snapshot isolation by default for postgres. For sqlite, this is a noop as only a single writer is allowed at any time. With this mode, we should guard against all types of anomalies, at the cost of extra locking and potential perf hits.

One thing we'll need to test out is if the DB driver will automatically do retries or not if a transaction cannot be serialized.

This is an attempt at fixing #333 at a global level.