### PR TITLE
itest: abstract the mint batch stress test 

### DIFF
--- a/itest/addrs_test.go
+++ b/itest/addrs_test.go
@@ -63,13 +63,13 @@ func testAddresses(t *harnessTest) {
 
 		// Make sure that eventually we see a single event for the
 		// address.
-		assertAddrEvent(t.t, secondTapd, addr, 1, statusDetected)
+		AssertAddrEvent(t.t, secondTapd, addr, 1, statusDetected)
 
 		// Mine a block to make sure the events are marked as confirmed.
 		mineBlocks(t, t.lndHarness, 1, 1)
 
 		// Eventually the event should be marked as confirmed.
-		assertAddrEvent(t.t, secondTapd, addr, 1, statusConfirmed)
+		AssertAddrEvent(t.t, secondTapd, addr, 1, statusConfirmed)
 
 		// To complete the transfer, we'll export the proof from the
 		// sender and import it into the receiver for each asset set.
@@ -78,7 +78,7 @@ func testAddresses(t *harnessTest) {
 		)
 
 		// Make sure we have imported and finalized all proofs.
-		assertNonInteractiveRecvComplete(t, secondTapd, idx+1)
+		AssertNonInteractiveRecvComplete(t.t, secondTapd, idx+1)
 
 		// Make sure the asset meta is also fetched correctly.
 		assetResp, err := secondTapd.FetchAssetMeta(
@@ -224,10 +224,10 @@ func runMultiSendTest(ctxt context.Context, t *harnessTest, alice,
 	t.Logf("Got response from sending assets: %v", sendRespJSON)
 
 	// Make sure that eventually we see a single event for the address.
-	assertAddrEvent(t.t, bob, bobAddr1, 1, statusDetected)
-	assertAddrEvent(t.t, bob, bobAddr2, 1, statusDetected)
-	assertAddrEvent(t.t, alice, aliceAddr1, 1, statusDetected)
-	assertAddrEvent(t.t, alice, aliceAddr2, 1, statusDetected)
+	AssertAddrEvent(t.t, bob, bobAddr1, 1, statusDetected)
+	AssertAddrEvent(t.t, bob, bobAddr2, 1, statusDetected)
+	AssertAddrEvent(t.t, alice, aliceAddr1, 1, statusDetected)
+	AssertAddrEvent(t.t, alice, aliceAddr2, 1, statusDetected)
 
 	// Mine a block to make sure the events are marked as confirmed.
 	_ = mineBlocks(t, t.lndHarness, 1, 1)[0]
@@ -248,8 +248,8 @@ func runMultiSendTest(ctxt context.Context, t *harnessTest, alice,
 	}
 
 	// Make sure we have imported and finalized all proofs.
-	assertNonInteractiveRecvComplete(t, bob, numRuns*2)
-	assertNonInteractiveRecvComplete(t, alice, numRuns*2)
+	AssertNonInteractiveRecvComplete(t.t, bob, numRuns*2)
+	AssertNonInteractiveRecvComplete(t.t, alice, numRuns*2)
 
 	// Now sanity check that we can actually list the transfer.
 	const (

--- a/itest/collectible_split_test.go
+++ b/itest/collectible_split_test.go
@@ -119,12 +119,12 @@ func testCollectibleSend(t *harnessTest) {
 	// Check the final state of both nodes. The main node should list 2
 	// zero-value transfers. and Bob should have 1. The main node should
 	// show a balance of zero, and Bob should hold the total asset supply.
-	assertTransfer(t.t, t.tapd, 0, 2, []uint64{0, fullAmount})
-	assertTransfer(t.t, t.tapd, 1, 2, []uint64{0, fullAmount})
-	assertBalanceByID(t.t, t.tapd, genInfo.AssetId, 0)
+	AssertTransfer(t.t, t.tapd, 0, 2, []uint64{0, fullAmount})
+	AssertTransfer(t.t, t.tapd, 1, 2, []uint64{0, fullAmount})
+	AssertBalanceByID(t.t, t.tapd, genInfo.AssetId, 0)
 
-	assertTransfer(t.t, secondTapd, 0, 1, []uint64{0, fullAmount})
-	assertBalanceByID(t.t, secondTapd, genInfo.AssetId, fullAmount)
+	AssertTransfer(t.t, secondTapd, 0, 1, []uint64{0, fullAmount})
+	AssertBalanceByID(t.t, secondTapd, genInfo.AssetId, fullAmount)
 
 	// The second daemon should list one group with one asset.
 	listGroupsResp, err := secondTapd.ListGroups(
@@ -159,7 +159,7 @@ func testCollectibleSend(t *harnessTest) {
 	})
 
 	// Only compare the spendable asset.
-	assertGroup(t.t, allAssets[0], groupedAssets[0], rpcGroupKey)
+	AssertGroup(t.t, allAssets[0], groupedAssets[0], rpcGroupKey)
 
 	aliceAssetsResp, err := t.tapd.ListAssets(
 		ctxb, &taprpc.ListAssetRequest{IncludeSpent: true},
@@ -189,5 +189,5 @@ func testCollectibleSend(t *harnessTest) {
 	)
 
 	// There's only one non-interactive receive event.
-	assertNonInteractiveRecvComplete(t, secondTapd, 3)
+	AssertNonInteractiveRecvComplete(t.t, secondTapd, 3)
 }

--- a/itest/full_value_split_test.go
+++ b/itest/full_value_split_test.go
@@ -116,10 +116,10 @@ func runFullValueSendTests(ctxt context.Context, t *harnessTest, alice,
 	// Check the final state of both nodes. The main node should list 2
 	// zero-value transfers. and Bob should have 1. The main node should
 	// show a balance of zero, and Bob should hold the total asset supply.
-	assertTransfer(t.t, alice, runIdx*2, numRuns*2, []uint64{0, fullAmount})
-	assertTransfer(t.t, alice, runIdx*2+1, numRuns*2, []uint64{0, fullAmount})
-	assertBalanceByID(t.t, alice, genInfo.AssetId, 0)
+	AssertTransfer(t.t, alice, runIdx*2, numRuns*2, []uint64{0, fullAmount})
+	AssertTransfer(t.t, alice, runIdx*2+1, numRuns*2, []uint64{0, fullAmount})
+	AssertBalanceByID(t.t, alice, genInfo.AssetId, 0)
 
-	assertTransfer(t.t, bob, runIdx, numRuns, []uint64{0, fullAmount})
-	assertBalanceByID(t.t, bob, genInfo.AssetId, fullAmount)
+	AssertTransfer(t.t, bob, runIdx, numRuns, []uint64{0, fullAmount})
+	AssertBalanceByID(t.t, bob, genInfo.AssetId, fullAmount)
 }

--- a/itest/interface.go
+++ b/itest/interface.go
@@ -1,0 +1,12 @@
+package itest
+
+import (
+	"github.com/lightninglabs/taproot-assets/taprpc"
+	unirpc "github.com/lightninglabs/taproot-assets/taprpc/universerpc"
+)
+
+// TapdClient is the interface that is used to interact with a tapd instance.
+type TapdClient interface {
+	taprpc.TaprootAssetsClient
+	unirpc.UniverseClient
+}

--- a/itest/mint_batch_stress_test.go
+++ b/itest/mint_batch_stress_test.go
@@ -83,7 +83,7 @@ func mintBatchStressTest(t *harnessTest, batchSize int,
 	}
 
 	// Use the first asset of the batch as the asset group anchor.
-	collectibleAnchorReq := copyRequest(&collectibleRequestTemplate)
+	collectibleAnchorReq := CopyRequest(&collectibleRequestTemplate)
 	incrementMintAsset(collectibleAnchorReq.Asset, 0)
 	collectibleAnchorReq.EnableEmission = true
 	batchReqs[0] = collectibleAnchorReq
@@ -91,7 +91,7 @@ func mintBatchStressTest(t *harnessTest, batchSize int,
 	// Generate the rest of the batch, with each asset referencing the group
 	// anchor we created above.
 	for i := 1; i < batchSize; i++ {
-		groupedAsset := copyRequest(&collectibleRequestTemplate)
+		groupedAsset := CopyRequest(&collectibleRequestTemplate)
 		incrementMintAsset(groupedAsset.Asset, i)
 		groupedAsset.Asset.GroupAnchor = collectibleAnchorReq.Asset.Name
 		batchReqs[i] = groupedAsset
@@ -108,7 +108,7 @@ func mintBatchStressTest(t *harnessTest, batchSize int,
 
 	// We can re-derive the group key to verify that the correct asset was
 	// used as the group anchor.
-	collectibleAnchor := verifyGroupAnchor(
+	collectibleAnchor := VerifyGroupAnchor(
 		t.t, mintBatch, collectibleAnchorReq.Asset.Name,
 	)
 	collectGroupKey := collectibleAnchor.AssetGroup.TweakedGroupKey
@@ -118,11 +118,11 @@ func mintBatchStressTest(t *harnessTest, batchSize int,
 	// equivalent balance, since the group is made of collectibles.
 	groupCount := 1
 	groupBalance := batchSize
-	assertNumGroups(t.t, t.tapd, groupCount)
-	assertGroupSizes(
+	AssertNumGroups(t.t, t.tapd, groupCount)
+	AssertGroupSizes(
 		t.t, t.tapd, []string{collectGroupKeyStr}, []int{batchSize},
 	)
-	assertBalanceByGroup(
+	AssertBalanceByGroup(
 		t.t, t.tapd, collectGroupKeyStr, uint64(groupBalance),
 	)
 
@@ -134,7 +134,7 @@ func mintBatchStressTest(t *harnessTest, batchSize int,
 	require.NoError(t.t, err)
 	require.Len(t.t, uniRoots.UniverseRoots, groupCount)
 
-	err = assertUniverseRoot(
+	err = AssertUniverseRoot(
 		t.t, t.tapd, groupBalance, nil, collectGroupKey,
 	)
 	require.NoError(t.t, err)
@@ -183,6 +183,6 @@ func mintBatchStressTest(t *harnessTest, batchSize int,
 	require.NoError(t.t, err)
 
 	require.Eventually(t.t, func() bool {
-		return assertUniverseStateEqual(t.t, t.tapd, bob)
+		return AssertUniverseStateEqual(t.t, t.tapd, bob)
 	}, minterTimeout, time.Second)
 }

--- a/itest/mint_batch_stress_test.go
+++ b/itest/mint_batch_stress_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"testing"
 	"time"
 
 	"github.com/lightninglabs/taproot-assets/fn"
@@ -30,28 +31,70 @@ var (
 )
 
 func testMintBatch100StressTest(t *harnessTest) {
-	mintBatchStressTest(t, 100, defaultWaitTimeout)
+	batchSize := 100
+	timeout := defaultWaitTimeout
+
+	testMintBatchNStressTest(t, batchSize, timeout)
 }
 
 func testMintBatch1kStressTest(t *harnessTest) {
-	mintBatchStressTest(t, 1000, defaultWaitTimeout*10)
+	batchSize := 1_000
+	timeout := defaultWaitTimeout * 10
+
+	testMintBatchNStressTest(t, batchSize, timeout)
 }
 
 func testMintBatch10kStressTest(t *harnessTest) {
-	mintBatchStressTest(t, 10000, defaultWaitTimeout*100)
+	batchSize := 10_000
+	timeout := defaultWaitTimeout * 100
+
+	testMintBatchNStressTest(t, batchSize, timeout)
 }
 
-func mintBatchStressTest(t *harnessTest, batchSize int,
-	minterTimeout time.Duration) {
+func testMintBatchNStressTest(t *harnessTest, batchSize int,
+	timeout time.Duration) {
 
+	// If we create a second tapd instance and sync the universe state,
+	// the synced tree should match the source tree.
+	bob := setupTapdHarness(
+		t.t, t, t.lndHarness.Bob, nil,
+	)
+	defer func() {
+		require.NoError(t.t, bob.stop(!*noDelete))
+	}()
+
+	mintBatches := func(reqs []*mintrpc.MintAssetRequest) []*taprpc.Asset {
+		return mintAssetsConfirmBatch(
+			t, t.tapd, reqs, withMintingTimeout(timeout),
+		)
+	}
+
+	imageMetadataBytes := GetImageMetadataBytes(t.t, ImageMetadataFileName)
+
+	mintBatchStressTest(
+		t.t, t.tapd, bob, t.tapd.rpcHost(), batchSize, mintBatches,
+		imageMetadataBytes, timeout,
+	)
+}
+
+// GetImageMetadataBytes returns the image metadata bytes from the given file.
+func GetImageMetadataBytes(t *testing.T, fileName string) []byte {
 	// Read base metadata.
-	imageMetadataHex, err := os.ReadFile(ImageMetadataFileName)
-	require.NoError(t.t, err)
+	imageMetadataHex, err := os.ReadFile(fileName)
+	require.NoError(t, err)
 
 	imageMetadataBytes, err := hex.DecodeString(
 		strings.Trim(string(imageMetadataHex), "\n"),
 	)
-	require.NoError(t.t, err)
+	require.NoError(t, err)
+
+	return imageMetadataBytes
+}
+
+func mintBatchStressTest(
+	t *testing.T, alice, bob TapdClient, aliceHost string, batchSize int,
+	mintAssets func([]*mintrpc.MintAssetRequest) []*taprpc.Asset,
+	imageMetadataBytes []byte, minterTimeout time.Duration) {
 
 	var (
 		batchReqs      = make([]*mintrpc.MintAssetRequest, batchSize)
@@ -100,16 +143,17 @@ func mintBatchStressTest(t *harnessTest, batchSize int,
 	// Submit the batch for minting. Use an extended timeout for the TX
 	// appearing in the mempool, so we can observe the minter hitting its
 	// own shorter default timeout.
-	t.LogfTimestamped("beginning minting of batch of %d assets", batchSize)
-	mintBatch := mintAssetsConfirmBatch(
-		t, t.tapd, batchReqs, withMintingTimeout(minterTimeout),
-	)
-	t.LogfTimestamped("finished batch mint of %d assets", batchSize)
+	LogfTimestamped(t, "beginning minting of batch of %d assets",
+		batchSize)
+
+	mintBatch := mintAssets(batchReqs)
+
+	LogfTimestamped(t, "finished batch mint of %d assets", batchSize)
 
 	// We can re-derive the group key to verify that the correct asset was
 	// used as the group anchor.
 	collectibleAnchor := VerifyGroupAnchor(
-		t.t, mintBatch, collectibleAnchorReq.Asset.Name,
+		t, mintBatch, collectibleAnchorReq.Asset.Name,
 	)
 	collectGroupKey := collectibleAnchor.AssetGroup.TweakedGroupKey
 	collectGroupKeyStr := hex.EncodeToString(collectGroupKey[:])
@@ -118,26 +162,30 @@ func mintBatchStressTest(t *harnessTest, batchSize int,
 	// equivalent balance, since the group is made of collectibles.
 	groupCount := 1
 	groupBalance := batchSize
-	AssertNumGroups(t.t, t.tapd, groupCount)
+
+	AssertNumGroups(t, alice, groupCount)
 	AssertGroupSizes(
-		t.t, t.tapd, []string{collectGroupKeyStr}, []int{batchSize},
+		t, alice, []string{collectGroupKeyStr},
+		[]int{batchSize},
 	)
 	AssertBalanceByGroup(
-		t.t, t.tapd, collectGroupKeyStr, uint64(groupBalance),
+		t, alice, collectGroupKeyStr, uint64(groupBalance),
 	)
 
 	// The universe tree should reflect the same properties about the batch;
 	// there should be one root with a group key and balance matching what
 	// we asserted previously.
 	ctx := context.Background()
-	uniRoots, err := t.tapd.AssetRoots(ctx, &unirpc.AssetRootRequest{})
-	require.NoError(t.t, err)
-	require.Len(t.t, uniRoots.UniverseRoots, groupCount)
+	uniRoots, err := alice.AssetRoots(
+		ctx, &unirpc.AssetRootRequest{},
+	)
+	require.NoError(t, err)
+	require.Len(t, uniRoots.UniverseRoots, groupCount)
 
 	err = AssertUniverseRoot(
-		t.t, t.tapd, groupBalance, nil, collectGroupKey,
+		t, alice, groupBalance, nil, collectGroupKey,
 	)
-	require.NoError(t.t, err)
+	require.NoError(t, err)
 
 	// The universe tree should also have a leaf for each asset minted.
 	// TODO(jhb): Resolve issue of 33-byte group key handling.
@@ -146,43 +194,36 @@ func mintBatchStressTest(t *harnessTest, batchSize int,
 			GroupKey: collectGroupKey[1:],
 		},
 	}
-	uniLeaves, err := t.tapd.AssetLeaves(ctx, &collectUniID)
-	require.NoError(t.t, err)
-	require.Len(t.t, uniLeaves.Leaves, batchSize)
+	uniLeaves, err := alice.AssetLeaves(ctx, &collectUniID)
+	require.NoError(t, err)
+	require.Len(t, uniLeaves.Leaves, batchSize)
 
 	// The universe tree should also have a key for each asset, with all
 	// outpoints matching the chain anchor of the group anchor.
 	mintOutpoint := collectibleAnchor.ChainAnchor.AnchorOutpoint
-	uniKeys, err := t.tapd.AssetLeafKeys(ctx, &collectUniID)
-	require.NoError(t.t, err)
-	require.Len(t.t, uniKeys.AssetKeys, batchSize)
+	uniKeys, err := alice.AssetLeafKeys(ctx, &collectUniID)
+	require.NoError(t, err)
+	require.Len(t, uniKeys.AssetKeys, batchSize)
 
 	correctOp := fn.All(uniKeys.AssetKeys, func(key *unirpc.AssetKey) bool {
 		return key.GetOpStr() == mintOutpoint
 	})
-	require.True(t.t, correctOp)
-
-	// If we create a second tapd instance and sync the universe state,
-	// the synced tree should match the source tree.
-	bob := setupTapdHarness(
-		t.t, t, t.lndHarness.Bob, nil,
-	)
-	defer func() {
-		require.NoError(t.t, bob.stop(!*noDelete))
-	}()
+	require.True(t, correctOp)
 
 	_, err = bob.AddFederationServer(
 		ctx, &unirpc.AddFederationServerRequest{
 			Servers: []*unirpc.UniverseFederationServer{
 				{
-					Host: t.tapd.rpcHost(),
+					Host: aliceHost,
 				},
 			},
 		},
 	)
-	require.NoError(t.t, err)
+	require.NoError(t, err)
 
-	require.Eventually(t.t, func() bool {
-		return AssertUniverseStateEqual(t.t, t.tapd, bob)
+	require.Eventually(t, func() bool {
+		return AssertUniverseStateEqual(
+			t, alice, bob,
+		)
 	}, minterTimeout, time.Second)
 }

--- a/itest/psbt_test.go
+++ b/itest/psbt_test.go
@@ -132,7 +132,7 @@ func testPsbtScriptHashLockSend(t *harnessTest) {
 		[]uint64{numUnits / 2, numUnits / 2}, 0, 1,
 	)
 	_ = sendProof(t, bob, alice, aliceAddr.ScriptKey, genInfo)
-	assertNonInteractiveRecvComplete(t, alice, 1)
+	AssertNonInteractiveRecvComplete(t.t, alice, 1)
 
 	aliceAssets, err := alice.ListAssets(ctxb, &taprpc.ListAssetRequest{
 		WithWitness: true,
@@ -256,7 +256,7 @@ func testPsbtScriptCheckSigSend(t *harnessTest) {
 		[]uint64{numUnits / 2, numUnits / 2}, 0, 1,
 	)
 	_ = sendProof(t, bob, alice, aliceAddr.ScriptKey, genInfo)
-	assertNonInteractiveRecvComplete(t, alice, 1)
+	AssertNonInteractiveRecvComplete(t.t, alice, 1)
 
 	aliceAssets, err := alice.ListAssets(ctxb, &taprpc.ListAssetRequest{
 		WithWitness: true,
@@ -458,8 +458,8 @@ func runPsbtInteractiveFullValueSendTest(ctxt context.Context, t *harnessTest,
 		require.NoError(t.t, err)
 		require.Len(t.t, receiverAssets.Assets, numReceiverAssets)
 		receivedAssets := groupAssetsByName(receiverAssets.Assets)
-		assertAssetState(
-			t, receivedAssets, genInfo.Name, genInfo.MetaHash,
+		AssertAssetState(
+			t.t, receivedAssets, genInfo.Name, genInfo.MetaHash,
 			assetAmountCheck(fullAmt),
 		)
 	}
@@ -1021,7 +1021,7 @@ func sendToTapscriptAddr(ctx context.Context, t *harnessTest, alice,
 		[]uint64{changeUnits, numUnits}, 0, 1,
 	)
 	_ = sendProof(t, alice, bob, bobAddr.ScriptKey, genInfo)
-	assertNonInteractiveRecvComplete(t, bob, 1)
+	AssertNonInteractiveRecvComplete(t.t, bob, 1)
 }
 
 func sendAssetAndAssert(ctx context.Context, t *harnessTest, alice,
@@ -1048,5 +1048,5 @@ func sendAssetAndAssert(ctx context.Context, t *harnessTest, alice,
 
 	// There are now two receive events (since only non-interactive sends
 	// appear in that RPC output).
-	assertNonInteractiveRecvComplete(t, bob, numInTransfers)
+	AssertNonInteractiveRecvComplete(t.t, bob, numInTransfers)
 }

--- a/itest/re-issuance_test.go
+++ b/itest/re-issuance_test.go
@@ -30,7 +30,7 @@ func testReIssuance(t *harnessTest) {
 
 	// We'll confirm that the node created two separate groups during
 	// minting.
-	assertNumGroups(t.t, t.tapd, groupCount)
+	AssertNumGroups(t.t, t.tapd, groupCount)
 
 	// We'll store the group keys and geneses from the minting to use
 	// later when creating addresses.
@@ -81,12 +81,12 @@ func testReIssuance(t *harnessTest) {
 
 	// Check the state of both nodes. The first node should show one
 	// zero-value transfer representing the send of the collectible.
-	assertTransfer(t.t, t.tapd, 0, 1, []uint64{0, 1})
-	assertBalanceByID(t.t, t.tapd, collectGenInfo.AssetId, 0)
+	AssertTransfer(t.t, t.tapd, 0, 1, []uint64{0, 1})
+	AssertBalanceByID(t.t, t.tapd, collectGenInfo.AssetId, 0)
 
 	// The second node should show a balance of 1 for exactly one group.
-	assertBalanceByID(t.t, secondTapd, collectGenInfo.AssetId, 1)
-	assertBalanceByGroup(t.t, secondTapd, encodedCollectGroupKey, 1)
+	AssertBalanceByID(t.t, secondTapd, collectGenInfo.AssetId, 1)
+	AssertBalanceByGroup(t.t, secondTapd, encodedCollectGroupKey, 1)
 
 	// Send half of the normal asset to the second node before reissuance.
 	normalGroupAddr, err := secondTapd.NewAddr(
@@ -109,7 +109,7 @@ func testReIssuance(t *harnessTest) {
 
 	// Reissue one more collectible and half the original mint amount for
 	// the normal asset.
-	reissuedAssets := copyRequests(simpleAssets)
+	reissuedAssets := CopyRequests(simpleAssets)
 
 	reissuedAssets[0].Asset.Amount = normalGroupMintHalf
 	reissuedAssets[0].Asset.GroupKey = normalGroupKey
@@ -132,7 +132,7 @@ func testReIssuance(t *harnessTest) {
 
 	// Check the node state after re-issuance. The total number of groups
 	// should still be two.
-	assertNumGroups(t.t, t.tapd, groupCount)
+	AssertNumGroups(t.t, t.tapd, groupCount)
 
 	// The normal group should hold two assets, while the collectible
 	// should only hold one, since the zero-value tombstone is only visible
@@ -148,16 +148,16 @@ func testReIssuance(t *harnessTest) {
 	collectGroup := groupsAfterReissue.Groups[encodedCollectGroupKey]
 	require.Len(t.t, collectGroup.Assets, 1)
 
-	assertSplitTombstoneTransfer(t.t, t.tapd, collectGenInfo.AssetId)
+	AssertSplitTombstoneTransfer(t.t, t.tapd, collectGenInfo.AssetId)
 
 	// The normal group balance should account for the re-issuance and
 	// equal the original mint amount. The collectible group balance should
 	// be back at 1.
-	assertBalanceByGroup(
+	AssertBalanceByGroup(
 		t.t, t.tapd, hex.EncodeToString(normalGroupKey),
 		normalGroupGen[0].Amount,
 	)
-	assertBalanceByGroup(
+	AssertBalanceByGroup(
 		t.t, t.tapd, hex.EncodeToString(collectGroupKey), 1,
 	)
 
@@ -184,7 +184,7 @@ func testReIssuance(t *harnessTest) {
 
 	// The second node should show two groups, with two assets in
 	// the collectible group and a total balance of 2 for that group.
-	assertNumGroups(t.t, secondTapd, groupCount)
+	AssertNumGroups(t.t, secondTapd, groupCount)
 	groupsSecondNode, err := secondTapd.ListGroups(
 		ctxb, &taprpc.ListGroupsRequest{},
 	)
@@ -193,7 +193,7 @@ func testReIssuance(t *harnessTest) {
 	collectGroupSecondNode := groupsSecondNode.Groups[encodedCollectGroupKey]
 	require.Equal(t.t, 2, len(collectGroupSecondNode.Assets))
 
-	assertBalanceByGroup(
+	AssertBalanceByGroup(
 		t.t, secondTapd, hex.EncodeToString(collectGroupKey), 2,
 	)
 
@@ -218,10 +218,10 @@ func testReIssuance(t *harnessTest) {
 
 	// The collectible balance on the minting node should be 1, and there
 	// should still be only two groups.
-	assertBalanceByGroup(
+	AssertBalanceByGroup(
 		t.t, t.tapd, hex.EncodeToString(collectGroupKey), 1,
 	)
-	assertNumGroups(t.t, t.tapd, groupCount)
+	AssertNumGroups(t.t, t.tapd, groupCount)
 }
 
 // testReIssuanceAmountOverflow tests that an error is returned when attempting
@@ -231,7 +231,7 @@ func testReIssuanceAmountOverflow(t *harnessTest) {
 	// endpoint.
 	t.Log("Minting asset with maximum possible amount")
 
-	assetIssueReqs := copyRequests(issuableAssets)
+	assetIssueReqs := CopyRequests(issuableAssets)
 	assetIssueReq := assetIssueReqs[0]
 
 	assetIssueReq.EnableEmission = true
@@ -248,7 +248,7 @@ func testReIssuanceAmountOverflow(t *harnessTest) {
 	// amount supported by the RPC endpoint.
 	t.Log("Re-issuing asset with maximum possible amount")
 
-	assetIssueReqs = copyRequests(simpleAssets)
+	assetIssueReqs = CopyRequests(simpleAssets)
 	assetIssueReq = assetIssueReqs[0]
 
 	// Reissue an amount which is minimally sufficient to lead to an
@@ -282,7 +282,7 @@ func testMintWithGroupKeyErrors(t *harnessTest) {
 
 	// Now, create a minting request to try and reissue into the group
 	// created during minting.
-	reissueRequest := copyRequest(simpleAssets[0])
+	reissueRequest := CopyRequest(simpleAssets[0])
 	reissueRequest.Asset.GroupKey = collectGroupKey
 
 	// A request must not have the emission flag set if a group key is given.

--- a/itest/round_trip_send_test.go
+++ b/itest/round_trip_send_test.go
@@ -112,15 +112,15 @@ func testRoundTripSend(t *harnessTest) {
 	// Check the final state of both nodes. Each node should list
 	// one transfer, and Alice should have 3/4 of the total units.
 	err = wait.NoError(func() error {
-		assertTransfer(t.t, t.tapd, 0, 1, []uint64{bobAmt, bobAmt})
-		assertBalanceByID(
+		AssertTransfer(t.t, t.tapd, 0, 1, []uint64{bobAmt, bobAmt})
+		AssertBalanceByID(
 			t.t, t.tapd, genInfo.AssetId, bobAmt+aliceAmt,
 		)
 
-		assertTransfer(
+		AssertTransfer(
 			t.t, secondTapd, 0, 1, []uint64{aliceAmt, aliceAmt},
 		)
-		assertBalanceByID(t.t, secondTapd, genInfo.AssetId, aliceAmt)
+		AssertBalanceByID(t.t, secondTapd, genInfo.AssetId, aliceAmt)
 
 		return nil
 	}, defaultTimeout/2)

--- a/itest/send_test.go
+++ b/itest/send_test.go
@@ -118,7 +118,7 @@ func testBasicSendUnidirectional(t *harnessTest) {
 		_ = sendProof(
 			t, t.tapd, secondTapd, bobAddr.ScriptKey, genInfo,
 		)
-		assertNonInteractiveRecvComplete(t, secondTapd, i+1)
+		AssertNonInteractiveRecvComplete(t.t, secondTapd, i+1)
 	}
 
 	// Close event stream.
@@ -216,7 +216,7 @@ func testResumePendingPackageSend(t *harnessTest) {
 
 		// Confirm with the receiver node that the asset was fully
 		// received.
-		assertNonInteractiveRecvComplete(t, recvTapd, i+1)
+		AssertNonInteractiveRecvComplete(t.t, recvTapd, i+1)
 	}
 }
 
@@ -289,11 +289,11 @@ func testBasicSendPassiveAsset(t *harnessTest) {
 		[]uint64{expectedAmtAfterSend, numUnitsSend}, 0, 1,
 	)
 	_ = sendProof(t, t.tapd, recvTapd, recvAddr.ScriptKey, genInfo)
-	assertNonInteractiveRecvComplete(t, recvTapd, 1)
+	AssertNonInteractiveRecvComplete(t.t, recvTapd, 1)
 
 	// Assert that the sending node returns the correct asset list via RPC.
 	assertListAssets(
-		t, ctxb, t.tapd, []MatchRpcAsset{
+		t.t, ctxb, t.tapd, []MatchRpcAsset{
 			func(asset *taprpc.Asset) bool {
 				return asset.Amount == 300 &&
 					asset.AssetGenesis.Name == "first-itestbuxx"
@@ -331,7 +331,7 @@ func testBasicSendPassiveAsset(t *harnessTest) {
 		[]uint64{expectedAmtAfterSend, numUnitsSend}, 1, 2,
 	)
 	_ = sendProof(t, t.tapd, recvTapd, recvAddr.ScriptKey, genInfo)
-	assertNonInteractiveRecvComplete(t, recvTapd, 2)
+	AssertNonInteractiveRecvComplete(t.t, recvTapd, 2)
 }
 
 // testReattemptFailedAssetSend tests that a failed attempt at sending an asset
@@ -542,7 +542,7 @@ func testOfflineReceiverEventuallyReceives(t *harnessTest) {
 	// Confirm that the receiver eventually receives the asset. Pause to
 	// give the receiver time to recognise the full send event.
 	t.Logf("Attempting to confirm asset received")
-	assertNonInteractiveRecvComplete(t, recvTapd, 1)
+	AssertNonInteractiveRecvComplete(t.t, recvTapd, 1)
 
 	wg.Wait()
 }
@@ -642,7 +642,7 @@ func testMultiInputSendNonInteractiveSingleID(t *harnessTest) {
 	)
 
 	_ = sendProof(t, t.tapd, bobTapd, addr.ScriptKey, genInfo)
-	assertNonInteractiveRecvComplete(t, bobTapd, 1)
+	AssertNonInteractiveRecvComplete(t.t, bobTapd, 1)
 
 	// Second of two send events from minting node to the secondary node.
 	addr, err = bobTapd.NewAddr(
@@ -662,7 +662,7 @@ func testMultiInputSendNonInteractiveSingleID(t *harnessTest) {
 	)
 
 	_ = sendProof(t, t.tapd, bobTapd, addr.ScriptKey, genInfo)
-	assertNonInteractiveRecvComplete(t, bobTapd, 2)
+	AssertNonInteractiveRecvComplete(t.t, bobTapd, 2)
 
 	t.Logf("Two separate send events complete, now attempting to send " +
 		"back the full amount in a single multi input send event")
@@ -685,7 +685,7 @@ func testMultiInputSendNonInteractiveSingleID(t *harnessTest) {
 	)
 
 	_ = sendProof(t, bobTapd, t.tapd, addr.ScriptKey, genInfo)
-	assertNonInteractiveRecvComplete(t, t.tapd, 1)
+	AssertNonInteractiveRecvComplete(t.t, t.tapd, 1)
 }
 
 // testSendMultipleCoins tests that we can send multiple transfers at the same
@@ -741,7 +741,7 @@ func testSendMultipleCoins(t *harnessTest) {
 			unitsPerPart, unitsPerPart,
 		}, 0, 1, numParts+1,
 	)
-	assertNonInteractiveRecvComplete(t, t.tapd, 5)
+	AssertNonInteractiveRecvComplete(t.t, t.tapd, 5)
 
 	// Next, we'll attempt to complete 5 parallel transfers with distinct
 	// addresses from our main node to Bob.
@@ -786,5 +786,5 @@ func testSendMultipleCoins(t *harnessTest) {
 	for _, addr := range bobAddrs {
 		_ = sendProof(t, t.tapd, secondTapd, addr.ScriptKey, genInfo)
 	}
-	assertNonInteractiveRecvComplete(t, secondTapd, 5)
+	AssertNonInteractiveRecvComplete(t.t, secondTapd, 5)
 }

--- a/itest/test_harness.go
+++ b/itest/test_harness.go
@@ -171,9 +171,7 @@ func (h *harnessTest) Log(args ...interface{}) {
 }
 
 func (h *harnessTest) LogfTimestamped(format string, args ...interface{}) {
-	timestamp := time.Now().Format(time.RFC3339Nano)
-	args = append([]interface{}{timestamp}, args...)
-	h.t.Logf("%s: "+format, args...)
+	LogfTimestamped(h.t, format, args...)
 }
 
 // shutdown stops both the mock universe and tapd server.
@@ -537,4 +535,11 @@ func lndKeyDescToTap(lnd keychain.KeyDescriptor) *taprpc.KeyDescriptor {
 			KeyIndex:  int32(lnd.Index),
 		},
 	}
+}
+
+// LogfTimestamped logs the given message with the current timestamp.
+func LogfTimestamped(t *testing.T, format string, args ...interface{}) {
+	timestamp := time.Now().Format(time.RFC3339Nano)
+	args = append([]interface{}{timestamp}, args...)
+	t.Logf("%s: "+format, args...)
 }

--- a/itest/universe_test.go
+++ b/itest/universe_test.go
@@ -107,7 +107,7 @@ func testUniverseSync(t *harnessTest) {
 
 		srcRoot, ok := universeRoots.UniverseRoots[uniKey]
 		require.True(t.t, ok)
-		require.True(t.t, assertUniverseRootEqual(srcRoot, newRoot))
+		require.True(t.t, AssertUniverseRootEqual(srcRoot, newRoot))
 	}
 
 	// Now we'll fetch the Universe roots from Bob. These should match the
@@ -117,7 +117,7 @@ func testUniverseSync(t *harnessTest) {
 	)
 	require.NoError(t.t, err)
 	require.True(
-		t.t, assertUniverseRootsEqual(universeRoots, universeRootsBob),
+		t.t, AssertUniverseRootsEqual(universeRoots, universeRootsBob),
 	)
 
 	// Finally, we'll ensure that the universe keys and leaves matches for
@@ -127,8 +127,8 @@ func testUniverseSync(t *harnessTest) {
 		return root.Id
 	},
 	)
-	assertUniverseKeysEqual(t.t, uniIDs, t.tapd, bob)
-	assertUniverseLeavesEqual(t.t, uniIDs, t.tapd, bob)
+	AssertUniverseKeysEqual(t.t, uniIDs, t.tapd, bob)
+	AssertUniverseLeavesEqual(t.t, uniIDs, t.tapd, bob)
 
 	// We should also be able to fetch an asset from Bob's Universe, and
 	// query for that asset with the compressed script key.
@@ -198,7 +198,7 @@ func testUniverseSync(t *harnessTest) {
 
 	firstAssetFromUni := firstAssetUniProof.AssetLeaf.Asset
 	firstAssetFromUni.PrevWitnesses = nil
-	assertAsset(t.t, rpcSimpleAssets[0], firstAssetFromUni)
+	AssertAsset(t.t, rpcSimpleAssets[0], firstAssetFromUni)
 
 	// Now we'll delete a universe root on Bob's node, and then re-sync it.
 	_, err = bob.DeleteAssetRoot(ctxt, &unirpc.DeleteRootQuery{
@@ -241,7 +241,7 @@ func testUniverseSync(t *harnessTest) {
 	)
 	require.NoError(t.t, err)
 	require.True(
-		t.t, assertUniverseRootsEqual(universeRoots, universeRootsBob),
+		t.t, AssertUniverseRootsEqual(universeRoots, universeRootsBob),
 	)
 }
 
@@ -410,12 +410,12 @@ func testUniverseFederation(t *harnessTest) {
 
 	// At this point, both nodes should have the same Universe roots.
 	require.Eventually(t.t, func() bool {
-		return assertUniverseStateEqual(t.t, bob, t.tapd)
+		return AssertUniverseStateEqual(t.t, bob, t.tapd)
 	}, defaultWaitTimeout, wait.PollInterval)
 
 	// Bob's Universe stats should show that he now has a single asset. We
 	// should also be able to query for stats specifically for the asset.
-	assertUniverseStats(t.t, bob, 1, 0, 1)
+	AssertUniverseStats(t.t, bob, 1, 0, 1)
 
 	// Test the content of the universe info call.
 	info, err := bob.Info(ctxt, &unirpc.InfoRequest{})
@@ -460,15 +460,15 @@ func testUniverseFederation(t *harnessTest) {
 	// At this point, both nodes should have the same Universe roots as Bob
 	// should have optimistically pushed the update to its federation
 	// members.
-	assertUniverseStateEqual(t.t, bob, t.tapd)
+	AssertUniverseStateEqual(t.t, bob, t.tapd)
 
 	// Bob's stats should also now show that there're three total asset as
 	// well as three proofs.
-	assertUniverseStats(t.t, bob, 3, 0, 3)
+	AssertUniverseStats(t.t, bob, 3, 0, 3)
 
 	// We should be able to find both the new assets in the set of universe
 	// stats for an asset.
-	assertUniverseAssetStats(t.t, bob, []*taprpc.Asset{
+	AssertUniverseAssetStats(t.t, bob, []*taprpc.Asset{
 		firstAsset[0], newAssets[0], newAssets[1],
 	})
 


### PR DESCRIPTION
In the first commit we make most of the checks used in the itest able to work with tapd/go testing primitives (like rpc clients and `*testing.T` structs) instead of depending on `testHarness`. That will allow us use those methods in tests that do not involve tapd harness but external tapd processes.

In the second commit we inject all the rpc clients and chain functionalities that it needs to operate so it does not depend on our itest suite and can be executed against real instances.

Part of #433 