### PR TITLE
Chain porter proof courier service initialised using configurable address

### DIFF
--- a/itest/aperture_harness.go
+++ b/itest/aperture_harness.go
@@ -21,10 +21,6 @@ type ApertureHarness struct {
 	// ListenAddr is the address that the aperture service is listening on.
 	ListenAddr string
 
-	// TlsCertPath is the path to the TLS certificate that the aperture
-	// service is using.
-	TlsCertPath string
-
 	// service is the instance of the aperture service that is running.
 	Service *aperture.Aperture
 }
@@ -59,9 +55,8 @@ func NewApertureHarness(t *testing.T, port int) ApertureHarness {
 	service := aperture.NewAperture(cfg)
 
 	return ApertureHarness{
-		ListenAddr:  listenAddr,
-		TlsCertPath: filepath.Join(baseDir, "tls.cert"),
-		Service:     service,
+		ListenAddr: listenAddr,
+		Service:    service,
 	}
 }
 

--- a/itest/tapd_harness.go
+++ b/itest/tapd_harness.go
@@ -163,7 +163,6 @@ func newTapdHarness(ht *harnessTest, cfg tapdConfig,
 		)
 
 		finalCfg.HashMailCourier = &proof.HashMailCourierCfg{
-			TlsCertPath:        typedProofCourier.TlsCertPath,
 			ReceiverAckTimeout: receiverAckTimeout,
 			BackoffCfg:         backoffCfg,
 		}

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -991,13 +991,19 @@ func (r *rpcServer) NewAddr(ctx context.Context,
 	// the default specified in the config.
 	courierAddr := r.cfg.DefaultProofCourierAddr
 	if in.ProofCourierAddr != "" {
-		courierAddr, err = proof.ParseCourierAddr(
+		addr, err := proof.ParseCourierAddrString(
 			in.ProofCourierAddr,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("invalid proof courier "+
 				"address: %w", err)
 		}
+
+		// At this point, we do not intend on creating a proof courier
+		// service instance. We are only interested in parsing and
+		// validating the address. We therefore convert the address into
+		// an url.URL type for storage in the address book.
+		courierAddr = addr.Url()
 	}
 
 	// Check that the proof courier address is set. This should never

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -1522,7 +1522,9 @@ func (r *rpcServer) FundVirtualPsbt(ctx context.Context,
 			return nil, fmt.Errorf("no recipients specified")
 		}
 
-		fundedVPkt, err = r.cfg.AssetWallet.FundAddressSend(ctx, addr)
+		fundedVPkt, _, err = r.cfg.AssetWallet.FundAddressSend(
+			ctx, addr,
+		)
 		if err != nil {
 			return nil, fmt.Errorf("error funding address send: "+
 				"%w", err)

--- a/tapcfg/server.go
+++ b/tapcfg/server.go
@@ -186,7 +186,6 @@ func genServerConfig(cfg *Config, cfgLogger btclog.Logger,
 	//  support a proof courier.
 	if cfg.HashMailCourier != nil {
 		proofCourierCfg = &proof.CourierCfg{
-			TlsCertPath:        cfg.HashMailCourier.TlsCertPath,
 			ReceiverAckTimeout: cfg.HashMailCourier.ReceiverAckTimeout,
 			BackoffCfg:         cfg.HashMailCourier.BackoffCfg,
 			DeliveryLog:        assetStore,

--- a/tapdb/assets_store.go
+++ b/tapdb/assets_store.go
@@ -2139,6 +2139,7 @@ func insertAssetTransferOutput(ctx context.Context, q ActiveAssetsStore,
 		ProofSuffix:         output.ProofSuffix,
 		NumPassiveAssets:    int32(output.Anchor.NumPassiveAssets),
 		OutputType:          int16(output.Type),
+		ProofCourierAddr:    output.ProofCourierAddr,
 	}
 
 	// There might not have been a split, so we can't rely on the split root
@@ -2260,8 +2261,9 @@ func fetchAssetTransferOutputs(ctx context.Context, q ActiveAssetsStore,
 				splitRootHash,
 				uint64(dbOut.SplitCommitmentRootValue.Int64),
 			),
-			ProofSuffix: dbOut.ProofSuffix,
-			Type:        tappsbt.VOutputType(dbOut.OutputType),
+			ProofSuffix:      dbOut.ProofSuffix,
+			Type:             tappsbt.VOutputType(dbOut.OutputType),
+			ProofCourierAddr: dbOut.ProofCourierAddr,
 		}
 
 		err = readOutPoint(

--- a/tapdb/sqlc/migrations/000005_transfers.up.sql
+++ b/tapdb/sqlc/migrations/000005_transfers.up.sql
@@ -51,7 +51,12 @@ CREATE TABLE IF NOT EXISTS asset_transfer_outputs (
 
     num_passive_assets INTEGER NOT NULL,
 
-    output_type SMALLINT NOT NULL
+    output_type SMALLINT NOT NULL,
+
+    -- proof_courier_addr is the proof courier service address associated with
+    -- the output. This value will be NULL for outputs that do not require proof
+    -- transfer.
+    proof_courier_addr BLOB
 );
 CREATE INDEX IF NOT EXISTS transfer_outputs_idx
     ON asset_transfer_outputs (transfer_id);

--- a/tapdb/sqlc/models.go
+++ b/tapdb/sqlc/models.go
@@ -124,6 +124,7 @@ type AssetTransferOutput struct {
 	ProofSuffix              []byte
 	NumPassiveAssets         int32
 	OutputType               int16
+	ProofCourierAddr         []byte
 }
 
 type AssetWitness struct {

--- a/tapdb/sqlc/queries/transfers.sql
+++ b/tapdb/sqlc/queries/transfers.sql
@@ -22,9 +22,9 @@ INSERT INTO asset_transfer_outputs (
     transfer_id, anchor_utxo, script_key, script_key_local,
     amount, serialized_witnesses, split_commitment_root_hash,
     split_commitment_root_value, proof_suffix, num_passive_assets,
-    output_type
+    output_type, proof_courier_addr
 ) VALUES (
-    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11
+    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12
 );
 
 -- name: QueryAssetTransfers :many
@@ -54,7 +54,7 @@ ORDER BY input_id;
 SELECT
     output_id, proof_suffix, amount, serialized_witnesses, script_key_local,
     split_commitment_root_hash, split_commitment_root_value, num_passive_assets,
-    output_type,
+    output_type, proof_courier_addr,
     utxos.utxo_id AS anchor_utxo_id,
     utxos.outpoint AS anchor_outpoint,
     utxos.amt_sats AS anchor_value,

--- a/tapdb/sqlc/transfers.sql.go
+++ b/tapdb/sqlc/transfers.sql.go
@@ -118,7 +118,7 @@ const fetchTransferOutputs = `-- name: FetchTransferOutputs :many
 SELECT
     output_id, proof_suffix, amount, serialized_witnesses, script_key_local,
     split_commitment_root_hash, split_commitment_root_value, num_passive_assets,
-    output_type,
+    output_type, proof_courier_addr,
     utxos.utxo_id AS anchor_utxo_id,
     utxos.outpoint AS anchor_outpoint,
     utxos.amt_sats AS anchor_value,
@@ -157,6 +157,7 @@ type FetchTransferOutputsRow struct {
 	SplitCommitmentRootValue sql.NullInt64
 	NumPassiveAssets         int32
 	OutputType               int16
+	ProofCourierAddr         []byte
 	AnchorUtxoID             int32
 	AnchorOutpoint           []byte
 	AnchorValue              int64
@@ -193,6 +194,7 @@ func (q *Queries) FetchTransferOutputs(ctx context.Context, transferID int32) ([
 			&i.SplitCommitmentRootValue,
 			&i.NumPassiveAssets,
 			&i.OutputType,
+			&i.ProofCourierAddr,
 			&i.AnchorUtxoID,
 			&i.AnchorOutpoint,
 			&i.AnchorValue,
@@ -280,9 +282,9 @@ INSERT INTO asset_transfer_outputs (
     transfer_id, anchor_utxo, script_key, script_key_local,
     amount, serialized_witnesses, split_commitment_root_hash,
     split_commitment_root_value, proof_suffix, num_passive_assets,
-    output_type
+    output_type, proof_courier_addr
 ) VALUES (
-    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11
+    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12
 )
 `
 
@@ -298,6 +300,7 @@ type InsertAssetTransferOutputParams struct {
 	ProofSuffix              []byte
 	NumPassiveAssets         int32
 	OutputType               int16
+	ProofCourierAddr         []byte
 }
 
 func (q *Queries) InsertAssetTransferOutput(ctx context.Context, arg InsertAssetTransferOutputParams) error {
@@ -313,6 +316,7 @@ func (q *Queries) InsertAssetTransferOutput(ctx context.Context, arg InsertAsset
 		arg.ProofSuffix,
 		arg.NumPassiveAssets,
 		arg.OutputType,
+		arg.ProofCourierAddr,
 	)
 	return err
 }

--- a/tapfreighter/chain_porter.go
+++ b/tapfreighter/chain_porter.go
@@ -768,9 +768,10 @@ func (p *ChainPorter) stateStep(currentPkg sendPackage) (*sendPackage, error) {
 			return nil, fmt.Errorf("unable to cast parcel to " +
 				"address parcel")
 		}
-		fundSendRes, err := p.cfg.AssetWallet.FundAddressSend(
-			ctx, addrParcel.destAddrs...,
-		)
+		fundSendRes, outputIdxToAddr, err :=
+			p.cfg.AssetWallet.FundAddressSend(
+				ctx, addrParcel.destAddrs...,
+			)
 		if err != nil {
 			return nil, fmt.Errorf("unable to fund address send: "+
 				"%w", err)
@@ -778,6 +779,7 @@ func (p *ChainPorter) stateStep(currentPkg sendPackage) (*sendPackage, error) {
 
 		currentPkg.VirtualPacket = fundSendRes.VPacket
 		currentPkg.InputCommitments = fundSendRes.InputCommitments
+		currentPkg.OutputIdxToAddr = outputIdxToAddr
 
 		currentPkg.SendState = SendStateVirtualSign
 

--- a/tapfreighter/chain_porter.go
+++ b/tapfreighter/chain_porter.go
@@ -57,7 +57,7 @@ type ChainPorterConfig struct {
 
 	// ProofCourier is used to optionally deliver the final proof to the
 	// user using an asynchronous transport mechanism.
-	ProofCourier proof.Courier[proof.Recipient]
+	ProofCourier proof.Courier
 
 	// ProofWatcher is used to watch new proofs for their anchor transaction
 	// to be confirmed safely with a minimum number of confirmations.

--- a/tapfreighter/interface.go
+++ b/tapfreighter/interface.go
@@ -201,6 +201,10 @@ type TransferOutput struct {
 	// includes all the proof information other than the final chain
 	// information.
 	ProofSuffix []byte
+
+	// ProofCourierAddr is the bytes encoded proof courier service address
+	// associated with this output.
+	ProofCourierAddr []byte
 }
 
 // OutboundParcel represents the database level delta of an outbound Taproot

--- a/tapfreighter/parcel.go
+++ b/tapfreighter/parcel.go
@@ -208,7 +208,7 @@ type PreSignedParcel struct {
 	inputCommitment *commitment.TapCommitment
 }
 
-// A compile-time assertion to ensure AddressParcel implements the parcel
+// A compile-time assertion to ensure PreSignedParcel implements the parcel
 // interface.
 var _ Parcel = (*PreSignedParcel)(nil)
 

--- a/tapfreighter/parcel.go
+++ b/tapfreighter/parcel.go
@@ -364,6 +364,17 @@ func (s *sendPackage) prepareForStorage(currentHeight uint32) (*OutboundParcel,
 	for idx := range vPkt.Outputs {
 		vOut := vPkt.Outputs[idx]
 
+		// Convert any proof courier address associated with this output
+		// to bytes for db storage.
+		var proofCourierAddrBytes []byte
+		if s.OutputIdxToAddr != nil {
+			if addr, ok := s.OutputIdxToAddr[idx]; ok {
+				proofCourierAddrBytes = []byte(
+					addr.ProofCourierAddr.String(),
+				)
+			}
+		}
+
 		anchorInternalKey := keychain.KeyDescriptor{
 			PubKey: vOut.AnchorOutputInternalKey,
 		}
@@ -453,6 +464,7 @@ func (s *sendPackage) prepareForStorage(currentHeight uint32) (*OutboundParcel,
 			WitnessData:         witness,
 			SplitCommitmentRoot: splitCommitmentRoot,
 			ProofSuffix:         proofSuffixBuf.Bytes(),
+			ProofCourierAddr:    proofCourierAddrBytes,
 		}
 	}
 

--- a/tapfreighter/parcel.go
+++ b/tapfreighter/parcel.go
@@ -259,6 +259,10 @@ type sendPackage struct {
 	// virtual asset transition transaction.
 	VirtualPacket *tappsbt.VPacket
 
+	// OutputIdxToAddr is a map from a VPacket's VOutput index to its
+	// associated Tap address.
+	OutputIdxToAddr tappsbt.OutputIdxToAddr
+
 	// InputCommitments is a map from virtual package input index to its
 	// associated Taproot Asset commitment.
 	InputCommitments tappsbt.InputCommitments

--- a/tappsbt/address.go
+++ b/tappsbt/address.go
@@ -9,16 +9,21 @@ import (
 	"github.com/lightningnetwork/lnd/keychain"
 )
 
+// OutputIdxToAddr is a map from a VPacket's VOutput index to its associated
+// Tap address.
+type OutputIdxToAddr map[int]address.Tap
+
 // FromAddresses creates an empty virtual transaction packet from the given
 // addresses. Because sending to an address is always non-interactive, a change
 // output is also added to the packet.
 func FromAddresses(receiverAddrs []*address.Tap,
-	firstOutputIndex uint32) (*VPacket, error) {
+	firstOutputIndex uint32) (*VPacket, OutputIdxToAddr, error) {
 
 	// We need at least one address to send to. Any special cases or
 	// interactive sends should go through the FundPacket method.
 	if len(receiverAddrs) < 1 {
-		return nil, fmt.Errorf("at least one address must be specified")
+		return nil, nil, fmt.Errorf("at least one address must be" +
+			"specified")
 	}
 
 	firstAddr := receiverAddrs[0]
@@ -46,6 +51,9 @@ func FromAddresses(receiverAddrs []*address.Tap,
 		ScriptKey:         asset.NUMSScriptKey,
 	})
 
+	// Map from output index to address.
+	outputIdxToAddr := make(OutputIdxToAddr, len(receiverAddrs))
+
 	// We start at output index 1 because we also have the change output
 	// above. We also just use continuous integers for the anchor output
 	// index, but start at the first one indicated by the caller.
@@ -62,9 +70,12 @@ func FromAddresses(receiverAddrs []*address.Tap,
 			AnchorOutputInternalKey:      &addr.InternalKey,
 			AnchorOutputTapscriptSibling: addr.TapscriptSibling,
 		})
+
+		outputIndex := len(pkt.Outputs) - 1
+		outputIdxToAddr[outputIndex] = *addr
 	}
 
-	return pkt, nil
+	return pkt, outputIdxToAddr, nil
 }
 
 // ForInteractiveSend creates a virtual transaction packet for sending an output

--- a/tappsbt/decode_test.go
+++ b/tappsbt/decode_test.go
@@ -105,7 +105,7 @@ func TestEncodingDecoding(t *testing.T) {
 				t, testParams, proofCourierAddr,
 			)
 
-			pkg, err := FromAddresses([]*address.Tap{addr.Tap}, 1)
+			pkg, _, err := FromAddresses([]*address.Tap{addr.Tap}, 1)
 			require.NoError(t, err)
 			pkg.Outputs = append(pkg.Outputs, &VOutput{
 				ScriptKey: asset.RandScriptKey(t),


### PR DESCRIPTION
This PR includes changes which allow us to persist a proof courier address for use in resuming a pending package's send process.

Fixes #446 