### PR TITLE
Fix multiple small issues with release, prepare for 0.2.2-alpha

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -22,6 +22,12 @@ env:
   GOPATH: /home/runner/work/go
   GO111MODULE: on
 
+  # If you change this value, please change it in the following files as well:
+  # /Dockerfile
+  # /dev.Dockerfile
+  # /make/builder.Dockerfile
+  # /taprpc/Dockerfile
+  # /tools/Dockerfile
   GO_VERSION: '1.20.5'
 
 jobs:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -78,6 +78,22 @@ jobs:
         run: go install -v ./...
 
   ########################
+  # cross compilation
+  ########################
+  cross-compile:
+    name: cross compilation
+    runs-on: ubuntu-latest
+    steps:
+      - name: git checkout
+        uses: actions/checkout@v3
+
+      - name: setup go ${{ env.GO_VERSION }}
+        uses: ./.github/actions/setup-go
+
+      - name: build release for all architectures
+        run: make release
+
+  ########################
   # Lint check.
   ########################
   lint-check:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 # If you change this value, please change it in the following files as well:
-# /.travis.yml
+# /.github/workflows/main.yaml
 # /dev.Dockerfile
 # /make/builder.Dockerfile
-# /.github/workflows/main.yml
-# /.github/workflows/release.yml
+# /taprpc/Dockerfile
+# /tools/Dockerfile
 FROM golang:1.20.5-alpine as builder
 
 # Force Go to use the cgo based DNS resolver. This is required to ensure DNS

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -1,4 +1,9 @@
-# IMAGE FOR BUILDING
+# If you change this value, please change it in the following files as well:
+# /.github/workflows/main.yaml
+# /Dockerfile
+# /make/builder.Dockerfile
+# /taprpc/Dockerfile
+# /tools/Dockerfile
 FROM golang:1.20.5 as builder 
 
 WORKDIR /app

--- a/itest/aperture_harness.go
+++ b/itest/aperture_harness.go
@@ -1,4 +1,4 @@
-package proof
+package itest
 
 import (
 	"crypto/tls"
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/lightninglabs/aperture"
+	"github.com/lightninglabs/taproot-assets/proof"
 	"github.com/lightningnetwork/lnd/lntest/wait"
 	"github.com/stretchr/testify/require"
 )
@@ -121,5 +122,5 @@ func (h *ApertureHarness) Stop() error {
 	return h.Service.Stop()
 }
 
-// Ensure that ApertureHarness implements the CourierHarness interface.
-var _ CourierHarness = (*ApertureHarness)(nil)
+// Ensure that ApertureHarness implements the proof.CourierHarness interface.
+var _ proof.CourierHarness = (*ApertureHarness)(nil)

--- a/itest/tapd_harness.go
+++ b/itest/tapd_harness.go
@@ -137,7 +137,7 @@ func newTapdHarness(ht *harnessTest, cfg tapdConfig,
 
 	// Populate proof courier specific config fields.
 	switch typedProofCourier := (proofCourier).(type) {
-	case *proof.ApertureHarness:
+	case *ApertureHarness:
 		// Use passed in backoff config or default config.
 		backoffCfg := &proof.BackoffCfg{
 			BackoffResetWait: 20 * time.Second,

--- a/itest/test_harness.go
+++ b/itest/test_harness.go
@@ -284,7 +284,7 @@ func setupHarnesses(t *testing.T, ht *harnessTest,
 
 	case proof.ApertureCourier:
 		port := nextAvailablePort()
-		apHarness := proof.NewApertureHarness(ht.t, port)
+		apHarness := NewApertureHarness(ht.t, port)
 		proofCourier = &apHarness
 	}
 

--- a/make/builder.Dockerfile
+++ b/make/builder.Dockerfile
@@ -1,9 +1,9 @@
 # If you change this value, please change it in the following files as well:
-# /.travis.yml
+# /.github/workflows/main.yaml
 # /Dockerfile
 # /dev.Dockerfile
-# /.github/workflows/main.yml
-# /.github/workflows/release.yml
+# /taprpc/Dockerfile
+# /tools/Dockerfile
 FROM golang:1.20.5-buster
 
 MAINTAINER Olaoluwa Osuntokun <laolu@lightning.engineering>

--- a/taprpc/Dockerfile
+++ b/taprpc/Dockerfile
@@ -1,3 +1,9 @@
+# If you change this value, please change it in the following files as well:
+# /.github/workflows/main.yaml
+# /Dockerfile
+# /dev.Dockerfile
+# /make/builder.Dockerfile
+# /tools/Dockerfile
 FROM golang:1.20.4-buster
 
 RUN apt-get update && apt-get install -y \

--- a/taprpc/Dockerfile
+++ b/taprpc/Dockerfile
@@ -4,7 +4,7 @@
 # /dev.Dockerfile
 # /make/builder.Dockerfile
 # /tools/Dockerfile
-FROM golang:1.20.4-buster
+FROM golang:1.20.5-buster
 
 RUN apt-get update && apt-get install -y \
   git \

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -4,7 +4,7 @@
 # /dev.Dockerfile
 # /make/builder.Dockerfile
 # /taprpc/Dockerfile
-FROM golang:1.20.4-buster
+FROM golang:1.20.5-buster
 
 RUN apt-get update && apt-get install -y git
 ENV GOCACHE=/tmp/build/.cache

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -1,3 +1,9 @@
+# If you change this value, please change it in the following files as well:
+# /.github/workflows/main.yaml
+# /Dockerfile
+# /dev.Dockerfile
+# /make/builder.Dockerfile
+# /taprpc/Dockerfile
 FROM golang:1.20.4-buster
 
 RUN apt-get update && apt-get install -y git

--- a/version.go
+++ b/version.go
@@ -45,7 +45,7 @@ const (
 	AppMinor uint = 2
 
 	// AppPatch defines the application patch for this binary.
-	AppPatch uint = 1
+	AppPatch uint = 2
 
 	// AppPreRelease MUST only contain characters from semanticAlphabet
 	// per the semantic versioning spec.


### PR DESCRIPTION
Replaces https://github.com/lightninglabs/taproot-assets/pull/377.

Adds some Golang version bumps that were missed in https://github.com/lightninglabs/taproot-assets/pull/375 and updates the comments on what files such a bump needs to update.

Also makes sure that we catch release compilation issues early by running the release build in CI.

Since there was already a tag pushed for `v0.2.1-alpha`, we need to bump the version to `v0.2.2-alpha`.