### PR TITLE
itest: resume pending package send

### DIFF
--- a/itest/assertions.go
+++ b/itest/assertions.go
@@ -384,7 +384,7 @@ func confirmAndAssetOutboundTransferWithOutputs(t *harnessTest,
 	require.NoError(t.t, err)
 	t.Logf("Got response from sending assets: %v", sendRespJSON)
 
-	// Mine a block to force the send we created above to confirm.
+	// Mine a block to force the send event to complete (confirm on-chain).
 	_ = mineBlocks(t, t.lndHarness, 1, 1)
 
 	// Confirm that we can externally view the transfer.

--- a/itest/integration_test.go
+++ b/itest/integration_test.go
@@ -47,24 +47,27 @@ func TestTaprootAssetsDaemon(t *testing.T) {
 			testCase.name)
 
 		success := t.Run(testCase.name, func(t1 *testing.T) {
+			// Create a subtest harness for each test case.
+			subTestLnd := lndHarness.Subtest(t1)
+
 			// The universe server and tapd client are both freshly
 			// created and later discarded for each test run to
 			// assure no state is taken over between runs.
 			tapdHarness, universeServer, proofCourier :=
 				setupHarnesses(
-					t1, ht, lndHarness,
+					t1, ht, subTestLnd,
 					testCase.proofCourierType,
 				)
-			lndHarness.EnsureConnected(
-				lndHarness.Alice, lndHarness.Bob,
+			subTestLnd.EnsureConnected(
+				subTestLnd.Alice, subTestLnd.Bob,
 			)
 
-			lndHarness.Alice.AddToLogf(logLine)
-			lndHarness.Bob.AddToLogf(logLine)
+			subTestLnd.Alice.AddToLogf(logLine)
+			subTestLnd.Bob.AddToLogf(logLine)
 
 			ht := ht.newHarnessTest(
-				t1, lndHarness, universeServer, tapdHarness,
-				proofCourier,
+				t1, subTestLnd, universeServer,
+				tapdHarness, proofCourier,
 			)
 
 			// Now we have everything to run the test case.

--- a/itest/test_list_on_test.go
+++ b/itest/test_list_on_test.go
@@ -30,6 +30,11 @@ var testCases = []*testCase{
 		proofCourierType: proof.ApertureCourier,
 	},
 	{
+		name:             "resume pending package send",
+		test:             testResumePendingPackageSend,
+		proofCourierType: proof.ApertureCourier,
+	},
+	{
 		name:             "reattempt failed asset send",
 		test:             testReattemptFailedAssetSend,
 		proofCourierType: proof.ApertureCourier,


### PR DESCRIPTION
This PR adds an itest which ensure that we resume the send procedure which was interrupted by a tapd restart.