### PR TITLE
version: bump version to v0.2.3-alpha

### DIFF
--- a/version.go
+++ b/version.go
@@ -45,7 +45,7 @@ const (
 	AppMinor uint = 2
 
 	// AppPatch defines the application patch for this binary.
-	AppPatch uint = 2
+	AppPatch uint = 3
 
 	// AppPreRelease MUST only contain characters from semanticAlphabet
 	// per the semantic versioning spec.


### PR DESCRIPTION
After https://github.com/lightninglabs/taproot-assets/pull/408 is merged through the merge queue, we'll want to release `v0.2.3-alpha`.