### PR TITLE
tapfreighter: add porter state SendStateResumeTransfer

### DIFF
--- a/tapfreighter/chain_porter.go
+++ b/tapfreighter/chain_porter.go
@@ -236,7 +236,8 @@ func (p *ChainPorter) waitForTransferTxConf(pkg *sendPackage) error {
 			err)
 	}
 
-	// Launch a goroutine that'll notify us when the transaction confirms.
+	// Listen on the confirmation channel for a notification that the
+	// transaction has confirmed.
 	defer confCancel()
 
 	var confEvent *chainntnfs.TxConfirmation

--- a/tapfreighter/parcel.go
+++ b/tapfreighter/parcel.go
@@ -63,6 +63,11 @@ const (
 	// SendStateComplete is the state which is reached once entire asset
 	// transfer process is complete.
 	SendStateComplete
+
+	// SendStateResumeTransfer is the first state executed upon the
+	// resumption of a transfer process which was previously successfully
+	// stored in persistent storage.
+	SendStateResumeTransfer
 )
 
 // String returns a human-readable version of SendState.
@@ -185,7 +190,7 @@ func (p *PendingParcel) pkg() *sendPackage {
 	// rebroadcast and then wait for the transfer to confirm.
 	return &sendPackage{
 		OutboundPkg: p.outboundPkg,
-		SendState:   SendStateBroadcast,
+		SendState:   SendStateResumeTransfer,
 	}
 }
 


### PR DESCRIPTION
In this state the porter determines the next appropriate state for resuming the processing of a pending package. The next state is determined based on whether the package anchor tx has been mined.

I haven't tested this change yet, but early feedback is welcomed.