### PR TITLE
tapgarden: minter perf fixes

### DIFF
--- a/universe/auto_syncer.go
+++ b/universe/auto_syncer.go
@@ -190,8 +190,11 @@ func (f *FederationEnvoy) syncUniverseState(ctx context.Context,
 	}
 
 	// If we synced anything from the server, then we'll log that here.
-	log.Infof("Synced new Universe leaves from server=%v, diff=%v",
-		spew.Sdump(addr), spew.Sdump(diff))
+	log.Infof("Synced new Universe leaves from server=%v", spew.Sdump(addr))
+	for _, d := range diff {
+		log.Infof("diff:\n%v", d.StringForInfoLog())
+		log.Debugf(d.StringForDebugLog())
+	}
 
 	// Log a new sync event in the background now that we know we were able
 	// to contract the remote server.

--- a/universe/base.go
+++ b/universe/base.go
@@ -104,7 +104,8 @@ func withBaseUni[T any](fetcher uniFetcher, id Identifier,
 func (a *MintingArchive) RootNode(ctx context.Context,
 	id Identifier) (BaseRoot, error) {
 
-	log.Debugf("Looking up root node for base Universe %v", spew.Sdump(id))
+	log.Debugf("Looking up root node for base Universe %v",
+		id.StringForLog())
 
 	return withBaseUni(a, id, func(baseUni BaseBackend) (BaseRoot, error) {
 		smtNode, assetName, err := baseUni.RootNode(ctx)

--- a/universe/syncer.go
+++ b/universe/syncer.go
@@ -179,10 +179,10 @@ func (s *SimpleSyncer) executeSync(ctx context.Context, diffEngine DiffEngine,
 			// TODO(roasbeef): inclusion w/ root here, also that
 			// it's the expected asset ID
 
-			log.Infof("UniverseRoot(%v): inserting new leaf",
-				uniID.String())
+			log.Debugf("UniverseRoot(%v): inserting new leaf",
+				uniID.StringForLog())
 			log.Tracef("UniverseRoot(%v): inserting new leaf for "+
-				"key=%v", uniID.String(), spew.Sdump(key))
+				"key=%v", uniID.StringForLog(), spew.Sdump(key))
 
 			// TODO(roasbeef): this is actually giving a lagging
 			// proof for each of them
@@ -202,7 +202,8 @@ func (s *SimpleSyncer) executeSync(ctx context.Context, diffEngine DiffEngine,
 		}
 
 		log.Infof("Universe sync for UniverseRoot(%v) complete, %d "+
-			"new leaves inserted", uniID.String(), len(keysToFetch))
+			"new leaves inserted", uniID.StringForLog(),
+			len(keysToFetch))
 
 		// TODO(roabseef): sanity check local and remote roots match
 		// now?
@@ -215,9 +216,10 @@ func (s *SimpleSyncer) executeSync(ctx context.Context, diffEngine DiffEngine,
 			NewLeafProofs:   fn.Collect(newLeaves),
 		}
 
-		log.Infof("Sync for UniverseRoot(%v) complete!", uniID.String())
+		log.Infof("Sync for UniverseRoot(%v) complete!",
+			uniID.StringForLog())
 		log.Tracef("Sync for UniverseRoot(%v) complete! New "+
-			"universe_root=%v", uniID.String(),
+			"universe_root=%v", uniID.StringForLog(),
 			spew.Sdump(remoteRoot))
 
 		return nil


### PR DESCRIPTION
Addresses issues #314 and #315.

Implements a header verifier that caches the correct block hash instead making multiple RPC calls for each minting proof generated, and also moves some slower methods in the sprout creation loop into separate goroutines.

It would be better to use a `threadPool` there instead of starting & stopping the goroutines manually. I think at this point the sprout creation loop is current bottlenecked on key tweaking for new group keys, but not entirely sure.