### PR TITLE
build: bump Go version, fix build for 32-bit machines

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -22,7 +22,7 @@ env:
   GOPATH: /home/runner/work/go
   GO111MODULE: on
 
-  GO_VERSION: '1.20.4'
+  GO_VERSION: '1.20.5'
 
 jobs:
   #######################

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # /make/builder.Dockerfile
 # /.github/workflows/main.yml
 # /.github/workflows/release.yml
-FROM golang:1.20.4-alpine as builder
+FROM golang:1.20.5-alpine as builder
 
 # Force Go to use the cgo based DNS resolver. This is required to ensure DNS
 # queries required to connect to linked containers succeed.

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -1,5 +1,5 @@
 # IMAGE FOR BUILDING
-FROM golang:1.20.4 as builder 
+FROM golang:1.20.5 as builder 
 
 WORKDIR /app
 

--- a/proof/aperture.go
+++ b/proof/aperture.go
@@ -1,3 +1,5 @@
+//go:build itest
+
 package proof
 
 import (

--- a/proof/aperture.go
+++ b/proof/aperture.go
@@ -51,7 +51,7 @@ func NewApertureHarness(t *testing.T, port int) ApertureHarness {
 		HashMail: &aperture.HashMailConfig{
 			Enabled:               true,
 			MessageRate:           time.Millisecond,
-			MessageBurstAllowance: math.MaxUint32,
+			MessageBurstAllowance: int(math.MaxInt32),
 		},
 		Prometheus: &aperture.PrometheusConfig{},
 		Tor:        &aperture.TorConfig{},


### PR DESCRIPTION
Bumps the go version, and also adds a build tag behind something only used for `itests`. We also fix an integer issue that can cause the build to fail on 32 bit machines. 