### PR TITLE
Asset metadata overwrite fix

### DIFF
--- a/itest/addrs_test.go
+++ b/itest/addrs_test.go
@@ -78,6 +78,17 @@ func testAddresses(t *harnessTest) {
 
 		// Make sure we have imported and finalized all proofs.
 		assertNonInteractiveRecvComplete(t, secondTapd, idx+1)
+
+		// Make sure the asset meta is also fetched correctly.
+		assetResp, err := secondTapd.FetchAssetMeta(
+			ctxt, &taprpc.FetchAssetMetaRequest{
+				Asset: &taprpc.FetchAssetMetaRequest_AssetId{
+					AssetId: a.AssetGenesis.AssetId,
+				},
+			},
+		)
+		require.NoError(t.t, err)
+		require.Equal(t.t, a.AssetGenesis.MetaHash, assetResp.MetaHash)
 	}
 
 	// Now sanity check that we can actually list the transfer.

--- a/tapdb/sqlc/assets.sql.go
+++ b/tapdb/sqlc/assets.sql.go
@@ -2095,8 +2095,9 @@ INSERT INTO assets_meta (
     -- In this case, we may be inserting the data+type for an existing blob. So
     -- we'll set both of those values. At this layer we assume the meta hash
     -- has been validated elsewhere.
-    DO UPDATE SET meta_data_blob = EXCLUDED.meta_data_blob, 
-        meta_data_type = EXCLUDED.meta_data_type
+    DO UPDATE SET meta_data_blob = COALESCE(EXCLUDED.meta_data_blob, assets_meta.meta_data_blob), 
+                  meta_data_type = COALESCE(EXCLUDED.meta_data_type, assets_meta.meta_data_type)
+        
 RETURNING meta_id
 `
 
@@ -2133,7 +2134,7 @@ INSERT INTO asset_proofs (
 ) VALUES (
     (SELECT asset_id FROM target_asset), $1
 ) ON CONFLICT (asset_id)
-    -- This is not a NOP, update the proof file in case it wasn't set before.
+    -- This is not a NOP, we always overwrite the proof with the new one.
     DO UPDATE SET proof_file = EXCLUDED.proof_file
 `
 

--- a/tapdb/sqlc/mssmt.sql.go
+++ b/tapdb/sqlc/mssmt.sql.go
@@ -295,6 +295,7 @@ INSERT INTO mssmt_roots (
 ) VALUES (
     $1, $2
 ) ON CONFLICT (namespace)
+    -- Not a NOP, we always overwrite the root hash.
     DO UPDATE SET root_hash = EXCLUDED.root_hash
 `
 

--- a/tapdb/sqlc/queries/assets.sql
+++ b/tapdb/sqlc/queries/assets.sql
@@ -624,7 +624,7 @@ INSERT INTO asset_proofs (
 ) VALUES (
     (SELECT asset_id FROM target_asset), @proof_file
 ) ON CONFLICT (asset_id)
-    -- This is not a NOP, update the proof file in case it wasn't set before.
+    -- This is not a NOP, we always overwrite the proof with the new one.
     DO UPDATE SET proof_file = EXCLUDED.proof_file;
 
 -- name: FetchAssetProofs :many
@@ -718,8 +718,9 @@ INSERT INTO assets_meta (
     -- In this case, we may be inserting the data+type for an existing blob. So
     -- we'll set both of those values. At this layer we assume the meta hash
     -- has been validated elsewhere.
-    DO UPDATE SET meta_data_blob = EXCLUDED.meta_data_blob, 
-        meta_data_type = EXCLUDED.meta_data_type
+    DO UPDATE SET meta_data_blob = COALESCE(EXCLUDED.meta_data_blob, assets_meta.meta_data_blob), 
+                  meta_data_type = COALESCE(EXCLUDED.meta_data_type, assets_meta.meta_data_type)
+        
 RETURNING meta_id;
 
 -- name: FetchAssetMeta :one

--- a/tapdb/sqlc/queries/mssmt.sql
+++ b/tapdb/sqlc/queries/mssmt.sql
@@ -64,6 +64,7 @@ INSERT INTO mssmt_roots (
 ) VALUES (
     $1, $2
 ) ON CONFLICT (namespace)
+    -- Not a NOP, we always overwrite the root hash.
     DO UPDATE SET root_hash = EXCLUDED.root_hash;
 
 -- name: FetchAllNodes :many


### PR DESCRIPTION
Fixes https://github.com/lightninglabs/taproot-assets/issues/368.

As @habibitcoin already correctly identified, one of our SQL queries is incorrect and overwrites valid meta information with `NULL` when importing a proof.