### PR TITLE
universe: update pushProofToFederation to make sure all servers are tried

### DIFF
--- a/universe/auto_syncer.go
+++ b/universe/auto_syncer.go
@@ -257,14 +257,20 @@ func (f *FederationEnvoy) pushProofToFederation(uniID Identifier, key BaseKey,
 	pushNewProof := func(ctx context.Context, addr ServerAddr) error {
 		remoteUniverseServer, err := f.cfg.NewRemoteRegistrar(addr)
 		if err != nil {
-			return fmt.Errorf("unable to connect to remote "+
-				"server(%v): %v", addr.HostStr(), err)
+			log.Warnf("cannot push proof unable to connect "+
+				"to remote server(%v): %v", addr.HostStr(),
+				err)
+			return nil
 		}
 
 		_, err = remoteUniverseServer.RegisterIssuance(
 			ctx, uniID, key, leaf,
 		)
-		return err
+		if err != nil {
+			log.Warnf("cannot push proof to remote "+
+				"server(%v): %v", addr.HostStr(), err)
+		}
+		return nil
 	}
 
 	// To conclude, we'll attempt to push the new proof to all the universe


### PR DESCRIPTION
In this commit, we fix a bug that would cause universe proof push to fail for all servers, if anyone of them was unreachable, or rejected the proof.

If we return `err` here, then eventually the context will be read by other goroutines, which is already cancelled at this point. This'll cause the push attempt to stop short.

We now long and return `nil` so the other goroutines will continue.

See https://github.com/lightninglabs/taproot-assets/issues/527 for more details.