### PR TITLE
Backoff procedure erroneously resumed between two different send events

### DIFF
--- a/tapfreighter/chain_porter.go
+++ b/tapfreighter/chain_porter.go
@@ -451,6 +451,7 @@ func (p *ChainPorter) storeProofs(sendPkg *sendPackage) error {
 		outputProofLocator := proof.Locator{
 			AssetID:   &firstInput.ID,
 			ScriptKey: *out.ScriptKey.PubKey,
+			OutPoint:  &firstInput.OutPoint,
 		}
 		outputProof := &proof.AnnotatedProof{
 			Locator: outputProofLocator,

--- a/tapfreighter/chain_porter.go
+++ b/tapfreighter/chain_porter.go
@@ -695,7 +695,15 @@ func (p *ChainPorter) transferReceiverProof(pkg *sendPackage) error {
 			return fmt.Errorf("error fetching passive asset "+
 				"proof file: %w", err)
 		}
-		passiveAssetProofFiles[proofLocator.Hash()] = proofFileBlob
+
+		// Hash proof locator.
+		hash, err := proofLocator.Hash()
+		if err != nil {
+			return fmt.Errorf("error hashing proof locator: %w",
+				err)
+		}
+
+		passiveAssetProofFiles[hash] = proofFileBlob
 	}
 
 	// At this point we have the confirmation signal, so we can mark the


### PR DESCRIPTION
Closes https://github.com/lightninglabs/taproot-assets/issues/508

This PR fixes the initial state of the proof courier's backoff procedure. Before this change, the initial state of the backoff procedure would erroneously include the previous send event(s). The fix involves using the outpoint to distinguish between send events.