### PR TITLE
multi: fix aperture config + bump golang version

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -22,7 +22,7 @@ env:
   GOPATH: /home/runner/work/go
   GO111MODULE: on
 
-  GO_VERSION: '1.20.4'
+  GO_VERSION: '1.20.5'
 
 jobs:
   #######################

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # /make/builder.Dockerfile
 # /.github/workflows/main.yml
 # /.github/workflows/release.yml
-FROM golang:1.20.4-alpine as builder
+FROM golang:1.20.5-alpine as builder
 
 # Force Go to use the cgo based DNS resolver. This is required to ensure DNS
 # queries required to connect to linked containers succeed.

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -1,5 +1,5 @@
 # IMAGE FOR BUILDING
-FROM golang:1.20.4 as builder 
+FROM golang:1.20.5 as builder 
 
 WORKDIR /app
 

--- a/make/builder.Dockerfile
+++ b/make/builder.Dockerfile
@@ -4,7 +4,7 @@
 # /dev.Dockerfile
 # /.github/workflows/main.yml
 # /.github/workflows/release.yml
-FROM golang:1.20.4-buster
+FROM golang:1.20.5-buster
 
 MAINTAINER Olaoluwa Osuntokun <laolu@lightning.engineering>
 

--- a/proof/aperture.go
+++ b/proof/aperture.go
@@ -49,7 +49,7 @@ func NewApertureHarness(t *testing.T, port int) ApertureHarness {
 		HashMail: &aperture.HashMailConfig{
 			Enabled:               true,
 			MessageRate:           time.Millisecond,
-			MessageBurstAllowance: math.MaxUint32,
+			MessageBurstAllowance: int(math.MaxInt32),
 		},
 		Prometheus: &aperture.PrometheusConfig{},
 		Tor:        &aperture.TorConfig{},


### PR DESCRIPTION
In this commit, we fix a test harness config value that overflowed. We also bump the golang version used in all docker images to 1.20.5.