### PR TITLE
address: add proof courier TLV field to Tap address

### DIFF
--- a/address/address.go
+++ b/address/address.go
@@ -78,6 +78,12 @@ const (
 	TapScriptVersion uint8 = 0
 )
 
+// ProofCourierAddr is the address of the proof courier that will be used to
+// distribute related proofs for this address.
+//
+// NOTE: See the proof package for more details.
+type ProofCourierAddr []byte
+
 // Tap represents a Taproot Asset address. Taproot Asset addresses specify an
 // asset, pubkey, and amount.
 type Tap struct {
@@ -118,6 +124,10 @@ type Tap struct {
 	// assetGen is the receiving asset's genesis metadata which directly
 	// maps to its unique ID within the Taproot Asset protocol.
 	assetGen asset.Genesis
+
+	// ProofCourierAddr is the address of the proof courier that will be
+	// used to distribute related proofs for this address.
+	ProofCourierAddr ProofCourierAddr
 }
 
 // New creates an address for receiving a Taproot asset.
@@ -125,7 +135,7 @@ func New(genesis asset.Genesis, groupKey *btcec.PublicKey,
 	groupSig *schnorr.Signature, scriptKey btcec.PublicKey,
 	internalKey btcec.PublicKey, amt uint64,
 	tapscriptSibling *commitment.TapscriptPreimage,
-	net *ChainParams) (*Tap, error) {
+	net *ChainParams, proofCourierAddr ProofCourierAddr) (*Tap, error) {
 
 	// Check for invalid combinations of asset type and amount.
 	// Collectible assets must have an amount of 1, and Normal assets must
@@ -173,6 +183,7 @@ func New(genesis asset.Genesis, groupKey *btcec.PublicKey,
 		TapscriptSibling: tapscriptSibling,
 		Amount:           amt,
 		assetGen:         genesis,
+		ProofCourierAddr: proofCourierAddr,
 	}
 	return &payload, nil
 }
@@ -312,6 +323,10 @@ func (a *Tap) EncodeRecords() []tlv.Record {
 	}
 	records = append(records, newAddressAmountRecord(&a.Amount))
 
+	records = append(
+		records, newProofCourierAddrRecord(&a.ProofCourierAddr),
+	)
+
 	return records
 }
 
@@ -326,6 +341,7 @@ func (a *Tap) DecodeRecords() []tlv.Record {
 		newAddressInternalKeyRecord(&a.InternalKey),
 		newAddressTapscriptSiblingRecord(&a.TapscriptSibling),
 		newAddressAmountRecord(&a.Amount),
+		newProofCourierAddrRecord(&a.ProofCourierAddr),
 	}
 }
 

--- a/address/address_test.go
+++ b/address/address_test.go
@@ -68,9 +68,11 @@ func randAddress(t *testing.T, net *ChainParams, groupPubKey, sibling bool,
 		groupSig = &groupInfo.Sig
 	}
 
+	proofCourierAddr := RandProofCourierAddr()
+
 	return New(
 		genesis, groupKey, groupSig, pubKeyCopy1, pubKeyCopy2, amount,
-		tapscriptSibling, net,
+		tapscriptSibling, net, proofCourierAddr,
 	)
 }
 

--- a/address/encoding.go
+++ b/address/encoding.go
@@ -40,3 +40,26 @@ func compressedPubKeyDecoder(r io.Reader, val any, buf *[8]byte, l uint64) error
 		val, "*btcec.PublicKey", l, btcec.PubKeyBytesLenCompressed,
 	)
 }
+
+func proofCourierAddrEncoder(w io.Writer, val any, buf *[8]byte) error {
+	if t, ok := val.(*ProofCourierAddr); ok {
+		addrBytes := []byte(*t)
+		return tlv.EVarBytes(w, &addrBytes, buf)
+	}
+	return tlv.NewTypeForEncodingErr(val, "*address.ProofCourierAddr")
+}
+
+func proofCourierAddrDecoder(r io.Reader, val any, buf *[8]byte, l uint64) error {
+	if typ, ok := val.(*ProofCourierAddr); ok {
+		var addrBytes []byte
+		err := tlv.DVarBytes(r, &addrBytes, buf, l)
+		if err != nil {
+			return err
+		}
+		*typ = addrBytes
+		return nil
+	}
+	return tlv.NewTypeForDecodingErr(
+		val, "*address.ProofCourierAddr", l, l,
+	)
+}

--- a/address/mock.go
+++ b/address/mock.go
@@ -207,7 +207,7 @@ func (ta *TestAddress) ToAddress(t testing.TB) *Tap {
 		ScriptKey:        *test.ParsePubKey(t, ta.ScriptKey),
 		InternalKey:      *test.ParsePubKey(t, ta.InternalKey),
 		Amount:           ta.Amount,
-		ProofCourierAddr: test.ParseHex(t, ta.ProofCourierAddr),
+		ProofCourierAddr: ProofCourierAddr(ta.ProofCourierAddr),
 	}
 
 	if ta.GroupKey != "" {

--- a/address/records.go
+++ b/address/records.go
@@ -99,7 +99,7 @@ func newProofCourierAddrRecord(addr *ProofCourierAddr) tlv.Record {
 	addrBytes := []byte(*addr)
 	recordSize := tlv.SizeVarBytes(&addrBytes)
 	return tlv.MakeDynamicRecord(
-		addrProofCourierAddrType, &addrBytes, recordSize,
-		tlv.EVarBytes, tlv.DVarBytes,
+		addrProofCourierAddrType, addr, recordSize,
+		proofCourierAddrEncoder, proofCourierAddrDecoder,
 	)
 }

--- a/address/records.go
+++ b/address/records.go
@@ -32,6 +32,9 @@ const (
 
 	// addrAmountType is the TLV type of the amount of the asset.
 	addrAmountType addressTLVType = 8
+
+	// addrProofCourierType is the TLV type of the proof courier address.
+	addrProofCourierAddrType addressTLVType = 10
 )
 
 func newAddressVersionRecord(version *asset.Version) tlv.Record {
@@ -89,5 +92,14 @@ func newAddressAmountRecord(amount *uint64) tlv.Record {
 	return tlv.MakeDynamicRecord(
 		addrAmountType, amount, recordSize,
 		asset.VarIntEncoder, asset.VarIntDecoder,
+	)
+}
+
+func newProofCourierAddrRecord(addr *ProofCourierAddr) tlv.Record {
+	addrBytes := []byte(*addr)
+	recordSize := tlv.SizeVarBytes(&addrBytes)
+	return tlv.MakeDynamicRecord(
+		addrProofCourierAddrType, &addrBytes, recordSize,
+		tlv.EVarBytes, tlv.DVarBytes,
 	)
 }

--- a/address/testdata/address_tlv_encoding_generated.json
+++ b/address/testdata/address_tlv_encoding_generated.json
@@ -9,9 +9,10 @@
         "script_key": "02a0afeb165f0ec36880b68e0baabd9ad9c62fd1a69aa998bc30e9a346202e078f",
         "internal_key": "02a0afeb165f0ec36880b68e0baabd9ad9c62fd1a69aa998bc30e9a346202e078f",
         "tapscript_sibling": "",
-        "amount": 5577006791947779410
+        "amount": 5577006791947779410,
+        "proof_courier_addr": "hashmail://rand.hashmail.proof.courier.oIYbI:443"
       },
-      "expected": "taprt1qqqsqq3q0gupzcctkv6s83jndsazy0fu4m9e8lj47je589fgahe8kyxn36fsgggz5zh7k9jlpmpk3q9k3c9640v6m8rzl5dxn25e30psax35vgpwq78svggz5zh7k9jlpmpk3q9k3c9640v6m8rzl5dxn25e30psax35vgpwq78ssz0lf4jcygg8ln74ypww4de",
+      "expected": "taprt1qqqsqq3q0gupzcctkv6s83jndsazy0fu4m9e8lj47je589fgahe8kyxn36fsgggz5zh7k9jlpmpk3q9k3c9640v6m8rzl5dxn25e30psax35vgpwq78svggz5zh7k9jlpmpk3q9k3c9640v6m8rzl5dxn25e30psax35vgpwq78ssz0lf4jcygg8ln74yz3sdpshx6rdv95kcw309aexzmny9e5xzumgd4skjmpwwpex7mmx9e3k7atjd9jhytn0f9vkyjf6xs6rxxwr5d8",
       "comment": "valid regtest address"
     },
     {
@@ -23,9 +24,10 @@
         "script_key": "02a0afeb165f0ec36880b68e0baabd9ad9c62fd1a69aa998bc30e9a346202e078f",
         "internal_key": "02a0afeb165f0ec36880b68e0baabd9ad9c62fd1a69aa998bc30e9a346202e078f",
         "tapscript_sibling": "",
-        "amount": 3510942875414458836
+        "amount": 3510942875414458836,
+        "proof_courier_addr": "hashmail://rand.hashmail.proof.courier.EzMoN:443"
       },
-      "expected": "tapsb1qqqsqq3q3t94z4pxzsja6cflmgvaacq22854c6fpm790gzzmc358q6u5dlkqgggz5zh7k9jlpmpk3q9k3c9640v6m8rzl5dxn25e30psax35vgpwq78svggz5zh7k9jlpmpk3q9k3c9640v6m8rzl5dxn25e30psax35vgpwq78ssz0lxzu4luvrc3cagnze50n",
+      "expected": "tapsb1qqqsqq3q3t94z4pxzsja6cflmgvaacq22854c6fpm790gzzmc358q6u5dlkqgggz5zh7k9jlpmpk3q9k3c9640v6m8rzl5dxn25e30psax35vgpwq78svggz5zh7k9jlpmpk3q9k3c9640v6m8rzl5dxn25e30psax35vgpwq78ssz0lxzu4luvrc3cagz3sdpshx6rdv95kcw309aexzmny9e5xzumgd4skjmpwwpex7mmx9e3k7atjd9jhytj90fxk7n36xs6rxepfdjc",
       "comment": "valid simnet address"
     },
     {
@@ -37,9 +39,10 @@
         "script_key": "02a0afeb165f0ec36880b68e0baabd9ad9c62fd1a69aa998bc30e9a346202e078f",
         "internal_key": "02a0afeb165f0ec36880b68e0baabd9ad9c62fd1a69aa998bc30e9a346202e078f",
         "tapscript_sibling": "",
-        "amount": 2740103009342231109
+        "amount": 2740103009342231109,
+        "proof_courier_addr": "hashmail://rand.hashmail.proof.courier.lXPwU:443"
       },
-      "expected": "taptb1qqqsqq3qvpzeew6dfe483wx9s4zl9lszdtfp00c04lhdtl678vehn3jcmhesgggz5zh7k9jlpmpk3q9k3c9640v6m8rzl5dxn25e30psax35vgpwq78svggz5zh7k9jlpmpk3q9k3c9640v6m8rzl5dxn25e30psax35vgpwq78ssz0lycrv626h62fy2yh5nl9",
+      "expected": "taptb1qqqsqq3qvpzeew6dfe483wx9s4zl9lszdtfp00c04lhdtl678vehn3jcmhesgggz5zh7k9jlpmpk3q9k3c9640v6m8rzl5dxn25e30psax35vgpwq78svggz5zh7k9jlpmpk3q9k3c9640v6m8rzl5dxn25e30psax35vgpwq78ssz0lycrv626h62fy2z3sdpshx6rdv95kcw309aexzmny9e5xzumgd4skjmpwwpex7mmx9e3k7atjd9jhytnvtpg8w4f6xs6rx43mhqe",
       "comment": "valid testnet address"
     },
     {
@@ -51,9 +54,10 @@
         "script_key": "02a0afeb165f0ec36880b68e0baabd9ad9c62fd1a69aa998bc30e9a346202e078f",
         "internal_key": "02a0afeb165f0ec36880b68e0baabd9ad9c62fd1a69aa998bc30e9a346202e078f",
         "tapscript_sibling": "",
-        "amount": 545291762129038907
+        "amount": 545291762129038907,
+        "proof_courier_addr": "hashmail://rand.hashmail.proof.courier.JoCpC:443"
       },
-      "expected": "tapbc1qqqsqq3q7trsuynpkaslpxzfnyv2eakv7xxhm88he447pj2qvv8svsatsvkqgggz5zh7k9jlpmpk3q9k3c9640v6m8rzl5dxn25e30psax35vgpwq78svggz5zh7k9jlpmpk3q9k3c9640v6m8rzl5dxn25e30psax35vgpwq78ssz0lq7g58al55hhrk5kk8n8",
+      "expected": "tapbc1qqqsqq3q7trsuynpkaslpxzfnyv2eakv7xxhm88he447pj2qvv8svsatsvkqgggz5zh7k9jlpmpk3q9k3c9640v6m8rzl5dxn25e30psax35vgpwq78svggz5zh7k9jlpmpk3q9k3c9640v6m8rzl5dxn25e30psax35vgpwq78ssz0lq7g58al55hhrkz3sdpshx6rdv95kcw309aexzmny9e5xzumgd4skjmpwwpex7mmx9e3k7atjd9jhytj2daphqse6xs6rxurf9ze",
       "comment": "valid mainnet address"
     },
     {
@@ -65,9 +69,10 @@
         "script_key": "02a0afeb165f0ec36880b68e0baabd9ad9c62fd1a69aa998bc30e9a346202e078f",
         "internal_key": "02a0afeb165f0ec36880b68e0baabd9ad9c62fd1a69aa998bc30e9a346202e078f",
         "tapscript_sibling": "",
-        "amount": 1
+        "amount": 1,
+        "proof_courier_addr": "hashmail://rand.hashmail.proof.courier.FnRzw:443"
       },
-      "expected": "taptb1qqqsqq3q0uaffvcy3m9uunetz6rw9hufhhjj6h4drtksz8m4lfjh3h9tpqusxggr7vkj8xgy6xka4eeg6xgh499ur5sy2kcjkfg6jg3dqd09q99f7avsgggz5zh7k9jlpmpk3q9k3c9640v6m8rzl5dxn25e30psax35vgpwq78svggz5zh7k9jlpmpk3q9k3c9640v6m8rzl5dxn25e30psax35vgpwq78ssqgph6yqh4",
+      "expected": "taptb1qqqsqq3q0uaffvcy3m9uunetz6rw9hufhhjj6h4drtksz8m4lfjh3h9tpqusxggr7vkj8xgy6xka4eeg6xgh499ur5sy2kcjkfg6jg3dqd09q99f7avsgggz5zh7k9jlpmpk3q9k3c9640v6m8rzl5dxn25e30psax35vgpwq78svggz5zh7k9jlpmpk3q9k3c9640v6m8rzl5dxn25e30psax35vgpwq78ssqgppgcxsctndpkkz6tv8ghj7unpdejzu6rpwd5x6ctfdsh8qun0danzucm0w4exjetj9erxu5n6wuargdpngctwqn",
       "comment": "signet group collectible"
     },
     {
@@ -79,9 +84,10 @@
         "script_key": "02a0afeb165f0ec36880b68e0baabd9ad9c62fd1a69aa998bc30e9a346202e078f",
         "internal_key": "02a0afeb165f0ec36880b68e0baabd9ad9c62fd1a69aa998bc30e9a346202e078f",
         "tapscript_sibling": "",
-        "amount": 1
+        "amount": 1,
+        "proof_courier_addr": "hashmail://rand.hashmail.proof.courier.QEuMt:443"
       },
-      "expected": "tapsb1qqqsqq3q0ksqh36tl6terqrl5gxmampzvdyfqnntl2xpp26rfy3rd8jdgarsgggz5zh7k9jlpmpk3q9k3c9640v6m8rzl5dxn25e30psax35vgpwq78svggz5zh7k9jlpmpk3q9k3c9640v6m8rzl5dxn25e30psax35vgpwq78ssqgp9p8f9l",
+      "expected": "tapsb1qqqsqq3q0ksqh36tl6terqrl5gxmampzvdyfqnntl2xpp26rfy3rd8jdgarsgggz5zh7k9jlpmpk3q9k3c9640v6m8rzl5dxn25e30psax35vgpwq78svggz5zh7k9jlpmpk3q9k3c9640v6m8rzl5dxn25e30psax35vgpwq78ssqgppgcxsctndpkkz6tv8ghj7unpdejzu6rpwd5x6ctfdsh8qun0danzucm0w4exjetj9eg52a2dwsargdpnsvxyc0",
       "comment": "simnet collectible"
     },
     {
@@ -93,9 +99,10 @@
         "script_key": "02a0afeb165f0ec36880b68e0baabd9ad9c62fd1a69aa998bc30e9a346202e078f",
         "internal_key": "02a0afeb165f0ec36880b68e0baabd9ad9c62fd1a69aa998bc30e9a346202e078f",
         "tapscript_sibling": "00c0126e6f7420612076616c696420736372697074",
-        "amount": 1
+        "amount": 1,
+        "proof_courier_addr": "hashmail://rand.hashmail.proof.courier.RtmoR:443"
       },
-      "expected": "tapsb1qqqsqq3qkcpam2h6cwmz200z8tspjd03pzlwjcmrah0hw3tvpcjw66n8v58sgggz5zh7k9jlpmpk3q9k3c9640v6m8rzl5dxn25e30psax35vgpwq78svggz5zh7k9jlpmpk3q9k3c9640v6m8rzl5dxn25e30psax35vgpwq78sw9gqcqfxumm5ypsjqanpd35kggrnvdexjur5pqqszpq7nl3",
+      "expected": "tapsb1qqqsqq3qkcpam2h6cwmz200z8tspjd03pzlwjcmrah0hw3tvpcjw66n8v58sgggz5zh7k9jlpmpk3q9k3c9640v6m8rzl5dxn25e30psax35vgpwq78svggz5zh7k9jlpmpk3q9k3c9640v6m8rzl5dxn25e30psax35vgpwq78sw9gqcqfxumm5ypsjqanpd35kggrnvdexjur5pqqszz3sdpshx6rdv95kcw309aexzmny9e5xzumgd4skjmpwwpex7mmx9e3k7atjd9jhytjjw3kk7536xs6rxmrwgxq",
       "comment": "simnet collectible with sibling"
     }
   ],

--- a/address/testdata/address_tlv_encoding_generated.json
+++ b/address/testdata/address_tlv_encoding_generated.json
@@ -10,9 +10,9 @@
         "internal_key": "02a0afeb165f0ec36880b68e0baabd9ad9c62fd1a69aa998bc30e9a346202e078f",
         "tapscript_sibling": "",
         "amount": 5577006791947779410,
-        "proof_courier_addr": "hashmail://rand.hashmail.proof.courier.oIYbI:443"
+        "proof_courier_addr": "hashmail://rand.hashmail.proof.courier.qaesC:443"
       },
-      "expected": "taprt1qqqsqq3q0gupzcctkv6s83jndsazy0fu4m9e8lj47je589fgahe8kyxn36fsgggz5zh7k9jlpmpk3q9k3c9640v6m8rzl5dxn25e30psax35vgpwq78svggz5zh7k9jlpmpk3q9k3c9640v6m8rzl5dxn25e30psax35vgpwq78ssz0lf4jcygg8ln74yz3sdpshx6rdv95kcw309aexzmny9e5xzumgd4skjmpwwpex7mmx9e3k7atjd9jhytn0f9vkyjf6xs6rxxwr5d8",
+      "expected": "taprt1qqqsqq3q0gupzcctkv6s83jndsazy0fu4m9e8lj47je589fgahe8kyxn36fsgggz5zh7k9jlpmpk3q9k3c9640v6m8rzl5dxn25e30psax35vgpwq78svggz5zh7k9jlpmpk3q9k3c9640v6m8rzl5dxn25e30psax35vgpwq78ssz0lf4jcygg8ln74yz3sdpshx6rdv95kcw309aexzmny9e5xzumgd4skjmpwwpex7mmx9e3k7atjd9jhytn3v9jhxse6xs6rxknyrta",
       "comment": "valid regtest address"
     },
     {
@@ -25,9 +25,9 @@
         "internal_key": "02a0afeb165f0ec36880b68e0baabd9ad9c62fd1a69aa998bc30e9a346202e078f",
         "tapscript_sibling": "",
         "amount": 3510942875414458836,
-        "proof_courier_addr": "hashmail://rand.hashmail.proof.courier.EzMoN:443"
+        "proof_courier_addr": "hashmail://rand.hashmail.proof.courier.aCZiu:443"
       },
-      "expected": "tapsb1qqqsqq3q3t94z4pxzsja6cflmgvaacq22854c6fpm790gzzmc358q6u5dlkqgggz5zh7k9jlpmpk3q9k3c9640v6m8rzl5dxn25e30psax35vgpwq78svggz5zh7k9jlpmpk3q9k3c9640v6m8rzl5dxn25e30psax35vgpwq78ssz0lxzu4luvrc3cagz3sdpshx6rdv95kcw309aexzmny9e5xzumgd4skjmpwwpex7mmx9e3k7atjd9jhytj90fxk7n36xs6rxepfdjc",
+      "expected": "tapsb1qqqsqq3q3t94z4pxzsja6cflmgvaacq22854c6fpm790gzzmc358q6u5dlkqgggz5zh7k9jlpmpk3q9k3c9640v6m8rzl5dxn25e30psax35vgpwq78svggz5zh7k9jlpmpk3q9k3c9640v6m8rzl5dxn25e30psax35vgpwq78ssz0lxzu4luvrc3cagz3sdpshx6rdv95kcw309aexzmny9e5xzumgd4skjmpwwpex7mmx9e3k7atjd9jhytnpgddxjaf6xs6rxrauttp",
       "comment": "valid simnet address"
     },
     {
@@ -40,9 +40,9 @@
         "internal_key": "02a0afeb165f0ec36880b68e0baabd9ad9c62fd1a69aa998bc30e9a346202e078f",
         "tapscript_sibling": "",
         "amount": 2740103009342231109,
-        "proof_courier_addr": "hashmail://rand.hashmail.proof.courier.lXPwU:443"
+        "proof_courier_addr": "hashmail://rand.hashmail.proof.courier.cYhkG:443"
       },
-      "expected": "taptb1qqqsqq3qvpzeew6dfe483wx9s4zl9lszdtfp00c04lhdtl678vehn3jcmhesgggz5zh7k9jlpmpk3q9k3c9640v6m8rzl5dxn25e30psax35vgpwq78svggz5zh7k9jlpmpk3q9k3c9640v6m8rzl5dxn25e30psax35vgpwq78ssz0lycrv626h62fy2z3sdpshx6rdv95kcw309aexzmny9e5xzumgd4skjmpwwpex7mmx9e3k7atjd9jhytnvtpg8w4f6xs6rx43mhqe",
+      "expected": "taptb1qqqsqq3qvpzeew6dfe483wx9s4zl9lszdtfp00c04lhdtl678vehn3jcmhesgggz5zh7k9jlpmpk3q9k3c9640v6m8rzl5dxn25e30psax35vgpwq78svggz5zh7k9jlpmpk3q9k3c9640v6m8rzl5dxn25e30psax35vgpwq78ssz0lycrv626h62fy2z3sdpshx6rdv95kcw309aexzmny9e5xzumgd4skjmpwwpex7mmx9e3k7atjd9jhytnrt95xk3e6xs6rx36yaql",
       "comment": "valid testnet address"
     },
     {
@@ -55,9 +55,9 @@
         "internal_key": "02a0afeb165f0ec36880b68e0baabd9ad9c62fd1a69aa998bc30e9a346202e078f",
         "tapscript_sibling": "",
         "amount": 545291762129038907,
-        "proof_courier_addr": "hashmail://rand.hashmail.proof.courier.JoCpC:443"
+        "proof_courier_addr": "hashmail://rand.hashmail.proof.courier.lDHTZ:443"
       },
-      "expected": "tapbc1qqqsqq3q7trsuynpkaslpxzfnyv2eakv7xxhm88he447pj2qvv8svsatsvkqgggz5zh7k9jlpmpk3q9k3c9640v6m8rzl5dxn25e30psax35vgpwq78svggz5zh7k9jlpmpk3q9k3c9640v6m8rzl5dxn25e30psax35vgpwq78ssz0lq7g58al55hhrkz3sdpshx6rdv95kcw309aexzmny9e5xzumgd4skjmpwwpex7mmx9e3k7atjd9jhytj2daphqse6xs6rxurf9ze",
+      "expected": "tapbc1qqqsqq3q7trsuynpkaslpxzfnyv2eakv7xxhm88he447pj2qvv8svsatsvkqgggz5zh7k9jlpmpk3q9k3c9640v6m8rzl5dxn25e30psax35vgpwq78svggz5zh7k9jlpmpk3q9k3c9640v6m8rzl5dxn25e30psax35vgpwq78ssz0lq7g58al55hhrkz3sdpshx6rdv95kcw309aexzmny9e5xzumgd4skjmpwwpex7mmx9e3k7atjd9jhytnvg3y9gk36xs6rxzncwzv",
       "comment": "valid mainnet address"
     },
     {
@@ -70,9 +70,9 @@
         "internal_key": "02a0afeb165f0ec36880b68e0baabd9ad9c62fd1a69aa998bc30e9a346202e078f",
         "tapscript_sibling": "",
         "amount": 1,
-        "proof_courier_addr": "hashmail://rand.hashmail.proof.courier.FnRzw:443"
+        "proof_courier_addr": "hashmail://rand.hashmail.proof.courier.xWYGz:443"
       },
-      "expected": "taptb1qqqsqq3q0uaffvcy3m9uunetz6rw9hufhhjj6h4drtksz8m4lfjh3h9tpqusxggr7vkj8xgy6xka4eeg6xgh499ur5sy2kcjkfg6jg3dqd09q99f7avsgggz5zh7k9jlpmpk3q9k3c9640v6m8rzl5dxn25e30psax35vgpwq78svggz5zh7k9jlpmpk3q9k3c9640v6m8rzl5dxn25e30psax35vgpwq78ssqgppgcxsctndpkkz6tv8ghj7unpdejzu6rpwd5x6ctfdsh8qun0danzucm0w4exjetj9erxu5n6wuargdpngctwqn",
+      "expected": "taptb1qqqsqq3q0uaffvcy3m9uunetz6rw9hufhhjj6h4drtksz8m4lfjh3h9tpqusxggr7vkj8xgy6xka4eeg6xgh499ur5sy2kcjkfg6jg3dqd09q99f7avsgggz5zh7k9jlpmpk3q9k3c9640v6m8rzl5dxn25e30psax35vgpwq78svggz5zh7k9jlpmpk3q9k3c9640v6m8rzl5dxn25e30psax35vgpwq78ssqgppgcxsctndpkkz6tv8ghj7unpdejzu6rpwd5x6ctfdsh8qun0danzucm0w4exjetj9eu9wk280gargdpncmrqcv",
       "comment": "signet group collectible"
     },
     {
@@ -85,9 +85,9 @@
         "internal_key": "02a0afeb165f0ec36880b68e0baabd9ad9c62fd1a69aa998bc30e9a346202e078f",
         "tapscript_sibling": "",
         "amount": 1,
-        "proof_courier_addr": "hashmail://rand.hashmail.proof.courier.QEuMt:443"
+        "proof_courier_addr": "hashmail://rand.hashmail.proof.courier.ctzay:443"
       },
-      "expected": "tapsb1qqqsqq3q0ksqh36tl6terqrl5gxmampzvdyfqnntl2xpp26rfy3rd8jdgarsgggz5zh7k9jlpmpk3q9k3c9640v6m8rzl5dxn25e30psax35vgpwq78svggz5zh7k9jlpmpk3q9k3c9640v6m8rzl5dxn25e30psax35vgpwq78ssqgppgcxsctndpkkz6tv8ghj7unpdejzu6rpwd5x6ctfdsh8qun0danzucm0w4exjetj9eg52a2dwsargdpnsvxyc0",
+      "expected": "tapsb1qqqsqq3q0ksqh36tl6terqrl5gxmampzvdyfqnntl2xpp26rfy3rd8jdgarsgggz5zh7k9jlpmpk3q9k3c9640v6m8rzl5dxn25e30psax35vgpwq78svggz5zh7k9jlpmpk3q9k3c9640v6m8rzl5dxn25e30psax35vgpwq78ssqgppgcxsctndpkkz6tv8ghj7unpdejzu6rpwd5x6ctfdsh8qun0danzucm0w4exjetj9e3hg7np0yargdpnz3vtjv",
       "comment": "simnet collectible"
     },
     {
@@ -100,9 +100,9 @@
         "internal_key": "02a0afeb165f0ec36880b68e0baabd9ad9c62fd1a69aa998bc30e9a346202e078f",
         "tapscript_sibling": "00c0126e6f7420612076616c696420736372697074",
         "amount": 1,
-        "proof_courier_addr": "hashmail://rand.hashmail.proof.courier.RtmoR:443"
+        "proof_courier_addr": "hashmail://rand.hashmail.proof.courier.DaCwk:443"
       },
-      "expected": "tapsb1qqqsqq3qkcpam2h6cwmz200z8tspjd03pzlwjcmrah0hw3tvpcjw66n8v58sgggz5zh7k9jlpmpk3q9k3c9640v6m8rzl5dxn25e30psax35vgpwq78svggz5zh7k9jlpmpk3q9k3c9640v6m8rzl5dxn25e30psax35vgpwq78sw9gqcqfxumm5ypsjqanpd35kggrnvdexjur5pqqszz3sdpshx6rdv95kcw309aexzmny9e5xzumgd4skjmpwwpex7mmx9e3k7atjd9jhytjjw3kk7536xs6rxmrwgxq",
+      "expected": "tapsb1qqqsqq3qkcpam2h6cwmz200z8tspjd03pzlwjcmrah0hw3tvpcjw66n8v58sgggz5zh7k9jlpmpk3q9k3c9640v6m8rzl5dxn25e30psax35vgpwq78svggz5zh7k9jlpmpk3q9k3c9640v6m8rzl5dxn25e30psax35vgpwq78sw9gqcqfxumm5ypsjqanpd35kggrnvdexjur5pqqszz3sdpshx6rdv95kcw309aexzmny9e5xzumgd4skjmpwwpex7mmx9e3k7atjd9jhytjyv9phw6e6xs6rxu5625l",
       "comment": "simnet collectible with sibling"
     }
   ],

--- a/proof/courier.go
+++ b/proof/courier.go
@@ -21,6 +21,8 @@ import (
 
 // CourierType is an enum that represents the different types of proof courier
 // services.
+//
+// TODO(ffranr): rename to CourierProtocol
 type CourierType int64
 
 const (
@@ -30,8 +32,46 @@ const (
 
 	// ApertureCourier is a courier that uses the hashmail protocol to
 	// deliver proofs.
+	//
+	// TODO(ffranr): rename to HashmailCourier (use protocol name rather
+	//  than service)
 	ApertureCourier
 )
+
+// Convert CourierProtocol to string
+func (p CourierType) String() string {
+	switch p {
+	case ApertureCourier:
+		return "hashmail"
+	default:
+		return "disabled_courier"
+	}
+}
+
+// CourierAddr is the address of the proof courier that will be used to
+// distribute related proofs for this address.
+type CourierAddr struct {
+	// Protocol is the protocol of the proof courier.
+	Protocol CourierType
+
+	// Port is the port of the proof courier.
+	Port uint16
+
+	// Hostname is the hostname of the proof courier service.
+	Hostname string
+}
+
+// String returns the URI string representation of the proof courier address.
+func (a CourierAddr) String() string {
+	return fmt.Sprintf(
+		"%s://%s:%d", a.Protocol.String(), a.Hostname, a.Port,
+	)
+}
+
+// Bytes returns the byte representation of the proof courier address.
+func (a CourierAddr) Bytes() []byte {
+	return []byte(a.String())
+}
 
 // CourierHarness interface is an integration testing harness for a proof
 // courier service.

--- a/tapcfg/config.go
+++ b/tapcfg/config.go
@@ -66,9 +66,13 @@ const (
 	// batch.
 	defaultBatchMintingInterval = time.Minute * 10
 
-	// defaultHashMailAddr is the default address we'll use to deliver
+	// defaultHashMailPort is the default hashmail service port we'll use to
 	// optionally deliver proofs for asynchronous sends.
-	defaultHashMailAddr = "mailbox.terminal.lightning.today:443"
+	defaultHashMailPort = 443
+
+	// defaultHashMailHostname is the default hashmail service hostname that
+	// we'll use to optionally deliver proofs for asynchronous sends.
+	defaultHashMailHostname = "mailbox.terminal.lightning.today"
 
 	// DatabaseBackendSqlite is the name of the SQLite database backend.
 	DatabaseBackendSqlite = "sqlite"
@@ -288,6 +292,10 @@ type Config struct {
 
 // DefaultConfig returns all default values for the Config struct.
 func DefaultConfig() Config {
+	hashMailAddr := fmt.Sprintf(
+		"%s:%d", defaultHashMailHostname, defaultHashMailPort,
+	)
+
 	return Config{
 		TapdDir:        DefaultTapdDir,
 		ConfigFile:     DefaultConfigFile,
@@ -325,7 +333,7 @@ func DefaultConfig() Config {
 		LogWriter:            build.NewRotatingLogWriter(),
 		BatchMintingInterval: defaultBatchMintingInterval,
 		HashMailCourier: &proof.HashMailCourierCfg{
-			Addr:               defaultHashMailAddr,
+			Addr:               hashMailAddr,
 			ReceiverAckTimeout: defaultProofTransferReceiverAckTimeout,
 			BackoffCfg: &proof.BackoffCfg{
 				BackoffResetWait: defaultProofTransferBackoffResetWait,

--- a/tapcfg/server.go
+++ b/tapcfg/server.go
@@ -92,12 +92,18 @@ func genServerConfig(cfg *Config, cfgLogger btclog.Logger,
 	keyRing := tap.NewLndRpcKeyRing(lndServices)
 	walletAnchor := tap.NewLndRpcWalletAnchor(lndServices)
 	chainBridge := tap.NewLndRpcChainBridge(lndServices)
+	proofCourierAddr := &proof.CourierAddr{
+		Protocol: proof.ApertureCourier,
+		Port:     defaultHashMailPort,
+		Hostname: defaultHashMailHostname,
+	}
 
 	addrBook := address.NewBook(address.BookConfig{
-		Store:        tapdbAddrBook,
-		StoreTimeout: tapdb.DefaultStoreTimeout,
-		KeyRing:      keyRing,
-		Chain:        tapChainParams,
+		Store:            tapdbAddrBook,
+		StoreTimeout:     tapdb.DefaultStoreTimeout,
+		KeyRing:          keyRing,
+		Chain:            tapChainParams,
+		ProofCourierAddr: proofCourierAddr.Bytes(),
 	})
 
 	assetStore := tapdb.NewAssetStore(assetDB)

--- a/tapdb/addrs.go
+++ b/tapdb/addrs.go
@@ -311,7 +311,7 @@ func (t *TapAddressBook) QueryAddrs(ctx context.Context,
 		dbAddrs, err := db.FetchAddrs(ctx, AddrQuery{
 			CreatedAfter:  params.CreatedAfter.UTC(),
 			CreatedBefore: params.CreatedBefore.UTC(),
-			NumOffset:     int32(params.Offset),
+			NumOffset:     params.Offset,
 			NumLimit:      limit,
 			UnmanagedOnly: params.UnmanagedOnly,
 		})

--- a/tapdb/addrs.go
+++ b/tapdb/addrs.go
@@ -416,7 +416,7 @@ func (t *TapAddressBook) QueryAddrs(ctx context.Context,
 			tapAddr, err := address.New(
 				assetGenesis, groupKey, groupSig, *scriptKey,
 				*internalKey, uint64(addr.Amount),
-				tapscriptSibling, t.params,
+				tapscriptSibling, t.params, nil,
 			)
 			if err != nil {
 				return fmt.Errorf("unable to make addr: %w", err)
@@ -552,7 +552,7 @@ func fetchAddr(ctx context.Context, db AddrBook, params *address.ChainParams,
 
 	tapAddr, err := address.New(
 		genesis, groupKey, groupSig, *scriptKey, *internalKey,
-		uint64(dbAddr.Amount), tapscriptSibling, params,
+		uint64(dbAddr.Amount), tapscriptSibling, params, nil,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("unable to make addr: %w", err)

--- a/tapdb/addrs_test.go
+++ b/tapdb/addrs_test.go
@@ -149,9 +149,12 @@ func TestAddressInsertion(t *testing.T) {
 
 	// Make a series of new addrs, then insert them into the DB.
 	const numAddrs = 5
+	proofCourierAddr := address.RandProofCourierAddr()
 	addrs := make([]address.AddrWithKeyInfo, numAddrs)
 	for i := 0; i < numAddrs; i++ {
-		addr, assetGen, assetGroup := address.RandAddr(t, chainParams)
+		addr, assetGen, assetGroup := address.RandAddr(
+			t, chainParams, proofCourierAddr,
+		)
 
 		addrs[i] = *addr
 
@@ -168,6 +171,11 @@ func TestAddressInsertion(t *testing.T) {
 	dbAddrs, err := addrBook.QueryAddrs(ctx, address.QueryParams{})
 	require.NoError(t, err)
 
+	// Set proof courier addresses on dbAddrs.
+	for i := range dbAddrs {
+		dbAddrs[i].ProofCourierAddr = proofCourierAddr
+	}
+
 	// The returned addresses should match up exactly.
 	require.Len(t, dbAddrs, numAddrs)
 	assertEqualAddrs(t, addrs, dbAddrs)
@@ -179,6 +187,9 @@ func TestAddressInsertion(t *testing.T) {
 			ctx, &addr.TaprootOutputKey,
 		)
 		require.NoError(t, err)
+
+		dbAddr.ProofCourierAddr = proofCourierAddr
+
 		assertEqualAddr(t, addr, *dbAddr)
 
 		// Also make sure the script key for this address was inserted
@@ -194,6 +205,12 @@ func TestAddressInsertion(t *testing.T) {
 		UnmanagedOnly: true,
 	})
 	require.NoError(t, err)
+
+	// Set proof courier addresses on dbAddrs.
+	for i := range dbAddrs {
+		dbAddrs[i].ProofCourierAddr = proofCourierAddr
+	}
+
 	require.Len(t, dbAddrs, numAddrs)
 	assertEqualAddrs(t, addrs, dbAddrs)
 
@@ -209,6 +226,12 @@ func TestAddressInsertion(t *testing.T) {
 		UnmanagedOnly: true,
 	})
 	require.NoError(t, err)
+
+	// Set proof courier addresses on dbAddrs.
+	for i := range dbAddrs {
+		dbAddrs[i].ProofCourierAddr = proofCourierAddr
+	}
+
 	require.Len(t, dbAddrs, 3)
 
 	// The ORDER BY clause should make sure the unmanaged addresses are
@@ -240,9 +263,12 @@ func TestAddressQuery(t *testing.T) {
 
 	// Make a series of new addrs, then insert them into the DB.
 	const numAddrs = 5
+	proofCourierAddr := address.RandProofCourierAddr()
 	addrs := make([]address.AddrWithKeyInfo, numAddrs)
 	for i := 0; i < numAddrs; i++ {
-		addr, assetGen, assetGroup := address.RandAddr(t, chainParams)
+		addr, assetGen, assetGroup := address.RandAddr(
+			t, chainParams, proofCourierAddr,
+		)
 
 		err := addrBook.db.ExecTx(
 			ctx, &writeTxOpts,
@@ -354,7 +380,10 @@ func TestAddrEventStatusDBEnum(t *testing.T) {
 	// Make sure an event with an invalid status cannot be created. This
 	// should be protected by a CHECK constraint on the column. If this
 	// fails, you need to update that constraint in the DB!
-	addr, assetGen, assetGroup := address.RandAddr(t, chainParams)
+	proofCourierAddr := address.RandProofCourierAddr()
+	addr, assetGen, assetGroup := address.RandAddr(
+		t, chainParams, proofCourierAddr,
+	)
 
 	var writeTxOpts AddrBookTxOptions
 	err := addrBook.db.ExecTx(
@@ -387,10 +416,13 @@ func TestAddrEventCreation(t *testing.T) {
 
 	// Create 5 addresses and then events with unconfirmed transactions.
 	const numAddrs = 5
+	proofCourierAddr := address.RandProofCourierAddr()
 	txns := make([]*lndclient.Transaction, numAddrs)
 	events := make([]*address.Event, numAddrs)
 	for i := 0; i < numAddrs; i++ {
-		addr, assetGen, assetGroup := address.RandAddr(t, chainParams)
+		addr, assetGen, assetGroup := address.RandAddr(
+			t, chainParams, proofCourierAddr,
+		)
 
 		var writeTxOpts AddrBookTxOptions
 		err := addrBook.db.ExecTx(
@@ -411,6 +443,7 @@ func TestAddrEventCreation(t *testing.T) {
 		)
 		require.NoError(t, err)
 
+		event.Addr.ProofCourierAddr = proofCourierAddr
 		events[i] = event
 	}
 
@@ -419,6 +452,12 @@ func TestAddrEventCreation(t *testing.T) {
 		ctx, address.EventQueryParams{},
 	)
 	require.NoError(t, err)
+
+	// Set proof courier address on pending events.
+	for idx := range pendingEvents {
+		pendingEvents[idx].Addr.ProofCourierAddr = proofCourierAddr
+	}
+
 	assertEqualAddrEvents(t, events, pendingEvents)
 
 	// If we try to create the same events again, we should just get the
@@ -429,6 +468,8 @@ func TestAddrEventCreation(t *testing.T) {
 			events[idx].Addr, txns[idx], events[idx].Outpoint.Index,
 		)
 		require.NoError(t, err)
+
+		actual.Addr.ProofCourierAddr = proofCourierAddr
 
 		assertEqualAddrEvent(t, *events[idx], *actual)
 	}
@@ -464,9 +505,12 @@ func TestAddressEventQuery(t *testing.T) {
 
 	// Make a series of new addrs, then insert them into the DB.
 	const numAddrs = 5
+	proofCourierAddr := address.RandProofCourierAddr()
 	addrs := make([]address.AddrWithKeyInfo, numAddrs)
 	for i := 0; i < numAddrs; i++ {
-		addr, assetGen, assetGroup := address.RandAddr(t, chainParams)
+		addr, assetGen, assetGroup := address.RandAddr(
+			t, chainParams, proofCourierAddr,
+		)
 
 		err := addrBook.db.ExecTx(
 			ctx, &writeTxOpts,

--- a/tapgarden/custodian_test.go
+++ b/tapgarden/custodian_test.go
@@ -44,11 +44,13 @@ func newAddrBook(t *testing.T, keyRing *tapgarden.MockKeyRing) (*address.Book,
 
 	addrTx := tapdb.NewTransactionExecutor(db, txCreator)
 	tapdbBook := tapdb.NewTapAddressBook(addrTx, chainParams)
+	proofCourierAddr := address.RandProofCourierAddr()
 	book := address.NewBook(address.BookConfig{
-		Store:        tapdbBook,
-		StoreTimeout: testTimeout,
-		Chain:        *chainParams,
-		KeyRing:      keyRing,
+		Store:            tapdbBook,
+		StoreTimeout:     testTimeout,
+		Chain:            *chainParams,
+		KeyRing:          keyRing,
+		ProofCourierAddr: proofCourierAddr,
 	})
 	return book, tapdbBook, db
 }
@@ -164,7 +166,9 @@ func newHarness(t *testing.T,
 }
 
 func randAddr(h *custodianHarness) *address.AddrWithKeyInfo {
-	addr, genesis, group := address.RandAddr(h.t, &address.RegressionNetTap)
+	addr, genesis, group := address.RandAddr(
+		h.t, &address.RegressionNetTap, h.addrBook.ProofCourierAddr(),
+	)
 
 	err := h.tapdbBook.InsertAssetGen(context.Background(), genesis, group)
 	require.NoError(h.t, err)
@@ -312,7 +316,7 @@ func mustMakeAddr(t *testing.T,
 	var p btcec.PublicKey
 	addr, err := address.New(
 		gen, groupKey, groupSig, scriptKey,
-		p, 1, nil, &address.TestNet3Tap,
+		p, 1, nil, &address.TestNet3Tap, nil,
 	)
 	require.NoError(t, err)
 

--- a/tappsbt/decode_test.go
+++ b/tappsbt/decode_test.go
@@ -100,7 +100,7 @@ func TestEncodingDecoding(t *testing.T) {
 	}{{
 		name: "minimal packet",
 		pkg: func(t *testing.T) *VPacket {
-			addr, _, _ := address.RandAddr(t, testParams)
+			addr, _, _ := address.RandAddr(t, testParams, nil)
 
 			pkg, err := FromAddresses([]*address.Tap{addr.Tap}, 1)
 			require.NoError(t, err)

--- a/tapscript/send_test.go
+++ b/tapscript/send_test.go
@@ -124,9 +124,12 @@ func initSpendScenario(t *testing.T) spendData {
 
 	// Addresses to cover both asset types and all three asset values.
 	// Store the receiver StateKeys as well.
+	proofCourierAddr := address.RandProofCourierAddr()
+
 	address1, err := address.New(
 		state.genesis1, nil, nil, state.receiverPubKey,
 		state.receiverPubKey, state.normalAmt1, nil, &address.MainNetTap,
+		proofCourierAddr,
 	)
 	require.NoError(t, err)
 	state.address1 = *address1
@@ -135,7 +138,7 @@ func initSpendScenario(t *testing.T) spendData {
 	address1CollectGroup, err := address.New(
 		state.genesis1collect, &state.groupKey.GroupPubKey,
 		&state.groupKey.Sig, state.receiverPubKey, state.receiverPubKey,
-		state.collectAmt, nil, &address.TestNet3Tap,
+		state.collectAmt, nil, &address.TestNet3Tap, proofCourierAddr,
 	)
 	require.NoError(t, err)
 	state.address1CollectGroup = *address1CollectGroup
@@ -144,7 +147,8 @@ func initSpendScenario(t *testing.T) spendData {
 
 	address2, err := address.New(
 		state.genesis1, nil, nil, state.receiverPubKey,
-		state.receiverPubKey, state.normalAmt2, nil, &address.MainNetTap,
+		state.receiverPubKey, state.normalAmt2, nil,
+		&address.MainNetTap, proofCourierAddr,
 	)
 	require.NoError(t, err)
 	state.address2 = *address2
@@ -2019,7 +2023,7 @@ var addressValidInputTestCases = []addressValidInputTestCase{{
 		address1testnet, err := address.New(
 			state.genesis1, nil, nil, state.receiverPubKey,
 			state.receiverPubKey, state.normalAmt1, nil,
-			&address.TestNet3Tap,
+			&address.TestNet3Tap, address.RandProofCourierAddr(),
 		)
 		require.NoError(t, err)
 
@@ -2092,6 +2096,7 @@ func TestPayToAddrScript(t *testing.T) {
 	addr1, err := address.New(
 		gen, nil, nil, *recipientScriptKey.PubKey, *internalKey,
 		sendAmt, nil, &address.RegressionNetTap,
+		address.RandProofCourierAddr(),
 	)
 	require.NoError(t, err)
 
@@ -2108,6 +2113,7 @@ func TestPayToAddrScript(t *testing.T) {
 	addr2, err := address.New(
 		gen, nil, nil, *recipientScriptKey.PubKey, *internalKey,
 		sendAmt, sibling, &address.RegressionNetTap,
+		address.RandProofCourierAddr(),
 	)
 	require.NoError(t, err)
 


### PR DESCRIPTION
Add mandatory TLV field. Ensure encoding/decoding unit tests pass.