### PR TITLE
tappsbt: fix incorrect test vectors

### DIFF
--- a/tappsbt/address.go
+++ b/tappsbt/address.go
@@ -2,7 +2,6 @@ package tappsbt
 
 import (
 	"fmt"
-	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/taproot-assets/address"
@@ -53,9 +52,6 @@ func FromAddresses(receiverAddrs []*address.Tap,
 	for idx := range receiverAddrs {
 		addr := receiverAddrs[idx]
 
-		schnorrInternalKey, _ := schnorr.ParsePubKey(
-			schnorr.SerializePubKey(&addr.InternalKey),
-		)
 		pkt.Outputs = append(pkt.Outputs, &VOutput{
 			Amount:            addr.Amount,
 			Interactive:       false,
@@ -63,7 +59,7 @@ func FromAddresses(receiverAddrs []*address.Tap,
 			ScriptKey: asset.NewScriptKey(
 				&addr.ScriptKey,
 			),
-			AnchorOutputInternalKey:      schnorrInternalKey,
+			AnchorOutputInternalKey:      &addr.InternalKey,
 			AnchorOutputTapscriptSibling: addr.TapscriptSibling,
 		})
 	}

--- a/tappsbt/mock.go
+++ b/tappsbt/mock.go
@@ -431,7 +431,7 @@ func NewTestFromVOutput(t testing.TB, v *VOutput,
 		Type:              uint8(v.Type),
 		Interactive:       v.Interactive,
 		AnchorOutputIndex: v.AnchorOutputIndex,
-		AnchorOutputInternalKey: test.HexSchnorrPubKey(
+		AnchorOutputInternalKey: test.HexPubKey(
 			v.AnchorOutputInternalKey,
 		),
 		AnchorOutputTapscriptSibling: commitment.HexTapscriptSibling(
@@ -541,7 +541,7 @@ func (to *TestVOutput) ToVOutput(t testing.TB) *VOutput {
 		Type:              VOutputType(to.Type),
 		Interactive:       to.Interactive,
 		AnchorOutputIndex: to.AnchorOutputIndex,
-		AnchorOutputInternalKey: test.ParseSchnorrPubKey(
+		AnchorOutputInternalKey: test.ParsePubKey(
 			t, to.AnchorOutputInternalKey,
 		),
 		AnchorOutputTapscriptSibling: commitment.ParseTapscriptSibling(

--- a/tappsbt/testdata/psbt_encoding_generated.json
+++ b/tappsbt/testdata/psbt_encoding_generated.json
@@ -50,7 +50,7 @@
             "type": 0,
             "interactive": false,
             "anchor_output_index": 1,
-            "anchor_output_internal_key": "4a821d5ec008712983929de448b8afb6c24e5a1b97367b9a65b6220d7f083fe3",
+            "anchor_output_internal_key": "034a821d5ec008712983929de448b8afb6c24e5a1b97367b9a65b6220d7f083fe3",
             "anchor_output_bip32_derivation": null,
             "anchor_output_tr_bip32_derivation": null,
             "anchor_output_tapscript_sibling": "",
@@ -83,7 +83,7 @@
         "version": 0,
         "chain_params_hrp": "tapbc"
       },
-      "expected": "cHNidP8BALQCAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAAAAIlEgfHm5sm5GOJXu9WedhViULIbErSIzre8BvD5tVAs2U/4/ao62aNILSSJRIEWKkswS0BuOiJLaWO1RHTmPLOQrTWKVzwxmNGJJ9NMGAAAAAAAAAAAiUSCb/fBsMyKz8/3kPZwT22tcWIL2n7umqVjBMS9I4ccbEQAAAAABcAEBAXEFdGFwYmMBcgEAAAFwZQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGq+37fMIYIQhRNK7IXx7CM1quNmCO+4hXgELi0poTfyAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXEIAAAAAAAAAAABcgABcwgAAAAAAAAAAAF1AAF4AAF6AAABcAEBAXEBAAFyCAAAAAAAAAAAAAFwAQABcQEAAXIIAAAAAAAAAAEBcyECSoIdXsAIcSmDkp3kSLivtsJOWhuXNnuaZbYiDX8IP+MAAXABAAFxAQABcggAAAAAAAAAAAA=",
+      "expected": "cHNidP8BALQCAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAAAAIlEgfHm5sm5GOJXu9WedhViULIbErSIzre8BvD5tVAs2U/4/ao62aNILSSJRIEWKkswS0BuOiJLaWO1RHTmPLOQrTWKVzwxmNGJJ9NMGAAAAAAAAAAAiUSCb/fBsMyKz8/3kPZwT22tcWIL2n7umqVjBMS9I4ccbEQAAAAABcAEBAXEFdGFwYmMBcgEAAAFwZQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGq+37fMIYIQhRNK7IXx7CM1quNmCO+4hXgELi0poTfyAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXEIAAAAAAAAAAABcgABcwgAAAAAAAAAAAF1AAF4AAF6AAABcAEBAXEBAAFyCAAAAAAAAAAAAAFwAQABcQEAAXIIAAAAAAAAAAEBcyEDSoIdXsAIcSmDkp3kSLivtsJOWhuXNnuaZbYiDX8IP+MAAXABAAFxAQABcggAAAAAAAAAAAA=",
       "comment": "minimal packet"
     },
     {
@@ -220,7 +220,7 @@
             "type": 1,
             "interactive": true,
             "anchor_output_index": 0,
-            "anchor_output_internal_key": "bf8fe2f725f33573b77e69e83c36f0d76d375cdbc1e3508550cc59c5b627c90c",
+            "anchor_output_internal_key": "02bf8fe2f725f33573b77e69e83c36f0d76d375cdbc1e3508550cc59c5b627c90c",
             "anchor_output_bip32_derivation": [
               {
                 "pub_key": "02bf8fe2f725f33573b77e69e83c36f0d76d375cdbc1e3508550cc59c5b627c90c",
@@ -318,7 +318,7 @@
             "type": 1,
             "interactive": false,
             "anchor_output_index": 1,
-            "anchor_output_internal_key": "bf8fe2f725f33573b77e69e83c36f0d76d375cdbc1e3508550cc59c5b627c90c",
+            "anchor_output_internal_key": "02bf8fe2f725f33573b77e69e83c36f0d76d375cdbc1e3508550cc59c5b627c90c",
             "anchor_output_bip32_derivation": [
               {
                 "pub_key": "02bf8fe2f725f33573b77e69e83c36f0d76d375cdbc1e3508550cc59c5b627c90c",


### PR DESCRIPTION
The address already contains the internal key as a compressed (33-byte) public key. But the test vectors were incorrectly using the x-only (32-byte) representation of the internal key, which lead to an incorrect stripping of the parity byte in the wrong place, which this PR now fixes.