### PR TITLE
GitHub: use maintained version of docker layer cache action

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -42,7 +42,8 @@ jobs:
         uses: actions/checkout@v3
 
       - name: docker image cache
-        uses: satackey/action-docker-layer-caching@v0.0.11
+        uses: jpribyl/action-docker-layer-caching@v0.1.1
+        continue-on-error: true
 
       - name: Generate sql models
         run: make sqlc-check


### PR DESCRIPTION
Looks like the old `satackey/action-docker-layer-caching` action has finally stopped working: https://github.com/lightninglabs/taproot-assets/actions/runs/5999726192/job/16270427354

We update to a forked version that is maintained and also allow the test to continue if the caching fails.