### PR TITLE
Rename aperture courier type to hashmail courier type

### DIFF
--- a/itest/tapd_harness.go
+++ b/itest/tapd_harness.go
@@ -169,7 +169,7 @@ func newTapdHarness(t *testing.T, ht *harnessTest, cfg tapdConfig,
 		}
 
 		finalCfg.DefaultProofCourierAddr = fmt.Sprintf(
-			"%s://%s", proof.ApertureCourier,
+			"%s://%s", proof.HashmailCourierType,
 			typedProofCourier.ListenAddr,
 		)
 

--- a/itest/test_harness.go
+++ b/itest/test_harness.go
@@ -280,7 +280,7 @@ func setupHarnesses(t *testing.T, ht *harnessTest,
 	case proof.DisabledCourier:
 		// Proof courier disabled, do nothing.
 
-	case proof.ApertureCourier:
+	case proof.HashmailCourierType:
 		port := nextAvailablePort()
 		apHarness := NewApertureHarness(ht.t, port)
 		proofCourier = &apHarness

--- a/itest/test_list_on_test.go
+++ b/itest/test_list_on_test.go
@@ -41,27 +41,27 @@ var testCases = []*testCase{
 	{
 		name:             "basic send unidirectional",
 		test:             testBasicSendUnidirectional,
-		proofCourierType: proof.ApertureCourier,
+		proofCourierType: proof.HashmailCourierType,
 	},
 	{
 		name:             "resume pending package send",
 		test:             testResumePendingPackageSend,
-		proofCourierType: proof.ApertureCourier,
+		proofCourierType: proof.HashmailCourierType,
 	},
 	{
 		name:             "reattempt failed asset send",
 		test:             testReattemptFailedAssetSend,
-		proofCourierType: proof.ApertureCourier,
+		proofCourierType: proof.HashmailCourierType,
 	},
 	{
 		name:             "offline receiver eventually receives",
 		test:             testOfflineReceiverEventuallyReceives,
-		proofCourierType: proof.ApertureCourier,
+		proofCourierType: proof.HashmailCourierType,
 	},
 	{
 		name:             "basic send passive asset",
 		test:             testBasicSendPassiveAsset,
-		proofCourierType: proof.ApertureCourier,
+		proofCourierType: proof.HashmailCourierType,
 	},
 	{
 		name: "send multiple coins",

--- a/proof/courier.go
+++ b/proof/courier.go
@@ -20,10 +20,8 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-// CourierType is an enum that represents the different types of proof courier
-// services.
-//
-// TODO(ffranr): Rename to CourierProtocol.
+// CourierType is an enum that represents the different proof courier services
+// protocols that are supported.
 type CourierType string
 
 const (

--- a/proof/courier.go
+++ b/proof/courier.go
@@ -31,12 +31,9 @@ const (
 	// courier is specified.
 	DisabledCourier CourierType = "disabled_courier"
 
-	// ApertureCourier is a courier that uses the hashmail protocol to
+	// HashmailCourierType is a courier that uses the hashmail protocol to
 	// deliver proofs.
-	//
-	// TODO(ffranr): Rename to HashmailCourier (use protocol name rather
-	//  than service).
-	ApertureCourier = "hashmail"
+	HashmailCourierType = "hashmail"
 )
 
 // CourierHarness interface is an integration testing harness for a proof
@@ -98,7 +95,7 @@ func ParseCourierAddrString(addr string) (CourierAddr, error) {
 func ParseCourierAddrUrl(addr url.URL) (CourierAddr, error) {
 	// Create new courier addr based on URL scheme.
 	switch addr.Scheme {
-	case ApertureCourier:
+	case HashmailCourierType:
 		return NewHashMailCourierAddr(addr)
 	}
 
@@ -148,7 +145,7 @@ func (h *HashMailCourierAddr) NewCourier(_ context.Context, cfg *CourierCfg,
 // URL. This function also performs hashmail protocol specific address
 // validation.
 func NewHashMailCourierAddr(addr url.URL) (*HashMailCourierAddr, error) {
-	if addr.Scheme != ApertureCourier {
+	if addr.Scheme != HashmailCourierType {
 		return nil, fmt.Errorf("expected hashmail courier protocol: %v",
 			addr.Scheme)
 	}
@@ -244,7 +241,7 @@ func serverDialOpts() ([]grpc.DialOption, error) {
 func NewHashMailBox(courierAddr *url.URL) (*HashMailBox,
 	error) {
 
-	if courierAddr.Scheme != ApertureCourier {
+	if courierAddr.Scheme != HashmailCourierType {
 		return nil, fmt.Errorf("unsupported courier protocol: %v",
 			courierAddr.Scheme)
 	}

--- a/tapcfg/config.go
+++ b/tapcfg/config.go
@@ -340,7 +340,7 @@ func DefaultConfig() Config {
 		BatchMintingInterval: defaultBatchMintingInterval,
 		ReOrgSafeDepth:       defaultReOrgSafeDepth,
 		DefaultProofCourierAddr: fmt.Sprintf(
-			"%s://%s", proof.ApertureCourier, fallbackHashMailAddr,
+			"%s://%s", proof.HashmailCourierType, fallbackHashMailAddr,
 		),
 		HashMailCourier: &proof.HashMailCourierCfg{
 			ReceiverAckTimeout: defaultProofTransferReceiverAckTimeout,

--- a/tapcfg/server.go
+++ b/tapcfg/server.go
@@ -159,7 +159,7 @@ func genServerConfig(cfg *Config, cfgLogger btclog.Logger,
 	// If no default proof courier address is set, use the fallback hashmail
 	// address.
 	fallbackHashmailCourierAddr := fmt.Sprintf(
-		"%s://%s", proof.ApertureCourier, fallbackHashMailAddr,
+		"%s://%s", proof.HashmailCourierType, fallbackHashMailAddr,
 	)
 	proofCourierAddr, err := proof.ParseCourierAddrString(
 		fallbackHashmailCourierAddr,


### PR DESCRIPTION
Aperture is the service. The courier type enum should organise supported courier address protocols.