### PR TITLE
Remove sendProof where possible from itests

### DIFF
--- a/itest/send_test.go
+++ b/itest/send_test.go
@@ -119,9 +119,6 @@ func testBasicSendUnidirectional(t *harnessTest) {
 			t, t.tapd, sendResp, genInfo.AssetId,
 			[]uint64{currentUnits, numUnits}, i, i+1,
 		)
-		_ = sendProof(
-			t, t.tapd, secondTapd, bobAddr.ScriptKey, genInfo,
-		)
 		AssertNonInteractiveRecvComplete(t.t, secondTapd, i+1)
 	}
 

--- a/tapgarden/custodian.go
+++ b/tapgarden/custodian.go
@@ -624,9 +624,17 @@ func (c *Custodian) setReceiveCompleted(event *address.Event,
 		Index: lastProof.InclusionProof.OutputIndex,
 	}
 
-	return c.cfg.AddrBook.CompleteEvent(
+	err = c.cfg.AddrBook.CompleteEvent(
 		ctxt, event, address.StatusCompleted, anchorPoint,
 	)
+	if err != nil {
+		return fmt.Errorf("error completing event: %w", err)
+	}
+
+	// Remove event from our cache of ongoing events.
+	delete(c.events, event.Outpoint)
+
+	return nil
 }
 
 // hasWalletTaprootOutput returns true if one of the outputs of the given

--- a/tapgarden/custodian.go
+++ b/tapgarden/custodian.go
@@ -337,11 +337,16 @@ func (c *Custodian) inspectWalletTx(walletTx *lndclient.Transaction) error {
 			return err
 		}
 
+		// We are not interested in the outpoint if we don't know of a
+		// pre-stored address associated with it.
+		if addr == nil {
+			continue
+		}
+
 		// TODO(ffranr): This proof courier disabled check should be
 		//  removed. It was implemented because some integration test do
 		//  not setup and use a proof courier.
-		skipProofCourier := c.cfg.ProofCourierCfg == nil || addr == nil
-		if skipProofCourier {
+		if c.cfg.ProofCourierCfg == nil {
 			continue
 		}
 


### PR DESCRIPTION
`sendProof` is a function which transports proof by querying from the sender node and inserting into the receiver node (all via RPC). This function should be avoided and the proof courier system should be used whenever possible.