### PR TITLE
universe: fix potential loop scoping bugs, add additional debug logging 

### DIFF
--- a/address/book.go
+++ b/address/book.go
@@ -11,8 +11,8 @@ import (
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/lndclient"
 	"github.com/lightninglabs/taproot-assets/asset"
-	"github.com/lightninglabs/taproot-assets/chanutils"
 	"github.com/lightninglabs/taproot-assets/commitment"
+	"github.com/lightninglabs/taproot-assets/fn"
 	"github.com/lightningnetwork/lnd/keychain"
 )
 
@@ -150,7 +150,7 @@ type Book struct {
 
 	// subscribers is a map of components that want to be notified on new
 	// address events, keyed by their subscription ID.
-	subscribers map[uint64]*chanutils.EventReceiver[*AddrWithKeyInfo]
+	subscribers map[uint64]*fn.EventReceiver[*AddrWithKeyInfo]
 
 	// subscriberMtx guards the subscribers map and access to the
 	// subscriptionID.
@@ -158,15 +158,15 @@ type Book struct {
 }
 
 // A compile-time assertion to make sure Book satisfies the
-// chanutils.EventPublisher interface.
-var _ chanutils.EventPublisher[*AddrWithKeyInfo, QueryParams] = (*Book)(nil)
+// fn.EventPublisher interface.
+var _ fn.EventPublisher[*AddrWithKeyInfo, QueryParams] = (*Book)(nil)
 
 // NewBook creates a new Book instance from the config.
 func NewBook(cfg BookConfig) *Book {
 	return &Book{
 		cfg: cfg,
 		subscribers: make(
-			map[uint64]*chanutils.EventReceiver[*AddrWithKeyInfo],
+			map[uint64]*fn.EventReceiver[*AddrWithKeyInfo],
 		),
 	}
 }
@@ -392,7 +392,7 @@ func (b *Book) CompleteEvent(ctx context.Context, event *Event,
 // marker onward existing items should be delivered on startup. If deliverFrom
 // is nil/zero/empty then all existing items will be delivered.
 func (b *Book) RegisterSubscriber(
-	receiver *chanutils.EventReceiver[*AddrWithKeyInfo],
+	receiver *fn.EventReceiver[*AddrWithKeyInfo],
 	deliverExisting bool, deliverFrom QueryParams) error {
 
 	b.subscriberMtx.Lock()
@@ -427,7 +427,7 @@ func (b *Book) RegisterSubscriber(
 // RemoveSubscriber removes the given subscriber and also stops it from
 // processing events.
 func (b *Book) RemoveSubscriber(
-	subscriber *chanutils.EventReceiver[*AddrWithKeyInfo]) error {
+	subscriber *fn.EventReceiver[*AddrWithKeyInfo]) error {
 
 	b.subscriberMtx.Lock()
 	defer b.subscriberMtx.Unlock()

--- a/cmd/tapd/main.go
+++ b/cmd/tapd/main.go
@@ -7,7 +7,7 @@ import (
 	"runtime/pprof"
 
 	"github.com/jessevdk/go-flags"
-	"github.com/lightninglabs/taproot-assets/chanutils"
+	"github.com/lightninglabs/taproot-assets/fn"
 	"github.com/lightninglabs/taproot-assets/tapcfg"
 	"github.com/lightningnetwork/lnd/signal"
 )
@@ -62,9 +62,7 @@ func main() {
 	// This concurrent error queue can be used by every component that can
 	// raise runtime errors. Using a queue will prevent us from blocking on
 	// sending errors to it, as long as the queue is running.
-	errQueue := chanutils.NewConcurrentQueue[error](
-		chanutils.DefaultQueueSize,
-	)
+	errQueue := fn.NewConcurrentQueue[error](fn.DefaultQueueSize)
 	errQueue.Start()
 	defer errQueue.Stop()
 

--- a/commitment/asset.go
+++ b/commitment/asset.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/lightninglabs/taproot-assets/asset"
-	"github.com/lightninglabs/taproot-assets/chanutils"
+	"github.com/lightninglabs/taproot-assets/fn"
 	"github.com/lightninglabs/taproot-assets/mssmt"
 	"golang.org/x/exp/maps"
 )
@@ -404,7 +404,7 @@ func (c *AssetCommitment) Copy() (*AssetCommitment, error) {
 
 	// First, we'll perform a deep copy of all the assets that this existing
 	// commitment is committing to.
-	newAssets := chanutils.CopyAll(maps.Values(c.Assets()))
+	newAssets := fn.CopyAll(maps.Values(c.Assets()))
 
 	// Now that we have a deep copy of all the assets, we can just create a
 	// brand-new commitment from the set of assets.

--- a/commitment/proof.go
+++ b/commitment/proof.go
@@ -5,7 +5,7 @@ import (
 	"io"
 
 	"github.com/lightninglabs/taproot-assets/asset"
-	"github.com/lightninglabs/taproot-assets/chanutils"
+	"github.com/lightninglabs/taproot-assets/fn"
 	"github.com/lightninglabs/taproot-assets/mssmt"
 	"github.com/lightningnetwork/lnd/tlv"
 )
@@ -129,7 +129,7 @@ func (p Proof) DeriveByAssetInclusion(asset *asset.Asset) (*TapCommitment,
 	)
 	log.Tracef("Derived asset inclusion proof for asset_id=%v, "+
 		"asset_commitment_key=%x, asset_commitment_leaf=%s",
-		asset.ID(), chanutils.ByteSlice(asset.AssetCommitmentKey()),
+		asset.ID(), fn.ByteSlice(asset.AssetCommitmentKey()),
 		assetCommitmentLeaf.NodeHash())
 
 	return NewTapCommitmentWithRoot(

--- a/commitment/tap.go
+++ b/commitment/tap.go
@@ -11,7 +11,7 @@ import (
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/lightninglabs/taproot-assets/asset"
-	"github.com/lightninglabs/taproot-assets/chanutils"
+	"github.com/lightninglabs/taproot-assets/fn"
 	"github.com/lightninglabs/taproot-assets/mssmt"
 	"golang.org/x/exp/maps"
 )
@@ -378,7 +378,7 @@ func (c *TapCommitment) Copy() (*TapCommitment, error) {
 	}
 
 	// Otherwise, we'll copy all the internal asset commitments.
-	newAssetCommitments, err := chanutils.CopyAllErr(
+	newAssetCommitments, err := fn.CopyAllErr(
 		maps.Values(c.assetCommitments),
 	)
 	if err != nil {

--- a/fn/concurrency.go
+++ b/fn/concurrency.go
@@ -1,4 +1,4 @@
-package chanutils
+package fn
 
 import (
 	"context"

--- a/fn/concurrency_test.go
+++ b/fn/concurrency_test.go
@@ -1,4 +1,4 @@
-package chanutils
+package fn
 
 import (
 	"context"

--- a/fn/context_guard.go
+++ b/fn/context_guard.go
@@ -1,4 +1,4 @@
-package chanutils
+package fn
 
 import (
 	"context"

--- a/fn/errors.go
+++ b/fn/errors.go
@@ -1,4 +1,4 @@
-package chanutils
+package fn
 
 import (
 	"context"

--- a/fn/errors_test.go
+++ b/fn/errors_test.go
@@ -1,4 +1,4 @@
-package chanutils
+package fn
 
 import (
 	"context"

--- a/fn/events.go
+++ b/fn/events.go
@@ -1,4 +1,4 @@
-package chanutils
+package fn
 
 import (
 	"fmt"

--- a/fn/func.go
+++ b/fn/func.go
@@ -1,4 +1,4 @@
-package chanutils
+package fn
 
 import "fmt"
 

--- a/fn/iter.go
+++ b/fn/iter.go
@@ -1,4 +1,4 @@
-package chanutils
+package fn
 
 // ForEachErr will iterate through all items in the passed slice, calling the
 // function f on each slice. If a call to f fails, then the function returns an

--- a/fn/memory.go
+++ b/fn/memory.go
@@ -1,4 +1,4 @@
-package chanutils
+package fn
 
 // Ptr returns the pointer of the given value. This is useful in instances
 // where a function returns the value, but a pointer is wanted. Without this,

--- a/fn/queue.go
+++ b/fn/queue.go
@@ -1,4 +1,4 @@
-package chanutils
+package fn
 
 import (
 	"container/list"

--- a/fn/recv.go
+++ b/fn/recv.go
@@ -1,4 +1,4 @@
-package chanutils
+package fn
 
 import (
 	"fmt"

--- a/fn/send.go
+++ b/fn/send.go
@@ -1,4 +1,4 @@
-package chanutils
+package fn
 
 // SendOrQuit attempts to and a message through channel c. If this succeeds,
 // then bool is returned. Otherwise if a quit signal is received first, then

--- a/fn/set.go
+++ b/fn/set.go
@@ -1,4 +1,4 @@
-package chanutils
+package fn
 
 import "golang.org/x/exp/maps"
 

--- a/itest/assertions.go
+++ b/itest/assertions.go
@@ -12,7 +12,7 @@ import (
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/taproot-assets/asset"
-	"github.com/lightninglabs/taproot-assets/chanutils"
+	"github.com/lightninglabs/taproot-assets/fn"
 	"github.com/lightninglabs/taproot-assets/proof"
 	"github.com/lightninglabs/taproot-assets/taprpc"
 	unirpc "github.com/lightninglabs/taproot-assets/taprpc/universerpc"
@@ -688,7 +688,7 @@ func assertUniverseRootsEqual(t *testing.T, a, b *unirpc.AssetRootResponse) {
 	// same set of asset IDs are being tracked.
 	uniKeys := maps.Keys(a.UniverseRoots)
 	require.Equal(t, len(a.UniverseRoots), len(b.UniverseRoots))
-	require.True(t, chanutils.All(uniKeys, func(key string) bool {
+	require.True(t, fn.All(uniKeys, func(key string) bool {
 		_, ok := b.UniverseRoots[key]
 		return ok
 	}))
@@ -805,7 +805,7 @@ func assertUniverseAssetStats(t *testing.T, node *tapdHarness,
 	require.Len(t, assetStats.AssetStats, len(assetIDs))
 
 	for _, assetStat := range assetStats.AssetStats {
-		found := chanutils.Any(assetIDs, func(id []byte) bool {
+		found := fn.Any(assetIDs, func(id []byte) bool {
 			return bytes.Equal(assetStat.AssetId, id)
 		})
 		require.True(t, found)

--- a/itest/assets_test.go
+++ b/itest/assets_test.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
-	"github.com/lightninglabs/taproot-assets/chanutils"
+	"github.com/lightninglabs/taproot-assets/fn"
 	"github.com/lightninglabs/taproot-assets/proof"
 	"github.com/lightninglabs/taproot-assets/taprpc"
 	"github.com/lightninglabs/taproot-assets/taprpc/mintrpc"
@@ -469,7 +469,7 @@ func testMintAssetNameCollisionError(t *harnessTest) {
 
 		return batch.Assets[0].AssetType == taprpc.AssetType_COLLECTIBLE
 	}
-	batchCollide, err := chanutils.First(allBatches, isCollidingBatch)
+	batchCollide, err := fn.First(allBatches, isCollidingBatch)
 	require.NoError(t.t, err)
 
 	require.Len(t.t, batchCollide.Assets, 1)

--- a/itest/multi_asset_group_test.go
+++ b/itest/multi_asset_group_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/lightninglabs/taproot-assets/asset"
-	"github.com/lightninglabs/taproot-assets/chanutils"
+	"github.com/lightninglabs/taproot-assets/fn"
 	"github.com/lightninglabs/taproot-assets/taprpc"
 	"github.com/lightninglabs/taproot-assets/taprpc/mintrpc"
 	"github.com/stretchr/testify/require"
@@ -91,7 +91,7 @@ func testMintMultiAssetGroups(t *harnessTest) {
 
 	// We need to fetch the minted group anchor asset, which includes the
 	// genesis information used to compute the tweak for the group key.
-	normalAnchor, err := chanutils.First(
+	normalAnchor, err := fn.First(
 		mintedBatch, func(asset *taprpc.Asset) bool {
 			return matchingName(asset, issuableAssets[0].Asset.Name)
 		},
@@ -104,7 +104,7 @@ func testMintMultiAssetGroups(t *harnessTest) {
 		normalAnchor.AssetGroup.TweakedGroupKey,
 	)
 
-	collectAnchor, err := chanutils.First(
+	collectAnchor, err := fn.First(
 		mintedBatch, func(asset *taprpc.Asset) bool {
 			return matchingName(asset, issuableAssets[1].Asset.Name)
 		},
@@ -130,7 +130,7 @@ func testMintMultiAssetGroups(t *harnessTest) {
 		require.NoError(t.t, secondTapd.stop(true))
 	}()
 
-	normalMember, err := chanutils.First(
+	normalMember, err := fn.First(
 		mintedBatch, func(asset *taprpc.Asset) bool {
 			return asset.Amount == normalAnchor.Amount/2
 		},
@@ -175,7 +175,7 @@ func testMintMultiAssetGroups(t *harnessTest) {
 		)
 		return isNotAnchor && isGrouped
 	}
-	collectMember, err := chanutils.First(mintedBatch, isCollectGroupMember)
+	collectMember, err := fn.First(mintedBatch, isCollectGroupMember)
 	require.NoError(t.t, err)
 
 	collectMemberGenInfo := collectMember.AssetGenesis

--- a/itest/universe_test.go
+++ b/itest/universe_test.go
@@ -8,7 +8,7 @@ import (
 	"io"
 
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
-	"github.com/lightninglabs/taproot-assets/chanutils"
+	"github.com/lightninglabs/taproot-assets/fn"
 	"github.com/lightninglabs/taproot-assets/taprpc"
 	unirpc "github.com/lightninglabs/taproot-assets/taprpc/universerpc"
 	"github.com/lightningnetwork/lnd/lntest/wait"
@@ -116,10 +116,9 @@ func testUniverseSync(t *harnessTest) {
 	// Finally, we'll ensure that the universe keys and leaves matches for
 	// both parties.
 	uniRoots := maps.Values(universeRoots.UniverseRoots)
-	uniIDs := chanutils.Map(uniRoots,
-		func(root *unirpc.UniverseRoot) *unirpc.ID {
-			return root.Id
-		},
+	uniIDs := fn.Map(uniRoots, func(root *unirpc.UniverseRoot) *unirpc.ID {
+		return root.Id
+	},
 	)
 	assertUniverseKeysEqual(t.t, uniIDs, t.tapd, bob)
 	assertUniverseLeavesEqual(t.t, uniIDs, t.tapd, bob)

--- a/mssmt/proof.go
+++ b/mssmt/proof.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/lightninglabs/taproot-assets/chanutils"
+	"github.com/lightninglabs/taproot-assets/fn"
 )
 
 var (
@@ -89,7 +89,7 @@ func (p *CompressedProof) Decompress() (*Proof, error) {
 	nodes := make([]Node, len(p.Bits))
 
 	// The number of 0 bits should match the number of pre-populated nodes.
-	numExpectedNodes := chanutils.Reduce(p.Bits, func(count int, bit bool) int {
+	numExpectedNodes := fn.Reduce(p.Bits, func(count int, bit bool) int {
 		if !bit {
 			return count + 1
 		}

--- a/proof/courier.go
+++ b/proof/courier.go
@@ -12,7 +12,7 @@ import (
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/lightninglabs/lightning-node-connect/hashmailrpc"
 	"github.com/lightninglabs/taproot-assets/asset"
-	"github.com/lightninglabs/taproot-assets/chanutils"
+	"github.com/lightninglabs/taproot-assets/fn"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
@@ -60,7 +60,7 @@ type Courier[Addr any] interface {
 
 	// SetSubscribers sets the set of subscribers that will be notified
 	// of proof courier related events.
-	SetSubscribers(map[uint64]*chanutils.EventReceiver[chanutils.Event])
+	SetSubscribers(map[uint64]*fn.EventReceiver[fn.Event])
 }
 
 // ProofMailbox represents an abstract store-and-forward mailbox that can be
@@ -369,7 +369,7 @@ type HashMailCourier struct {
 
 	// subscribers is a map of components that want to be notified on new
 	// events, keyed by their subscription ID.
-	subscribers map[uint64]*chanutils.EventReceiver[chanutils.Event]
+	subscribers map[uint64]*fn.EventReceiver[fn.Event]
 
 	// subscriberMtx guards the subscribers map and access to the
 	// subscriptionID.
@@ -383,7 +383,7 @@ func NewHashMailCourier(cfg *HashMailCourierCfg, mailbox ProofMailbox,
 	deliveryLog DeliveryLog) (*HashMailCourier, error) {
 
 	subscribers := make(
-		map[uint64]*chanutils.EventReceiver[chanutils.Event],
+		map[uint64]*fn.EventReceiver[fn.Event],
 	)
 	return &HashMailCourier{
 		cfg:         cfg,
@@ -638,7 +638,7 @@ func (h *HashMailCourier) backoffExec(ctx context.Context,
 }
 
 // publishSubscriberEvent publishes an event to all subscribers.
-func (h *HashMailCourier) publishSubscriberEvent(event chanutils.Event) {
+func (h *HashMailCourier) publishSubscriberEvent(event fn.Event) {
 	// Lock the subscriber mutex to ensure that we don't modify the
 	// subscriber map while we're iterating over it.
 	h.subscriberMtx.Lock()
@@ -733,7 +733,7 @@ func (h *HashMailCourier) ReceiveProof(ctx context.Context, recipient Recipient,
 // SetSubscribers sets the subscribers for the courier. This method is
 // thread-safe.
 func (h *HashMailCourier) SetSubscribers(
-	subscribers map[uint64]*chanutils.EventReceiver[chanutils.Event]) {
+	subscribers map[uint64]*fn.EventReceiver[fn.Event]) {
 
 	h.subscriberMtx.Lock()
 	defer h.subscriberMtx.Unlock()

--- a/proof/taproot.go
+++ b/proof/taproot.go
@@ -12,8 +12,8 @@ import (
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/lightninglabs/taproot-assets/asset"
-	"github.com/lightninglabs/taproot-assets/chanutils"
 	"github.com/lightninglabs/taproot-assets/commitment"
+	"github.com/lightninglabs/taproot-assets/fn"
 	"github.com/lightningnetwork/lnd/tlv"
 )
 
@@ -291,7 +291,7 @@ func (p TaprootProof) DeriveByAssetInclusion(
 
 	log.Tracef("Derived Taproot Asset commitment taproot_asset_root=%x, "+
 		"internal_key=%x, taproot_key=%x",
-		chanutils.ByteSlice(tapCommitment.TapscriptRoot(nil)),
+		fn.ByteSlice(tapCommitment.TapscriptRoot(nil)),
 		p.InternalKey.SerializeCompressed(),
 		schnorr.SerializePubKey(pubKey))
 
@@ -349,7 +349,7 @@ func (p TaprootProof) DeriveByAssetExclusion(assetCommitmentKey,
 
 	log.Tracef("Derived Taproot Asset commitment taproot_asset_root=%x, "+
 		"internal_key=%x",
-		chanutils.ByteSlice(commitment.TapscriptRoot(nil)),
+		fn.ByteSlice(commitment.TapscriptRoot(nil)),
 		p.InternalKey.SerializeCompressed())
 
 	return deriveTaprootKeysFromTapCommitment(

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -22,8 +22,8 @@ import (
 	proxy "github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/lightninglabs/taproot-assets/address"
 	"github.com/lightninglabs/taproot-assets/asset"
-	"github.com/lightninglabs/taproot-assets/chanutils"
 	"github.com/lightninglabs/taproot-assets/commitment"
+	"github.com/lightninglabs/taproot-assets/fn"
 	"github.com/lightninglabs/taproot-assets/mssmt"
 	"github.com/lightninglabs/taproot-assets/proof"
 	"github.com/lightninglabs/taproot-assets/rpcperms"
@@ -435,7 +435,7 @@ func (r *rpcServer) ListBatches(_ context.Context,
 		return nil, fmt.Errorf("unable to list batches: %w", err)
 	}
 
-	rpcBatches, err := chanutils.MapErr(batches, marshalMintingBatch)
+	rpcBatches, err := fn.MapErr(batches, marshalMintingBatch)
 	if err != nil {
 		return nil, err
 	}
@@ -1760,9 +1760,7 @@ func (r *rpcServer) SubscribeSendAssetEventNtfns(
 
 	// Create a new event subscriber and pass a copy to the chain porter.
 	// We will then read events from the subscriber.
-	eventSubscriber := chanutils.NewEventReceiver[chanutils.Event](
-		chanutils.DefaultQueueSize,
-	)
+	eventSubscriber := fn.NewEventReceiver[fn.Event](fn.DefaultQueueSize)
 	defer eventSubscriber.Stop()
 
 	err := r.cfg.ChainPorter.RegisterSubscriber(eventSubscriber, false, false)
@@ -1816,7 +1814,7 @@ func (r *rpcServer) SubscribeSendAssetEventNtfns(
 
 // marshallSendAssetEvent maps a ChainPorter event to its RPC counterpart.
 func marshallSendAssetEvent(
-	eventInterface chanutils.Event) (*taprpc.SendAssetEvent, error) {
+	eventInterface fn.Event) (*taprpc.SendAssetEvent, error) {
 
 	switch event := eventInterface.(type) {
 	case *tapfreighter.ExecuteSendStateEvent:
@@ -1863,7 +1861,7 @@ func marshalMintingBatch(batch *tapgarden.MintingBatch) (*mintrpc.MintingBatch,
 		var seedlingMeta *taprpc.AssetMeta
 		if seedling.Meta != nil {
 			seedlingMeta = &taprpc.AssetMeta{
-				MetaHash: chanutils.ByteSlice(
+				MetaHash: fn.ByteSlice(
 					seedling.Meta.MetaHash(),
 				),
 				Data: seedling.Meta.Data,
@@ -2684,7 +2682,7 @@ func (r *rpcServer) ListFederationServers(ctx context.Context,
 	}
 
 	return &unirpc.ListFederationServersResponse{
-		Servers: chanutils.Map(uniServers, marshalUniverseServer),
+		Servers: fn.Map(uniServers, marshalUniverseServer),
 	}, nil
 }
 
@@ -2701,7 +2699,7 @@ func (r *rpcServer) AddFederationServer(ctx context.Context,
 	in *unirpc.AddFederationServerRequest,
 ) (*unirpc.AddFederationServerResponse, error) {
 
-	serversToAdd := chanutils.Map(in.Servers, unmarshalUniverseServer)
+	serversToAdd := fn.Map(in.Servers, unmarshalUniverseServer)
 
 	err := r.cfg.UniverseFederation.AddServer(serversToAdd...)
 	if err != nil {
@@ -2717,7 +2715,7 @@ func (r *rpcServer) DeleteFederationServer(ctx context.Context,
 	in *unirpc.DeleteFederationServerRequest,
 ) (*unirpc.DeleteFederationServerResponse, error) {
 
-	serversToDel := chanutils.Map(in.Servers, unmarshalUniverseServer)
+	serversToDel := fn.Map(in.Servers, unmarshalUniverseServer)
 
 	err := r.cfg.FederationDB.RemoveServers(ctx, serversToDel...)
 	if err != nil {
@@ -2748,7 +2746,7 @@ func (r *rpcServer) ProveAssetOwnership(ctx context.Context,
 		return nil, fmt.Errorf("asset ID must be 32 bytes")
 	}
 
-	assetID := chanutils.ToArray[asset.ID](in.AssetId)
+	assetID := fn.ToArray[asset.ID](in.AssetId)
 	proofBlob, err := r.cfg.ProofArchive.FetchProof(ctx, proof.Locator{
 		AssetID:   &assetID,
 		ScriptKey: *scriptKey,
@@ -2875,16 +2873,16 @@ func (r *rpcServer) QueryAssetStats(ctx context.Context,
 			AssetTypeFilter: func() *asset.Type {
 				switch req.AssetTypeFilter {
 				case unirpc.AssetTypeFilter_FILTER_ASSET_NORMAL:
-					return chanutils.Ptr(asset.Normal)
+					return fn.Ptr(asset.Normal)
 
 				case unirpc.AssetTypeFilter_FILTER_ASSET_COLLECTIBLE:
-					return chanutils.Ptr(asset.Collectible)
+					return fn.Ptr(asset.Collectible)
 
 				default:
 					return nil
 				}
 			}(),
-			AssetIDFilter: chanutils.ToArray[asset.ID](
+			AssetIDFilter: fn.ToArray[asset.ID](
 				req.AssetIdFilter,
 			),
 			SortBy: universe.SyncStatsSort(req.SortBy),
@@ -2898,7 +2896,7 @@ func (r *rpcServer) QueryAssetStats(ctx context.Context,
 
 	snapshots := assetStats.SyncStats
 	resp := &unirpc.UniverseAssetStats{
-		AssetStats: chanutils.Map(snapshots, marshalAssetSyncSnapshot),
+		AssetStats: fn.Map(snapshots, marshalAssetSyncSnapshot),
 	}
 
 	return resp, nil

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -2594,15 +2594,15 @@ func (r *rpcServer) marshalUniverseDiff(ctx context.Context,
 		SyncedUniverses: make([]*unirpc.SyncedUniverse, 0, len(uniDiff)),
 	}
 
-	for _, diff := range uniDiff {
+	err := fn.ForEachErr(uniDiff, func(diff universe.AssetSyncDiff) error {
 		oldUniRoot, err := marshalUniverseRoot(diff.OldUniverseRoot)
 		if err != nil {
-			return nil, fmt.Errorf("unable to marshal old "+
-				"uni root: %w", err)
+			return fmt.Errorf("unable to marshal old uni "+
+				"root: %w", err)
 		}
 		newUniRoot, err := marshalUniverseRoot(diff.NewUniverseRoot)
 		if err != nil {
-			return nil, fmt.Errorf("unable to marshal new unit "+
+			return fmt.Errorf("unable to marshal new unit "+
 				"root: %w", err)
 		}
 
@@ -2610,7 +2610,7 @@ func (r *rpcServer) marshalUniverseDiff(ctx context.Context,
 		for i, leaf := range diff.NewLeafProofs {
 			leaves[i], err = r.marshalAssetLeaf(ctx, leaf)
 			if err != nil {
-				return nil, err
+				return err
 			}
 		}
 
@@ -2621,6 +2621,10 @@ func (r *rpcServer) marshalUniverseDiff(ctx context.Context,
 				NewAssetLeaves: leaves,
 			},
 		)
+		return nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	return resp, nil

--- a/server.go
+++ b/server.go
@@ -10,7 +10,7 @@ import (
 
 	proxy "github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/lightninglabs/lndclient"
-	"github.com/lightninglabs/taproot-assets/chanutils"
+	"github.com/lightninglabs/taproot-assets/fn"
 	"github.com/lightninglabs/taproot-assets/perms"
 	"github.com/lightninglabs/taproot-assets/rpcperms"
 	"github.com/lightninglabs/taproot-assets/taprpc"
@@ -301,7 +301,7 @@ func (s *Server) RunUntilShutdown(mainErrChan <-chan error) error {
 
 		// We'll report the error to the main daemon, but only if this
 		// isn't a context cancel.
-		if chanutils.IsCanceled(err) {
+		if fn.IsCanceled(err) {
 			return nil
 		}
 

--- a/tapdb/addrs.go
+++ b/tapdb/addrs.go
@@ -17,8 +17,8 @@ import (
 	"github.com/lightninglabs/lndclient"
 	"github.com/lightninglabs/taproot-assets/address"
 	"github.com/lightninglabs/taproot-assets/asset"
-	"github.com/lightninglabs/taproot-assets/chanutils"
 	"github.com/lightninglabs/taproot-assets/commitment"
+	"github.com/lightninglabs/taproot-assets/fn"
 	"github.com/lightninglabs/taproot-assets/tapdb/sqlc"
 	"github.com/lightningnetwork/lnd/keychain"
 )
@@ -901,7 +901,7 @@ func (a *TapAddressBook) QueryAssetGroup(ctx context.Context,
 		assetGroup.Genesis = &asset.Genesis{
 			FirstPrevOut: genesisPrevOut,
 			Tag:          assetGen.AssetTag,
-			MetaHash: chanutils.ToArray[[32]byte](
+			MetaHash: fn.ToArray[[32]byte](
 				assetGen.MetaHash,
 			),
 			OutputIndex: uint32(assetGen.OutputIndex),

--- a/tapdb/asset_minting.go
+++ b/tapdb/asset_minting.go
@@ -13,8 +13,8 @@ import (
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/taproot-assets/asset"
-	"github.com/lightninglabs/taproot-assets/chanutils"
 	"github.com/lightninglabs/taproot-assets/commitment"
+	"github.com/lightninglabs/taproot-assets/fn"
 	"github.com/lightninglabs/taproot-assets/proof"
 	"github.com/lightninglabs/taproot-assets/tapdb/sqlc"
 	"github.com/lightninglabs/taproot-assets/tapgarden"
@@ -723,7 +723,7 @@ func (a *AssetMintingStore) FetchNonFinalBatches(
 			return marshalMintingBatch(ctx, q, convBatch)
 		}
 
-		batches, err = chanutils.MapErr(dbBatches, parseBatch)
+		batches, err = fn.MapErr(dbBatches, parseBatch)
 		if err != nil {
 			return fmt.Errorf("batch parsing failed: %w", err)
 		}
@@ -758,7 +758,7 @@ func (a *AssetMintingStore) FetchAllBatches(
 			return marshalMintingBatch(ctx, q, convBatch)
 		}
 
-		batches, err = chanutils.MapErr(dbBatches, parseBatch)
+		batches, err = fn.MapErr(dbBatches, parseBatch)
 		if err != nil {
 			return fmt.Errorf("batch parsing failed: %w", err)
 		}

--- a/tapdb/asset_minting_test.go
+++ b/tapdb/asset_minting_test.go
@@ -15,8 +15,8 @@ import (
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/taproot-assets/asset"
-	"github.com/lightninglabs/taproot-assets/chanutils"
 	"github.com/lightninglabs/taproot-assets/commitment"
+	"github.com/lightninglabs/taproot-assets/fn"
 	"github.com/lightninglabs/taproot-assets/proof"
 	"github.com/lightninglabs/taproot-assets/tapdb/sqlc"
 	"github.com/lightninglabs/taproot-assets/tapgarden"
@@ -744,7 +744,7 @@ func TestCommitBatchChainActions(t *testing.T) {
 
 		return count
 	}
-	numKeyGroups := chanutils.Reduce(mintedAssets, keyGroupSumReducer)
+	numKeyGroups := fn.Reduce(mintedAssets, keyGroupSumReducer)
 	assetBalancesByGroup, err := confAssets.QueryAssetBalancesByGroup(
 		ctx, nil,
 	)

--- a/tapdb/universe.go
+++ b/tapdb/universe.go
@@ -12,7 +12,7 @@ import (
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/taproot-assets/asset"
-	"github.com/lightninglabs/taproot-assets/chanutils"
+	"github.com/lightninglabs/taproot-assets/fn"
 	"github.com/lightninglabs/taproot-assets/mssmt"
 	"github.com/lightninglabs/taproot-assets/proof"
 	"github.com/lightninglabs/taproot-assets/tapdb/sqlc"
@@ -308,7 +308,7 @@ func (b *BaseUniverseTree) RegisterIssuance(ctx context.Context,
 		// overlay.
 		universeRootID, err := db.UpsertUniverseRoot(ctx, NewUniverseRoot{
 			NamespaceRoot: b.smtNamespace,
-			AssetID:       chanutils.ByteSlice(leaf.ID()),
+			AssetID:       fn.ByteSlice(leaf.ID()),
 			GroupKey:      groupKeyBytes,
 		})
 		if err != nil {

--- a/tapdb/universe.go
+++ b/tapdb/universe.go
@@ -437,7 +437,7 @@ func (b *BaseUniverseTree) FetchIssuanceProof(ctx context.Context,
 		// Now that we have all the leaves we need to query, we'll look
 		// each up them up in the universe tree, obtaining a merkle
 		// proof for each of them along the way.
-		for _, leaf := range universeLeaves {
+		return fn.ForEachErr(universeLeaves, func(leaf UniverseLeaf) error {
 			scriptPub, err := schnorr.ParsePubKey(leaf.ScriptKeyBytes)
 			if err != nil {
 				return err
@@ -493,9 +493,9 @@ func (b *BaseUniverseTree) FetchIssuanceProof(ctx context.Context,
 			}
 
 			proofs = append(proofs, proof)
-		}
 
-		return nil
+			return nil
+		})
 	})
 	if dbErr != nil {
 		return nil, dbErr
@@ -517,7 +517,7 @@ func (b *BaseUniverseTree) MintingKeys(ctx context.Context,
 			return err
 		}
 
-		for _, key := range universeKeys {
+		return fn.ForEachErr(universeKeys, func(key UniverseKeys) error {
 			scriptKeyPub, err := schnorr.ParsePubKey(
 				key.ScriptKeyBytes,
 			)
@@ -539,9 +539,9 @@ func (b *BaseUniverseTree) MintingKeys(ctx context.Context,
 				MintingOutpoint: genPoint,
 				ScriptKey:       &scriptKey,
 			})
-		}
 
-		return nil
+			return nil
+		})
 	})
 	if dbErr != nil {
 		return nil, dbErr
@@ -571,11 +571,11 @@ func (b *BaseUniverseTree) MintingLeaves(ctx context.Context,
 			return err
 		}
 
-		for _, leaf := range universeLeaves {
+		return fn.ForEachErr(universeLeaves, func(dbLeaf UniverseLeaf) error {
 			// For each leaf, we'll decode the proof, and then also
 			// fetch the genesis asset information for that leaf.
 			leafAssetGen, err := fetchGenesis(
-				ctx, db, leaf.GenAssetID,
+				ctx, db, dbLeaf.GenAssetID,
 			)
 			if err != nil {
 				return err
@@ -587,8 +587,8 @@ func (b *BaseUniverseTree) MintingLeaves(ctx context.Context,
 				GenesisWithGroup: universe.GenesisWithGroup{
 					Genesis: leafAssetGen,
 				},
-				GenesisProof: leaf.GenesisProof,
-				Amt:          uint64(leaf.SumAmt),
+				GenesisProof: dbLeaf.GenesisProof,
+				Amt:          uint64(dbLeaf.SumAmt),
 			}
 			if b.id.GroupKey != nil {
 				leaf.GroupKey = &asset.GroupKey{
@@ -597,9 +597,9 @@ func (b *BaseUniverseTree) MintingLeaves(ctx context.Context,
 			}
 
 			leaves = append(leaves, leaf)
-		}
 
-		return nil
+			return nil
+		})
 	})
 	if dbErr != nil {
 		return nil, dbErr

--- a/tapdb/universe_stats.go
+++ b/tapdb/universe_stats.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/lightninglabs/taproot-assets/asset"
-	"github.com/lightninglabs/taproot-assets/chanutils"
+	"github.com/lightninglabs/taproot-assets/fn"
 	"github.com/lightninglabs/taproot-assets/tapdb/sqlc"
 	"github.com/lightninglabs/taproot-assets/universe"
 )
@@ -251,7 +251,7 @@ func (u *UniverseStats) QuerySyncStats(ctx context.Context,
 		for _, assetStat := range assetStats {
 			stats := universe.AssetSyncSnapshot{
 				TotalSupply: uint64(assetStat.AssetSupply),
-				AssetID: chanutils.ToArray[asset.ID](
+				AssetID: fn.ToArray[asset.ID](
 					assetStat.AssetID,
 				),
 				AssetName:   assetStat.AssetName,

--- a/tapdb/universe_stats_test.go
+++ b/tapdb/universe_stats_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	"github.com/lightninglabs/taproot-assets/asset"
-	"github.com/lightninglabs/taproot-assets/chanutils"
+	"github.com/lightninglabs/taproot-assets/fn"
 	"github.com/lightninglabs/taproot-assets/tapdb/sqlc"
 	"github.com/lightninglabs/taproot-assets/universe"
 	"github.com/stretchr/testify/require"
@@ -323,10 +323,9 @@ func TestUniverseQuerySyncFilters(t *testing.T) {
 		},
 		{
 			name:       "type",
-			typeFilter: chanutils.Ptr(asset.Type(rand.Int() % 2)),
+			typeFilter: fn.Ptr(asset.Type(rand.Int() % 2)),
 			queryCheck: func(s *universe.AssetSyncStats) bool {
-				typeCount := chanutils.Reduce(
-					sh.universeLeaves,
+				typeCount := fn.Reduce(sh.universeLeaves,
 					func(acc int, p *universe.IssuanceProof) int {
 						if p.Leaf.Type == *s.Query.AssetTypeFilter {
 							return acc + 1

--- a/tapdb/universe_test.go
+++ b/tapdb/universe_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/lightninglabs/taproot-assets/asset"
-	"github.com/lightninglabs/taproot-assets/chanutils"
+	"github.com/lightninglabs/taproot-assets/fn"
 	"github.com/lightninglabs/taproot-assets/internal/test"
 	"github.com/lightninglabs/taproot-assets/mssmt"
 	"github.com/lightninglabs/taproot-assets/proof"
@@ -79,7 +79,7 @@ func TestUniverseEmptyTree(t *testing.T) {
 func randBaseKey(t *testing.T) universe.BaseKey {
 	return universe.BaseKey{
 		MintingOutpoint: test.RandOp(t),
-		ScriptKey: chanutils.Ptr(
+		ScriptKey: fn.Ptr(
 			asset.NewScriptKey(test.RandPubKey(t)),
 		),
 	}
@@ -206,7 +206,7 @@ func TestUniverseIssuanceProofs(t *testing.T) {
 	require.Equal(t, numLeaves, len(mintingKeys))
 
 	// The set of leaves we created above should match what was returned.
-	require.True(t, chanutils.All(mintingKeys, func(key universe.BaseKey) bool {
+	require.True(t, fn.All(mintingKeys, func(key universe.BaseKey) bool {
 		for _, testLeaf := range testLeaves {
 			if reflect.DeepEqual(key, testLeaf.BaseKey) {
 				return true
@@ -221,7 +221,7 @@ func TestUniverseIssuanceProofs(t *testing.T) {
 	dbLeaves, err := baseUniverse.MintingLeaves(ctx)
 	require.NoError(t, err)
 	require.Equal(t, numLeaves, len(dbLeaves))
-	require.True(t, chanutils.All(dbLeaves, func(leaf universe.MintingLeaf) bool {
+	require.True(t, fn.All(dbLeaves, func(leaf universe.MintingLeaf) bool {
 		for _, testLeaf := range testLeaves {
 			if leaf.Genesis.ID() == testLeaf.MintingLeaf.Genesis.ID() {
 				return true
@@ -343,7 +343,7 @@ func TestUniverseTreeIsolation(t *testing.T) {
 	require.NoError(t, err)
 
 	// We should be able to find both of the roots we've inserted above.
-	require.True(t, chanutils.All(rootNodes, func(rootNode universe.BaseRoot) bool {
+	require.True(t, fn.All(rootNodes, func(rootNode universe.BaseRoot) bool {
 		for _, rootNode := range rootNodes {
 			if mssmt.IsEqualNode(rootNode.Node, groupRoot) {
 				return true

--- a/tapfreighter/interface.go
+++ b/tapfreighter/interface.go
@@ -11,8 +11,8 @@ import (
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/taproot-assets/asset"
-	"github.com/lightninglabs/taproot-assets/chanutils"
 	"github.com/lightninglabs/taproot-assets/commitment"
+	"github.com/lightninglabs/taproot-assets/fn"
 	"github.com/lightninglabs/taproot-assets/mssmt"
 	"github.com/lightninglabs/taproot-assets/proof"
 	"github.com/lightninglabs/taproot-assets/tapgarden"
@@ -335,5 +335,5 @@ type Porter interface {
 
 	// EventPublisher is a subscription interface that allows callers to
 	// subscribe to events that are relevant to the Porter.
-	chanutils.EventPublisher[chanutils.Event, bool]
+	fn.EventPublisher[fn.Event, bool]
 }

--- a/tapfreighter/parcel.go
+++ b/tapfreighter/parcel.go
@@ -10,8 +10,8 @@ import (
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/taproot-assets/address"
 	"github.com/lightninglabs/taproot-assets/asset"
-	"github.com/lightninglabs/taproot-assets/chanutils"
 	"github.com/lightninglabs/taproot-assets/commitment"
+	"github.com/lightninglabs/taproot-assets/fn"
 	"github.com/lightninglabs/taproot-assets/mssmt"
 	"github.com/lightninglabs/taproot-assets/proof"
 	"github.com/lightninglabs/taproot-assets/tappsbt"
@@ -624,7 +624,7 @@ func addOtherOutputExclusionProofs(outputs []*tappsbt.VOutput,
 		log.Tracef("Generated exclusion proof for anchor output index "+
 			"%d with asset_id=%v, taproot_asset_root=%x, "+
 			"internal_key=%x", outIndex, asset.ID(),
-			chanutils.ByteSlice(tapTree.TapscriptRoot(nil)),
+			fn.ByteSlice(tapTree.TapscriptRoot(nil)),
 			vOut.AnchorOutputInternalKey.SerializeCompressed())
 
 		siblingPreimage := vOut.AnchorOutputTapscriptSibling

--- a/tapfreighter/wallet.go
+++ b/tapfreighter/wallet.go
@@ -17,8 +17,8 @@ import (
 	"github.com/davecgh/go-spew/spew"
 	"github.com/lightninglabs/taproot-assets/address"
 	"github.com/lightninglabs/taproot-assets/asset"
-	"github.com/lightninglabs/taproot-assets/chanutils"
 	"github.com/lightninglabs/taproot-assets/commitment"
+	"github.com/lightninglabs/taproot-assets/fn"
 	"github.com/lightninglabs/taproot-assets/mssmt"
 	"github.com/lightninglabs/taproot-assets/proof"
 	"github.com/lightninglabs/taproot-assets/tapgarden"
@@ -427,7 +427,7 @@ func (f *AssetWallet) FundPacket(ctx context.Context,
 		)
 	}
 
-	inputsScriptKeys := chanutils.Map(
+	inputsScriptKeys := fn.Map(
 		vPkt.Inputs, func(vInput *tappsbt.VInput) *btcec.PublicKey {
 			return vInput.Asset().ScriptKey.PubKey
 		},
@@ -622,9 +622,8 @@ func (f *AssetWallet) setVPacketInputs(ctx context.Context,
 
 		log.Tracef("Input commitment taproot_asset_root=%x, "+
 			"internal_key=%x, pk_script=%x, trimmed_merkle_root=%x",
-			chanutils.ByteSlice(
-				assetInput.Commitment.TapscriptRoot(nil),
-			), internalKey.PubKey.SerializeCompressed(),
+			fn.ByteSlice(assetInput.Commitment.TapscriptRoot(nil)),
+			internalKey.PubKey.SerializeCompressed(),
 			anchorPkScript, anchorMerkleRoot[:])
 
 		// We'll also include an inclusion proof for the input asset in

--- a/tapgarden/caretaker.go
+++ b/tapgarden/caretaker.go
@@ -13,8 +13,8 @@ import (
 	"github.com/btcsuite/btcd/wire"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/lightninglabs/taproot-assets/asset"
-	"github.com/lightninglabs/taproot-assets/chanutils"
 	"github.com/lightninglabs/taproot-assets/commitment"
+	"github.com/lightninglabs/taproot-assets/fn"
 	"github.com/lightninglabs/taproot-assets/proof"
 	"github.com/lightninglabs/taproot-assets/universe"
 	"github.com/lightningnetwork/lnd/chainntnfs"
@@ -99,7 +99,7 @@ type BatchCaretaker struct {
 
 	// ContextGuard provides a wait group and main quit channel that can be
 	// used to create guarded contexts.
-	*chanutils.ContextGuard
+	*fn.ContextGuard
 }
 
 // NewBatchCaretaker creates a new Taproot Asset caretaker based on the passed
@@ -111,7 +111,7 @@ func NewBatchCaretaker(cfg *BatchCaretakerConfig) *BatchCaretaker {
 		batchKey:  asset.ToSerialized(cfg.Batch.BatchKey.PubKey),
 		cfg:       cfg,
 		confEvent: make(chan *chainntnfs.TxConfirmation, 1),
-		ContextGuard: &chanutils.ContextGuard{
+		ContextGuard: &fn.ContextGuard{
 			DefaultTimeout: DefaultTimeout,
 			Quit:           make(chan struct{}),
 		},

--- a/tapgarden/custodian_test.go
+++ b/tapgarden/custodian_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/lightninglabs/lndclient"
 	"github.com/lightninglabs/taproot-assets/address"
 	"github.com/lightninglabs/taproot-assets/asset"
-	"github.com/lightninglabs/taproot-assets/chanutils"
+	"github.com/lightninglabs/taproot-assets/fn"
 	"github.com/lightninglabs/taproot-assets/internal/test"
 	"github.com/lightninglabs/taproot-assets/proof"
 	"github.com/lightninglabs/taproot-assets/tapdb"
@@ -90,13 +90,13 @@ type custodianHarness struct {
 // assertStartup makes sure the custodian was started correctly.
 func (h *custodianHarness) assertStartup() {
 	// Make sure SubscribeTransactions is called on startup.
-	_, err := chanutils.RecvOrTimeout(
+	_, err := fn.RecvOrTimeout(
 		h.walletAnchor.SubscribeTxSignal, testTimeout,
 	)
 	require.NoError(h.t, err)
 
 	// Make sure ListTransactions is called on startup.
-	_, err = chanutils.RecvOrTimeout(
+	_, err = fn.RecvOrTimeout(
 		h.walletAnchor.ListTxnsSignal, testTimeout,
 	)
 	require.NoError(h.t, err)
@@ -114,7 +114,7 @@ func (h *custodianHarness) assertAddrsRegistered(
 	addrs ...*address.AddrWithKeyInfo) {
 
 	for _, addr := range addrs {
-		pubKey, err := chanutils.RecvOrTimeout(
+		pubKey, err := fn.RecvOrTimeout(
 			h.walletAnchor.ImportPubKeySignal, testTimeout,
 		)
 		require.NoError(h.t, err)

--- a/tappsbt/encode.go
+++ b/tappsbt/encode.go
@@ -13,8 +13,8 @@ import (
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/taproot-assets/asset"
-	"github.com/lightninglabs/taproot-assets/chanutils"
 	"github.com/lightninglabs/taproot-assets/commitment"
+	"github.com/lightninglabs/taproot-assets/fn"
 	"github.com/lightningnetwork/lnd/tlv"
 )
 
@@ -280,7 +280,7 @@ func tlvEncoder(val any, enc tlv.Encoder) encoderFunc {
 
 		return []*customPsbtField{
 			{
-				Key:   chanutils.CopySlice(key),
+				Key:   fn.CopySlice(key),
 				Value: b.Bytes(),
 			},
 		}, nil
@@ -314,11 +314,11 @@ func assetEncoder(a *asset.Asset) encoderFunc {
 func booleanEncoder(val bool) encoderFunc {
 	return func(key []byte) ([]*customPsbtField, error) {
 		unknown := &customPsbtField{
-			Key:   chanutils.CopySlice(key),
-			Value: chanutils.CopySlice(falseAsBytes),
+			Key:   fn.CopySlice(key),
+			Value: fn.CopySlice(falseAsBytes),
 		}
 		if val {
-			unknown.Value = chanutils.CopySlice(trueAsBytes)
+			unknown.Value = fn.CopySlice(trueAsBytes)
 		}
 
 		return []*customPsbtField{unknown}, nil
@@ -337,7 +337,7 @@ func bip32DerivationEncoder(derivations []*psbt.Bip32Derivation) encoderFunc {
 		for idx := range derivations {
 			d := derivations[idx]
 
-			keyCopy := chanutils.CopySlice(key)
+			keyCopy := fn.CopySlice(key)
 			unknowns[idx] = &customPsbtField{
 				Key: append(keyCopy, d.PubKey...),
 				Value: psbt.SerializeBIP32Derivation(
@@ -368,7 +368,7 @@ func taprootBip32DerivationEncoder(
 				return nil, err
 			}
 
-			keyCopy := chanutils.CopySlice(key)
+			keyCopy := fn.CopySlice(key)
 			unknowns[idx] = &customPsbtField{
 				Key:   append(keyCopy, d.XOnlyPubKey...),
 				Value: value,

--- a/tappsbt/interface.go
+++ b/tappsbt/interface.go
@@ -11,8 +11,8 @@ import (
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/lightninglabs/taproot-assets/address"
 	"github.com/lightninglabs/taproot-assets/asset"
-	"github.com/lightninglabs/taproot-assets/chanutils"
 	"github.com/lightninglabs/taproot-assets/commitment"
+	"github.com/lightninglabs/taproot-assets/fn"
 	"github.com/lightningnetwork/lnd/keychain"
 )
 
@@ -196,31 +196,31 @@ func (p *VPacket) HasSplitCommitment() (bool, error) {
 // HasSplitRootOutput determines if this virtual transaction has a split root
 // output.
 func (p *VPacket) HasSplitRootOutput() bool {
-	return chanutils.Any(p.Outputs, VOutIsSplitRoot)
+	return fn.Any(p.Outputs, VOutIsSplitRoot)
 }
 
 // HasInteractiveOutput determines if this virtual transaction has an
 // interactive output.
 func (p *VPacket) HasInteractiveOutput() bool {
-	return chanutils.Any(p.Outputs, VOutIsInteractive)
+	return fn.Any(p.Outputs, VOutIsInteractive)
 }
 
 // SplitRootOutput returns the split root output in the virtual transaction, or
 // an error if there is none or more than one.
 func (p *VPacket) SplitRootOutput() (*VOutput, error) {
-	count := chanutils.Count(p.Outputs, VOutIsSplitRoot)
+	count := fn.Count(p.Outputs, VOutIsSplitRoot)
 	if count != 1 {
 		return nil, fmt.Errorf("expected 1 split root output, got %d",
 			count)
 	}
 
-	return chanutils.First(p.Outputs, VOutIsSplitRoot)
+	return fn.First(p.Outputs, VOutIsSplitRoot)
 }
 
 // FirstNonSplitRootOutput returns the first non-change output in the virtual
 // transaction.
 func (p *VPacket) FirstNonSplitRootOutput() (*VOutput, error) {
-	result, err := chanutils.First(p.Outputs, VOutIsNotSplitRoot)
+	result, err := fn.First(p.Outputs, VOutIsNotSplitRoot)
 	if err != nil {
 		return nil, fmt.Errorf("no non split root output found")
 	}
@@ -231,7 +231,7 @@ func (p *VPacket) FirstNonSplitRootOutput() (*VOutput, error) {
 // FirstInteractiveOutput returns the first interactive output in the virtual
 // transaction.
 func (p *VPacket) FirstInteractiveOutput() (*VOutput, error) {
-	result, err := chanutils.First(p.Outputs, VOutIsInteractive)
+	result, err := fn.First(p.Outputs, VOutIsInteractive)
 	if err != nil {
 		return nil, fmt.Errorf("no interactive output found")
 	}
@@ -602,7 +602,7 @@ func AddBip32Derivation(derivations []*psbt.Bip32Derivation,
 	}
 
 	predicate := bip32DerivationKeyEqual(target.PubKey)
-	if chanutils.Any(derivations, predicate) {
+	if fn.Any(derivations, predicate) {
 		return derivations
 	}
 
@@ -619,7 +619,7 @@ func AddTaprootBip32Derivation(derivations []*psbt.TaprootBip32Derivation,
 	}
 
 	predicate := taprootBip32DerivationKeyEqual(target.XOnlyPubKey)
-	if chanutils.Any(derivations, predicate) {
+	if fn.Any(derivations, predicate) {
 		return derivations
 	}
 

--- a/tapscript/send.go
+++ b/tapscript/send.go
@@ -724,7 +724,7 @@ func CreateOutputCommitments(inputTapCommitments tappsbt.InputCommitments,
 
 	// Merge all input Taproot Asset commitments into a single commitment.
 	//
-	// TODO(ffranr): Use `chanutils.ForEach` and `inputTapCommitments[1:]`.
+	// TODO(ffranr): Use `fn.ForEach` and `inputTapCommitments[1:]`.
 	inputTapCommitment := inputTapCommitments[0]
 	for idx := range inputTapCommitments {
 		if idx == 0 {

--- a/universe/base.go
+++ b/universe/base.go
@@ -217,7 +217,8 @@ func (a *MintingArchive) RegisterIssuance(ctx context.Context, id Identifier,
 			context.Background(), id, key,
 		)
 		if err != nil {
-			log.Warnf("unable to log new proof event: %v", err)
+			log.Warnf("unable to log new proof event (id=%v): %v",
+				spew.Sdump(id), err)
 		}
 	}()
 
@@ -240,7 +241,9 @@ func (a *MintingArchive) FetchIssuanceProof(ctx context.Context, id Identifier,
 				context.Background(), id, key,
 			)
 			if err != nil {
-				log.Warnf("unable to log sync event: %v", err)
+				log.Warnf("unable to log sync event "+
+					"(id=%v, key=%v): %v", spew.Sdump(id),
+					spew.Sdump(key), err)
 			}
 		}()
 	}()

--- a/universe_rpc_registrar.go
+++ b/universe_rpc_registrar.go
@@ -6,7 +6,7 @@ import (
 	"crypto/tls"
 	"fmt"
 
-	"github.com/lightninglabs/taproot-assets/chanutils"
+	"github.com/lightninglabs/taproot-assets/fn"
 	"github.com/lightninglabs/taproot-assets/mssmt"
 	unirpc "github.com/lightninglabs/taproot-assets/taprpc/universerpc"
 	"github.com/lightninglabs/taproot-assets/universe"
@@ -84,7 +84,7 @@ func unmarshalIssuanceProof(ctx context.Context,
 	return &universe.IssuanceProof{
 		MintingKey: baseKey,
 		UniverseRoot: mssmt.NewComputedBranch(
-			chanutils.ToArray[mssmt.NodeHash](
+			fn.ToArray[mssmt.NodeHash](
 				proofResp.UniverseRoot.MssmtRoot.RootHash,
 			),
 			uint64(proofResp.UniverseRoot.MssmtRoot.RootSum),


### PR DESCRIPTION
In this commit we rename the `chanutils` package to `fn`, as it's much shorter, and how houses generic functions that deal with more than just channels.

We then attempt to fix some potential loop scoping bugs in the universe code. Finally, we add some logging to print out the id+key for the fail universe log sync events. 