### PR TITLE
itest: basic send test re-uses the same recv address for multiple sends

### DIFF
--- a/itest/send_test.go
+++ b/itest/send_test.go
@@ -93,15 +93,16 @@ func testBasicSend(t *harnessTest) {
 	// addresses from our main node to Bob.
 	currentUnits := simpleAssets[0].Asset.Amount
 
-	for i := 0; i < numSends; i++ {
-		bobAddr, err := secondTapd.NewAddr(
-			ctxb, &taprpc.NewAddrRequest{
-				AssetId: genInfo.AssetId,
-				Amt:     numUnits,
-			},
-		)
-		require.NoError(t.t, err)
+	// Issue a single address which will be reused for each send.
+	bobAddr, err := secondTapd.NewAddr(
+		ctxb, &taprpc.NewAddrRequest{
+			AssetId: genInfo.AssetId,
+			Amt:     numUnits,
+		},
+	)
+	require.NoError(t.t, err)
 
+	for i := 0; i < numSends; i++ {
 		// Deduct what we sent from the expected current number of
 		// units.
 		currentUnits -= numUnits

--- a/itest/send_test.go
+++ b/itest/send_test.go
@@ -16,7 +16,7 @@ import (
 
 // testBasicSend tests that we can properly send assets back and forth between
 // nodes.
-func testBasicSend(t *harnessTest) {
+func testBasicSendUnidirectional(t *harnessTest) {
 	var (
 		ctxb = context.Background()
 		wg   sync.WaitGroup

--- a/itest/test_list_on_test.go
+++ b/itest/test_list_on_test.go
@@ -25,8 +25,8 @@ var testCases = []*testCase{
 		test: testMultiAddress,
 	},
 	{
-		name:             "basic send",
-		test:             testBasicSend,
+		name:             "basic send unidirectional",
+		test:             testBasicSendUnidirectional,
 		proofCourierType: proof.ApertureCourier,
 	},
 	{


### PR DESCRIPTION
This aim of this change is just to make it clear that an address can be re-used for multiple send events.