### PR TITLE
tapcfg: ensure log rotator created after config validation

### DIFF
--- a/tapcfg/config.go
+++ b/tapcfg/config.go
@@ -414,17 +414,6 @@ func LoadConfig(interceptor signal.Interceptor) (*Config, btclog.Logger, error) 
 		return nil, nil, err
 	}
 
-	// Initialize logging at the default logging level.
-	tap.SetupLoggers(cfg.LogWriter, interceptor)
-	err = cfg.LogWriter.InitLogRotator(
-		filepath.Join(cfg.LogDir, defaultLogFilename),
-		cfg.MaxLogFileSize, cfg.MaxLogFiles,
-	)
-	if err != nil {
-		_, _ = fmt.Fprintln(os.Stderr, err.Error())
-		return nil, nil, err
-	}
-
 	cfgLogger := cfg.LogWriter.GenSubLogger("CONF", nil)
 
 	// Make sure everything we just loaded makes sense.
@@ -436,6 +425,17 @@ func LoadConfig(interceptor signal.Interceptor) (*Config, btclog.Logger, error) 
 		}
 
 		cfgLogger.Warnf("Error validating config: %v", err)
+		return nil, nil, err
+	}
+
+	// Initialize logging at the default logging level.
+	tap.SetupLoggers(cfg.LogWriter, interceptor)
+	err = cfg.LogWriter.InitLogRotator(
+		filepath.Join(cleanCfg.LogDir, defaultLogFilename),
+		cleanCfg.MaxLogFileSize, cfg.MaxLogFiles,
+	)
+	if err != nil {
+		_, _ = fmt.Fprintln(os.Stderr, err.Error())
 		return nil, nil, err
 	}
 


### PR DESCRIPTION
In this commit, we fix a bug that would cause the logs to always go to the default log location even if a different base dir was set. Before this commit, we'd create the log rotators before the call to `ValidateConfig`, which is where we modify the log dir location to be relative to the final base dir.

The fix here is simple: create the log rotator _after_ the config has been validated.