### PR TITLE
tapdb/universe: fix universe event logging for grouped assets

### DIFF
--- a/tapdb/sqlc/queries/universe.sql
+++ b/tapdb/sqlc/queries/universe.sql
@@ -87,9 +87,11 @@ SELECT * FROM universe_servers;
 
 -- name: InsertNewSyncEvent :exec
 WITH root_asset_id AS (
-    SELECT id
-    FROM universe_roots
-    WHERE asset_id = @asset_id
+    SELECT leaves.universe_root_id AS id
+    FROM universe_leaves leaves
+    JOIN genesis_info_view gen
+        ON leaves.asset_genesis_id = gen.gen_asset_id
+    WHERE gen.asset_id = @asset_id
 )
 INSERT INTO universe_events (
     event_type, universe_root_id, event_time
@@ -99,9 +101,11 @@ INSERT INTO universe_events (
 
 -- name: InsertNewProofEvent :exec
 WITH root_asset_id AS (
-    SELECT id
-    FROM universe_roots
-    WHERE asset_id = @asset_id
+    SELECT leaves.universe_root_id AS id
+    FROM universe_leaves leaves
+    JOIN genesis_info_view gen
+        ON leaves.asset_genesis_id = gen.gen_asset_id
+    WHERE gen.asset_id = @asset_id
 )
 INSERT INTO universe_events (
     event_type, universe_root_id, event_time

--- a/tapdb/sqlc/universe.sql.go
+++ b/tapdb/sqlc/universe.sql.go
@@ -97,9 +97,11 @@ func (q *Queries) FetchUniverseRoot(ctx context.Context, namespace string) (Fetc
 
 const insertNewProofEvent = `-- name: InsertNewProofEvent :exec
 WITH root_asset_id AS (
-    SELECT id
-    FROM universe_roots
-    WHERE asset_id = $2
+    SELECT leaves.universe_root_id AS id
+    FROM universe_leaves leaves
+    JOIN genesis_info_view gen
+        ON leaves.asset_genesis_id = gen.gen_asset_id
+    WHERE gen.asset_id = $2
 )
 INSERT INTO universe_events (
     event_type, universe_root_id, event_time
@@ -120,9 +122,11 @@ func (q *Queries) InsertNewProofEvent(ctx context.Context, arg InsertNewProofEve
 
 const insertNewSyncEvent = `-- name: InsertNewSyncEvent :exec
 WITH root_asset_id AS (
-    SELECT id
-    FROM universe_roots
-    WHERE asset_id = $2
+    SELECT leaves.universe_root_id AS id
+    FROM universe_leaves leaves
+    JOIN genesis_info_view gen
+        ON leaves.asset_genesis_id = gen.gen_asset_id
+    WHERE gen.asset_id = $2
 )
 INSERT INTO universe_events (
     event_type, universe_root_id, event_time


### PR DESCRIPTION
In this commit, we fix the universe event logging for grouped assets. As is, when we go to insert assets with a group, then the "first" inserted asset is what's known as the `asset_id` in the `universe_roots` table. When we go to log a proof insert/sync event, and the even only has an asset ID, we may end up with a failed query, as only the "first" asset ID would return the row we want.

In order to fix this, rather than trying to match the asset ID with a root, we instead find the _leaf_ for that asset ID, then use that to get the primary key of the universe root via it's foreign key ref.

Fixes https://github.com/lightninglabs/taproot-assets/issues/313