### PR TITLE
Add multiverse RPC proof courier

### DIFF
--- a/asset/asset.go
+++ b/asset/asset.go
@@ -822,6 +822,37 @@ func (a *Asset) IsBurn() bool {
 	return IsBurnKey(a.ScriptKey.PubKey, a.PrevWitnesses[0])
 }
 
+// PrimaryPrevID returns the primary prev ID of an asset. This is the prev ID of
+// the first witness, unless the first witness is a split-commitment witness,
+// in which case it is the prev ID of the first witness of the root asset.
+// The first witness effectively corresponds to the asset's direct lineage.
+func (a *Asset) PrimaryPrevID() (*PrevID, error) {
+	if len(a.PrevWitnesses) == 0 {
+		return nil, fmt.Errorf("asset missing previous witnesses")
+	}
+
+	// The primary prev ID is stored on the root asset if this asset is a
+	// split output. We determine whether this asset is a split output by
+	// inspecting the first previous witness.
+	primaryWitness := a.PrevWitnesses[0]
+	isSplitOutput := IsSplitCommitWitness(primaryWitness)
+
+	// If this is a split output, then we need to look up the first PrevID
+	// in the split root asset.
+	if isSplitOutput {
+		rootAsset := primaryWitness.SplitCommitment.RootAsset
+		if len(rootAsset.PrevWitnesses) == 0 {
+			return nil, fmt.Errorf("asset missing previous " +
+				"witnesses")
+		}
+		return rootAsset.PrevWitnesses[0].PrevID, nil
+	}
+
+	// This asset is not a split output, so we can just return the PrevID
+	// found in the first witness.
+	return primaryWitness.PrevID, nil
+}
+
 // Copy returns a deep copy of an Asset.
 func (a *Asset) Copy() *Asset {
 	assetCopy := *a

--- a/cmd/tapcli/universe.go
+++ b/cmd/tapcli/universe.go
@@ -7,6 +7,7 @@ import (
 
 	tap "github.com/lightninglabs/taproot-assets"
 	"github.com/lightninglabs/taproot-assets/proof"
+	"github.com/lightninglabs/taproot-assets/taprpc"
 	"github.com/lightninglabs/taproot-assets/taprpc/universerpc"
 	unirpc "github.com/lightninglabs/taproot-assets/taprpc/universerpc"
 	"github.com/lightningnetwork/lnd/lncfg"
@@ -417,7 +418,7 @@ func universeProofInsert(ctx *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	rpcAsset, err := tap.MarshalAsset(
+	rpcAsset, err := taprpc.MarshalAsset(
 		ctxc, &assetProof.Asset, false, true, nil,
 	)
 	if err != nil {

--- a/itest/send_test.go
+++ b/itest/send_test.go
@@ -20,8 +20,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// testBasicSend tests that we can properly send assets back and forth between
-// nodes.
+// testBasicSendUnidirectional tests that we can properly send assets back and
+// forth between nodes.
 func testBasicSendUnidirectional(t *harnessTest) {
 	var (
 		ctxb = context.Background()

--- a/itest/tapd_harness.go
+++ b/itest/tapd_harness.go
@@ -177,6 +177,13 @@ func newTapdHarness(t *testing.T, ht *harnessTest, cfg tapdConfig,
 			ReceiverAckTimeout: receiverAckTimeout,
 			BackoffCfg:         backoffCfg,
 		}
+
+	case *UniverseRPCHarness:
+		finalCfg.DefaultProofCourierAddr = fmt.Sprintf(
+			"%s://%s", proof.UniverseRpcCourierType,
+			typedProofCourier.ListenAddr,
+		)
+
 	default:
 		finalCfg.DefaultProofCourierAddr = ""
 		finalCfg.HashMailCourier = nil

--- a/itest/test_harness.go
+++ b/itest/test_harness.go
@@ -284,6 +284,9 @@ func setupHarnesses(t *testing.T, ht *harnessTest,
 		port := nextAvailablePort()
 		apHarness := NewApertureHarness(ht.t, port)
 		proofCourier = &apHarness
+
+	case proof.UniverseRpcCourierType:
+		proofCourier = NewUniverseRPCHarness(t, ht, lndHarness.Bob)
 	}
 
 	// Start the proof courier harness if specified.

--- a/itest/test_harness.go
+++ b/itest/test_harness.go
@@ -175,7 +175,7 @@ func (h *harnessTest) LogfTimestamped(format string, args ...interface{}) {
 }
 
 // shutdown stops both the mock universe and tapd server.
-func (h *harnessTest) shutdown(t *testing.T) error {
+func (h *harnessTest) shutdown(_ *testing.T) error {
 	h.universeServer.stop()
 
 	if h.proofCourier != nil {

--- a/itest/test_list_on_test.go
+++ b/itest/test_list_on_test.go
@@ -44,6 +44,11 @@ var testCases = []*testCase{
 		proofCourierType: proof.HashmailCourierType,
 	},
 	{
+		name:             "basic send universerpc proof courier",
+		test:             testBasicSendUnidirectional,
+		proofCourierType: proof.UniverseRpcCourierType,
+	},
+	{
 		name:             "resume pending package send",
 		test:             testResumePendingPackageSend,
 		proofCourierType: proof.HashmailCourierType,

--- a/itest/universerpc_harness.go
+++ b/itest/universerpc_harness.go
@@ -1,0 +1,51 @@
+package itest
+
+import (
+	"testing"
+
+	"github.com/lightninglabs/taproot-assets/proof"
+	"github.com/lightningnetwork/lnd/lntest/node"
+	"github.com/stretchr/testify/require"
+)
+
+// UniverseRPCHarness is an integration testing harness for the universe tap
+// service.
+type UniverseRPCHarness struct {
+	// service is the instance of the universe tap service.
+	service *tapdHarness
+
+	// ListenAddr is the address that the service is listening on.
+	ListenAddr string
+}
+
+// NewUniverseRPCHarness creates a new test harness for a universe tap service.
+func NewUniverseRPCHarness(t *testing.T, ht *harnessTest,
+	lndHarness *node.HarnessNode) *UniverseRPCHarness {
+
+	service, err := newTapdHarness(
+		t, ht, tapdConfig{
+			NetParams: harnessNetParams,
+			LndNode:   lndHarness,
+		}, nil, nil, nil,
+	)
+	require.NoError(t, err)
+
+	return &UniverseRPCHarness{
+		service:    service,
+		ListenAddr: service.rpcHost(),
+	}
+}
+
+// Start starts the service.
+func (h *UniverseRPCHarness) Start(_ chan error) error {
+	return h.service.start(false)
+}
+
+// Stop stops the service.
+func (h *UniverseRPCHarness) Stop() error {
+	return h.service.stop(true)
+}
+
+// Ensure that NewUniverseRPCHarness implements the proof.CourierHarness
+// interface.
+var _ proof.CourierHarness = (*UniverseRPCHarness)(nil)

--- a/proof/archive.go
+++ b/proof/archive.go
@@ -57,6 +57,10 @@ type Locator struct {
 	// ScriptKey specifies the script key of the asset to fetch/store. This
 	// field MUST be specified.
 	ScriptKey btcec.PublicKey
+
+	// OutPoint is the outpoint of the associated asset. This field is
+	// optional.
+	OutPoint *wire.OutPoint
 }
 
 // Hash returns a SHA256 hash of the bytes serialized locator.

--- a/proof/courier.go
+++ b/proof/courier.go
@@ -54,8 +54,6 @@ type CourierHarness interface {
 // part of the non-interactive send flow. A sender can use this given the
 // abstracted Addr/source type to send a proof to the receiver. Conversely, a
 // receiver can use this to fetch a proof from the sender.
-//
-// TODO(roasbeef): FileSystemCourier, RpcCourier
 type Courier interface {
 	// DeliverProof attempts to delivery a proof to the receiver, using the
 	// information in the Addr type.

--- a/proof/proof.go
+++ b/proof/proof.go
@@ -131,7 +131,9 @@ type Watcher interface {
 // Proof encodes all of the data necessary to prove a valid state transition for
 // an asset has occurred within an on-chain transaction.
 type Proof struct {
-	// PrevOut is the previous on-chain outpoint of the asset.
+	// PrevOut is the previous on-chain outpoint of the asset. This outpoint
+	// is that of the first on-chain input. Outpoints which correspond to
+	// the other inputs can be found in AdditionalInputs.
 	PrevOut wire.OutPoint
 
 	// BlockHeader is the current block header committing to the on-chain

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -2909,16 +2909,27 @@ func (r *rpcServer) QueryProof(ctx context.Context,
 		return nil, err
 	}
 
+	rpcsLog.Debugf("[QueryProof]: fetching proof at "+
+		"(universeID=%x, leafKey=%x)", universeID,
+		leafKey.UniverseKey())
+
 	proofs, err := r.cfg.BaseUniverse.FetchIssuanceProof(
 		ctx, universeID, leafKey,
 	)
 	if err != nil {
+		rpcsLog.Debugf("[QueryProof]: error querying for proof at "+
+			"(universeID=%x, leafKey=%x)", universeID,
+			leafKey.UniverseKey())
 		return nil, err
 	}
 
 	// TODO(roasbeef): query may return multiple proofs, if allow key to
 	// not be fully specified
 	proof := proofs[0]
+
+	rpcsLog.Debugf("[QueryProof]: found proof at "+
+		"(universeID=%x, leafKey=%x)", universeID,
+		leafKey.UniverseKey())
 
 	return r.marshalIssuanceProof(ctx, req, proof)
 }
@@ -2976,12 +2987,20 @@ func (r *rpcServer) InsertProof(ctx context.Context,
 		return nil, err
 	}
 
+	rpcsLog.Debugf("[InsertProof]: inserting proof at "+
+		"(universeID=%x, leafKey=%x)", universeID,
+		leafKey.UniverseKey())
+
 	newUniverseState, err := r.cfg.BaseUniverse.RegisterIssuance(
 		ctx, universeID, leafKey, assetLeaf,
 	)
 	if err != nil {
 		return nil, err
 	}
+
+	universeRootHash := newUniverseState.UniverseRoot.NodeHash()
+	rpcsLog.Debugf("[InsertProof]: proof inserted, new universe root: %x",
+		universeRootHash[:])
 
 	return r.marshalIssuanceProof(ctx, req.Key, newUniverseState)
 }

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -604,7 +604,7 @@ func (r *rpcServer) fetchRpcAssets(ctx context.Context, withWitness,
 func (r *rpcServer) marshalChainAsset(ctx context.Context, a *tapdb.ChainAsset,
 	withWitness bool) (*taprpc.Asset, error) {
 
-	rpcAsset, err := MarshalAsset(
+	rpcAsset, err := taprpc.MarshalAsset(
 		ctx, a.Asset, a.IsSpent, withWitness, r.cfg.AddrBook,
 	)
 	if err != nil {
@@ -636,97 +636,6 @@ func (r *rpcServer) marshalChainAsset(ctx context.Context, a *tapdb.ChainAsset,
 	if a.AnchorLeaseOwner != [32]byte{} {
 		rpcAsset.LeaseOwner = a.AnchorLeaseOwner[:]
 		rpcAsset.LeaseExpiry = a.AnchorLeaseExpiry.UTC().Unix()
-	}
-
-	return rpcAsset, nil
-}
-
-// KeyLookup is used to determine whether a key is under the control of the
-// local wallet.
-type KeyLookup interface {
-	// IsLocalKey returns true if the key is under the control of the
-	// wallet and can be derived by it.
-	IsLocalKey(ctx context.Context, desc keychain.KeyDescriptor) bool
-}
-
-func MarshalAsset(ctx context.Context, a *asset.Asset,
-	isSpent, withWitness bool,
-	keyRing KeyLookup) (*taprpc.Asset, error) {
-
-	assetID := a.Genesis.ID()
-	scriptKeyIsLocal := false
-	if a.ScriptKey.TweakedScriptKey != nil && keyRing != nil {
-		scriptKeyIsLocal = keyRing.IsLocalKey(
-			ctx, a.ScriptKey.RawKey,
-		)
-	}
-
-	rpcAsset := &taprpc.Asset{
-		Version: int32(a.Version),
-		AssetGenesis: &taprpc.GenesisInfo{
-			GenesisPoint: a.Genesis.FirstPrevOut.String(),
-			Name:         a.Genesis.Tag,
-			MetaHash:     a.Genesis.MetaHash[:],
-			AssetId:      assetID[:],
-			OutputIndex:  a.Genesis.OutputIndex,
-		},
-		AssetType:        taprpc.AssetType(a.Type),
-		Amount:           a.Amount,
-		LockTime:         int32(a.LockTime),
-		RelativeLockTime: int32(a.RelativeLockTime),
-		ScriptVersion:    int32(a.ScriptVersion),
-		ScriptKey:        a.ScriptKey.PubKey.SerializeCompressed(),
-		ScriptKeyIsLocal: scriptKeyIsLocal,
-		IsSpent:          isSpent,
-		IsBurn:           a.IsBurn(),
-	}
-
-	if a.GroupKey != nil {
-		var rawKey []byte
-		if a.GroupKey.RawKey.PubKey != nil {
-			rawKey = a.GroupKey.RawKey.PubKey.SerializeCompressed()
-		}
-		rpcAsset.AssetGroup = &taprpc.AssetGroup{
-			RawGroupKey:     rawKey,
-			TweakedGroupKey: a.GroupKey.GroupPubKey.SerializeCompressed(),
-			AssetIdSig:      a.GroupKey.Sig.Serialize(),
-		}
-	}
-
-	if withWitness {
-		for idx := range a.PrevWitnesses {
-			witness := a.PrevWitnesses[idx]
-
-			prevID := witness.PrevID
-			rpcPrevID := &taprpc.PrevInputAsset{
-				AnchorPoint: prevID.OutPoint.String(),
-				AssetId:     prevID.ID[:],
-				ScriptKey:   prevID.ScriptKey[:],
-			}
-
-			var rpcSplitCommitment *taprpc.SplitCommitment
-			if witness.SplitCommitment != nil {
-				rootAsset, err := MarshalAsset(
-					ctx, &witness.SplitCommitment.RootAsset,
-					false, true, nil,
-				)
-				if err != nil {
-					return nil, err
-				}
-
-				rpcSplitCommitment = &taprpc.SplitCommitment{
-					RootAsset: rootAsset,
-				}
-			}
-
-			rpcAsset.PrevWitnesses = append(
-				rpcAsset.PrevWitnesses, &taprpc.PrevWitness{
-					PrevId:          rpcPrevID,
-					TxWitness:       witness.TxWitness,
-					SplitCommitment: rpcSplitCommitment,
-				},
-			)
-		}
 	}
 
 	return rpcAsset, nil
@@ -2764,7 +2673,7 @@ func (r *rpcServer) AssetLeafKeys(ctx context.Context,
 	return resp, nil
 }
 
-func marshalAssetLeaf(ctx context.Context, keys KeyLookup,
+func marshalAssetLeaf(ctx context.Context, keys taprpc.KeyLookup,
 	assetLeaf *universe.MintingLeaf) (*unirpc.AssetLeaf, error) {
 
 	// In order to display the full asset, we'll also encode the genesis
@@ -2774,7 +2683,7 @@ func marshalAssetLeaf(ctx context.Context, keys KeyLookup,
 		return nil, err
 	}
 
-	rpcAsset, err := MarshalAsset(
+	rpcAsset, err := taprpc.MarshalAsset(
 		ctx, &assetLeaf.GenesisProof.Asset, false, true, keys,
 	)
 	if err != nil {

--- a/tapdb/assets_store_test.go
+++ b/tapdb/assets_store_test.go
@@ -339,7 +339,9 @@ func TestImportAssetProof(t *testing.T) {
 	// Finally, we'll verify all the anchor information that was inserted
 	// on disk.
 	require.Equal(t, testProof.AnchorBlockHash, dbAsset.AnchorBlockHash)
-	require.Equal(t, testProof.OutPoint, dbAsset.AnchorOutpoint)
+	require.Equal(
+		t, testProof.AssetSnapshot.OutPoint, dbAsset.AnchorOutpoint,
+	)
 	require.Equal(t, testProof.AnchorTx.TxHash(), dbAsset.AnchorTx.TxHash())
 
 	// We should also be able to fetch the proof we just inserted using the
@@ -395,7 +397,9 @@ func TestImportAssetProof(t *testing.T) {
 	// Finally, we'll verify all the anchor information that was inserted
 	// on disk.
 	require.Equal(t, testProof.AnchorBlockHash, dbAsset.AnchorBlockHash)
-	require.Equal(t, testProof.OutPoint, dbAsset.AnchorOutpoint)
+	require.Equal(
+		t, testProof.AssetSnapshot.OutPoint, dbAsset.AnchorOutpoint,
+	)
 	require.Equal(t, testProof.AnchorTx.TxHash(), dbAsset.AnchorTx.TxHash())
 }
 

--- a/tapfreighter/chain_porter.go
+++ b/tapfreighter/chain_porter.go
@@ -1012,8 +1012,9 @@ func (p *ChainPorter) stateStep(currentPkg sendPackage) (*sendPackage, error) {
 		err := p.storeProofs(&currentPkg)
 		return &currentPkg, err
 
-	// At this point, the transfer transaction is confirmed on-chain. We go
-	// on to store the sender and receiver proofs in the proof archive.
+	// At this point, the transfer transaction is confirmed on-chain, and
+	// we've stored the sender and receiver proofs in the proof archive.
+	// We'll now attempt to transfer the receiver proof to the receiver.
 	case SendStateReceiverProofTransfer:
 		// We'll set the package state to complete early here so the
 		// main loop breaks out. We'll continue to attempt proof

--- a/tapgarden/custodian.go
+++ b/tapgarden/custodian.go
@@ -386,6 +386,7 @@ func (c *Custodian) inspectWalletTx(walletTx *lndclient.Transaction) error {
 			loc := proof.Locator{
 				AssetID:   &assetID,
 				ScriptKey: addr.ScriptKey,
+				OutPoint:  &op,
 			}
 			addrProof, err := courier.ReceiveProof(ctx, loc)
 			if err != nil {

--- a/tapgarden/custodian.go
+++ b/tapgarden/custodian.go
@@ -18,6 +18,10 @@ import (
 	"github.com/lightningnetwork/lnd/lnrpc"
 )
 
+const (
+	defaultProofRetrievalDelay = 5 * time.Second
+)
+
 // CustodianConfig houses all the items that the Custodian needs to carry out
 // its duties.
 type CustodianConfig struct {
@@ -381,6 +385,10 @@ func (c *Custodian) inspectWalletTx(walletTx *lndclient.Transaction) error {
 					"service handle: %v", err)
 				return
 			}
+
+			// Sleep to give the sender an opportunity to transfer
+			// the proof to the proof courier service.
+			time.Sleep(defaultProofRetrievalDelay)
 
 			// Attempt to receive proof via proof courier service.
 			loc := proof.Locator{

--- a/taprpc/marshal.go
+++ b/taprpc/marshal.go
@@ -1,0 +1,100 @@
+package taprpc
+
+import (
+	"context"
+
+	"github.com/lightninglabs/taproot-assets/asset"
+	"github.com/lightningnetwork/lnd/keychain"
+)
+
+// KeyLookup is used to determine whether a key is under the control of the
+// local wallet.
+type KeyLookup interface {
+	// IsLocalKey returns true if the key is under the control of the
+	// wallet and can be derived by it.
+	IsLocalKey(ctx context.Context, desc keychain.KeyDescriptor) bool
+}
+
+// MarshalAsset converts an asset to its rpc representation.
+func MarshalAsset(ctx context.Context, a *asset.Asset,
+	isSpent, withWitness bool,
+	keyRing KeyLookup) (*Asset, error) {
+
+	assetID := a.Genesis.ID()
+	scriptKeyIsLocal := false
+	if a.ScriptKey.TweakedScriptKey != nil && keyRing != nil {
+		scriptKeyIsLocal = keyRing.IsLocalKey(
+			ctx, a.ScriptKey.RawKey,
+		)
+	}
+
+	rpcAsset := &Asset{
+		Version: int32(a.Version),
+		AssetGenesis: &GenesisInfo{
+			GenesisPoint: a.Genesis.FirstPrevOut.String(),
+			Name:         a.Genesis.Tag,
+			MetaHash:     a.Genesis.MetaHash[:],
+			AssetId:      assetID[:],
+			OutputIndex:  a.Genesis.OutputIndex,
+		},
+		AssetType:        AssetType(a.Type),
+		Amount:           a.Amount,
+		LockTime:         int32(a.LockTime),
+		RelativeLockTime: int32(a.RelativeLockTime),
+		ScriptVersion:    int32(a.ScriptVersion),
+		ScriptKey:        a.ScriptKey.PubKey.SerializeCompressed(),
+		ScriptKeyIsLocal: scriptKeyIsLocal,
+		IsSpent:          isSpent,
+		IsBurn:           a.IsBurn(),
+	}
+
+	if a.GroupKey != nil {
+		var rawKey []byte
+		if a.GroupKey.RawKey.PubKey != nil {
+			rawKey = a.GroupKey.RawKey.PubKey.SerializeCompressed()
+		}
+		rpcAsset.AssetGroup = &AssetGroup{
+			RawGroupKey:     rawKey,
+			TweakedGroupKey: a.GroupKey.GroupPubKey.SerializeCompressed(),
+			AssetIdSig:      a.GroupKey.Sig.Serialize(),
+		}
+	}
+
+	if withWitness {
+		for idx := range a.PrevWitnesses {
+			witness := a.PrevWitnesses[idx]
+
+			prevID := witness.PrevID
+			rpcPrevID := &PrevInputAsset{
+				AnchorPoint: prevID.OutPoint.String(),
+				AssetId:     prevID.ID[:],
+				ScriptKey:   prevID.ScriptKey[:],
+			}
+
+			var rpcSplitCommitment *SplitCommitment
+			if witness.SplitCommitment != nil {
+				rootAsset, err := MarshalAsset(
+					ctx, &witness.SplitCommitment.RootAsset,
+					false, true, nil,
+				)
+				if err != nil {
+					return nil, err
+				}
+
+				rpcSplitCommitment = &SplitCommitment{
+					RootAsset: rootAsset,
+				}
+			}
+
+			rpcAsset.PrevWitnesses = append(
+				rpcAsset.PrevWitnesses, &PrevWitness{
+					PrevId:          rpcPrevID,
+					TxWitness:       witness.TxWitness,
+					SplitCommitment: rpcSplitCommitment,
+				},
+			)
+		}
+	}
+
+	return rpcAsset, nil
+}

--- a/taprpc/universerpc/marshal.go
+++ b/taprpc/universerpc/marshal.go
@@ -1,0 +1,53 @@
+package universerpc
+
+import (
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/wire"
+)
+
+// MarshalOutpoint marshals a wire.OutPoint into an RPC ready Outpoint.
+//
+// TODO(ffranr): Move this package's Outpoint type and this marshal function to
+// somewhere more general.
+func MarshalOutpoint(outPoint wire.OutPoint) *Outpoint {
+	return &Outpoint{
+		HashStr: outPoint.Hash.String(),
+		Index:   int32(outPoint.Index),
+	}
+}
+
+// MarshalAssetKey returns an RPC ready AssetKey.
+func MarshalAssetKey(outPoint wire.OutPoint,
+	scriptKeyPubKey *btcec.PublicKey) *AssetKey {
+
+	scriptKeyBytes := scriptKeyPubKey.SerializeCompressed()
+
+	return &AssetKey{
+		Outpoint: &AssetKey_Op{
+			Op: MarshalOutpoint(outPoint),
+		},
+		ScriptKey: &AssetKey_ScriptKeyBytes{
+			ScriptKeyBytes: scriptKeyBytes,
+		},
+	}
+}
+
+// MarshalUniverseID returns an RPC ready universe ID.
+func MarshalUniverseID(assetIDBytes []byte, groupKeyBytes []byte) *ID {
+	// We will marshal either a group key ID or an asset ID. If group key
+	// bytes are given, we marshal a group key ID, otherwise we marshal an
+	// asset ID.
+	if groupKeyBytes != nil {
+		return &ID{
+			Id: &ID_GroupKey{
+				GroupKey: groupKeyBytes,
+			},
+		}
+	}
+
+	return &ID{
+		Id: &ID_AssetId{
+			AssetId: assetIDBytes,
+		},
+	}
+}

--- a/universe/base.go
+++ b/universe/base.go
@@ -236,14 +236,6 @@ func (a *MintingArchive) verifyIssuanceProof(ctx context.Context, id Identifier,
 		return nil, fmt.Errorf("asset id mismatch: expected %v, got %v",
 			id.AssetID, newAsset.ID())
 
-	// The outpoint of the final resting place of the asset should match
-	// the leaf key
-	//
-	// TODO(roasbeef): this restrict to issuance
-	case assetSnapshot.OutPoint != key.MintingOutpoint:
-		return nil, fmt.Errorf("outpoint mismatch: expected %v, got %v",
-			key.MintingOutpoint, assetSnapshot.OutPoint)
-
 	// The script key should also match exactly.
 	case !newAsset.ScriptKey.PubKey.IsEqual(key.ScriptKey.PubKey):
 		return nil, fmt.Errorf("script key mismatch: expected %v, got "+

--- a/universe/base.go
+++ b/universe/base.go
@@ -7,8 +7,10 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/davecgh/go-spew/spew"
+	"github.com/lightninglabs/taproot-assets/asset"
 	"github.com/lightninglabs/taproot-assets/fn"
 	"github.com/lightninglabs/taproot-assets/proof"
 )
@@ -170,11 +172,21 @@ func (a *MintingArchive) RegisterIssuance(ctx context.Context, id Identifier,
 	// Otherwise, this is a new proof, so we'll first perform validation of
 	// the minting leaf to ensure it's a valid issuance proof.
 	//
-	// The proofs we insert are just the state transition, so we'll encode
-	// it as a file first as that's what the expected wants.
 	//
 	// TODO(roasbeef): add option to skip proof verification?
-	assetSnapshot, err := a.verifyIssuanceProof(ctx, id, key, leaf)
+
+	// Before we can validate a non-issuance proof we need to fetch the
+	// previous asset snapshot (which is the proof verification result for
+	// the previous/parent proof in the proof file).
+	prevAssetSnapshot, err := a.getPrevAssetSnapshot(ctx, id, *newProof)
+	if err != nil {
+		return nil, fmt.Errorf("unable to fetch previous asset "+
+			"snapshot: %w", err)
+	}
+
+	assetSnapshot, err := a.verifyIssuanceProof(
+		ctx, id, key, leaf, prevAssetSnapshot,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -207,10 +219,11 @@ func (a *MintingArchive) RegisterIssuance(ctx context.Context, id Identifier,
 // verifyIssuanceProof verifies the passed minting leaf is a valid issuance
 // proof, returning the asset snapshot if so.
 func (a *MintingArchive) verifyIssuanceProof(ctx context.Context, id Identifier,
-	key BaseKey, leaf *MintingLeaf) (*proof.AssetSnapshot, error) {
+	key BaseKey, leaf *MintingLeaf,
+	prevAssetSnapshot *proof.AssetSnapshot) (*proof.AssetSnapshot, error) {
 
 	assetSnapshot, err := leaf.GenesisProof.Verify(
-		ctx, nil, a.cfg.HeaderVerifier,
+		ctx, prevAssetSnapshot, a.cfg.HeaderVerifier,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("unable to verify proof: %v", err)
@@ -259,7 +272,7 @@ func (a *MintingArchive) RegisterNewIssuanceBatch(ctx context.Context,
 	err := fn.ParSlice(
 		ctx, items, func(ctx context.Context, i *IssuanceItem) error {
 			assetSnapshot, err := a.verifyIssuanceProof(
-				ctx, i.ID, i.Key, i.Leaf,
+				ctx, i.ID, i.Key, i.Leaf, nil,
 			)
 			if err != nil {
 				return err
@@ -296,6 +309,62 @@ func (a *MintingArchive) RegisterNewIssuanceBatch(ctx context.Context,
 	}()
 
 	return nil
+}
+
+// getPrevAssetSnapshot returns the previous asset snapshot for the passed
+// proof. If the proof is a genesis proof, then nil is returned.
+func (a *MintingArchive) getPrevAssetSnapshot(ctx context.Context,
+	uniID Identifier, newProof proof.Proof) (*proof.AssetSnapshot, error) {
+
+	// If this is a genesis proof, then there is no previous asset (and
+	// therefore no previous asset snapshot).
+	if newProof.Asset.HasGenesisWitness() {
+		return nil, nil
+	}
+
+	// Query for proof associated with the previous asset.
+	prevID, err := newProof.Asset.PrimaryPrevID()
+	if err != nil {
+		return nil, err
+	}
+
+	if prevID == nil {
+		return nil, fmt.Errorf("no previous asset ID found")
+	}
+
+	// Parse script key for previous asset.
+	prevScriptKeyPubKey, err := btcec.ParsePubKey(
+		prevID.ScriptKey[:],
+	)
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse previous "+
+			"script key: %v", err)
+	}
+	prevScriptKey := asset.NewScriptKey(prevScriptKeyPubKey)
+
+	prevBaseKey := BaseKey{
+		MintingOutpoint: prevID.OutPoint,
+		ScriptKey:       &prevScriptKey,
+	}
+
+	prevProofs, err := a.cfg.Multiverse.FetchIssuanceProof(
+		ctx, uniID, prevBaseKey,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("unable to fetch previous "+
+			"proof: %v", err)
+	}
+
+	prevProof := prevProofs[0].Leaf.GenesisProof
+
+	// Construct minimal asset snapshot for previous asset.
+	// This is a minimal the proof verification result for the
+	// previous (input) asset. We know that it was already verified
+	// as it was present in the multiverse/universe archive.
+	return &proof.AssetSnapshot{
+		Asset:    &prevProof.Asset,
+		OutPoint: prevID.OutPoint,
+	}, nil
 }
 
 // FetchIssuanceProof attempts to fetch an issuance proof for the target base


### PR DESCRIPTION
This PR adds a new multiverse RPC proof service handle for use in the chain porter.

This PR should close these issues when merged:
* https://github.com/lightninglabs/taproot-assets/issues/439
* https://github.com/lightninglabs/taproot-assets/issues/467
* https://github.com/lightninglabs/taproot-assets/issues/344

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lightninglabs/taproot-assets/473)
<!-- Reviewable:end -->
