### PR TITLE
Fix proof courier in integration test

### DIFF
--- a/itest/send_test.go
+++ b/itest/send_test.go
@@ -119,9 +119,6 @@ func testBasicSendUnidirectional(t *harnessTest) {
 			t, t.tapd, sendResp, genInfo.AssetId,
 			[]uint64{currentUnits, numUnits}, i, i+1,
 		)
-		_ = sendProof(
-			t, t.tapd, secondTapd, bobAddr.ScriptKey, genInfo,
-		)
 		AssertNonInteractiveRecvComplete(t.t, secondTapd, i+1)
 	}
 
@@ -211,10 +208,6 @@ func testResumePendingPackageSend(t *harnessTest) {
 			// node.
 			t.lndHarness.MineBlocks(6)
 		}
-
-		_ = sendProof(
-			t, sendTapd, recvTapd, recvAddr.ScriptKey, genInfo,
-		)
 
 		// Confirm with the receiver node that the asset was fully
 		// received.

--- a/itest/tapd_harness.go
+++ b/itest/tapd_harness.go
@@ -144,7 +144,7 @@ func newTapdHarness(ht *harnessTest, cfg tapdConfig,
 	case *ApertureHarness:
 		// Use passed in backoff config or default config.
 		backoffCfg := &proof.BackoffCfg{
-			BackoffResetWait: 20 * time.Second,
+			BackoffResetWait: 2 * time.Second,
 			NumTries:         3,
 			InitialBackoff:   2 * time.Second,
 			MaxBackoff:       2 * time.Second,

--- a/proof/courier.go
+++ b/proof/courier.go
@@ -510,7 +510,7 @@ func (h *HashMailCourier) DeliverProof(ctx context.Context,
 	proof *AnnotatedProof) error {
 
 	log.Infof("Attempting to deliver receiver proof for send of "+
-		"asset_id=%x, amt=%v", h.recipient.AssetID, h.recipient.Amount)
+		"asset_id=%v, amt=%v", h.recipient.AssetID, h.recipient.Amount)
 
 	// Compute the stream IDs for the sender and receiver.
 	senderStreamID := deriveSenderStreamID(h.recipient)

--- a/proof/proof.go
+++ b/proof/proof.go
@@ -147,6 +147,15 @@ type Proof struct {
 	ChallengeWitness wire.TxWitness
 }
 
+// OutPoint returns the outpoint that commits to the asset associated with this
+// proof.
+func (p *Proof) OutPoint() wire.OutPoint {
+	return wire.OutPoint{
+		Hash:  p.AnchorTx.TxHash(),
+		Index: p.InclusionProof.OutputIndex,
+	}
+}
+
 // EncodeRecords returns the set of known TLV records to encode a Proof.
 func (p *Proof) EncodeRecords() []tlv.Record {
 	records := make([]tlv.Record, 0, 9)


### PR DESCRIPTION
Replaces https://github.com/lightninglabs/taproot-assets/pull/483.

We noticed that the hashmail proof courier didn't work properly in the integration tests (while working on the new RPC based courier).
This PR fixes two issues that lead to the hashmail proof courier not working correctly in the itest:
 - One test sends to the same TAP address multiple times, but the custodian only ever looked at one and then bailed out (because we didn't delete completed events, kudos to @ffranr for finding this).
 - The hashmail courier looks at previous send attempts and then goes into a backoff wait if the same proof (or at least what looks like the same proof because it has the same script key and asset ID because it's two different transfers to the same address). That backoff time was simply longer than we waited for the proof to arrive.
