### PR TITLE
taprpc: fix api docs generator hint

### DIFF
--- a/taprpc/taprootassets.proto
+++ b/taprpc/taprootassets.proto
@@ -75,7 +75,7 @@ service TaprootAssets {
     */
     rpc VerifyProof (ProofFile) returns (VerifyProofResponse);
 
-    /* tarocli: `proofs decode`
+    /* tapcli: `proofs decode`
     DecodeProof attempts to decode a given proof file into human readable
     format.
     */

--- a/taprpc/taprootassets.swagger.json
+++ b/taprpc/taprootassets.swagger.json
@@ -440,7 +440,7 @@
     },
     "/v1/taproot-assets/proofs/decode": {
       "post": {
-        "summary": "tarocli: `proofs decode`\nDecodeProof attempts to decode a given proof file into human readable\nformat.",
+        "summary": "tapcli: `proofs decode`\nDecodeProof attempts to decode a given proof file into human readable\nformat.",
         "operationId": "TaprootAssets_DecodeProof",
         "responses": {
           "200": {

--- a/taprpc/taprootassets_grpc.pb.go
+++ b/taprpc/taprootassets_grpc.pb.go
@@ -64,7 +64,7 @@ type TaprootAssetsClient interface {
 	// VerifyProof attempts to verify a given proof file that claims to be anchored
 	// at the specified genesis point.
 	VerifyProof(ctx context.Context, in *ProofFile, opts ...grpc.CallOption) (*VerifyProofResponse, error)
-	// tarocli: `proofs decode`
+	// tapcli: `proofs decode`
 	// DecodeProof attempts to decode a given proof file into human readable
 	// format.
 	DecodeProof(ctx context.Context, in *DecodeProofRequest, opts ...grpc.CallOption) (*DecodeProofResponse, error)
@@ -346,7 +346,7 @@ type TaprootAssetsServer interface {
 	// VerifyProof attempts to verify a given proof file that claims to be anchored
 	// at the specified genesis point.
 	VerifyProof(context.Context, *ProofFile) (*VerifyProofResponse, error)
-	// tarocli: `proofs decode`
+	// tapcli: `proofs decode`
 	// DecodeProof attempts to decode a given proof file into human readable
 	// format.
 	DecodeProof(context.Context, *DecodeProofRequest) (*DecodeProofResponse, error)


### PR DESCRIPTION
The API docs generator failed because `tarocli` no longer is a valid command.

Fixes https://github.com/lightninglabs/lightning-api-ng/issues/21.