### PR TITLE
version: bump version to v0.2.1-alpha

### DIFF
--- a/version.go
+++ b/version.go
@@ -45,7 +45,7 @@ const (
 	AppMinor uint = 2
 
 	// AppPatch defines the application patch for this binary.
-	AppPatch uint = 0
+	AppPatch uint = 1
 
 	// AppPreRelease MUST only contain characters from semanticAlphabet
 	// per the semantic versioning spec.


### PR DESCRIPTION
First step to releasing v0.2.1.

Verified with `tapcli-debug -v`.