### PR TITLE
bug hunting: attempt to lock coins for Tap addr until 10min time out

### DIFF
--- a/itest/test_list_on_test.go
+++ b/itest/test_list_on_test.go
@@ -44,6 +44,11 @@ var testCases = []*testCase{
 		proofCourierType: proof.HashmailCourierType,
 	},
 	{
+		name:             "basic b",
+		test:             testB,
+		proofCourierType: proof.HashmailCourierType,
+	},
+	{
 		name:             "basic send universerpc proof courier",
 		test:             testBasicSendUnidirectional,
 		proofCourierType: proof.UniverseRpcCourierType,


### PR DESCRIPTION
This PR shouldn't be merged.

This PR attempts to reproduce bug: https://github.com/lightninglabs/taproot-assets/issues/508

It does so by creating an itest that does the following using the same Tap address throughout:
1. Kick off an asset send event. Do not mine.
2. Kick off another send event. This should through up a coin lock error and force the address to get stuck behind a timeout.
3. Mine 6 blocks.
4. Kick off another send event which should have succeeded (but does not) were it not for step 2.

In it's current state, this PR does not capture the bug. I thought that it used to, but having cleaned up the code, it doesn't anymore.