### PR TITLE
proof: fix unnecessary trailing newline

### DIFF
--- a/proof/fuzz_test.go
+++ b/proof/fuzz_test.go
@@ -14,7 +14,6 @@ func FuzzFile(f *testing.F) {
 		f := &File{}
 
 		_ = f.Decode(bytes.NewReader(fileData))
-
 	})
 }
 


### PR DESCRIPTION
Fixes a linting error that found its way onto the `main` branch somehow.