### PR TITLE
Multiverse register issuance

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -3010,7 +3010,7 @@ func (r *rpcServer) VerifyAssetOwnership(ctx context.Context,
 	}, nil
 }
 
-// UniverseStats returns a set of aggregrate statistics for the current state
+// UniverseStats returns a set of aggregate statistics for the current state
 // of the Universe.
 func (r *rpcServer) UniverseStats(ctx context.Context,
 	req *unirpc.StatsRequest) (*unirpc.StatsResponse, error) {

--- a/tapdb/universe.go
+++ b/tapdb/universe.go
@@ -277,6 +277,46 @@ func (b *BaseUniverseTree) RegisterIssuance(ctx context.Context,
 	key universe.BaseKey, leaf *universe.MintingLeaf,
 	metaReveal *proof.MetaReveal) (*universe.IssuanceProof, error) {
 
+	var (
+		writeTx BaseUniverseStoreOptions
+
+		err           error
+		issuanceProof *universe.IssuanceProof
+	)
+
+	// Limit to a single writer at a time.
+	b.registrationMtx.Lock()
+	defer b.registrationMtx.Unlock()
+
+	dbErr := b.db.ExecTx(ctx, &writeTx, func(dbTx BaseUniverseStore) error {
+		issuanceProof, _, err = universeRegisterIssuance(
+			ctx, dbTx, b.id, key, leaf, metaReveal,
+		)
+		return err
+	})
+	if dbErr != nil {
+		return nil, dbErr
+	}
+
+	return issuanceProof, nil
+}
+
+// universeRegisterIssuance inserts a new minting leaf within the universe
+// tree, stored at the base key.
+//
+// This function returns the newly registered issuance proof and the new
+// universe root.
+//
+// NOTE: This function accepts a db transaction, as it's used when making
+// broader DB updates.
+func universeRegisterIssuance(ctx context.Context, dbTx BaseUniverseStore,
+	id universe.Identifier, key universe.BaseKey,
+	leaf *universe.MintingLeaf,
+	metaReveal *proof.MetaReveal) (*universe.IssuanceProof, mssmt.Node,
+	error) {
+
+	namespace := idToNameSpace(id)
+
 	// With the tree store created, we'll now obtain byte representation of
 	// the minting key, as that'll be the key in the SMT itself.
 	smtKey := key.UniverseKey()
@@ -286,103 +326,88 @@ func (b *BaseUniverseTree) RegisterIssuance(ctx context.Context,
 	leafNode := leaf.SmtLeafNode()
 
 	var groupKeyBytes []byte
-	if b.id.GroupKey != nil {
-		groupKeyBytes = schnorr.SerializePubKey(b.id.GroupKey)
+	if id.GroupKey != nil {
+		groupKeyBytes = schnorr.SerializePubKey(id.GroupKey)
 	}
 
 	mintingPointBytes, err := encodeOutpoint(key.MintingOutpoint)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	// Up to this point many writers can perform all required read
-	// operations to prepare and validate the keys. But since we're now
-	// actually starting to write, we want to limit this to a single writer
-	// at a time.
-	b.registrationMtx.Lock()
-	defer b.registrationMtx.Unlock()
-
 	var (
-		writeTx BaseUniverseStoreOptions
-
 		leafInclusionProof *mssmt.Proof
 		universeRoot       mssmt.Node
 	)
-	dbErr := b.db.ExecTx(ctx, &writeTx, func(db BaseUniverseStore) error {
-		// First, we'll instantiate a new compact tree instance from the
-		// backing tree store.
-		universeTree := mssmt.NewCompactedTree(
-			newTreeStoreWrapperTx(db, b.smtNamespace),
-		)
 
-		// Now that we have a tree instance linked to this DB
-		// transaction, we'll insert the leaf into the tree based on
-		// its SMT key.
-		_, err := universeTree.Insert(ctx, smtKey, leafNode)
-		if err != nil {
-			return err
-		}
+	// First, we'll instantiate a new compact tree instance from the
+	// backing tree store.
+	universeTree := mssmt.NewCompactedTree(
+		newTreeStoreWrapperTx(dbTx, namespace),
+	)
 
-		// Next, we'll upsert the universe root in the DB, which gives
-		// us the root ID that we'll use to insert the universe leaf
-		// overlay.
-		universeRootID, err := db.UpsertUniverseRoot(ctx, NewUniverseRoot{
-			NamespaceRoot: b.smtNamespace,
-			AssetID:       fn.ByteSlice(leaf.ID()),
-			GroupKey:      groupKeyBytes,
-		})
-		if err != nil {
-			return err
-		}
+	// Now that we have a tree instance linked to this DB
+	// transaction, we'll insert the leaf into the tree based on
+	// its SMT key.
+	_, err = universeTree.Insert(ctx, smtKey, leafNode)
+	if err != nil {
+		return nil, nil, err
+	}
 
-		// Before we insert the asset genesis, we'll insert the meta
-		// first. The reveal may or may not be populated, which'll also
-		// insert the opauqe meta blob on disk.
-		_, err = maybeUpsertAssetMeta(
-			ctx, db, &leaf.Genesis, metaReveal,
-		)
-		if err != nil {
-			return err
-		}
-
-		assetGenID, err := upsertAssetGen(
-			ctx, db, leaf.Genesis, leaf.GroupKey,
-		)
-		if err != nil {
-			return err
-		}
-
-		scriptKeyBytes := schnorr.SerializePubKey(key.ScriptKey.PubKey)
-		err = db.InsertUniverseLeaf(ctx, NewUniverseLeaf{
-			AssetGenesisID:    assetGenID,
-			ScriptKeyBytes:    scriptKeyBytes,
-			UniverseRootID:    universeRootID,
-			LeafNodeKey:       smtKey[:],
-			LeafNodeNamespace: b.smtNamespace,
-			MintingPoint:      mintingPointBytes,
-		})
-		if err != nil {
-			return err
-		}
-
-		// Finally, we'll obtain the merkle proof from the tree for the
-		// leaf we just inserted.
-		leafInclusionProof, err = universeTree.MerkleProof(ctx, smtKey)
-		if err != nil {
-			return err
-		}
-
-		// With the insertion complete, we'll now fetch the root of the
-		// tree as it stands so we can return it to the caller.
-		universeRoot, err = universeTree.Root(ctx)
-		if err != nil {
-			return err
-		}
-
-		return nil
+	// Next, we'll upsert the universe root in the DB, which gives
+	// us the root ID that we'll use to insert the universe leaf
+	// overlay.
+	universeRootID, err := dbTx.UpsertUniverseRoot(ctx, NewUniverseRoot{
+		NamespaceRoot: namespace,
+		AssetID:       fn.ByteSlice(leaf.ID()),
+		GroupKey:      groupKeyBytes,
 	})
-	if dbErr != nil {
-		return nil, dbErr
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Before we insert the asset genesis, we'll insert the meta
+	// first. The reveal may or may not be populated, which'll also
+	// insert the opauqe meta blob on disk.
+	_, err = maybeUpsertAssetMeta(
+		ctx, dbTx, &leaf.Genesis, metaReveal,
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	assetGenID, err := upsertAssetGen(
+		ctx, dbTx, leaf.Genesis, leaf.GroupKey,
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	scriptKeyBytes := schnorr.SerializePubKey(key.ScriptKey.PubKey)
+	err = dbTx.InsertUniverseLeaf(ctx, NewUniverseLeaf{
+		AssetGenesisID:    assetGenID,
+		ScriptKeyBytes:    scriptKeyBytes,
+		UniverseRootID:    universeRootID,
+		LeafNodeKey:       smtKey[:],
+		LeafNodeNamespace: namespace,
+		MintingPoint:      mintingPointBytes,
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Finally, we'll obtain the merkle proof from the tree for the
+	// leaf we just inserted.
+	leafInclusionProof, err = universeTree.MerkleProof(ctx, smtKey)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// With the insertion complete, we'll now fetch the root of the tree as
+	// it stands and return it to the caller.
+	universeRoot, err = universeTree.Root(ctx)
+	if err != nil {
+		return nil, nil, err
 	}
 
 	return &universe.IssuanceProof{
@@ -390,7 +415,7 @@ func (b *BaseUniverseTree) RegisterIssuance(ctx context.Context,
 		UniverseRoot:   universeRoot,
 		InclusionProof: leafInclusionProof,
 		Leaf:           leaf,
-	}, nil
+	}, universeRoot, nil
 }
 
 // FetchIssuanceProof returns an issuance proof for the target key. If the key

--- a/tapdb/universe_forest.go
+++ b/tapdb/universe_forest.go
@@ -66,8 +66,8 @@ func NewBaseUniverseForest(db BatchedUniverseForest) *BaseUniverseForest {
 	}
 }
 
-// RootNodes returns the complete set of known root nodes for the set of assets
-// tracked in the base Universe.
+// RootNodes returns the complete set of known base universe root nodes for the
+// set of base universes tracked in the universe forest.
 func (b *BaseUniverseForest) RootNodes(ctx context.Context) ([]universe.BaseRoot, error) {
 	var uniRoots []universe.BaseRoot
 

--- a/tapdb/universe_forest.go
+++ b/tapdb/universe_forest.go
@@ -68,10 +68,13 @@ func NewBaseUniverseForest(db BatchedUniverseForest) *BaseUniverseForest {
 
 // RootNodes returns the complete set of known base universe root nodes for the
 // set of base universes tracked in the universe forest.
-func (b *BaseUniverseForest) RootNodes(ctx context.Context) ([]universe.BaseRoot, error) {
-	var uniRoots []universe.BaseRoot
+func (b *BaseUniverseForest) RootNodes(
+	ctx context.Context) ([]universe.BaseRoot, error) {
 
-	readTx := NewBaseUniverseForestReadTx()
+	var (
+		uniRoots []universe.BaseRoot
+		readTx   = NewBaseUniverseForestReadTx()
+	)
 
 	dbErr := b.db.ExecTx(ctx, &readTx, func(db BaseUniverseForestStore) error {
 		dbRoots, err := db.UniverseRoots(ctx)

--- a/tapdb/universe_forest.go
+++ b/tapdb/universe_forest.go
@@ -31,8 +31,8 @@ func (b *BaseUniverseForestOptions) ReadOnly() bool {
 	return b.readOnly
 }
 
-// NewBaseUniverseForestReadTx creates a new read-only transaction for the base
-// universe.
+// NewBaseUniverseForestReadTx creates a new read-only transaction for the
+// universe forest.
 func NewBaseUniverseForestReadTx() BaseUniverseForestOptions {
 	return BaseUniverseForestOptions{
 		readOnly: true,
@@ -48,9 +48,7 @@ type BatchedUniverseForest interface {
 	BatchedTx[BaseUniverseForestStore]
 }
 
-// BaseUniverseForest implements the persistent storage for the Base universe
-// for a given asset. The minting outpoints stored of the asset are used to key
-// into the universe tree.
+// BaseUniverseForest implements the persistent storage for a universe forest.
 //
 // NOTE: This implements the universe.BaseForest interface.
 type BaseUniverseForest struct {

--- a/tapdb/universe_forest.go
+++ b/tapdb/universe_forest.go
@@ -40,7 +40,8 @@ func NewBaseUniverseForestReadTx() BaseUniverseForestOptions {
 }
 
 // BasedUniverseForest is a wrapper around the base universe forest that allows
-// us perform batch queries with all the relevant query interfaces.
+// us to perform batch transactional databse queries with all the relevant query
+// interfaces.
 type BatchedUniverseForest interface {
 	BaseUniverseForestStore
 

--- a/tapdb/universe_test.go
+++ b/tapdb/universe_test.go
@@ -335,7 +335,7 @@ func TestUniverseTreeIsolation(t *testing.T) {
 	normalLeaf, err := insertRandLeaf(t, ctx, normalUniverse, nil)
 	require.NoError(t, err)
 
-	// We should be able to get the roots for both fo the trees.
+	// We should be able to get the roots for both of the trees.
 	groupRoot, _, err := groupUniverse.RootNode(ctx)
 	require.NoError(t, err)
 

--- a/universe/base.go
+++ b/universe/base.go
@@ -202,8 +202,8 @@ func (a *MintingArchive) RegisterIssuance(ctx context.Context, id Identifier,
 
 	// Now that we know the proof is valid, we'll insert it into the base
 	// universe backend, and return the new issuance proof.
-	issuanceProof, err := baseUni.RegisterIssuance(
-		ctx, key, leaf, assetSnapshot.MetaReveal,
+	issuanceProof, err := a.cfg.UniverseForest.RegisterIssuance(
+		ctx, id, key, leaf, assetSnapshot.MetaReveal,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("unable to register new "+

--- a/universe/interface.go
+++ b/universe/interface.go
@@ -40,14 +40,20 @@ type Identifier struct {
 	GroupKey *btcec.PublicKey
 }
 
-// String returns a string representation of the ID.
-func (i *Identifier) String() string {
+// Bytes returns a bytes representation of the ID.
+func (i *Identifier) Bytes() [32]byte {
 	if i.GroupKey != nil {
 		h := sha256.Sum256(schnorr.SerializePubKey(i.GroupKey))
-		return hex.EncodeToString(h[:])
+		return h
 	}
 
-	return hex.EncodeToString(i.AssetID[:])
+	return i.AssetID
+}
+
+// String returns a string representation of the ID.
+func (i *Identifier) String() string {
+	idBytes := i.Bytes()
+	return hex.EncodeToString(idBytes[:])
 }
 
 // StringForLog returns a string representation of the ID for logging.

--- a/universe/interface.go
+++ b/universe/interface.go
@@ -381,10 +381,11 @@ type Syncer interface {
 // DiffEngine is a Universe diff engine that can be used to compare the state
 // of two universes and find the set of assets that are different between them.
 type DiffEngine interface {
-	BaseForest
-
 	// RootNode returns the root node for a given base universe.
 	RootNode(ctx context.Context, id Identifier) (BaseRoot, error)
+
+	// RootNodes returns the set of root nodes for all known universes.
+	RootNodes(ctx context.Context) ([]BaseRoot, error)
 
 	// MintingKeys returns all the keys inserted in the universe.
 	MintingKeys(ctx context.Context, id Identifier) ([]BaseKey, error)

--- a/universe/interface.go
+++ b/universe/interface.go
@@ -221,6 +221,10 @@ type BaseForest interface {
 	// of assets tracked in the base Universe.
 	RootNodes(ctx context.Context) ([]BaseRoot, error)
 
+	RegisterIssuance(ctx context.Context, id Identifier, key BaseKey,
+		leaf *MintingLeaf,
+		metaReveal *proof.MetaReveal) (*IssuanceProof, error)
+
 	// TODO(roasbeef): other stats stuff here, like total number of assets, etc
 	//  * also eventually want pull/fetch stats, can be pulled out into another instance
 }


### PR DESCRIPTION
This PR contains new functionality for registering an asset issuance in a multiverse MS-SMT.

Depends on https://github.com/lightninglabs/taproot-assets/pull/346 . Will be removed from draft once https://github.com/lightninglabs/taproot-assets/pull/346 is merged.