### PR TITLE
Generalise multiverse method names to support all proofs.

### DIFF
--- a/config.go
+++ b/config.go
@@ -69,7 +69,7 @@ type DatabaseConfig struct {
 
 	TapAddrBook *tapdb.TapAddressBook
 
-	Multiverse *tapdb.BaseMultiverse
+	Multiverse *tapdb.MultiverseStore
 
 	FederationDB *tapdb.UniverseFederationDB
 }

--- a/itest/tapd_harness.go
+++ b/itest/tapd_harness.go
@@ -49,7 +49,7 @@ const (
 	// defaultProofTransferReceiverAckTimeout is the default itest specific
 	// timeout we'll use for waiting for a receiver to acknowledge a proof
 	// transfer.
-	defaultProofTransferReceiverAckTimeout = 5 * time.Second
+	defaultProofTransferReceiverAckTimeout = 15 * time.Second
 )
 
 // tapdHarness is a test harness that holds everything that is needed to

--- a/tapcfg/server.go
+++ b/tapcfg/server.go
@@ -115,7 +115,7 @@ func genServerConfig(cfg *Config, cfgLogger btclog.Logger,
 			return db.WithTx(tx)
 		},
 	)
-	multiverse := tapdb.NewBaseMultiverse(multiverseDB)
+	multiverse := tapdb.NewMultiverseStore(multiverseDB)
 
 	uniStatsDB := tapdb.NewTransactionExecutor(
 		db, func(tx *sql.Tx) tapdb.UniverseStatsStore {

--- a/tapdb/multiverse.go
+++ b/tapdb/multiverse.go
@@ -213,9 +213,9 @@ func (b *MultiverseStore) FetchIssuanceProof(ctx context.Context,
 	return proofs, nil
 }
 
-// RegisterIssuance inserts a new minting leaf within the multiverse tree and
-// the universe tree that corresponds to the given base key.
-func (b *MultiverseStore) RegisterIssuance(ctx context.Context,
+// UpsertProofLeaf upserts a proof leaf within the multiverse tree and the
+// universe tree that corresponds to the given key.
+func (b *MultiverseStore) UpsertProofLeaf(ctx context.Context,
 	id universe.Identifier, key universe.BaseKey,
 	leaf *universe.MintingLeaf,
 	metaReveal *proof.MetaReveal) (*universe.IssuanceProof, error) {

--- a/tapdb/multiverse.go
+++ b/tapdb/multiverse.go
@@ -152,11 +152,11 @@ func (b *MultiverseStore) RootNodes(
 	return uniRoots, nil
 }
 
-// FetchIssuanceProof returns an issuance proof for the target key. If the key
-// doesn't have a script key specified, then all the proofs for the minting
-// outpoint will be returned. If neither are specified, then proofs for all the
-// inserted leaves will be returned.
-func (b *MultiverseStore) FetchIssuanceProof(ctx context.Context,
+// FetchProofLeaf returns a proof leaf for the target key. If the key
+// doesn't have a script key specified, then all the proof leafs for the minting
+// outpoint will be returned. If neither are specified, then all inserted proof
+// leafs will be returned.
+func (b *MultiverseStore) FetchProofLeaf(ctx context.Context,
 	id universe.Identifier,
 	universeKey universe.BaseKey) ([]*universe.IssuanceProof, error) {
 

--- a/tapdb/multiverse.go
+++ b/tapdb/multiverse.go
@@ -52,10 +52,10 @@ type BatchedMultiverse interface {
 	BatchedTx[BaseMultiverseStore]
 }
 
-// BaseMultiverse implements the persistent storage for a multiverse.
+// MultiverseStore implements the persistent storage for a multiverse.
 //
 // NOTE: This implements the universe.BaseMultiverse interface.
-type BaseMultiverse struct {
+type MultiverseStore struct {
 	db BatchedMultiverse
 
 	// TODO(roasbeef): actually the start of multiverse?
@@ -64,15 +64,15 @@ type BaseMultiverse struct {
 }
 
 // NewBaseMultiverse creates a new base multiverse.
-func NewBaseMultiverse(db BatchedMultiverse) *BaseMultiverse {
-	return &BaseMultiverse{
+func NewBaseMultiverse(db BatchedMultiverse) *MultiverseStore {
+	return &MultiverseStore{
 		db: db,
 	}
 }
 
 // RootNodes returns the complete set of known base universe root nodes for the
 // set of base universes tracked in the multiverse.
-func (b *BaseMultiverse) RootNodes(
+func (b *MultiverseStore) RootNodes(
 	ctx context.Context) ([]universe.BaseRoot, error) {
 
 	var (
@@ -156,7 +156,7 @@ func (b *BaseMultiverse) RootNodes(
 // doesn't have a script key specified, then all the proofs for the minting
 // outpoint will be returned. If neither are specified, then proofs for all the
 // inserted leaves will be returned.
-func (b *BaseMultiverse) FetchIssuanceProof(ctx context.Context,
+func (b *MultiverseStore) FetchIssuanceProof(ctx context.Context,
 	id universe.Identifier,
 	universeKey universe.BaseKey) ([]*universe.IssuanceProof, error) {
 
@@ -215,7 +215,7 @@ func (b *BaseMultiverse) FetchIssuanceProof(ctx context.Context,
 
 // RegisterIssuance inserts a new minting leaf within the multiverse tree and
 // the universe tree that corresponds to the given base key.
-func (b *BaseMultiverse) RegisterIssuance(ctx context.Context,
+func (b *MultiverseStore) RegisterIssuance(ctx context.Context,
 	id universe.Identifier, key universe.BaseKey,
 	leaf *universe.MintingLeaf,
 	metaReveal *proof.MetaReveal) (*universe.IssuanceProof, error) {
@@ -297,7 +297,7 @@ func (b *BaseMultiverse) RegisterIssuance(ctx context.Context,
 
 // RegisterBatchIssuance inserts a new minting leaf batch within the multiverse
 // tree and the universe tree that corresponds to the given base key(s).
-func (b *BaseMultiverse) RegisterBatchIssuance(ctx context.Context,
+func (b *MultiverseStore) RegisterBatchIssuance(ctx context.Context,
 	items []*universe.IssuanceItem) error {
 
 	insertProof := func(item *universe.IssuanceItem,

--- a/tapdb/multiverse.go
+++ b/tapdb/multiverse.go
@@ -63,8 +63,8 @@ type MultiverseStore struct {
 	// * drop base in front?
 }
 
-// NewBaseMultiverse creates a new base multiverse.
-func NewBaseMultiverse(db BatchedMultiverse) *MultiverseStore {
+// NewMultiverseStore creates a new multiverse DB store handle.
+func NewMultiverseStore(db BatchedMultiverse) *MultiverseStore {
 	return &MultiverseStore{
 		db: db,
 	}

--- a/tapdb/multiverse.go
+++ b/tapdb/multiverse.go
@@ -54,7 +54,7 @@ type BatchedMultiverse interface {
 
 // MultiverseStore implements the persistent storage for a multiverse.
 //
-// NOTE: This implements the universe.BaseMultiverse interface.
+// NOTE: This implements the universe.MultiverseArchive interface.
 type MultiverseStore struct {
 	db BatchedMultiverse
 

--- a/tapdb/universe_test.go
+++ b/tapdb/universe_test.go
@@ -400,7 +400,7 @@ func TestUniverseTreeIsolation(t *testing.T) {
 			return db.WithTx(tx)
 		},
 	)
-	multiverse := NewBaseMultiverse(multiverseDB)
+	multiverse := NewMultiverseStore(multiverseDB)
 
 	rootNodes, err := multiverse.RootNodes(ctx)
 	require.NoError(t, err)

--- a/universe/base.go
+++ b/universe/base.go
@@ -30,7 +30,7 @@ type MintingArchiveConfig struct {
 
 	// Multiverse is used to interact with the set of known base
 	// universe trees, and also obtain associated metadata and statistics.
-	Multiverse BaseMultiverse
+	Multiverse MultiverseArchive
 
 	// UniverseStats is used to export statistics related to the set of
 	// external/internal queries to the base universe instance.

--- a/universe/base.go
+++ b/universe/base.go
@@ -193,7 +193,7 @@ func (a *MintingArchive) RegisterIssuance(ctx context.Context, id Identifier,
 
 	// Now that we know the proof is valid, we'll insert it into the base
 	// multiverse backend, and return the new issuance proof.
-	issuanceProof, err := a.cfg.Multiverse.RegisterIssuance(
+	issuanceProof, err := a.cfg.Multiverse.UpsertProofLeaf(
 		ctx, id, key, leaf, assetSnapshot.MetaReveal,
 	)
 	if err != nil {

--- a/universe/base.go
+++ b/universe/base.go
@@ -145,7 +145,7 @@ func (a *MintingArchive) RegisterIssuance(ctx context.Context, id Identifier,
 
 	// We'll first check to see if we already know of this leaf within the
 	// multiverse. If so, then we'll return the existing issuance proof.
-	issuanceProofs, err := a.cfg.Multiverse.FetchIssuanceProof(ctx, id, key)
+	issuanceProofs, err := a.cfg.Multiverse.FetchProofLeaf(ctx, id, key)
 	switch {
 	case err == nil && len(issuanceProofs) > 0:
 		issuanceProof := issuanceProofs[0]
@@ -347,7 +347,7 @@ func (a *MintingArchive) getPrevAssetSnapshot(ctx context.Context,
 		ScriptKey:       &prevScriptKey,
 	}
 
-	prevProofs, err := a.cfg.Multiverse.FetchIssuanceProof(
+	prevProofs, err := a.cfg.Multiverse.FetchProofLeaf(
 		ctx, uniID, prevBaseKey,
 	)
 	if err != nil {
@@ -390,7 +390,7 @@ func (a *MintingArchive) FetchIssuanceProof(ctx context.Context, id Identifier,
 		}()
 	}()
 
-	return a.cfg.Multiverse.FetchIssuanceProof(ctx, id, key)
+	return a.cfg.Multiverse.FetchProofLeaf(ctx, id, key)
 }
 
 // MintingKeys returns the set of minting keys known for the specified base

--- a/universe/interface.go
+++ b/universe/interface.go
@@ -243,9 +243,9 @@ type BaseMultiverse interface {
 	// of assets tracked in the base Universe.
 	RootNodes(ctx context.Context) ([]BaseRoot, error)
 
-	// RegisterIssuance inserts a new minting (issuance) leaf within the
-	// multiverse tree, stored at the given base key.
-	RegisterIssuance(ctx context.Context, id Identifier, key BaseKey,
+	// UpsertProofLeaf upserts a proof leaf within the multiverse tree and
+	// the universe tree that corresponds to the given key.
+	UpsertProofLeaf(ctx context.Context, id Identifier, key BaseKey,
 		leaf *MintingLeaf,
 		metaReveal *proof.MetaReveal) (*IssuanceProof, error)
 

--- a/universe/interface.go
+++ b/universe/interface.go
@@ -234,11 +234,11 @@ type BaseRoot struct {
 	GroupedAssets map[asset.ID]uint64
 }
 
-// BaseMultiverse is an interface used to keep track of the set of base universe
+// MultiverseArchive is an interface used to keep track of the set of universe
 // roots that we know of. The BaseBackend interface is used to interact with a
 // particular base universe, while this is used to obtain aggregate information
 // about the universes.
-type BaseMultiverse interface {
+type MultiverseArchive interface {
 	// RootNodes returns the complete set of known root nodes for the set
 	// of assets tracked in the base Universe.
 	RootNodes(ctx context.Context) ([]BaseRoot, error)

--- a/universe/interface.go
+++ b/universe/interface.go
@@ -254,11 +254,11 @@ type MultiverseArchive interface {
 	// base key(s).
 	RegisterBatchIssuance(ctx context.Context, items []*IssuanceItem) error
 
-	// FetchIssuanceProof returns an issuance proof for the target key. If
-	// the key doesn't have a script key specified, then all the proofs for
-	// the minting outpoint will be returned. If neither are specified, then
-	// proofs for all the inserted leaves will be returned.
-	FetchIssuanceProof(ctx context.Context, id Identifier,
+	// FetchProofLeaf returns a proof leaf for the target key. If the key
+	// doesn't have a script key specified, then all the proof leafs for the
+	// minting outpoint will be returned. If neither are specified, then all
+	// inserted proof leafs will be returned.
+	FetchProofLeaf(ctx context.Context, id Identifier,
 		key BaseKey) ([]*IssuanceProof, error)
 
 	// TODO(roasbeef): other stats stuff here, like total number of assets, etc


### PR DESCRIPTION
This PR renames multiverse store and archive method names to reflect the fact that they are now handle transfer proofs in addition to issuance proofs.

We should merge https://github.com/lightninglabs/taproot-assets/pull/473 first.