### PR TITLE
tapdb: properly set max connections for postgres

### DIFF
--- a/tapdb/postgres.go
+++ b/tapdb/postgres.go
@@ -33,7 +33,7 @@ type PostgresConfig struct {
 	User               string `long:"user" description:"Database user."`
 	Password           string `long:"password" description:"Database user's password."`
 	DBName             string `long:"dbname" description:"Database name to use."`
-	MaxOpenConnections int32  `long:"maxconnections" description:"Max open connections to keep alive to the database server."`
+	MaxOpenConnections int    `long:"maxconnections" description:"Max open connections to keep alive to the database server."`
 	RequireSSL         bool   `long:"requiressl" description:"Whether to require using SSL (mode: require) when connecting to the server."`
 }
 
@@ -71,6 +71,15 @@ func NewPostgresStore(cfg *PostgresConfig) (*PostgresStore, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	maxConns := defaultMaxConns
+	if cfg.MaxOpenConnections > 0 {
+		maxConns = cfg.MaxOpenConnections
+	}
+
+	rawDb.SetMaxOpenConns(maxConns)
+	rawDb.SetMaxIdleConns(maxConns)
+	rawDb.SetConnMaxLifetime(connIdleLifetime)
 
 	if !cfg.SkipMigrations {
 		// Now that the database is open, populate the database with

--- a/tapdb/sqlite.go
+++ b/tapdb/sqlite.go
@@ -24,11 +24,12 @@ const (
 	// transactions are started immediately.
 	sqliteTxLockImmediate = "_txlock=immediate"
 
-	// maxConns is the number of permitted active and idle connections. We
-	// want to limit this so it isn't unlimited. We use the same value for
-	// the number of idle connections as, this can speed up queries given a
-	// new connection doesn't need to be established each time.
-	maxConns = 25
+	// defaultMaxConns is the number of permitted active and idle
+	// connections. We want to limit this so it isn't unlimited. We use the
+	// same value for the number of idle connections as, this can speed up
+	// queries given a new connection doesn't need to be established each
+	// time.
+	defaultMaxConns = 25
 
 	// connIdleLifetime is the amount of time a connection can be idle.
 	connIdleLifetime = 5 * time.Minute
@@ -112,8 +113,8 @@ func NewSqliteStore(cfg *SqliteConfig) (*SqliteStore, error) {
 		return nil, err
 	}
 
-	db.SetMaxOpenConns(maxConns)
-	db.SetMaxIdleConns(maxConns)
+	db.SetMaxOpenConns(defaultMaxConns)
+	db.SetMaxIdleConns(defaultMaxConns)
 	db.SetConnMaxLifetime(connIdleLifetime)
 
 	if !cfg.SkipMigrations {


### PR DESCRIPTION
The default is unlimited, means that with the default postgres limit of 100, you'll run into errors.