### PR TITLE
Remove lnd references in user-visible issue copy

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue-template--updated-from-lnd.md
+++ b/.github/ISSUE_TEMPLATE/issue-template--updated-from-lnd.md
@@ -1,5 +1,5 @@
 ---
-name: Issue template, updated from lnd
+name: Issue template
 about: Create a report to help us improve
 title: "[bug]: "
 labels: needs triage


### PR DESCRIPTION
When clicking "New Issue", the copy in the label referenced lnd which is confusing given expectations are to create a taproot-assets issue