### PR TITLE
tapfreighter: validate proof courier address before commencing send

### DIFF
--- a/proof/courier.go
+++ b/proof/courier.go
@@ -97,8 +97,8 @@ func ParseCourierAddrUrl(addr url.URL) (CourierAddr, error) {
 		return NewHashMailCourierAddr(addr)
 	}
 
-	return nil, fmt.Errorf("unknown courier address protocol: %v",
-		addr.Scheme)
+	return nil, fmt.Errorf("unknown courier address protocol "+
+		"(consider updating tapd): %v", addr.Scheme)
 }
 
 // HashMailCourierAddr is a hashmail protocol specific implementation of the

--- a/tapfreighter/chain_porter.go
+++ b/tapfreighter/chain_porter.go
@@ -172,6 +172,15 @@ func (p *ChainPorter) Stop() error {
 // RequestShipment is the main external entry point to the porter. This request
 // a new transfer take place.
 func (p *ChainPorter) RequestShipment(req Parcel) (*OutboundParcel, error) {
+	// Perform validation on the parcel before we continue. This is a good
+	// point to perform validation because it is at the external entry point
+	// to the porter. We will therefore catch invalid parcels before locking
+	// coins or broadcasting.
+	err := req.Validate()
+	if err != nil {
+		return nil, fmt.Errorf("failed to validate parcel: %w", err)
+	}
+
 	if !fn.SendOrQuit(p.exportReqs, req, p.Quit) {
 		return nil, fmt.Errorf("ChainPorter shutting down")
 	}

--- a/tapfreighter/parcel.go
+++ b/tapfreighter/parcel.go
@@ -107,6 +107,9 @@ type Parcel interface {
 
 	// kit returns the parcel kit used for delivery.
 	kit() *parcelKit
+
+	// Validate validates the parcel.
+	Validate() error
 }
 
 // parcelKit is a struct that contains the channels that are used to deliver
@@ -160,6 +163,28 @@ func (p *AddressParcel) kit() *parcelKit {
 	return p.parcelKit
 }
 
+// Validate validates the parcel.
+func (p *AddressParcel) Validate() error {
+	// We need at least one address to send to in an address parcel.
+	if len(p.destAddrs) < 1 {
+		return fmt.Errorf("at least one Tap address must be " +
+			"specified in address parcel")
+	}
+
+	for idx := range p.destAddrs {
+		tapAddr := p.destAddrs[idx]
+
+		// Validate proof courier addresses.
+		_, err := proof.ParseCourierAddrUrl(tapAddr.ProofCourierAddr)
+		if err != nil {
+			return fmt.Errorf("invalid proof courier address: %w",
+				err)
+		}
+	}
+
+	return nil
+}
+
 // PendingParcel is a parcel that has not yet completed delivery.
 type PendingParcel struct {
 	*parcelKit
@@ -192,6 +217,12 @@ func (p *PendingParcel) pkg() *sendPackage {
 // kit returns the parcel kit used for delivery.
 func (p *PendingParcel) kit() *parcelKit {
 	return p.parcelKit
+}
+
+// Validate validates the parcel.
+func (p *PendingParcel) Validate() error {
+	// A pending parcel should have already been validated.
+	return nil
 }
 
 // PreSignedParcel is a request to issue an asset transfer of a pre-signed
@@ -244,6 +275,12 @@ func (p *PreSignedParcel) pkg() *sendPackage {
 // kit returns the parcel kit used for delivery.
 func (p *PreSignedParcel) kit() *parcelKit {
 	return p.parcelKit
+}
+
+// Validate validates the parcel.
+func (p *PreSignedParcel) Validate() error {
+	// TODO(ffranr): Add validation where appropriate.
+	return nil
 }
 
 // sendPackage houses the information we need to complete a package transfer.


### PR DESCRIPTION
This PR closes issue https://github.com/lightninglabs/taproot-assets/issues/455 .