### PR TITLE
address+tapdb: rename field: Tap.Version -> Tap.AssetVersion

### DIFF
--- a/address/address.go
+++ b/address/address.go
@@ -85,8 +85,8 @@ type Tap struct {
 	// to encode the Taproot Asset address.
 	ChainParams *ChainParams
 
-	// Version is the Taproot Asset version of the asset.
-	Version asset.Version
+	// AssetVersion is the Taproot Asset version of the asset.
+	AssetVersion asset.Version
 
 	// AssetID is the asset ID of the asset.
 	AssetID asset.ID
@@ -164,7 +164,7 @@ func New(genesis asset.Genesis, groupKey *btcec.PublicKey,
 
 	payload := Tap{
 		ChainParams:      net,
-		Version:          asset.V0,
+		AssetVersion:     asset.V0,
 		AssetID:          genesis.ID(),
 		GroupKey:         groupKey,
 		groupSig:         groupSig,
@@ -296,7 +296,7 @@ func (a *Tap) TaprootOutputKey() (*btcec.PublicKey, error) {
 // address at runtime.
 func (a *Tap) EncodeRecords() []tlv.Record {
 	records := make([]tlv.Record, 0, 6)
-	records = append(records, newAddressVersionRecord(&a.Version))
+	records = append(records, newAddressVersionRecord(&a.AssetVersion))
 	records = append(records, newAddressAssetID(&a.AssetID))
 
 	if a.GroupKey != nil {
@@ -319,7 +319,7 @@ func (a *Tap) EncodeRecords() []tlv.Record {
 // decoding.
 func (a *Tap) DecodeRecords() []tlv.Record {
 	return []tlv.Record{
-		newAddressVersionRecord(&a.Version),
+		newAddressVersionRecord(&a.AssetVersion),
 		newAddressAssetID(&a.AssetID),
 		newAddressGroupKeyRecord(&a.GroupKey),
 		newAddressScriptKeyRecord(&a.ScriptKey),

--- a/address/address_test.go
+++ b/address/address_test.go
@@ -85,7 +85,7 @@ func randEncodedAddress(t *testing.T, net *ChainParams, groupPubKey,
 func assertAddressEqual(t *testing.T, a, b *Tap) {
 	t.Helper()
 
-	require.Equal(t, a.Version, b.Version)
+	require.Equal(t, a.AssetVersion, b.AssetVersion)
 	require.Equal(t, a.AssetID, b.AssetID)
 	require.Equal(t, a.GroupKey, b.GroupKey)
 	require.Equal(t, a.ScriptKey, b.ScriptKey)

--- a/tapdb/addrs.go
+++ b/tapdb/addrs.go
@@ -258,7 +258,7 @@ func (t *TapAddressBook) InsertAddrs(ctx context.Context,
 				groupKeyBytes = addr.GroupKey.SerializeCompressed()
 			}
 			_, err = db.InsertAddr(ctx, NewAddr{
-				Version:          int16(addr.Version),
+				Version:          int16(addr.AssetVersion),
 				GenesisAssetID:   genAssetID,
 				GroupKey:         groupKeyBytes,
 				ScriptKeyID:      scriptKeyID,
@@ -421,7 +421,7 @@ func (t *TapAddressBook) QueryAddrs(ctx context.Context,
 			if err != nil {
 				return fmt.Errorf("unable to make addr: %w", err)
 			}
-			tapAddr.Version = asset.Version(addr.Version)
+			tapAddr.AssetVersion = asset.Version(addr.Version)
 
 			addrs = append(addrs, address.AddrWithKeyInfo{
 				Tap: tapAddr,
@@ -557,7 +557,7 @@ func fetchAddr(ctx context.Context, db AddrBook, params *address.ChainParams,
 	if err != nil {
 		return nil, fmt.Errorf("unable to make addr: %w", err)
 	}
-	tapAddr.Version = asset.Version(dbAddr.Version)
+	tapAddr.AssetVersion = asset.Version(dbAddr.Version)
 
 	return &address.AddrWithKeyInfo{
 		Tap: tapAddr,


### PR DESCRIPTION
This commit clarifies that the version information currently stored in the tap address relates to the asset version and not to the address version.