### PR TITLE
itest: add missing build tag

### DIFF
--- a/itest/addrs_test.go
+++ b/itest/addrs_test.go
@@ -1,3 +1,5 @@
+//go:build itest
+
 package itest
 
 import (

--- a/itest/assertions.go
+++ b/itest/assertions.go
@@ -1,3 +1,5 @@
+//go:build itest
+
 package itest
 
 import (

--- a/itest/assets_test.go
+++ b/itest/assets_test.go
@@ -1,3 +1,5 @@
+//go:build itest
+
 package itest
 
 import (

--- a/itest/collectible_split_test.go
+++ b/itest/collectible_split_test.go
@@ -1,3 +1,5 @@
+//go:build itest
+
 package itest
 
 import (

--- a/itest/full_value_split_test.go
+++ b/itest/full_value_split_test.go
@@ -1,3 +1,5 @@
+//go:build itest
+
 package itest
 
 import (

--- a/itest/mint_batch_stress_test.go
+++ b/itest/mint_batch_stress_test.go
@@ -1,3 +1,5 @@
+//go:build itest
+
 package itest
 
 import (

--- a/itest/multi_asset_group_test.go
+++ b/itest/multi_asset_group_test.go
@@ -1,3 +1,5 @@
+//go:build itest
+
 package itest
 
 import (

--- a/itest/psbt_test.go
+++ b/itest/psbt_test.go
@@ -1,3 +1,5 @@
+//go:build itest
+
 package itest
 
 import (

--- a/itest/re-issuance_test.go
+++ b/itest/re-issuance_test.go
@@ -1,3 +1,5 @@
+//go:build itest
+
 package itest
 
 import (

--- a/itest/round_trip_send_test.go
+++ b/itest/round_trip_send_test.go
@@ -1,3 +1,5 @@
+//go:build itest
+
 package itest
 
 import (

--- a/itest/send_test.go
+++ b/itest/send_test.go
@@ -1,3 +1,5 @@
+//go:build itest
+
 package itest
 
 import (

--- a/itest/server_harness.go
+++ b/itest/server_harness.go
@@ -1,3 +1,5 @@
+//go:build itest
+
 package itest
 
 import (

--- a/itest/tapd_harness.go
+++ b/itest/tapd_harness.go
@@ -1,3 +1,5 @@
+//go:build itest
+
 package itest
 
 import (

--- a/itest/test_harness.go
+++ b/itest/test_harness.go
@@ -1,3 +1,5 @@
+//go:build itest
+
 package itest
 
 import (

--- a/itest/universe_test.go
+++ b/itest/universe_test.go
@@ -1,3 +1,5 @@
+//go:build itest
+
 package itest
 
 import (

--- a/proof/aperture.go
+++ b/proof/aperture.go
@@ -1,3 +1,5 @@
+//go:build itest
+
 package proof
 
 import (


### PR DESCRIPTION
Avoid building itests when building for a release.