### PR TITLE
Cleanup proof courier addr

### DIFF
--- a/address/address.go
+++ b/address/address.go
@@ -126,6 +126,9 @@ type Tap struct {
 }
 
 // New creates an address for receiving a Taproot asset.
+//
+// TODO(ffranr): This function takes many arguments. Add a struct to better
+// organise its arguments.
 func New(genesis asset.Genesis, groupKey *btcec.PublicKey,
 	groupSig *schnorr.Signature, scriptKey btcec.PublicKey,
 	internalKey btcec.PublicKey, amt uint64,

--- a/address/address.go
+++ b/address/address.go
@@ -122,7 +122,7 @@ type Tap struct {
 
 	// ProofCourierAddr is the address of the proof courier that will be
 	// used to distribute related proofs for this address.
-	ProofCourierAddr *url.URL
+	ProofCourierAddr url.URL
 }
 
 // New creates an address for receiving a Taproot asset.
@@ -130,7 +130,7 @@ func New(genesis asset.Genesis, groupKey *btcec.PublicKey,
 	groupSig *schnorr.Signature, scriptKey btcec.PublicKey,
 	internalKey btcec.PublicKey, amt uint64,
 	tapscriptSibling *commitment.TapscriptPreimage,
-	net *ChainParams, proofCourierAddr *url.URL) (*Tap, error) {
+	net *ChainParams, proofCourierAddr url.URL) (*Tap, error) {
 
 	// Check for invalid combinations of asset type and amount.
 	// Collectible assets must have an amount of 1, and Normal assets must

--- a/address/book.go
+++ b/address/book.go
@@ -175,8 +175,7 @@ func NewBook(cfg BookConfig) *Book {
 // NewAddress creates a new Taproot Asset address based on the input parameters.
 func (b *Book) NewAddress(ctx context.Context, assetID asset.ID, amount uint64,
 	tapscriptSibling *commitment.TapscriptPreimage,
-	proofCourierAddr *url.URL) (*AddrWithKeyInfo,
-	error) {
+	proofCourierAddr url.URL) (*AddrWithKeyInfo, error) {
 
 	// Before we proceed and make new keys, make sure that we actually know
 	// of this asset ID already.
@@ -212,8 +211,7 @@ func (b *Book) NewAddressWithKeys(ctx context.Context, assetID asset.ID,
 	amount uint64, scriptKey asset.ScriptKey,
 	internalKeyDesc keychain.KeyDescriptor,
 	tapscriptSibling *commitment.TapscriptPreimage,
-	proofCourierAddr *url.URL) (*AddrWithKeyInfo,
-	error) {
+	proofCourierAddr url.URL) (*AddrWithKeyInfo, error) {
 
 	// Before we proceed, we'll make sure that the asset group is known to
 	// the local store. Otherwise, we can't make an address as we haven't

--- a/address/encoding.go
+++ b/address/encoding.go
@@ -44,16 +44,16 @@ func compressedPubKeyDecoder(r io.Reader, val any, buf *[8]byte, l uint64) error
 
 // urlEncoder encodes a url.URL as a variable length byte slice.
 func urlEncoder(w io.Writer, val any, buf *[8]byte) error {
-	if t, ok := val.(**url.URL); ok {
+	if t, ok := val.(*url.URL); ok {
 		addrBytes := []byte((*t).String())
 		return tlv.EVarBytes(w, &addrBytes, buf)
 	}
 	return tlv.NewTypeForEncodingErr(val, "*url.URL")
 }
 
-// urlDecoder decodes a variable length byte slice as a url.URL.
+// urlDecoder decodes a variable length byte slice as an url.URL.
 func urlDecoder(r io.Reader, val any, buf *[8]byte, l uint64) error {
-	if t, ok := val.(**url.URL); ok {
+	if t, ok := val.(*url.URL); ok {
 		var addrBytes []byte
 		err := tlv.DVarBytes(r, &addrBytes, buf, l)
 		if err != nil {
@@ -64,7 +64,7 @@ func urlDecoder(r io.Reader, val any, buf *[8]byte, l uint64) error {
 		if err != nil {
 			return err
 		}
-		*t = addr
+		*t = *addr
 
 		return nil
 	}

--- a/address/mock.go
+++ b/address/mock.go
@@ -17,18 +17,18 @@ import (
 
 // RandProofCourierAddr returns a proof courier address with fields populated
 // with valid but random values.
-func RandProofCourierAddr(t testing.TB) *url.URL {
+func RandProofCourierAddr(t testing.TB) url.URL {
 	addr, err := url.ParseRequestURI(
 		"hashmail://rand.hashmail.proof.courier:443",
 	)
 	require.NoError(t, err)
 
-	return addr
+	return *addr
 }
 
 // RandAddr creates a random address for testing.
 func RandAddr(t testing.TB, params *ChainParams,
-	proofCourierAddr *url.URL) (*AddrWithKeyInfo,
+	proofCourierAddr url.URL) (*AddrWithKeyInfo,
 	*asset.Genesis, *asset.GroupKey) {
 
 	scriptKeyPriv := test.RandPrivKey(t)
@@ -198,7 +198,7 @@ func (ta *TestAddress) ToAddress(t testing.TB) *Tap {
 		ScriptKey:        *test.ParsePubKey(t, ta.ScriptKey),
 		InternalKey:      *test.ParsePubKey(t, ta.InternalKey),
 		Amount:           ta.Amount,
-		ProofCourierAddr: proofCourierAddr,
+		ProofCourierAddr: *proofCourierAddr,
 	}
 
 	if ta.GroupKey != "" {

--- a/address/mock.go
+++ b/address/mock.go
@@ -18,6 +18,7 @@ import (
 // RandProofCourierAddr returns a proof courier address with fields populated
 // with valid but random values.
 func RandProofCourierAddr(t testing.TB) url.URL {
+	// TODO(ffranr): Add more randomness to the address.
 	addr, err := url.ParseRequestURI(
 		"hashmail://rand.hashmail.proof.courier:443",
 	)

--- a/address/records.go
+++ b/address/records.go
@@ -97,9 +97,9 @@ func newAddressAmountRecord(amount *uint64) tlv.Record {
 	)
 }
 
-func newProofCourierAddrRecord(addr **url.URL) tlv.Record {
+func newProofCourierAddrRecord(addr *url.URL) tlv.Record {
 	var addrBytes []byte
-	if *addr != nil {
+	if addr != nil {
 		addrBytes = []byte((*addr).String())
 	}
 	recordSize := tlv.SizeVarBytes(&addrBytes)

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -989,9 +989,9 @@ func (r *rpcServer) NewAddr(ctx context.Context,
 
 	// Parse the proof courier address if one was provided, otherwise use
 	// the default specified in the config.
-	proofCourierAddr := r.cfg.DefaultProofCourierAddr
+	courierAddr := r.cfg.DefaultProofCourierAddr
 	if in.ProofCourierAddr != "" {
-		proofCourierAddr, err = proof.ParseCourierAddr(
+		courierAddr, err = proof.ParseCourierAddr(
 			in.ProofCourierAddr,
 		)
 		if err != nil {
@@ -999,6 +999,14 @@ func (r *rpcServer) NewAddr(ctx context.Context,
 				"address: %w", err)
 		}
 	}
+
+	// Check that the proof courier address is set. This should never
+	// happen, but we check anyway to avoid panics (possibly caused by
+	// future erroneous config changes).
+	if courierAddr == nil {
+		return nil, fmt.Errorf("no proof courier address provided")
+	}
+	proofCourierAddr := *courierAddr
 
 	if len(in.AssetId) != 32 {
 		return nil, fmt.Errorf("invalid asset id length")

--- a/tapdb/addrs.go
+++ b/tapdb/addrs.go
@@ -435,7 +435,7 @@ func (t *TapAddressBook) QueryAddrs(ctx context.Context,
 				assetGenesis, groupKey, groupSig, *scriptKey,
 				*internalKey, uint64(addr.Amount),
 				tapscriptSibling, t.params,
-				proofCourierAddr,
+				*proofCourierAddr,
 			)
 			if err != nil {
 				return fmt.Errorf("unable to make addr: %w", err)
@@ -580,7 +580,7 @@ func fetchAddr(ctx context.Context, db AddrBook, params *address.ChainParams,
 	tapAddr, err := address.New(
 		genesis, groupKey, groupSig, *scriptKey, *internalKey,
 		uint64(dbAddr.Amount), tapscriptSibling, params,
-		proofCourierAddr,
+		*proofCourierAddr,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("unable to make addr: %w", err)

--- a/tapgarden/custodian_test.go
+++ b/tapgarden/custodian_test.go
@@ -317,9 +317,10 @@ func mustMakeAddr(t *testing.T,
 	groupSig *schnorr.Signature, scriptKey btcec.PublicKey) *address.Tap {
 
 	var p btcec.PublicKey
+	proofCourierAddr := address.RandProofCourierAddr(t)
 	addr, err := address.New(
 		gen, groupKey, groupSig, scriptKey,
-		p, 1, nil, &address.TestNet3Tap, nil,
+		p, 1, nil, &address.TestNet3Tap, proofCourierAddr,
 	)
 	require.NoError(t, err)
 

--- a/tappsbt/decode_test.go
+++ b/tappsbt/decode_test.go
@@ -100,7 +100,10 @@ func TestEncodingDecoding(t *testing.T) {
 	}{{
 		name: "minimal packet",
 		pkg: func(t *testing.T) *VPacket {
-			addr, _, _ := address.RandAddr(t, testParams, nil)
+			proofCourierAddr := address.RandProofCourierAddr(t)
+			addr, _, _ := address.RandAddr(
+				t, testParams, proofCourierAddr,
+			)
 
 			pkg, err := FromAddresses([]*address.Tap{addr.Tap}, 1)
 			require.NoError(t, err)

--- a/taprpc/taprootassets.pb.go
+++ b/taprpc/taprootassets.pb.go
@@ -2597,7 +2597,7 @@ type NewAddrRequest struct {
 	// commitment of the asset.
 	TapscriptSibling []byte `protobuf:"bytes,5,opt,name=tapscript_sibling,json=tapscriptSibling,proto3" json:"tapscript_sibling,omitempty"`
 	// An optional proof courier address for use in proof transfer. If unspecified,
-	// the daemon configured default address will be used
+	// the daemon configured default address will be used.
 	ProofCourierAddr string `protobuf:"bytes,6,opt,name=proof_courier_addr,json=proofCourierAddr,proto3" json:"proof_courier_addr,omitempty"`
 }
 

--- a/taprpc/taprootassets.proto
+++ b/taprpc/taprootassets.proto
@@ -630,7 +630,7 @@ message NewAddrRequest {
 
     /*
     An optional proof courier address for use in proof transfer. If unspecified,
-    the daemon configured default address will be used
+    the daemon configured default address will be used.
      */
     string proof_courier_addr = 6;
 }

--- a/taprpc/taprootassets.swagger.json
+++ b/taprpc/taprootassets.swagger.json
@@ -1531,7 +1531,7 @@
         },
         "proof_courier_addr": {
           "type": "string",
-          "title": "An optional proof courier address for use in proof transfer. If unspecified,\nthe daemon configured default address will be used"
+          "description": "An optional proof courier address for use in proof transfer. If unspecified,\nthe daemon configured default address will be used."
         }
       }
     },


### PR DESCRIPTION
Major change in this PR is that the proof courier addr field in the Tap address structure is no longer a pointer. I think this change makes sense because the field is mandatory and should never be `nil`.

Created this PR to address these review comments: https://github.com/lightninglabs/taproot-assets/pull/450#pullrequestreview-1588024716 and https://github.com/lightninglabs/taproot-assets/pull/450#pullrequestreview-1588020864