### PR TITLE
Group key witness support

### DIFF
--- a/asset/mock.go
+++ b/asset/mock.go
@@ -3,10 +3,17 @@ package asset
 import (
 	"bytes"
 	"encoding/hex"
+	"fmt"
 	"testing"
 
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/lndclient"
 	"github.com/lightninglabs/taproot-assets/internal/test"
 	"github.com/lightninglabs/taproot-assets/mssmt"
+	"github.com/lightningnetwork/lnd/input"
 	"github.com/stretchr/testify/require"
 )
 
@@ -53,6 +60,110 @@ func RandGroupKeyWithSigner(t testing.TB, genesis Genesis) (*GroupKey, []byte) {
 	require.NoError(t, err)
 
 	return groupKey, privateKey.Serialize()
+}
+
+// SignOutputRaw creates a signature for a single input.
+// Taken from lnd/lnwallet/btcwallet/signer:L344, SignOutputRaw
+func SignOutputRaw(priv *btcec.PrivateKey, tx *wire.MsgTx,
+	signDesc *input.SignDescriptor) (*schnorr.Signature, error) {
+
+	witnessScript := signDesc.WitnessScript
+
+	privKey := priv
+	var maybeTweakPrivKey *btcec.PrivateKey
+
+	switch {
+	case signDesc.SingleTweak != nil:
+		maybeTweakPrivKey = input.TweakPrivKey(
+			privKey, signDesc.SingleTweak,
+		)
+
+	case signDesc.DoubleTweak != nil:
+		maybeTweakPrivKey = input.DeriveRevocationPrivKey(
+			privKey, signDesc.DoubleTweak,
+		)
+
+	default:
+		maybeTweakPrivKey = privKey
+	}
+
+	privKey = maybeTweakPrivKey
+
+	// In case of a taproot output any signature is always a Schnorr
+	// signature, based on the new tapscript sighash algorithm.
+	if !txscript.IsPayToTaproot(signDesc.Output.PkScript) {
+		return nil, fmt.Errorf("mock signer: output script not taproot")
+	}
+
+	sigHashes := txscript.NewTxSigHashes(
+		tx, signDesc.PrevOutputFetcher,
+	)
+
+	// Are we spending a script path or the key path? The API is slightly
+	// different, so we need to account for that to get the raw signature.
+	var (
+		rawSig []byte
+		err    error
+	)
+	switch signDesc.SignMethod {
+	case input.TaprootKeySpendBIP0086SignMethod,
+		input.TaprootKeySpendSignMethod:
+
+		// This function tweaks the private key using the tap root key
+		// supplied as the tweak.
+		rawSig, err = txscript.RawTxInTaprootSignature(
+			tx, sigHashes, signDesc.InputIndex,
+			signDesc.Output.Value, signDesc.Output.PkScript,
+			signDesc.TapTweak, signDesc.HashType, privKey,
+		)
+
+	case input.TaprootScriptSpendSignMethod:
+		leaf := txscript.TapLeaf{
+			LeafVersion: txscript.BaseLeafVersion,
+			Script:      witnessScript,
+		}
+		rawSig, err = txscript.RawTxInTapscriptSignature(
+			tx, sigHashes, signDesc.InputIndex,
+			signDesc.Output.Value, signDesc.Output.PkScript,
+			leaf, signDesc.HashType, privKey,
+		)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	return schnorr.ParseSignature(rawSig)
+}
+
+func SignVirtualTx(priv *btcec.PrivateKey, signDesc *lndclient.SignDescriptor,
+	tx *wire.MsgTx, prevOut *wire.TxOut) (*schnorr.Signature, error) {
+
+	prevOutFetcher := txscript.NewCannedPrevOutputFetcher(
+		prevOut.PkScript, prevOut.Value,
+	)
+
+	sigHashes := txscript.NewTxSigHashes(tx, prevOutFetcher)
+
+	fullSignDesc := input.SignDescriptor{
+		KeyDesc:           signDesc.KeyDesc,
+		SingleTweak:       signDesc.SingleTweak,
+		DoubleTweak:       signDesc.DoubleTweak,
+		TapTweak:          signDesc.TapTweak,
+		WitnessScript:     signDesc.WitnessScript,
+		SignMethod:        signDesc.SignMethod,
+		Output:            signDesc.Output,
+		HashType:          signDesc.HashType,
+		SigHashes:         sigHashes,
+		PrevOutputFetcher: prevOutFetcher,
+		InputIndex:        signDesc.InputIndex,
+	}
+
+	sig, err := SignOutputRaw(priv, tx, &fullSignDesc)
+	if err != nil {
+		return nil, err
+	}
+
+	return sig, nil
 }
 
 // RandScriptKey creates a random script key for testing.

--- a/tapgarden/mock.go
+++ b/tapgarden/mock.go
@@ -452,14 +452,18 @@ func NewMockGenSigner(keyRing *MockKeyRing) *MockGenSigner {
 	}
 }
 
-func (m *MockGenSigner) SignGenesis(desc keychain.KeyDescriptor,
-	initialGen asset.Genesis, currentGen *asset.Genesis) (*btcec.PublicKey,
+func (m *MockGenSigner) SignVirtualTx(signDesc *lndclient.SignDescriptor,
+	virtualTx *wire.MsgTx, prevOut *wire.TxOut) (*btcec.PublicKey,
 	*schnorr.Signature, error) {
 
-	priv := m.KeyRing.Keys[desc.KeyLocator]
+	priv := m.KeyRing.Keys[signDesc.KeyDesc.KeyLocator]
 	signer := asset.NewRawKeyGenesisSigner(priv)
-	return signer.SignGenesis(desc, initialGen, currentGen)
+	return signer.SignVirtualTx(signDesc, virtualTx, prevOut)
 }
+
+// A compile-time assertion to ensure MockGenSigner meets the GenesisSigner
+// interface.
+var _ asset.GenesisSigner = (*MockGenSigner)(nil)
 
 type MockProofArchive struct {
 }

--- a/tapscript/mock.go
+++ b/tapscript/mock.go
@@ -1,14 +1,11 @@
 package tapscript
 
 import (
-	"fmt"
-
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
-	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/lndclient"
-	"github.com/lightningnetwork/lnd/input"
+	"github.com/lightninglabs/taproot-assets/asset"
 )
 
 type MockSigner struct {
@@ -21,106 +18,10 @@ func NewMockSigner(privKey *btcec.PrivateKey) *MockSigner {
 	}
 }
 
-// SignOutputRaw creates a signature for a single input.
-// Taken from lnd/lnwallet/btcwallet/signer:L344, SignOutputRaw
-func (m *MockSigner) SignOutputRaw(tx *wire.MsgTx,
-	signDesc *input.SignDescriptor) (*schnorr.Signature, error) {
-
-	witnessScript := signDesc.WitnessScript
-
-	privKey := m.PrivKey
-	var maybeTweakPrivKey *btcec.PrivateKey
-
-	switch {
-	case signDesc.SingleTweak != nil:
-		maybeTweakPrivKey = input.TweakPrivKey(
-			privKey, signDesc.SingleTweak,
-		)
-
-	case signDesc.DoubleTweak != nil:
-		maybeTweakPrivKey = input.DeriveRevocationPrivKey(
-			privKey, signDesc.DoubleTweak,
-		)
-
-	default:
-		maybeTweakPrivKey = privKey
-	}
-
-	privKey = maybeTweakPrivKey
-
-	// In case of a taproot output any signature is always a Schnorr
-	// signature, based on the new tapscript sighash algorithm.
-	if !txscript.IsPayToTaproot(signDesc.Output.PkScript) {
-		return nil, fmt.Errorf("mock signer: output script not taproot")
-	}
-
-	sigHashes := txscript.NewTxSigHashes(
-		tx, signDesc.PrevOutputFetcher,
-	)
-
-	// Are we spending a script path or the key path? The API is slightly
-	// different, so we need to account for that to get the raw signature.
-	var (
-		rawSig []byte
-		err    error
-	)
-	switch signDesc.SignMethod {
-	case input.TaprootKeySpendBIP0086SignMethod,
-		input.TaprootKeySpendSignMethod:
-
-		// This function tweaks the private key using the tap root key
-		// supplied as the tweak.
-		rawSig, err = txscript.RawTxInTaprootSignature(
-			tx, sigHashes, signDesc.InputIndex,
-			signDesc.Output.Value, signDesc.Output.PkScript,
-			signDesc.TapTweak, signDesc.HashType, privKey,
-		)
-
-	case input.TaprootScriptSpendSignMethod:
-		leaf := txscript.TapLeaf{
-			LeafVersion: txscript.BaseLeafVersion,
-			Script:      witnessScript,
-		}
-		rawSig, err = txscript.RawTxInTapscriptSignature(
-			tx, sigHashes, signDesc.InputIndex,
-			signDesc.Output.Value, signDesc.Output.PkScript,
-			leaf, signDesc.HashType, privKey,
-		)
-	}
-	if err != nil {
-		return nil, err
-	}
-
-	return schnorr.ParseSignature(rawSig)
-}
-
 func (m *MockSigner) SignVirtualTx(signDesc *lndclient.SignDescriptor,
 	tx *wire.MsgTx, prevOut *wire.TxOut) (*schnorr.Signature, error) {
 
-	prevOutFetcher := txscript.NewCannedPrevOutputFetcher(
-		prevOut.PkScript, prevOut.Value,
-	)
-
-	sigHashes := txscript.NewTxSigHashes(tx, prevOutFetcher)
-
-	fullSignDesc := input.SignDescriptor{
-		KeyDesc:           signDesc.KeyDesc,
-		SingleTweak:       signDesc.SingleTweak,
-		DoubleTweak:       signDesc.DoubleTweak,
-		TapTweak:          signDesc.TapTweak,
-		WitnessScript:     signDesc.WitnessScript,
-		SignMethod:        signDesc.SignMethod,
-		Output:            signDesc.Output,
-		HashType:          signDesc.HashType,
-		SigHashes:         sigHashes,
-		PrevOutputFetcher: prevOutFetcher,
-		InputIndex:        signDesc.InputIndex,
-	}
-
-	sig, err := m.SignOutputRaw(tx, &fullSignDesc)
-	if err != nil {
-		return nil, err
-	}
-
-	return sig, nil
+	return asset.SignVirtualTx(m.PrivKey, signDesc, tx, prevOut)
 }
+
+var _ Signer = (*MockSigner)(nil)

--- a/tapscript/tx.go
+++ b/tapscript/tx.go
@@ -71,65 +71,99 @@ func virtualTxInPrevOut(root mssmt.Node) *wire.OutPoint {
 	)
 }
 
+// virtualGenesisTxIn computes the single input of a Taproot Asset virtual
+// transaction where the asset is both a genesis asset and part of an asset
+// group. The input MS-SMT commits to the genesis asset with witnesses removed.
+func virtualGenesisTxIn(newAsset *asset.Asset) (*wire.TxIn, mssmt.Tree, error) {
+	inputTree := mssmt.NewCompactedTree(mssmt.NewDefaultStore())
+
+	// TODO(bhandras): thread the context through.
+	ctx := context.TODO()
+
+	// For genesis assets with a group key, we must clear the witness field
+	// before building the input MS-SMT. We use this copy of the genesis
+	// asset as the input asset for the virtual transaction.
+	copyWithoutWitness := newAsset.Copy()
+	for i := range copyWithoutWitness.PrevWitnesses {
+		copyWithoutWitness.PrevWitnesses[i].TxWitness = nil
+	}
+
+	key := asset.ZeroPrevID.Hash()
+	leaf, err := copyWithoutWitness.Leaf()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	_, err = inputTree.Insert(ctx, key, leaf)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	treeRoot, err := inputTree.Root(context.Background())
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO(roasbeef): document empty hash usage here
+	prevOut := virtualTxInPrevOut(treeRoot)
+
+	return wire.NewTxIn(prevOut, nil, nil), inputTree, nil
+}
+
 // virtualTxIn computes the single input of a Taproot Asset virtual transaction.
 // The input prevout's hash is the root of a MS-SMT committing to all inputs of
 // a state transition.
 func virtualTxIn(newAsset *asset.Asset, prevAssets commitment.InputSet) (
 	*wire.TxIn, mssmt.Tree, error) {
 
-	// Genesis assets shouldn't have any inputs committed, so they'll have
-	// an empty input tree.
-	isGenesisAsset := newAsset.HasGenesisWitness()
 	inputTree := mssmt.NewCompactedTree(mssmt.NewDefaultStore())
-	if !isGenesisAsset {
-		// For each input we'll locate the asset UTXO beign spent, then
-		// insert that into a new SMT, with the key being the hash of
-		// the prevID pointer, and the value being the leaf itself.
-		inputsConsumed := make(
-			map[asset.PrevID]struct{}, len(prevAssets),
-		)
+	// For each input we'll locate the asset UTXO beign spent, then
+	// insert that into a new SMT, with the key being the hash of
+	// the prevID pointer, and the value being the leaf itself.
+	inputsConsumed := make(
+		map[asset.PrevID]struct{}, len(prevAssets),
+	)
 
-		// TODO(bhandras): thread the context through.
-		ctx := context.TODO()
+	// TODO(bhandras): thread the context through.
+	ctx := context.TODO()
 
-		for _, input := range newAsset.PrevWitnesses {
-			// At this point, each input MUST have a prev ID.
-			if input.PrevID == nil {
-				return nil, nil, ErrNoInputs
-			}
-
-			// The set of prev assets are similar to the prev
-			// output fetcher used in taproot.
-			prevAsset, ok := prevAssets[*input.PrevID]
-			if !ok {
-				return nil, nil, ErrNoInputs
-			}
-
-			// Now we'll insert this prev asset leaf into the tree.
-			// The generated leaf includes the amount of the asset,
-			// so the sum of this tree will be the total amount
-			// being spent.
-			key := input.PrevID.Hash()
-			leaf, err := prevAsset.Leaf()
-			if err != nil {
-				return nil, nil, err
-			}
-			_, err = inputTree.Insert(ctx, key, leaf)
-			if err != nil {
-				return nil, nil, err
-			}
-
-			inputsConsumed[*input.PrevID] = struct{}{}
+	for _, input := range newAsset.PrevWitnesses {
+		// At this point, each input MUST have a prev ID.
+		if input.PrevID == nil {
+			return nil, nil, ErrNoInputs
 		}
 
-		// In this context, the set of referenced inputs should match
-		// the set of previous assets. This ensures no duplicate inputs
-		// are being spent.
-		//
-		// TODO(roasbeef): make further explicit?
-		if len(inputsConsumed) != len(prevAssets) {
-			return nil, nil, ErrInputMismatch
+		// The set of prev assets are similar to the prev
+		// output fetcher used in taproot.
+		prevAsset, ok := prevAssets[*input.PrevID]
+		if !ok {
+			return nil, nil, ErrNoInputs
 		}
+
+		// Now we'll insert this prev asset leaf into the tree.
+		// The generated leaf includes the amount of the asset,
+		// so the sum of this tree will be the total amount
+		// being spent.
+		key := input.PrevID.Hash()
+		leaf, err := prevAsset.Leaf()
+		if err != nil {
+			return nil, nil, err
+		}
+		_, err = inputTree.Insert(ctx, key, leaf)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		inputsConsumed[*input.PrevID] = struct{}{}
+	}
+
+	// In this context, the set of referenced inputs should match
+	// the set of previous assets. This ensures no duplicate inputs
+	// are being spent.
+	//
+	// TODO(roasbeef): make further explicit?
+	if len(inputsConsumed) != len(prevAssets) {
+		return nil, nil, ErrInputMismatch
 	}
 
 	treeRoot, err := inputTree.Root(context.Background())
@@ -220,8 +254,19 @@ func virtualTxOut(asset *asset.Asset) (*wire.TxOut, error) {
 func VirtualTx(newAsset *asset.Asset, prevAssets commitment.InputSet) (
 	*wire.MsgTx, mssmt.Tree, error) {
 
+	var (
+		txIn      *wire.TxIn
+		inputTree mssmt.Tree
+		err       error
+	)
+
 	// We'll start by mapping all inputs into a MS-SMT.
-	txIn, inputTree, err := virtualTxIn(newAsset, prevAssets)
+	switch newAsset.HasGenesisWitnessForGroup() {
+	case true:
+		txIn, inputTree, err = virtualGenesisTxIn(newAsset)
+	case false:
+		txIn, inputTree, err = virtualTxIn(newAsset, prevAssets)
+	}
 	if err != nil {
 		return nil, nil, err
 	}
@@ -263,8 +308,19 @@ func InputAssetPrevOut(prevAsset asset.Asset) (*wire.TxOut, error) {
 	var pkScript []byte
 	switch prevAsset.ScriptVersion {
 	case asset.ScriptV0:
-		var err error
-		pkScript, err = PayToTaprootScript(prevAsset.ScriptKey.PubKey)
+		var (
+			err           error
+			validationKey = prevAsset.ScriptKey.PubKey
+		)
+
+		// If the input asset is a genesis asset that is part of an
+		// asset group, we need to validate the group witness against
+		// the tweaked group key and not the genesis asset script key.
+		if prevAsset.HasGenesisWitnessForGroup() {
+			validationKey = &prevAsset.GroupKey.GroupPubKey
+		}
+
+		pkScript, err = PayToTaprootScript(validationKey)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Implements changes outlined in https://github.com/lightninglabs/taproot-assets/issues/466.

Known TODOs:

- [ ] VM execution in `DeriveGroupKey` to verify witness correctness
- [ ] Copy group witness to `asset.PrevWitnesses` where need so the witness gets serialized
- [ ] update `proof.Verify` to use new genesis asset definition
- [ ] Resolve dependency cycle with `tapscript` package
- [ ] New unit test cases for features introduced in past PRs

Approach:

- Modify the `virtualTx` methods to add new branches for creating a virtual TX for a genesis grouped asset.

- Modify the VM to prevent an early exit for genesis grouped assets, and add early assertions for such assets.

- Update `DeriveGroupKey` to sign over a virtualTx representing minting of a genesis grouped asset.

- Update `DeriveGroupKey` to accept external scripts and support different signing methods.

Open questions:

- Can we reuse the existing `VirtualTxSigner` for the `GenesisSigner`?

- Is there other data needed for a group key script path authorization here besides a single `TapLeaf`? In `CreateTaprootSignature` I see validation against other fields but not use of those other fields for signing.

- How can we resolve the `tapscript` dependency cycle? I see two issues, one being the placement of `RawKeyGenesisSigner` code, which AFAICT is only used in tests. The other is that, the `asset` package can't call methods from the `tapscript` package without causing a cycle, but with the current setup `DeriveGroupKey` must build a virtual TX at some point. I think one option may be to move some of the group signing logic into the `tapscript` package.