### PR TITLE
Generalise universe structs/methods/variables to support transfer proofs in addition to issuance proofs

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -2674,7 +2674,7 @@ func (r *rpcServer) AssetLeafKeys(ctx context.Context,
 }
 
 func marshalAssetLeaf(ctx context.Context, keys taprpc.KeyLookup,
-	assetLeaf *universe.MintingLeaf) (*unirpc.AssetLeaf, error) {
+	assetLeaf *universe.Leaf) (*unirpc.AssetLeaf, error) {
 
 	// In order to display the full asset, we'll also encode the genesis
 	// proof.
@@ -2698,7 +2698,7 @@ func marshalAssetLeaf(ctx context.Context, keys taprpc.KeyLookup,
 
 // marshalAssetLeaf marshals an asset leaf into the RPC form.
 func (r *rpcServer) marshalAssetLeaf(ctx context.Context,
-	assetLeaf *universe.MintingLeaf) (*unirpc.AssetLeaf, error) {
+	assetLeaf *universe.Leaf) (*unirpc.AssetLeaf, error) {
 
 	return marshalAssetLeaf(ctx, r.cfg.AddrBook, assetLeaf)
 }
@@ -2935,7 +2935,7 @@ func (r *rpcServer) QueryProof(ctx context.Context,
 }
 
 // unmarshalAssetLeaf unmarshals an asset leaf from the RPC form.
-func unmarshalAssetLeaf(leaf *unirpc.AssetLeaf) (*universe.MintingLeaf, error) {
+func unmarshalAssetLeaf(leaf *unirpc.AssetLeaf) (*universe.Leaf, error) {
 	// We'll just pull the asset details from the serialized issuance proof
 	// itself.
 	var assetProof proof.Proof
@@ -2948,7 +2948,7 @@ func unmarshalAssetLeaf(leaf *unirpc.AssetLeaf) (*universe.MintingLeaf, error) {
 	// TODO(roasbeef): double check posted file format everywhere
 	//  * raw proof, or within file?
 
-	return &universe.MintingLeaf{
+	return &universe.Leaf{
 		GenesisWithGroup: universe.GenesisWithGroup{
 			Genesis:  assetProof.Asset.Genesis,
 			GroupKey: assetProof.Asset.GroupKey,

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -2679,12 +2679,12 @@ func marshalAssetLeaf(ctx context.Context, keys taprpc.KeyLookup,
 	// In order to display the full asset, we'll also encode the genesis
 	// proof.
 	var buf bytes.Buffer
-	if err := assetLeaf.GenesisProof.Encode(&buf); err != nil {
+	if err := assetLeaf.Proof.Encode(&buf); err != nil {
 		return nil, err
 	}
 
 	rpcAsset, err := taprpc.MarshalAsset(
-		ctx, &assetLeaf.GenesisProof.Asset, false, true, keys,
+		ctx, &assetLeaf.Proof.Asset, false, true, keys,
 	)
 	if err != nil {
 		return nil, err
@@ -2953,8 +2953,8 @@ func unmarshalAssetLeaf(leaf *unirpc.AssetLeaf) (*universe.Leaf, error) {
 			Genesis:  assetProof.Asset.Genesis,
 			GroupKey: assetProof.Asset.GroupKey,
 		},
-		GenesisProof: &assetProof,
-		Amt:          assetProof.Asset.Amount,
+		Proof: &assetProof,
+		Amt:   assetProof.Asset.Amount,
 	}, nil
 }
 

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -2851,7 +2851,7 @@ func (r *rpcServer) marshalIssuanceProof(ctx context.Context,
 	req *unirpc.UniverseKey,
 	proof *universe.Proof) (*unirpc.AssetProofResponse, error) {
 
-	uniProof, err := marshalMssmtProof(proof.InclusionProof)
+	uniProof, err := marshalMssmtProof(proof.UniverseInclusionProof)
 	if err != nil {
 		return nil, err
 	}

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -2628,7 +2628,7 @@ func (r *rpcServer) DeleteAssetRoot(ctx context.Context,
 	return &unirpc.DeleteRootResponse{}, nil
 }
 
-func marshalLeafKey(leafKey universe.BaseKey) *unirpc.AssetKey {
+func marshalLeafKey(leafKey universe.LeafKey) *unirpc.AssetKey {
 	return &unirpc.AssetKey{
 		Outpoint: &unirpc.AssetKey_OpStr{
 			OpStr: leafKey.MintingOutpoint.String(),
@@ -2765,9 +2765,9 @@ func UnmarshalOutpoint(outpoint string) (*wire.OutPoint, error) {
 }
 
 // unmarshalLeafKey unmarshals a leaf key from the RPC form.
-func unmarshalLeafKey(key *unirpc.AssetKey) (universe.BaseKey, error) {
+func unmarshalLeafKey(key *unirpc.AssetKey) (universe.LeafKey, error) {
 	var (
-		baseKey universe.BaseKey
+		baseKey universe.LeafKey
 		err     error
 	)
 

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -2849,7 +2849,7 @@ func marshalMssmtProof(proof *mssmt.Proof) ([]byte, error) {
 // marshalIssuanceProof marshals an issuance proof into the RPC form.
 func (r *rpcServer) marshalIssuanceProof(ctx context.Context,
 	req *unirpc.UniverseKey,
-	proof *universe.IssuanceProof) (*unirpc.AssetProofResponse, error) {
+	proof *universe.Proof) (*unirpc.AssetProofResponse, error) {
 
 	uniProof, err := marshalMssmtProof(proof.InclusionProof)
 	if err != nil {

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -2764,10 +2764,10 @@ func UnmarshalOutpoint(outpoint string) (*wire.OutPoint, error) {
 	}, nil
 }
 
-// unmarshalLeafKey unmarshals a leaf key from the RPC form.
+// unmarshalLeafKey un-marshals a leaf key from the RPC form.
 func unmarshalLeafKey(key *unirpc.AssetKey) (universe.LeafKey, error) {
 	var (
-		baseKey universe.LeafKey
+		leafKey universe.LeafKey
 		err     error
 	)
 
@@ -2775,31 +2775,31 @@ func unmarshalLeafKey(key *unirpc.AssetKey) (universe.LeafKey, error) {
 	case key.GetScriptKeyBytes() != nil:
 		pubKey, err := parseUserKey(key.GetScriptKeyBytes())
 		if err != nil {
-			return baseKey, err
+			return leafKey, err
 		}
 
-		baseKey.ScriptKey = &asset.ScriptKey{
+		leafKey.ScriptKey = &asset.ScriptKey{
 			PubKey: pubKey,
 		}
 
 	case key.GetScriptKeyStr() != "":
 		scriptKeyBytes, sErr := hex.DecodeString(key.GetScriptKeyStr())
 		if sErr != nil {
-			return baseKey, err
+			return leafKey, err
 		}
 
 		pubKey, err := parseUserKey(scriptKeyBytes)
 		if err != nil {
-			return baseKey, err
+			return leafKey, err
 		}
 
-		baseKey.ScriptKey = &asset.ScriptKey{
+		leafKey.ScriptKey = &asset.ScriptKey{
 			PubKey: pubKey,
 		}
 	default:
 		// TODO(roasbeef): can actually allow not to be, then would
 		// fetch all for the given outpoint
-		return baseKey, fmt.Errorf("script key must be set")
+		return leafKey, fmt.Errorf("script key must be set")
 	}
 
 	switch {
@@ -2809,29 +2809,29 @@ func unmarshalLeafKey(key *unirpc.AssetKey) (universe.LeafKey, error) {
 		outpointStr := key.GetOpStr()
 		outpoint, err := UnmarshalOutpoint(outpointStr)
 		if err != nil {
-			return baseKey, err
+			return leafKey, err
 		}
 
-		baseKey.OutPoint = *outpoint
+		leafKey.OutPoint = *outpoint
 
 	case key.GetOutpoint() != nil:
 		op := key.GetOp()
 
 		hash, err := chainhash.NewHashFromStr(op.HashStr)
 		if err != nil {
-			return baseKey, err
+			return leafKey, err
 		}
 
-		baseKey.OutPoint = wire.OutPoint{
+		leafKey.OutPoint = wire.OutPoint{
 			Hash:  *hash,
 			Index: uint32(op.Index),
 		}
 
 	default:
-		return baseKey, fmt.Errorf("outpoint not set: %v", err)
+		return leafKey, fmt.Errorf("outpoint not set: %v", err)
 	}
 
-	return baseKey, nil
+	return leafKey, nil
 }
 
 // marshalMssmtProof marshals a MS-SMT proof into the RPC form.

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -2736,7 +2736,7 @@ func (r *rpcServer) AssetLeaves(ctx context.Context,
 	return resp, nil
 }
 
-// unmarshalOutpoint unmarshals an outpoint from a string received via RPC.
+// UnmarshalOutpoint un-marshals an outpoint from a string received via RPC.
 func UnmarshalOutpoint(outpoint string) (*wire.OutPoint, error) {
 	parts := strings.Split(outpoint, ":")
 	if len(parts) != 2 {

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -2657,7 +2657,7 @@ func (r *rpcServer) AssetLeafKeys(ctx context.Context,
 	// TODO(roasbeef): tell above if was tring or not, then would set
 	// below diff
 
-	leafKeys, err := r.cfg.BaseUniverse.MintingKeys(ctx, universeID)
+	leafKeys, err := r.cfg.BaseUniverse.UniverseLeafKeys(ctx, universeID)
 	if err != nil {
 		return nil, err
 	}

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -2631,7 +2631,7 @@ func (r *rpcServer) DeleteAssetRoot(ctx context.Context,
 func marshalLeafKey(leafKey universe.LeafKey) *unirpc.AssetKey {
 	return &unirpc.AssetKey{
 		Outpoint: &unirpc.AssetKey_OpStr{
-			OpStr: leafKey.MintingOutpoint.String(),
+			OpStr: leafKey.OutPoint.String(),
 		},
 		ScriptKey: &unirpc.AssetKey_ScriptKeyBytes{
 			ScriptKeyBytes: schnorr.SerializePubKey(
@@ -2812,7 +2812,7 @@ func unmarshalLeafKey(key *unirpc.AssetKey) (universe.LeafKey, error) {
 			return baseKey, err
 		}
 
-		baseKey.MintingOutpoint = *outpoint
+		baseKey.OutPoint = *outpoint
 
 	case key.GetOutpoint() != nil:
 		op := key.GetOp()
@@ -2822,7 +2822,7 @@ func unmarshalLeafKey(key *unirpc.AssetKey) (universe.LeafKey, error) {
 			return baseKey, err
 		}
 
-		baseKey.MintingOutpoint = wire.OutPoint{
+		baseKey.OutPoint = wire.OutPoint{
 			Hash:  *hash,
 			Index: uint32(op.Index),
 		}

--- a/tapdb/multiverse.go
+++ b/tapdb/multiverse.go
@@ -232,7 +232,7 @@ func (b *MultiverseStore) UpsertProofLeaf(ctx context.Context,
 			universeRoot mssmt.Node
 			err          error
 		)
-		issuanceProof, universeRoot, err = universeRegisterIssuance(
+		issuanceProof, universeRoot, err = universeUpsertProofLeaf(
 			ctx, dbTx, id, key, leaf, metaReveal,
 		)
 		if err != nil {
@@ -305,7 +305,7 @@ func (b *MultiverseStore) RegisterBatchIssuance(ctx context.Context,
 
 		// Register issuance in the asset (group) specific universe
 		// tree.
-		_, universeRoot, err := universeRegisterIssuance(
+		_, universeRoot, err := universeUpsertProofLeaf(
 			ctx, dbTx, item.ID, item.Key, item.Leaf,
 			item.MetaReveal,
 		)

--- a/tapdb/multiverse.go
+++ b/tapdb/multiverse.go
@@ -158,11 +158,11 @@ func (b *MultiverseStore) RootNodes(
 // leafs will be returned.
 func (b *MultiverseStore) FetchProofLeaf(ctx context.Context,
 	id universe.Identifier,
-	universeKey universe.LeafKey) ([]*universe.IssuanceProof, error) {
+	universeKey universe.LeafKey) ([]*universe.Proof, error) {
 
 	var (
 		readTx = NewBaseUniverseReadTx()
-		proofs []*universe.IssuanceProof
+		proofs []*universe.Proof
 	)
 
 	dbErr := b.db.ExecTx(ctx, &readTx, func(dbTx BaseMultiverseStore) error {
@@ -218,11 +218,11 @@ func (b *MultiverseStore) FetchProofLeaf(ctx context.Context,
 func (b *MultiverseStore) UpsertProofLeaf(ctx context.Context,
 	id universe.Identifier, key universe.LeafKey,
 	leaf *universe.Leaf,
-	metaReveal *proof.MetaReveal) (*universe.IssuanceProof, error) {
+	metaReveal *proof.MetaReveal) (*universe.Proof, error) {
 
 	var (
 		writeTx       BaseMultiverseOptions
-		issuanceProof *universe.IssuanceProof
+		issuanceProof *universe.Proof
 	)
 
 	execTxFunc := func(dbTx BaseMultiverseStore) error {

--- a/tapdb/multiverse.go
+++ b/tapdb/multiverse.go
@@ -158,7 +158,7 @@ func (b *MultiverseStore) RootNodes(
 // leafs will be returned.
 func (b *MultiverseStore) FetchProofLeaf(ctx context.Context,
 	id universe.Identifier,
-	universeKey universe.BaseKey) ([]*universe.IssuanceProof, error) {
+	universeKey universe.LeafKey) ([]*universe.IssuanceProof, error) {
 
 	var (
 		readTx = NewBaseUniverseReadTx()
@@ -216,7 +216,7 @@ func (b *MultiverseStore) FetchProofLeaf(ctx context.Context,
 // UpsertProofLeaf upserts a proof leaf within the multiverse tree and the
 // universe tree that corresponds to the given key.
 func (b *MultiverseStore) UpsertProofLeaf(ctx context.Context,
-	id universe.Identifier, key universe.BaseKey,
+	id universe.Identifier, key universe.LeafKey,
 	leaf *universe.MintingLeaf,
 	metaReveal *proof.MetaReveal) (*universe.IssuanceProof, error) {
 

--- a/tapdb/multiverse.go
+++ b/tapdb/multiverse.go
@@ -167,7 +167,7 @@ func (b *MultiverseStore) FetchProofLeaf(ctx context.Context,
 
 	dbErr := b.db.ExecTx(ctx, &readTx, func(dbTx BaseMultiverseStore) error {
 		var err error
-		proofs, err = universeFetchIssuanceProof(
+		proofs, err = universeFetchProofLeaf(
 			ctx, id, universeKey, dbTx,
 		)
 		if err != nil {

--- a/tapdb/multiverse.go
+++ b/tapdb/multiverse.go
@@ -217,7 +217,7 @@ func (b *MultiverseStore) FetchProofLeaf(ctx context.Context,
 // universe tree that corresponds to the given key.
 func (b *MultiverseStore) UpsertProofLeaf(ctx context.Context,
 	id universe.Identifier, key universe.LeafKey,
-	leaf *universe.MintingLeaf,
+	leaf *universe.Leaf,
 	metaReveal *proof.MetaReveal) (*universe.IssuanceProof, error) {
 
 	var (

--- a/tapdb/universe.go
+++ b/tapdb/universe.go
@@ -414,10 +414,10 @@ func universeUpsertProofLeaf(ctx context.Context, dbTx BaseUniverseStore,
 	}
 
 	return &universe.Proof{
-		LeafKey:        key,
-		UniverseRoot:   universeRoot,
-		InclusionProof: leafInclusionProof,
-		Leaf:           leaf,
+		LeafKey:                key,
+		UniverseRoot:           universeRoot,
+		UniverseInclusionProof: leafInclusionProof,
+		Leaf:                   leaf,
 	}, universeRoot, nil
 }
 
@@ -547,9 +547,9 @@ func universeFetchProofLeaf(ctx context.Context,
 		}
 
 		issuanceProof := &universe.Proof{
-			LeafKey:        universeKey,
-			UniverseRoot:   rootNode,
-			InclusionProof: leafProof,
+			LeafKey:                universeKey,
+			UniverseRoot:           rootNode,
+			UniverseInclusionProof: leafProof,
 			Leaf: &universe.Leaf{
 				GenesisWithGroup: universe.GenesisWithGroup{
 					Genesis: leafAssetGen,

--- a/tapdb/universe.go
+++ b/tapdb/universe.go
@@ -414,7 +414,7 @@ func universeUpsertProofLeaf(ctx context.Context, dbTx BaseUniverseStore,
 	}
 
 	return &universe.IssuanceProof{
-		MintingKey:     key,
+		LeafKey:        key,
 		UniverseRoot:   universeRoot,
 		InclusionProof: leafInclusionProof,
 		Leaf:           leaf,
@@ -547,7 +547,7 @@ func universeFetchProofLeaf(ctx context.Context,
 		}
 
 		issuanceProof := &universe.IssuanceProof{
-			MintingKey:     universeKey,
+			LeafKey:        universeKey,
 			UniverseRoot:   rootNode,
 			InclusionProof: leafProof,
 			Leaf: &universe.Leaf{

--- a/tapdb/universe.go
+++ b/tapdb/universe.go
@@ -435,7 +435,7 @@ func (b *BaseUniverseTree) FetchIssuanceProof(ctx context.Context,
 
 	dbErr := b.db.ExecTx(ctx, &readTx, func(dbTx BaseUniverseStore) error {
 		var err error
-		proofs, err = universeFetchIssuanceProof(
+		proofs, err = universeFetchProofLeaf(
 			ctx, b.id, universeKey, dbTx,
 		)
 		return err
@@ -447,14 +447,14 @@ func (b *BaseUniverseTree) FetchIssuanceProof(ctx context.Context,
 	return proofs, nil
 }
 
-// universeFetchIssuanceProof returns issuance proofs for the target universe.
+// universeFetchProofLeaf returns proof leaves for the target universe.
 //
-// If the given universe key doesn't have a script key specified, then a proof
-// will be returned for each minting outpoint.
+// If the given universe leaf key doesn't have a script key specified, then a
+// proof will be returned for each minting outpoint.
 //
 // NOTE: This function accepts a database transaction and is called when making
 // broader DB updates.
-func universeFetchIssuanceProof(ctx context.Context,
+func universeFetchProofLeaf(ctx context.Context,
 	id universe.Identifier, universeKey universe.LeafKey,
 	dbTx BaseUniverseStore) ([]*universe.IssuanceProof, error) {
 

--- a/tapdb/universe.go
+++ b/tapdb/universe.go
@@ -289,7 +289,7 @@ func (b *BaseUniverseTree) RegisterIssuance(ctx context.Context,
 		issuanceProof *universe.IssuanceProof
 	)
 	dbErr := b.db.ExecTx(ctx, &writeTx, func(dbTx BaseUniverseStore) error {
-		issuanceProof, _, err = universeRegisterIssuance(
+		issuanceProof, _, err = universeUpsertProofLeaf(
 			ctx, dbTx, b.id, key, leaf, metaReveal,
 		)
 		return err
@@ -301,15 +301,15 @@ func (b *BaseUniverseTree) RegisterIssuance(ctx context.Context,
 	return issuanceProof, nil
 }
 
-// universeRegisterIssuance upserts a minting leaf within the universe tree,
-// stored at the base key.
+// universeUpsertProofLeaf upserts a proof leaf within the universe tree (stored
+// at the proof leaf key).
 //
-// This function returns the newly registered issuance proof and the new
-// universe root.
+// This function returns the inserted/updated proof leaf and the new universe
+// root.
 //
 // NOTE: This function accepts a db transaction, as it's used when making
 // broader DB updates.
-func universeRegisterIssuance(ctx context.Context, dbTx BaseUniverseStore,
+func universeUpsertProofLeaf(ctx context.Context, dbTx BaseUniverseStore,
 	id universe.Identifier, key universe.LeafKey,
 	leaf *universe.MintingLeaf,
 	metaReveal *proof.MetaReveal) (*universe.IssuanceProof, mssmt.Node,

--- a/tapdb/universe.go
+++ b/tapdb/universe.go
@@ -280,13 +280,13 @@ func upsertAssetGen(ctx context.Context, db UpsertAssetStore,
 // at the base key.
 func (b *BaseUniverseTree) RegisterIssuance(ctx context.Context,
 	key universe.LeafKey, leaf *universe.Leaf,
-	metaReveal *proof.MetaReveal) (*universe.IssuanceProof, error) {
+	metaReveal *proof.MetaReveal) (*universe.Proof, error) {
 
 	var (
 		writeTx BaseUniverseStoreOptions
 
 		err           error
-		issuanceProof *universe.IssuanceProof
+		issuanceProof *universe.Proof
 	)
 	dbErr := b.db.ExecTx(ctx, &writeTx, func(dbTx BaseUniverseStore) error {
 		issuanceProof, _, err = universeUpsertProofLeaf(
@@ -312,7 +312,7 @@ func (b *BaseUniverseTree) RegisterIssuance(ctx context.Context,
 func universeUpsertProofLeaf(ctx context.Context, dbTx BaseUniverseStore,
 	id universe.Identifier, key universe.LeafKey,
 	leaf *universe.Leaf,
-	metaReveal *proof.MetaReveal) (*universe.IssuanceProof, mssmt.Node,
+	metaReveal *proof.MetaReveal) (*universe.Proof, mssmt.Node,
 	error) {
 
 	namespace := id.String()
@@ -413,7 +413,7 @@ func universeUpsertProofLeaf(ctx context.Context, dbTx BaseUniverseStore,
 		return nil, nil, err
 	}
 
-	return &universe.IssuanceProof{
+	return &universe.Proof{
 		LeafKey:        key,
 		UniverseRoot:   universeRoot,
 		InclusionProof: leafInclusionProof,
@@ -426,11 +426,11 @@ func universeUpsertProofLeaf(ctx context.Context, dbTx BaseUniverseStore,
 // outpoint will be returned. If neither are specified, then proofs for all the
 // inserted leaves will be returned.
 func (b *BaseUniverseTree) FetchIssuanceProof(ctx context.Context,
-	universeKey universe.LeafKey) ([]*universe.IssuanceProof, error) {
+	universeKey universe.LeafKey) ([]*universe.Proof, error) {
 
 	var (
 		readTx = NewBaseUniverseReadTx()
-		proofs []*universe.IssuanceProof
+		proofs []*universe.Proof
 	)
 
 	dbErr := b.db.ExecTx(ctx, &readTx, func(dbTx BaseUniverseStore) error {
@@ -456,7 +456,7 @@ func (b *BaseUniverseTree) FetchIssuanceProof(ctx context.Context,
 // broader DB updates.
 func universeFetchProofLeaf(ctx context.Context,
 	id universe.Identifier, universeKey universe.LeafKey,
-	dbTx BaseUniverseStore) ([]*universe.IssuanceProof, error) {
+	dbTx BaseUniverseStore) ([]*universe.Proof, error) {
 
 	namespace := id.String()
 
@@ -474,7 +474,7 @@ func universeFetchProofLeaf(ctx context.Context,
 		return nil, err
 	}
 
-	var proofs []*universe.IssuanceProof
+	var proofs []*universe.Proof
 
 	// First, we'll make a new instance of the universe tree, as we'll query
 	// it directly to obtain the set of leaves we care about.
@@ -546,7 +546,7 @@ func universeFetchProofLeaf(ctx context.Context,
 			return fmt.Errorf("unable to decode proof: %w", err)
 		}
 
-		issuanceProof := &universe.IssuanceProof{
+		issuanceProof := &universe.Proof{
 			LeafKey:        universeKey,
 			UniverseRoot:   rootNode,
 			InclusionProof: leafProof,

--- a/tapdb/universe.go
+++ b/tapdb/universe.go
@@ -279,7 +279,7 @@ func upsertAssetGen(ctx context.Context, db UpsertAssetStore,
 // RegisterIssuance inserts a new minting leaf within the universe tree, stored
 // at the base key.
 func (b *BaseUniverseTree) RegisterIssuance(ctx context.Context,
-	key universe.BaseKey, leaf *universe.MintingLeaf,
+	key universe.LeafKey, leaf *universe.MintingLeaf,
 	metaReveal *proof.MetaReveal) (*universe.IssuanceProof, error) {
 
 	var (
@@ -310,7 +310,7 @@ func (b *BaseUniverseTree) RegisterIssuance(ctx context.Context,
 // NOTE: This function accepts a db transaction, as it's used when making
 // broader DB updates.
 func universeRegisterIssuance(ctx context.Context, dbTx BaseUniverseStore,
-	id universe.Identifier, key universe.BaseKey,
+	id universe.Identifier, key universe.LeafKey,
 	leaf *universe.MintingLeaf,
 	metaReveal *proof.MetaReveal) (*universe.IssuanceProof, mssmt.Node,
 	error) {
@@ -426,7 +426,7 @@ func universeRegisterIssuance(ctx context.Context, dbTx BaseUniverseStore,
 // outpoint will be returned. If neither are specified, then proofs for all the
 // inserted leaves will be returned.
 func (b *BaseUniverseTree) FetchIssuanceProof(ctx context.Context,
-	universeKey universe.BaseKey) ([]*universe.IssuanceProof, error) {
+	universeKey universe.LeafKey) ([]*universe.IssuanceProof, error) {
 
 	var (
 		readTx = NewBaseUniverseReadTx()
@@ -455,7 +455,7 @@ func (b *BaseUniverseTree) FetchIssuanceProof(ctx context.Context,
 // NOTE: This function accepts a database transaction and is called when making
 // broader DB updates.
 func universeFetchIssuanceProof(ctx context.Context,
-	id universe.Identifier, universeKey universe.BaseKey,
+	id universe.Identifier, universeKey universe.LeafKey,
 	dbTx BaseUniverseStore) ([]*universe.IssuanceProof, error) {
 
 	namespace := id.String()
@@ -521,7 +521,7 @@ func universeFetchIssuanceProof(ctx context.Context,
 
 		// Next, we'll fetch the leaf node from the tree and also obtain
 		// a merkle proof for the leaf alongside it.
-		universeKey := universe.BaseKey{
+		universeKey := universe.LeafKey{
 			MintingOutpoint: universeKey.MintingOutpoint,
 			ScriptKey:       &scriptKey,
 		}
@@ -585,9 +585,9 @@ func universeFetchIssuanceProof(ctx context.Context,
 
 // MintingKeys returns all the keys inserted in the universe.
 func (b *BaseUniverseTree) MintingKeys(ctx context.Context,
-) ([]universe.BaseKey, error) {
+) ([]universe.LeafKey, error) {
 
-	var baseKeys []universe.BaseKey
+	var baseKeys []universe.LeafKey
 
 	readTx := NewBaseUniverseReadTx()
 	dbErr := b.db.ExecTx(ctx, &readTx, func(db BaseUniverseStore) error {
@@ -614,7 +614,7 @@ func (b *BaseUniverseTree) MintingKeys(ctx context.Context,
 				return err
 			}
 
-			baseKeys = append(baseKeys, universe.BaseKey{
+			baseKeys = append(baseKeys, universe.LeafKey{
 				MintingOutpoint: genPoint,
 				ScriptKey:       &scriptKey,
 			})

--- a/tapdb/universe.go
+++ b/tapdb/universe.go
@@ -380,7 +380,7 @@ func universeUpsertProofLeaf(ctx context.Context, dbTx BaseUniverseStore,
 	}
 
 	assetGenID, err := upsertAssetGen(
-		ctx, dbTx, leaf.Genesis, leaf.GroupKey, leaf.GenesisProof,
+		ctx, dbTx, leaf.Genesis, leaf.GroupKey, leaf.Proof,
 	)
 	if err != nil {
 		return nil, nil, err
@@ -554,8 +554,8 @@ func universeFetchProofLeaf(ctx context.Context,
 				GenesisWithGroup: universe.GenesisWithGroup{
 					Genesis: leafAssetGen,
 				},
-				GenesisProof: &genProof,
-				Amt:          uint64(leaf.SumAmt),
+				Proof: &genProof,
+				Amt:   uint64(leaf.SumAmt),
 			},
 		}
 		if id.GroupKey != nil {
@@ -675,8 +675,8 @@ func (b *BaseUniverseTree) MintingLeaves(
 				GenesisWithGroup: universe.GenesisWithGroup{
 					Genesis: leafAssetGen,
 				},
-				GenesisProof: &genProof,
-				Amt:          uint64(dbLeaf.SumAmt),
+				Proof: &genProof,
+				Amt:   uint64(dbLeaf.SumAmt),
 			}
 			if b.id.GroupKey != nil {
 				leaf.GroupKey = &asset.GroupKey{

--- a/tapdb/universe.go
+++ b/tapdb/universe.go
@@ -587,7 +587,7 @@ func universeFetchIssuanceProof(ctx context.Context,
 func (b *BaseUniverseTree) MintingKeys(ctx context.Context,
 ) ([]universe.LeafKey, error) {
 
-	var baseKeys []universe.LeafKey
+	var leafKeys []universe.LeafKey
 
 	readTx := NewBaseUniverseReadTx()
 	dbErr := b.db.ExecTx(ctx, &readTx, func(db BaseUniverseStore) error {
@@ -614,7 +614,7 @@ func (b *BaseUniverseTree) MintingKeys(ctx context.Context,
 				return err
 			}
 
-			baseKeys = append(baseKeys, universe.LeafKey{
+			leafKeys = append(leafKeys, universe.LeafKey{
 				OutPoint:  genPoint,
 				ScriptKey: &scriptKey,
 			})
@@ -626,7 +626,7 @@ func (b *BaseUniverseTree) MintingKeys(ctx context.Context,
 		return nil, dbErr
 	}
 
-	return baseKeys, nil
+	return leafKeys, nil
 }
 
 // MintingLeaves returns all the minting leaves inserted into the universe.

--- a/tapdb/universe.go
+++ b/tapdb/universe.go
@@ -279,7 +279,7 @@ func upsertAssetGen(ctx context.Context, db UpsertAssetStore,
 // RegisterIssuance inserts a new minting leaf within the universe tree, stored
 // at the base key.
 func (b *BaseUniverseTree) RegisterIssuance(ctx context.Context,
-	key universe.LeafKey, leaf *universe.MintingLeaf,
+	key universe.LeafKey, leaf *universe.Leaf,
 	metaReveal *proof.MetaReveal) (*universe.IssuanceProof, error) {
 
 	var (
@@ -311,7 +311,7 @@ func (b *BaseUniverseTree) RegisterIssuance(ctx context.Context,
 // broader DB updates.
 func universeUpsertProofLeaf(ctx context.Context, dbTx BaseUniverseStore,
 	id universe.Identifier, key universe.LeafKey,
-	leaf *universe.MintingLeaf,
+	leaf *universe.Leaf,
 	metaReveal *proof.MetaReveal) (*universe.IssuanceProof, mssmt.Node,
 	error) {
 
@@ -321,7 +321,7 @@ func universeUpsertProofLeaf(ctx context.Context, dbTx BaseUniverseStore,
 	// the minting key, as that'll be the key in the SMT itself.
 	smtKey := key.UniverseKey()
 
-	// The value stored in the MS-SMT will be the serialized MintingLeaf,
+	// The value stored in the MS-SMT will be the serialized Leaf,
 	// so we'll convert that into raw bytes now.
 	leafNode, err := leaf.SmtLeafNode()
 	if err != nil {
@@ -550,7 +550,7 @@ func universeFetchProofLeaf(ctx context.Context,
 			MintingKey:     universeKey,
 			UniverseRoot:   rootNode,
 			InclusionProof: leafProof,
-			Leaf: &universe.MintingLeaf{
+			Leaf: &universe.Leaf{
 				GenesisWithGroup: universe.GenesisWithGroup{
 					Genesis: leafAssetGen,
 				},
@@ -631,9 +631,9 @@ func (b *BaseUniverseTree) MintingKeys(ctx context.Context,
 
 // MintingLeaves returns all the minting leaves inserted into the universe.
 func (b *BaseUniverseTree) MintingLeaves(
-	ctx context.Context) ([]universe.MintingLeaf, error) {
+	ctx context.Context) ([]universe.Leaf, error) {
 
-	var leaves []universe.MintingLeaf
+	var leaves []universe.Leaf
 
 	readTx := NewBaseUniverseReadTx()
 	dbErr := b.db.ExecTx(ctx, &readTx, func(db BaseUniverseStore) error {
@@ -671,7 +671,7 @@ func (b *BaseUniverseTree) MintingLeaves(
 
 			// Now that we have the leaves, we'll encode them all
 			// into the set of minting leaves.
-			leaf := universe.MintingLeaf{
+			leaf := universe.Leaf{
 				GenesisWithGroup: universe.GenesisWithGroup{
 					Genesis: leafAssetGen,
 				},

--- a/tapdb/universe.go
+++ b/tapdb/universe.go
@@ -333,7 +333,7 @@ func universeRegisterIssuance(ctx context.Context, dbTx BaseUniverseStore,
 		groupKeyBytes = schnorr.SerializePubKey(id.GroupKey)
 	}
 
-	mintingPointBytes, err := encodeOutpoint(key.MintingOutpoint)
+	mintingPointBytes, err := encodeOutpoint(key.OutPoint)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -469,7 +469,7 @@ func universeFetchIssuanceProof(ctx context.Context,
 		)
 	}
 
-	mintingPointBytes, err := encodeOutpoint(universeKey.MintingOutpoint)
+	mintingPointBytes, err := encodeOutpoint(universeKey.OutPoint)
 	if err != nil {
 		return nil, err
 	}
@@ -522,8 +522,8 @@ func universeFetchIssuanceProof(ctx context.Context,
 		// Next, we'll fetch the leaf node from the tree and also obtain
 		// a merkle proof for the leaf alongside it.
 		universeKey := universe.LeafKey{
-			MintingOutpoint: universeKey.MintingOutpoint,
-			ScriptKey:       &scriptKey,
+			OutPoint:  universeKey.OutPoint,
+			ScriptKey: &scriptKey,
 		}
 		smtKey := universeKey.UniverseKey()
 		leafProof, err := universeTree.MerkleProof(
@@ -615,8 +615,8 @@ func (b *BaseUniverseTree) MintingKeys(ctx context.Context,
 			}
 
 			baseKeys = append(baseKeys, universe.LeafKey{
-				MintingOutpoint: genPoint,
-				ScriptKey:       &scriptKey,
+				OutPoint:  genPoint,
+				ScriptKey: &scriptKey,
 			})
 
 			return nil

--- a/tapdb/universe_stats.go
+++ b/tapdb/universe_stats.go
@@ -127,7 +127,7 @@ func NewUniverseStats(db BatchedUniverseStats,
 
 // LogSyncEvent logs a sync event for the target universe.
 func (u *UniverseStats) LogSyncEvent(ctx context.Context,
-	uniID universe.Identifier, key universe.BaseKey) error {
+	uniID universe.Identifier, key universe.LeafKey) error {
 
 	var writeTxOpts UniverseStatsOptions
 	return u.db.ExecTx(ctx, &writeTxOpts, func(db UniverseStatsStore) error {
@@ -178,7 +178,7 @@ func (u *UniverseStats) LogSyncEvents(ctx context.Context,
 
 // LogNewProofEvent logs a new proof insertion event for the target universe.
 func (u *UniverseStats) LogNewProofEvent(ctx context.Context,
-	uniID universe.Identifier, key universe.BaseKey) error {
+	uniID universe.Identifier, key universe.LeafKey) error {
 
 	var writeTxOpts UniverseStatsOptions
 	return u.db.ExecTx(ctx, &writeTxOpts, func(db UniverseStatsStore) error {

--- a/tapdb/universe_stats_test.go
+++ b/tapdb/universe_stats_test.go
@@ -31,8 +31,8 @@ func newUniverseStatsWithDB(db *BaseDB, clock clock.Clock) (*UniverseStats,
 
 type uniStatsHarness struct {
 	assetUniverses []*BaseUniverseTree
-	universeLeaves []*universe.IssuanceProof
-	leafIndex      map[asset.ID]*universe.IssuanceProof
+	universeLeaves []*universe.Proof
+	leafIndex      map[asset.ID]*universe.Proof
 
 	db *UniverseStats
 
@@ -44,8 +44,8 @@ func newUniStatsHarness(t *testing.T, numAssets int, db *BaseDB,
 
 	stats := &uniStatsHarness{
 		assetUniverses: make([]*BaseUniverseTree, numAssets),
-		universeLeaves: make([]*universe.IssuanceProof, numAssets),
-		leafIndex:      make(map[asset.ID]*universe.IssuanceProof),
+		universeLeaves: make([]*universe.Proof, numAssets),
+		leafIndex:      make(map[asset.ID]*universe.Proof),
 		db:             statsDB,
 		t:              t,
 	}
@@ -539,7 +539,7 @@ func TestUniverseQuerySyncFilters(t *testing.T) {
 			typeFilter: fn.Ptr(asset.Type(rand.Int() % 2)),
 			queryCheck: func(s *universe.AssetSyncStats) bool {
 				typeCount := fn.Reduce(sh.universeLeaves,
-					func(acc int, p *universe.IssuanceProof) int {
+					func(acc int, p *universe.Proof) int {
 						if p.Leaf.Type == *s.Query.AssetTypeFilter {
 							return acc + 1
 						}

--- a/tapdb/universe_stats_test.go
+++ b/tapdb/universe_stats_test.go
@@ -80,7 +80,7 @@ func newUniStatsHarness(t *testing.T, numAssets int, db *BaseDB,
 func (u *uniStatsHarness) logProofEventByIndex(i int) {
 	ctx := context.Background()
 	err := u.db.LogNewProofEvent(
-		ctx, u.assetUniverses[i].id, u.universeLeaves[i].MintingKey,
+		ctx, u.assetUniverses[i].id, u.universeLeaves[i].LeafKey,
 	)
 	require.NoError(u.t, err)
 }
@@ -88,7 +88,7 @@ func (u *uniStatsHarness) logProofEventByIndex(i int) {
 func (u *uniStatsHarness) logSyncEventByIndex(i int) {
 	ctx := context.Background()
 	err := u.db.LogSyncEvent(
-		ctx, u.assetUniverses[i].id, u.universeLeaves[i].MintingKey,
+		ctx, u.assetUniverses[i].id, u.universeLeaves[i].LeafKey,
 	)
 	require.NoError(u.t, err)
 }
@@ -175,9 +175,7 @@ func TestUniverseStatsEvents(t *testing.T) {
 
 		require.Equal(t, assetStat.TotalSupply, leaf.Leaf.Amt)
 
-		if sh.universeLeaves[assetToSync].MintingKey ==
-			leaf.MintingKey {
-
+		if sh.universeLeaves[assetToSync].LeafKey == leaf.LeafKey {
 			require.Equal(t, int(assetStat.TotalSyncs), 1)
 		}
 

--- a/tapdb/universe_test.go
+++ b/tapdb/universe_test.go
@@ -77,7 +77,7 @@ func TestUniverseEmptyTree(t *testing.T) {
 	require.ErrorIs(t, err, universe.ErrNoUniverseRoot)
 }
 
-func randBaseKey(t *testing.T) universe.LeafKey {
+func randLeafKey(t *testing.T) universe.LeafKey {
 	return universe.LeafKey{
 		OutPoint: test.RandOp(t),
 		ScriptKey: fn.Ptr(
@@ -153,7 +153,7 @@ func TestUniverseIssuanceProofs(t *testing.T) {
 	// scriptKey) leaf pairs.
 	testLeaves := make([]leafWithKey, numLeaves)
 	for i := 0; i < numLeaves; i++ {
-		targetKey := randBaseKey(t)
+		targetKey := randLeafKey(t)
 		leaf := randMintingLeaf(t, assetGen, id.GroupKey)
 
 		testLeaves[i] = leafWithKey{targetKey, leaf}
@@ -323,7 +323,7 @@ func TestUniverseMetaBlob(t *testing.T) {
 
 	// With the meta constructed, we can insert a test leaf into the DB
 	// now.
-	targetKey := randBaseKey(t)
+	targetKey := randLeafKey(t)
 	leaf := randMintingLeaf(t, assetGen, id.GroupKey)
 
 	_, err := baseUniverse.RegisterIssuance(ctx, targetKey, &leaf, meta)
@@ -350,7 +350,7 @@ func insertRandLeaf(t *testing.T, ctx context.Context, tree *BaseUniverseTree,
 		targetGen = asset.RandGenesis(t, asset.Normal)
 	}
 
-	targetKey := randBaseKey(t)
+	targetKey := randLeafKey(t)
 	leaf := randMintingLeaf(t, targetGen, tree.id.GroupKey)
 
 	return tree.RegisterIssuance(ctx, targetKey, &leaf, nil)
@@ -451,11 +451,11 @@ func TestUniverseLeafQuery(t *testing.T) {
 
 	// We'll create three new leaves, all of them will share the exact same
 	// minting outpoint, but will have distinct script keys.
-	rootMintingPoint := randBaseKey(t).OutPoint
+	rootMintingPoint := randLeafKey(t).OutPoint
 
 	leafToScriptKey := make(map[asset.SerializedKey]universe.MintingLeaf)
 	for i := 0; i < numLeafs; i++ {
-		targetKey := randBaseKey(t)
+		targetKey := randLeafKey(t)
 		targetKey.OutPoint = rootMintingPoint
 
 		leaf := randMintingLeaf(t, assetGen, id.GroupKey)

--- a/tapdb/universe_test.go
+++ b/tapdb/universe_test.go
@@ -113,8 +113,8 @@ func randMintingLeaf(t *testing.T, assetGen asset.Genesis,
 		GenesisWithGroup: universe.GenesisWithGroup{
 			Genesis: assetGen,
 		},
-		GenesisProof: randProof(t),
-		Amt:          uint64(rand.Int31()),
+		Proof: randProof(t),
+		Amt:   uint64(rand.Int31()),
 	}
 	if groupKey != nil {
 		leaf.GroupKey = &asset.GroupKey{
@@ -255,7 +255,7 @@ func TestUniverseIssuanceProofs(t *testing.T) {
 	// leaves we just inserted.
 	for idx := range testLeaves {
 		testLeaf := &testLeaves[idx]
-		testLeaf.Leaf.GenesisProof = randProof(t)
+		testLeaf.Leaf.Proof = randProof(t)
 
 		targetKey := testLeaf.LeafKey
 		issuanceProof, err := baseUniverse.RegisterIssuance(

--- a/tapdb/universe_test.go
+++ b/tapdb/universe_test.go
@@ -77,8 +77,8 @@ func TestUniverseEmptyTree(t *testing.T) {
 	require.ErrorIs(t, err, universe.ErrNoUniverseRoot)
 }
 
-func randBaseKey(t *testing.T) universe.BaseKey {
-	return universe.BaseKey{
+func randBaseKey(t *testing.T) universe.LeafKey {
+	return universe.LeafKey{
 		MintingOutpoint: test.RandOp(t),
 		ScriptKey: fn.Ptr(
 			asset.NewScriptKey(test.RandPubKey(t)),
@@ -127,7 +127,7 @@ func randMintingLeaf(t *testing.T, assetGen asset.Genesis,
 
 // leaWithKey is a two tuple that associates new minting leaf with a key.
 type leafWithKey struct {
-	universe.BaseKey
+	universe.LeafKey
 
 	universe.MintingLeaf
 }
@@ -166,7 +166,7 @@ func TestUniverseIssuanceProofs(t *testing.T) {
 		// Each new leaf should add to the accumulated sum.
 		leafSum += testLeaf.Amt
 
-		targetKey := testLeaf.BaseKey
+		targetKey := testLeaf.LeafKey
 		leaf := testLeaf.MintingLeaf
 
 		issuanceProof, err := baseUniverse.RegisterIssuance(
@@ -228,9 +228,9 @@ func TestUniverseIssuanceProofs(t *testing.T) {
 	require.Equal(t, numLeaves, len(mintingKeys))
 
 	// The set of leaves we created above should match what was returned.
-	require.True(t, fn.All(mintingKeys, func(key universe.BaseKey) bool {
+	require.True(t, fn.All(mintingKeys, func(key universe.LeafKey) bool {
 		return fn.Any(testLeaves, func(testLeaf leafWithKey) bool {
-			return reflect.DeepEqual(key, testLeaf.BaseKey)
+			return reflect.DeepEqual(key, testLeaf.LeafKey)
 		})
 	}))
 
@@ -257,7 +257,7 @@ func TestUniverseIssuanceProofs(t *testing.T) {
 		testLeaf := &testLeaves[idx]
 		testLeaf.MintingLeaf.GenesisProof = randProof(t)
 
-		targetKey := testLeaf.BaseKey
+		targetKey := testLeaf.LeafKey
 		issuanceProof, err := baseUniverse.RegisterIssuance(
 			ctx, targetKey, &testLeaf.MintingLeaf, nil,
 		)
@@ -472,7 +472,7 @@ func TestUniverseLeafQuery(t *testing.T) {
 
 	// If we query for only the minting point, then all three leaves should
 	// be returned.
-	proofs, err := baseUniverse.FetchIssuanceProof(ctx, universe.BaseKey{
+	proofs, err := baseUniverse.FetchIssuanceProof(ctx, universe.LeafKey{
 		MintingOutpoint: rootMintingPoint,
 	})
 	require.NoError(t, err)
@@ -484,7 +484,7 @@ func TestUniverseLeafQuery(t *testing.T) {
 		scriptKey, err := btcec.ParsePubKey(scriptKeyBytes[:])
 		require.NoError(t, err)
 
-		p, err := baseUniverse.FetchIssuanceProof(ctx, universe.BaseKey{
+		p, err := baseUniverse.FetchIssuanceProof(ctx, universe.LeafKey{
 			MintingOutpoint: rootMintingPoint,
 			ScriptKey: &asset.ScriptKey{
 				PubKey: scriptKey,

--- a/tapdb/universe_test.go
+++ b/tapdb/universe_test.go
@@ -204,7 +204,7 @@ func TestUniverseIssuanceProofs(t *testing.T) {
 		uniProof := dbProof[0]
 
 		// The proof should have the proper values populated.
-		require.Equal(t, targetKey, uniProof.MintingKey)
+		require.Equal(t, targetKey, uniProof.LeafKey)
 		require.True(
 			t, mssmt.IsEqualNode(rootNode, uniProof.UniverseRoot),
 		)
@@ -214,7 +214,7 @@ func TestUniverseIssuanceProofs(t *testing.T) {
 		node, err = uniProof.Leaf.SmtLeafNode()
 		require.NoError(t, err)
 		dbProofRoot := uniProof.InclusionProof.Root(
-			uniProof.MintingKey.UniverseKey(), node,
+			uniProof.LeafKey.UniverseKey(), node,
 		)
 		require.True(
 			t, mssmt.IsEqualNode(uniProof.UniverseRoot, dbProofRoot),

--- a/tapdb/universe_test.go
+++ b/tapdb/universe_test.go
@@ -191,7 +191,7 @@ func TestUniverseIssuanceProofs(t *testing.T) {
 		// root of the SMT.
 		node, err := leaf.SmtLeafNode()
 		require.NoError(t, err)
-		proofRoot := issuanceProof.InclusionProof.Root(
+		proofRoot := issuanceProof.UniverseInclusionProof.Root(
 			targetKey.UniverseKey(), node,
 		)
 		require.True(t, mssmt.IsEqualNode(rootNode, proofRoot))
@@ -213,7 +213,7 @@ func TestUniverseIssuanceProofs(t *testing.T) {
 		// proof.
 		node, err = uniProof.Leaf.SmtLeafNode()
 		require.NoError(t, err)
-		dbProofRoot := uniProof.InclusionProof.Root(
+		dbProofRoot := uniProof.UniverseInclusionProof.Root(
 			uniProof.LeafKey.UniverseKey(), node,
 		)
 		require.True(

--- a/tapdb/universe_test.go
+++ b/tapdb/universe_test.go
@@ -125,7 +125,7 @@ func randMintingLeaf(t *testing.T, assetGen asset.Genesis,
 	return leaf
 }
 
-// leaWithKey is a two tuple that associates new minting leaf with a key.
+// leaWithKey is a two tuple that associates universe leaf key with a leaf.
 type leafWithKey struct {
 	universe.LeafKey
 

--- a/tapdb/universe_test.go
+++ b/tapdb/universe_test.go
@@ -107,9 +107,9 @@ func randProof(t *testing.T) *proof.Proof {
 }
 
 func randMintingLeaf(t *testing.T, assetGen asset.Genesis,
-	groupKey *btcec.PublicKey) universe.MintingLeaf {
+	groupKey *btcec.PublicKey) universe.Leaf {
 
-	leaf := universe.MintingLeaf{
+	leaf := universe.Leaf{
 		GenesisWithGroup: universe.GenesisWithGroup{
 			Genesis: assetGen,
 		},
@@ -129,7 +129,7 @@ func randMintingLeaf(t *testing.T, assetGen asset.Genesis,
 type leafWithKey struct {
 	universe.LeafKey
 
-	universe.MintingLeaf
+	universe.Leaf
 }
 
 // TestUniverseIssuanceProofs tests that we're able to insert issuance proofs
@@ -167,7 +167,7 @@ func TestUniverseIssuanceProofs(t *testing.T) {
 		leafSum += testLeaf.Amt
 
 		targetKey := testLeaf.LeafKey
-		leaf := testLeaf.MintingLeaf
+		leaf := testLeaf.Leaf
 
 		issuanceProof, err := baseUniverse.RegisterIssuance(
 			ctx, targetKey, &leaf, nil,
@@ -239,10 +239,10 @@ func TestUniverseIssuanceProofs(t *testing.T) {
 	dbLeaves, err := baseUniverse.MintingLeaves(ctx)
 	require.NoError(t, err)
 	require.Equal(t, numLeaves, len(dbLeaves))
-	require.True(t, fn.All(dbLeaves, func(leaf universe.MintingLeaf) bool {
+	require.True(t, fn.All(dbLeaves, func(leaf universe.Leaf) bool {
 		return fn.All(testLeaves, func(testLeaf leafWithKey) bool {
 			return leaf.Genesis.ID() ==
-				testLeaf.MintingLeaf.Genesis.ID()
+				testLeaf.Leaf.Genesis.ID()
 		})
 	}))
 
@@ -255,11 +255,11 @@ func TestUniverseIssuanceProofs(t *testing.T) {
 	// leaves we just inserted.
 	for idx := range testLeaves {
 		testLeaf := &testLeaves[idx]
-		testLeaf.MintingLeaf.GenesisProof = randProof(t)
+		testLeaf.Leaf.GenesisProof = randProof(t)
 
 		targetKey := testLeaf.LeafKey
 		issuanceProof, err := baseUniverse.RegisterIssuance(
-			ctx, targetKey, &testLeaf.MintingLeaf, nil,
+			ctx, targetKey, &testLeaf.Leaf, nil,
 		)
 		require.NoError(t, err)
 
@@ -453,7 +453,7 @@ func TestUniverseLeafQuery(t *testing.T) {
 	// minting outpoint, but will have distinct script keys.
 	rootMintingPoint := randLeafKey(t).OutPoint
 
-	leafToScriptKey := make(map[asset.SerializedKey]universe.MintingLeaf)
+	leafToScriptKey := make(map[asset.SerializedKey]universe.Leaf)
 	for i := 0; i < numLeafs; i++ {
 		targetKey := randLeafKey(t)
 		targetKey.OutPoint = rootMintingPoint

--- a/tapdb/universe_test.go
+++ b/tapdb/universe_test.go
@@ -341,7 +341,7 @@ func TestUniverseMetaBlob(t *testing.T) {
 }
 
 func insertRandLeaf(t *testing.T, ctx context.Context, tree *BaseUniverseTree,
-	assetGen *asset.Genesis) (*universe.IssuanceProof, error) {
+	assetGen *asset.Genesis) (*universe.Proof, error) {
 
 	var targetGen asset.Genesis
 	if assetGen != nil {

--- a/tapdb/universe_test.go
+++ b/tapdb/universe_test.go
@@ -79,7 +79,7 @@ func TestUniverseEmptyTree(t *testing.T) {
 
 func randBaseKey(t *testing.T) universe.LeafKey {
 	return universe.LeafKey{
-		MintingOutpoint: test.RandOp(t),
+		OutPoint: test.RandOp(t),
 		ScriptKey: fn.Ptr(
 			asset.NewScriptKey(test.RandPubKey(t)),
 		),
@@ -451,12 +451,12 @@ func TestUniverseLeafQuery(t *testing.T) {
 
 	// We'll create three new leaves, all of them will share the exact same
 	// minting outpoint, but will have distinct script keys.
-	rootMintingPoint := randBaseKey(t).MintingOutpoint
+	rootMintingPoint := randBaseKey(t).OutPoint
 
 	leafToScriptKey := make(map[asset.SerializedKey]universe.MintingLeaf)
 	for i := 0; i < numLeafs; i++ {
 		targetKey := randBaseKey(t)
-		targetKey.MintingOutpoint = rootMintingPoint
+		targetKey.OutPoint = rootMintingPoint
 
 		leaf := randMintingLeaf(t, assetGen, id.GroupKey)
 
@@ -473,7 +473,7 @@ func TestUniverseLeafQuery(t *testing.T) {
 	// If we query for only the minting point, then all three leaves should
 	// be returned.
 	proofs, err := baseUniverse.FetchIssuanceProof(ctx, universe.LeafKey{
-		MintingOutpoint: rootMintingPoint,
+		OutPoint: rootMintingPoint,
 	})
 	require.NoError(t, err)
 	require.Len(t, proofs, numLeafs)
@@ -485,7 +485,7 @@ func TestUniverseLeafQuery(t *testing.T) {
 		require.NoError(t, err)
 
 		p, err := baseUniverse.FetchIssuanceProof(ctx, universe.LeafKey{
-			MintingOutpoint: rootMintingPoint,
+			OutPoint: rootMintingPoint,
 			ScriptKey: &asset.ScriptKey{
 				PubKey: scriptKey,
 			},

--- a/tapgarden/caretaker.go
+++ b/tapgarden/caretaker.go
@@ -1046,7 +1046,7 @@ func (b *BatchCaretaker) storeMintingProof(ctx context.Context,
 	// The base key is the set of bytes that keys into the universe, this'll
 	// be the outpoint where it was created at and the script key for that
 	// asset.
-	baseKey := universe.LeafKey{
+	leafKey := universe.LeafKey{
 		OutPoint: wire.OutPoint{
 			Hash:  mintTxHash,
 			Index: b.anchorOutputIndex,
@@ -1074,7 +1074,7 @@ func (b *BatchCaretaker) storeMintingProof(ctx context.Context,
 
 	return blob, &universe.IssuanceItem{
 		ID:   uniID,
-		Key:  baseKey,
+		Key:  leafKey,
 		Leaf: mintingLeaf,
 	}, nil
 }

--- a/tapgarden/caretaker.go
+++ b/tapgarden/caretaker.go
@@ -1047,7 +1047,7 @@ func (b *BatchCaretaker) storeMintingProof(ctx context.Context,
 	// be the outpoint where it was created at and the script key for that
 	// asset.
 	baseKey := universe.LeafKey{
-		MintingOutpoint: wire.OutPoint{
+		OutPoint: wire.OutPoint{
 			Hash:  mintTxHash,
 			Index: b.anchorOutputIndex,
 		},

--- a/tapgarden/caretaker.go
+++ b/tapgarden/caretaker.go
@@ -1068,8 +1068,8 @@ func (b *BatchCaretaker) storeMintingProof(ctx context.Context,
 		// The universe tree store only the asset state transition and
 		// not also the proof file checksum (as the root is effectively
 		// a checksum), so we'll use just the state transition.
-		GenesisProof: mintingProof,
-		Amt:          a.Amount,
+		Proof: mintingProof,
+		Amt:   a.Amount,
 	}
 
 	return blob, &universe.IssuanceItem{

--- a/tapgarden/caretaker.go
+++ b/tapgarden/caretaker.go
@@ -1046,7 +1046,7 @@ func (b *BatchCaretaker) storeMintingProof(ctx context.Context,
 	// The base key is the set of bytes that keys into the universe, this'll
 	// be the outpoint where it was created at and the script key for that
 	// asset.
-	baseKey := universe.BaseKey{
+	baseKey := universe.LeafKey{
 		MintingOutpoint: wire.OutPoint{
 			Hash:  mintTxHash,
 			Index: b.anchorOutputIndex,

--- a/tapgarden/caretaker.go
+++ b/tapgarden/caretaker.go
@@ -1062,7 +1062,7 @@ func (b *BatchCaretaker) storeMintingProof(ctx context.Context,
 	if groupKey != nil {
 		uniGen.GroupKey = groupKey
 	}
-	mintingLeaf := &universe.MintingLeaf{
+	mintingLeaf := &universe.Leaf{
 		GenesisWithGroup: uniGen,
 
 		// The universe tree store only the asset state transition and

--- a/tapgarden/planter.go
+++ b/tapgarden/planter.go
@@ -896,7 +896,7 @@ func (c *ChainPlanter) updateMintingProofs(proofs []*proof.Proof) error {
 		if p.Asset.GroupKey != nil {
 			uniGen.GroupKey = p.Asset.GroupKey
 		}
-		mintingLeaf := &universe.MintingLeaf{
+		mintingLeaf := &universe.Leaf{
 			GenesisWithGroup: uniGen,
 			GenesisProof:     p,
 			Amt:              p.Asset.Amount,

--- a/tapgarden/planter.go
+++ b/tapgarden/planter.go
@@ -880,7 +880,7 @@ func (c *ChainPlanter) updateMintingProofs(proofs []*proof.Proof) error {
 		// The base key is the set of bytes that keys into the universe,
 		// this'll be the outpoint where it was created at and the
 		// script key for that asset.
-		baseKey := universe.LeafKey{
+		leafKey := universe.LeafKey{
 			OutPoint: wire.OutPoint{
 				Hash:  p.AnchorTx.TxHash(),
 				Index: p.InclusionProof.OutputIndex,
@@ -902,7 +902,7 @@ func (c *ChainPlanter) updateMintingProofs(proofs []*proof.Proof) error {
 			Amt:              p.Asset.Amount,
 		}
 		_, err = c.cfg.Universe.RegisterIssuance(
-			ctx, uniID, baseKey, mintingLeaf,
+			ctx, uniID, leafKey, mintingLeaf,
 		)
 		if err != nil {
 			return fmt.Errorf("unable to update issuance: %v", err)

--- a/tapgarden/planter.go
+++ b/tapgarden/planter.go
@@ -880,7 +880,7 @@ func (c *ChainPlanter) updateMintingProofs(proofs []*proof.Proof) error {
 		// The base key is the set of bytes that keys into the universe,
 		// this'll be the outpoint where it was created at and the
 		// script key for that asset.
-		baseKey := universe.BaseKey{
+		baseKey := universe.LeafKey{
 			MintingOutpoint: wire.OutPoint{
 				Hash:  p.AnchorTx.TxHash(),
 				Index: p.InclusionProof.OutputIndex,

--- a/tapgarden/planter.go
+++ b/tapgarden/planter.go
@@ -881,7 +881,7 @@ func (c *ChainPlanter) updateMintingProofs(proofs []*proof.Proof) error {
 		// this'll be the outpoint where it was created at and the
 		// script key for that asset.
 		baseKey := universe.LeafKey{
-			MintingOutpoint: wire.OutPoint{
+			OutPoint: wire.OutPoint{
 				Hash:  p.AnchorTx.TxHash(),
 				Index: p.InclusionProof.OutputIndex,
 			},

--- a/tapgarden/planter.go
+++ b/tapgarden/planter.go
@@ -898,7 +898,7 @@ func (c *ChainPlanter) updateMintingProofs(proofs []*proof.Proof) error {
 		}
 		mintingLeaf := &universe.Leaf{
 			GenesisWithGroup: uniGen,
-			GenesisProof:     p,
+			Proof:            p,
 			Amt:              p.Asset.Amount,
 		}
 		_, err = c.cfg.Universe.RegisterIssuance(

--- a/universe/auto_syncer.go
+++ b/universe/auto_syncer.go
@@ -69,7 +69,7 @@ type FederationPushReq struct {
 	// Leaf is the new leaf to add.
 	Leaf *Leaf
 
-	resp chan *IssuanceProof
+	resp chan *Proof
 	err  chan error
 }
 
@@ -419,13 +419,13 @@ func (f *FederationEnvoy) syncer() {
 //
 // NOTE: This is part of the universe.Registrar interface.
 func (f *FederationEnvoy) RegisterIssuance(_ context.Context, id Identifier,
-	key LeafKey, leaf *Leaf) (*IssuanceProof, error) {
+	key LeafKey, leaf *Leaf) (*Proof, error) {
 
 	pushReq := &FederationPushReq{
 		ID:   id,
 		Key:  key,
 		Leaf: leaf,
-		resp: make(chan *IssuanceProof, 1),
+		resp: make(chan *Proof, 1),
 		err:  make(chan error, 1),
 	}
 

--- a/universe/auto_syncer.go
+++ b/universe/auto_syncer.go
@@ -64,7 +64,7 @@ type FederationPushReq struct {
 
 	// Key is the leaf key in the Universe that the new leaf should be
 	// added to.
-	Key BaseKey
+	Key LeafKey
 
 	// Leaf is the new leaf to add.
 	Leaf *MintingLeaf
@@ -225,7 +225,7 @@ func (f *FederationEnvoy) syncUniverseState(ctx context.Context,
 
 // pushProofToFederation attempts to push out a new proof to the current
 // federation in parallel.
-func (f *FederationEnvoy) pushProofToFederation(uniID Identifier, key BaseKey,
+func (f *FederationEnvoy) pushProofToFederation(uniID Identifier, key LeafKey,
 	leaf *MintingLeaf) {
 
 	ctx, cancel := f.WithCtxQuit()
@@ -419,7 +419,7 @@ func (f *FederationEnvoy) syncer() {
 //
 // NOTE: This is part of the universe.Registrar interface.
 func (f *FederationEnvoy) RegisterIssuance(_ context.Context, id Identifier,
-	key BaseKey, leaf *MintingLeaf) (*IssuanceProof, error) {
+	key LeafKey, leaf *MintingLeaf) (*IssuanceProof, error) {
 
 	pushReq := &FederationPushReq{
 		ID:   id,

--- a/universe/auto_syncer.go
+++ b/universe/auto_syncer.go
@@ -67,7 +67,7 @@ type FederationPushReq struct {
 	Key LeafKey
 
 	// Leaf is the new leaf to add.
-	Leaf *MintingLeaf
+	Leaf *Leaf
 
 	resp chan *IssuanceProof
 	err  chan error
@@ -226,7 +226,7 @@ func (f *FederationEnvoy) syncUniverseState(ctx context.Context,
 // pushProofToFederation attempts to push out a new proof to the current
 // federation in parallel.
 func (f *FederationEnvoy) pushProofToFederation(uniID Identifier, key LeafKey,
-	leaf *MintingLeaf) {
+	leaf *Leaf) {
 
 	ctx, cancel := f.WithCtxQuit()
 	defer cancel()
@@ -419,7 +419,7 @@ func (f *FederationEnvoy) syncer() {
 //
 // NOTE: This is part of the universe.Registrar interface.
 func (f *FederationEnvoy) RegisterIssuance(_ context.Context, id Identifier,
-	key LeafKey, leaf *MintingLeaf) (*IssuanceProof, error) {
+	key LeafKey, leaf *Leaf) (*IssuanceProof, error) {
 
 	pushReq := &FederationPushReq{
 		ID:   id,

--- a/universe/base.go
+++ b/universe/base.go
@@ -141,7 +141,7 @@ func (a *MintingArchive) RegisterIssuance(ctx context.Context, id Identifier,
 	log.Debugf("Inserting new proof into Universe: id=%v, base_key=%v",
 		id.StringForLog(), spew.Sdump(key))
 
-	newProof := leaf.GenesisProof
+	newProof := leaf.Proof
 
 	// We'll first check to see if we already know of this leaf within the
 	// multiverse. If so, then we'll return the existing issuance proof.
@@ -154,7 +154,7 @@ func (a *MintingArchive) RegisterIssuance(ctx context.Context, id Identifier,
 		// TX was re-organized out of the chain. If the block hash is
 		// still the same, we don't see this as an update and just
 		// return the existing proof.
-		existingProof := issuanceProof.Leaf.GenesisProof
+		existingProof := issuanceProof.Leaf.Proof
 		if existingProof.BlockHeader.BlockHash() ==
 			newProof.BlockHeader.BlockHash() {
 
@@ -222,7 +222,7 @@ func (a *MintingArchive) verifyIssuanceProof(ctx context.Context, id Identifier,
 	key LeafKey, leaf *Leaf,
 	prevAssetSnapshot *proof.AssetSnapshot) (*proof.AssetSnapshot, error) {
 
-	assetSnapshot, err := leaf.GenesisProof.Verify(
+	assetSnapshot, err := leaf.Proof.Verify(
 		ctx, prevAssetSnapshot, a.cfg.HeaderVerifier,
 	)
 	if err != nil {
@@ -355,7 +355,7 @@ func (a *MintingArchive) getPrevAssetSnapshot(ctx context.Context,
 			"proof: %v", err)
 	}
 
-	prevProof := prevProofs[0].Leaf.GenesisProof
+	prevProof := prevProofs[0].Leaf.Proof
 
 	// Construct minimal asset snapshot for previous asset.
 	// This is a minimal the proof verification result for the

--- a/universe/base.go
+++ b/universe/base.go
@@ -136,7 +136,7 @@ func (a *MintingArchive) RootNodes(ctx context.Context) ([]BaseRoot, error) {
 // error if the passed minting proof is invalid. If the leaf is already known,
 // then no action is taken and the existing issuance commitment proof returned.
 func (a *MintingArchive) RegisterIssuance(ctx context.Context, id Identifier,
-	key BaseKey, leaf *MintingLeaf) (*IssuanceProof, error) {
+	key LeafKey, leaf *MintingLeaf) (*IssuanceProof, error) {
 
 	log.Debugf("Inserting new proof into Universe: id=%v, base_key=%v",
 		id.StringForLog(), spew.Sdump(key))
@@ -219,7 +219,7 @@ func (a *MintingArchive) RegisterIssuance(ctx context.Context, id Identifier,
 // verifyIssuanceProof verifies the passed minting leaf is a valid issuance
 // proof, returning the asset snapshot if so.
 func (a *MintingArchive) verifyIssuanceProof(ctx context.Context, id Identifier,
-	key BaseKey, leaf *MintingLeaf,
+	key LeafKey, leaf *MintingLeaf,
 	prevAssetSnapshot *proof.AssetSnapshot) (*proof.AssetSnapshot, error) {
 
 	assetSnapshot, err := leaf.GenesisProof.Verify(
@@ -342,7 +342,7 @@ func (a *MintingArchive) getPrevAssetSnapshot(ctx context.Context,
 	}
 	prevScriptKey := asset.NewScriptKey(prevScriptKeyPubKey)
 
-	prevBaseKey := BaseKey{
+	prevBaseKey := LeafKey{
 		MintingOutpoint: prevID.OutPoint,
 		ScriptKey:       &prevScriptKey,
 	}
@@ -370,7 +370,7 @@ func (a *MintingArchive) getPrevAssetSnapshot(ctx context.Context,
 // FetchIssuanceProof attempts to fetch an issuance proof for the target base
 // leaf based on the universe identifier (assetID/groupKey).
 func (a *MintingArchive) FetchIssuanceProof(ctx context.Context, id Identifier,
-	key BaseKey) ([]*IssuanceProof, error) {
+	key LeafKey) ([]*IssuanceProof, error) {
 
 	log.Debugf("Retrieving Universe proof for: id=%v, base_key=%v",
 		id.StringForLog(), spew.Sdump(key))
@@ -396,11 +396,11 @@ func (a *MintingArchive) FetchIssuanceProof(ctx context.Context, id Identifier,
 // MintingKeys returns the set of minting keys known for the specified base
 // universe identifier.
 func (a *MintingArchive) MintingKeys(ctx context.Context,
-	id Identifier) ([]BaseKey, error) {
+	id Identifier) ([]LeafKey, error) {
 
 	log.Debugf("Retrieving all keys for Universe: id=%v", id.StringForLog())
 
-	return withBaseUni(a, id, func(baseUni BaseBackend) ([]BaseKey, error) {
+	return withBaseUni(a, id, func(baseUni BaseBackend) ([]LeafKey, error) {
 		return baseUni.MintingKeys(ctx)
 	})
 }

--- a/universe/base.go
+++ b/universe/base.go
@@ -393,9 +393,9 @@ func (a *MintingArchive) FetchIssuanceProof(ctx context.Context, id Identifier,
 	return a.cfg.Multiverse.FetchProofLeaf(ctx, id, key)
 }
 
-// MintingKeys returns the set of minting keys known for the specified base
+// UniverseLeafKeys returns the set of leaf keys known for the specified
 // universe identifier.
-func (a *MintingArchive) MintingKeys(ctx context.Context,
+func (a *MintingArchive) UniverseLeafKeys(ctx context.Context,
 	id Identifier) ([]LeafKey, error) {
 
 	log.Debugf("Retrieving all keys for Universe: id=%v", id.StringForLog())

--- a/universe/base.go
+++ b/universe/base.go
@@ -343,8 +343,8 @@ func (a *MintingArchive) getPrevAssetSnapshot(ctx context.Context,
 	prevScriptKey := asset.NewScriptKey(prevScriptKeyPubKey)
 
 	prevBaseKey := LeafKey{
-		MintingOutpoint: prevID.OutPoint,
-		ScriptKey:       &prevScriptKey,
+		OutPoint:  prevID.OutPoint,
+		ScriptKey: &prevScriptKey,
 	}
 
 	prevProofs, err := a.cfg.Multiverse.FetchProofLeaf(

--- a/universe/base.go
+++ b/universe/base.go
@@ -136,7 +136,7 @@ func (a *MintingArchive) RootNodes(ctx context.Context) ([]BaseRoot, error) {
 // error if the passed minting proof is invalid. If the leaf is already known,
 // then no action is taken and the existing issuance commitment proof returned.
 func (a *MintingArchive) RegisterIssuance(ctx context.Context, id Identifier,
-	key LeafKey, leaf *Leaf) (*IssuanceProof, error) {
+	key LeafKey, leaf *Leaf) (*Proof, error) {
 
 	log.Debugf("Inserting new proof into Universe: id=%v, base_key=%v",
 		id.StringForLog(), spew.Sdump(key))
@@ -370,7 +370,7 @@ func (a *MintingArchive) getPrevAssetSnapshot(ctx context.Context,
 // FetchIssuanceProof attempts to fetch an issuance proof for the target base
 // leaf based on the universe identifier (assetID/groupKey).
 func (a *MintingArchive) FetchIssuanceProof(ctx context.Context, id Identifier,
-	key LeafKey) ([]*IssuanceProof, error) {
+	key LeafKey) ([]*Proof, error) {
 
 	log.Debugf("Retrieving Universe proof for: id=%v, base_key=%v",
 		id.StringForLog(), spew.Sdump(key))

--- a/universe/base.go
+++ b/universe/base.go
@@ -136,7 +136,7 @@ func (a *MintingArchive) RootNodes(ctx context.Context) ([]BaseRoot, error) {
 // error if the passed minting proof is invalid. If the leaf is already known,
 // then no action is taken and the existing issuance commitment proof returned.
 func (a *MintingArchive) RegisterIssuance(ctx context.Context, id Identifier,
-	key LeafKey, leaf *MintingLeaf) (*IssuanceProof, error) {
+	key LeafKey, leaf *Leaf) (*IssuanceProof, error) {
 
 	log.Debugf("Inserting new proof into Universe: id=%v, base_key=%v",
 		id.StringForLog(), spew.Sdump(key))
@@ -219,7 +219,7 @@ func (a *MintingArchive) RegisterIssuance(ctx context.Context, id Identifier,
 // verifyIssuanceProof verifies the passed minting leaf is a valid issuance
 // proof, returning the asset snapshot if so.
 func (a *MintingArchive) verifyIssuanceProof(ctx context.Context, id Identifier,
-	key LeafKey, leaf *MintingLeaf,
+	key LeafKey, leaf *Leaf,
 	prevAssetSnapshot *proof.AssetSnapshot) (*proof.AssetSnapshot, error) {
 
 	assetSnapshot, err := leaf.GenesisProof.Verify(
@@ -408,13 +408,13 @@ func (a *MintingArchive) MintingKeys(ctx context.Context,
 // MintingLeaves returns the set of minting leaves known for the specified base
 // universe.
 func (a *MintingArchive) MintingLeaves(ctx context.Context,
-	id Identifier) ([]MintingLeaf, error) {
+	id Identifier) ([]Leaf, error) {
 
 	log.Debugf("Retrieving all leaves for Universe: id=%v",
 		id.StringForLog())
 
 	return withBaseUni(
-		a, id, func(baseUni BaseBackend) ([]MintingLeaf, error) {
+		a, id, func(baseUni BaseBackend) ([]Leaf, error) {
 			return baseUni.MintingLeaves(ctx)
 		},
 	)

--- a/universe/base.go
+++ b/universe/base.go
@@ -342,13 +342,13 @@ func (a *MintingArchive) getPrevAssetSnapshot(ctx context.Context,
 	}
 	prevScriptKey := asset.NewScriptKey(prevScriptKeyPubKey)
 
-	prevBaseKey := LeafKey{
+	prevLeafKey := LeafKey{
 		OutPoint:  prevID.OutPoint,
 		ScriptKey: &prevScriptKey,
 	}
 
 	prevProofs, err := a.cfg.Multiverse.FetchProofLeaf(
-		ctx, uniID, prevBaseKey,
+		ctx, uniID, prevLeafKey,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("unable to fetch previous "+

--- a/universe/interface.go
+++ b/universe/interface.go
@@ -153,9 +153,9 @@ type Proof struct {
 	// within.
 	UniverseRoot mssmt.Node
 
-	// InclusionProof is the inclusion proof for the asset within the
-	// universe tree.
-	InclusionProof *mssmt.Proof
+	// UniverseInclusionProof is the universe inclusion proof for the asset
+	// within the universe tree.
+	UniverseInclusionProof *mssmt.Proof
 
 	// MultiverseRoot is the root of the multiverse tree that the asset is
 	// located within.
@@ -175,7 +175,7 @@ func (i *Proof) VerifyRoot(expectedRoot mssmt.Node) (bool, error) {
 		return false, err
 	}
 
-	reconstructedRoot := i.InclusionProof.Root(
+	reconstructedRoot := i.UniverseInclusionProof.Root(
 		i.LeafKey.UniverseKey(), leafNode,
 	)
 

--- a/universe/interface.go
+++ b/universe/interface.go
@@ -110,9 +110,9 @@ func (m *MintingLeaf) SmtLeafNode() (*mssmt.LeafNode, error) {
 // sha256(mintingOutpoint || scriptKey). This ensures that all
 // leaves for a given asset will be uniquely keyed in the universe tree.
 type LeafKey struct {
-	// MintingOutpoint is the minting outpoint, or the outpoint where the
-	// newly created assets reside within.
-	MintingOutpoint wire.OutPoint
+	// OutPoint is the outpoint at which the asset referenced by this key
+	// resides.
+	OutPoint wire.OutPoint
 
 	// ScriptKey is the script key of the base asset. If this isn't
 	// specified, then the caller is attempting to query for all the script
@@ -126,7 +126,7 @@ type LeafKey struct {
 func (b LeafKey) UniverseKey() [32]byte {
 	// key = sha256(mintingOutpoint || scriptKey)
 	h := sha256.New()
-	_ = wire.WriteOutPoint(h, 0, 0, &b.MintingOutpoint)
+	_ = wire.WriteOutPoint(h, 0, 0, &b.OutPoint)
 	h.Write(schnorr.SerializePubKey(b.ScriptKey.PubKey))
 
 	var k [32]byte

--- a/universe/interface.go
+++ b/universe/interface.go
@@ -466,8 +466,8 @@ type DiffEngine interface {
 	// RootNodes returns the set of root nodes for all known universes.
 	RootNodes(ctx context.Context) ([]BaseRoot, error)
 
-	// MintingKeys returns all the keys inserted in the universe.
-	MintingKeys(ctx context.Context, id Identifier) ([]LeafKey, error)
+	// UniverseLeafKeys returns all the keys inserted in the universe.
+	UniverseLeafKeys(ctx context.Context, id Identifier) ([]LeafKey, error)
 
 	// FetchIssuanceProof attempts to fetch an issuance proof for the
 	// target base leaf based on the universe identifier (assetID/groupKey).

--- a/universe/interface.go
+++ b/universe/interface.go
@@ -82,10 +82,10 @@ type GenesisWithGroup struct {
 	*asset.GroupKey
 }
 
-// MintingLeaf is a leaf node in the SMT that represents a minting output. For
-// each new asset created for a given asset/universe, a new minting leaf is
+// Leaf is a leaf node in the SMT that represents an asset issuance or transfer.
+// For each asset issued or transferred for a given universe, a new leaf is
 // created.
-type MintingLeaf struct {
+type Leaf struct {
 	GenesisWithGroup
 
 	// GenesisProof is the proof of the newly created asset.
@@ -96,7 +96,7 @@ type MintingLeaf struct {
 }
 
 // SmtLeafNode returns the SMT leaf node for the given minting leaf.
-func (m *MintingLeaf) SmtLeafNode() (*mssmt.LeafNode, error) {
+func (m *Leaf) SmtLeafNode() (*mssmt.LeafNode, error) {
 	var buf bytes.Buffer
 	if err := m.GenesisProof.Encode(&buf); err != nil {
 		return nil, err
@@ -152,7 +152,7 @@ type IssuanceProof struct {
 	InclusionProof *mssmt.Proof
 
 	// Leaf is the leaf node for the asset within the universe tree.
-	Leaf *MintingLeaf
+	Leaf *Leaf
 
 	// MultiverseRoot is the root of the multiverse tree that the asset is
 	// located within.
@@ -193,7 +193,7 @@ type BaseBackend interface {
 	// tree, stored at the base key. The metaReveal type is purely
 	// optional, and should be specified if the genesis proof committed to
 	// a non-zero meta hash.
-	RegisterIssuance(ctx context.Context, key LeafKey, leaf *MintingLeaf,
+	RegisterIssuance(ctx context.Context, key LeafKey, leaf *Leaf,
 		metaReveal *proof.MetaReveal) (*IssuanceProof, error)
 
 	// FetchIssuanceProof returns an issuance proof for the target key. If
@@ -210,7 +210,7 @@ type BaseBackend interface {
 
 	// MintingLeaves returns all the minting leaves inserted into the
 	// universe.
-	MintingLeaves(ctx context.Context) ([]MintingLeaf, error)
+	MintingLeaves(ctx context.Context) ([]Leaf, error)
 
 	// DeleteUniverse deletes all leaves, and the root, for a given base
 	// universe.
@@ -246,7 +246,7 @@ type MultiverseArchive interface {
 	// UpsertProofLeaf upserts a proof leaf within the multiverse tree and
 	// the universe tree that corresponds to the given key.
 	UpsertProofLeaf(ctx context.Context, id Identifier, key LeafKey,
-		leaf *MintingLeaf,
+		leaf *Leaf,
 		metaReveal *proof.MetaReveal) (*IssuanceProof, error)
 
 	// RegisterBatchIssuance inserts a new minting leaf batch within the
@@ -271,7 +271,7 @@ type Registrar interface {
 	// RegisterIssuance inserts a new minting leaf within the target
 	// universe tree (based on the ID), stored at the base key.
 	RegisterIssuance(ctx context.Context, id Identifier, key LeafKey,
-		leaf *MintingLeaf) (*IssuanceProof, error)
+		leaf *Leaf) (*IssuanceProof, error)
 }
 
 // IssuanceItem is an item that can be used to register a new issuance within a
@@ -285,7 +285,7 @@ type IssuanceItem struct {
 	Key LeafKey
 
 	// Leaf is the minting leaf that was created.
-	Leaf *MintingLeaf
+	Leaf *Leaf
 
 	// MetaReveal is the meta reveal that was created.
 	MetaReveal *proof.MetaReveal
@@ -435,7 +435,7 @@ type AssetSyncDiff struct {
 
 	// NewAssetLeaves is the set of new leaf proofs that were added to the
 	// Universe.
-	NewLeafProofs []*MintingLeaf
+	NewLeafProofs []*Leaf
 
 	// TODO(roasbeef): ability to return if things failed?
 	//  * can used a sealed interface to return the error

--- a/universe/interface.go
+++ b/universe/interface.go
@@ -88,8 +88,9 @@ type GenesisWithGroup struct {
 type Leaf struct {
 	GenesisWithGroup
 
-	// GenesisProof is the proof of the newly created asset.
-	GenesisProof *proof.Proof
+	// Proof is either an issuance proof or a transfer proof associated with
+	// the issuance or spend event which this leaf represents.
+	Proof *proof.Proof
 
 	// Amt is the amount of units created.
 	Amt uint64
@@ -98,7 +99,7 @@ type Leaf struct {
 // SmtLeafNode returns the SMT leaf node for the given minting leaf.
 func (m *Leaf) SmtLeafNode() (*mssmt.LeafNode, error) {
 	var buf bytes.Buffer
-	if err := m.GenesisProof.Encode(&buf); err != nil {
+	if err := m.Proof.Encode(&buf); err != nil {
 		return nil, err
 	}
 

--- a/universe/interface.go
+++ b/universe/interface.go
@@ -141,8 +141,8 @@ func (b LeafKey) UniverseKey() [32]byte {
 // (based on the proof in the leaf), and that the asset is committed to within
 // the universe root.
 type IssuanceProof struct {
-	// MintingKey is the minting key for the asset.
-	MintingKey LeafKey
+	// LeafKey is the universe leaf key for the asset issuance or spend.
+	LeafKey LeafKey
 
 	// UniverseRoot is the root of the universe that the asset is located
 	// within.
@@ -174,7 +174,7 @@ func (i *IssuanceProof) VerifyRoot(expectedRoot mssmt.Node) (bool, error) {
 	}
 
 	reconstructedRoot := i.InclusionProof.Root(
-		i.MintingKey.UniverseKey(), leafNode,
+		i.LeafKey.UniverseKey(), leafNode,
 	)
 
 	return mssmt.IsEqualNode(i.UniverseRoot, expectedRoot) &&

--- a/universe/interface.go
+++ b/universe/interface.go
@@ -92,11 +92,11 @@ type Leaf struct {
 	// the issuance or spend event which this leaf represents.
 	Proof *proof.Proof
 
-	// Amt is the amount of units created.
+	// Amt is the amount of units associated with the coin.
 	Amt uint64
 }
 
-// SmtLeafNode returns the SMT leaf node for the given minting leaf.
+// SmtLeafNode returns the SMT leaf node for the given leaf.
 func (m *Leaf) SmtLeafNode() (*mssmt.LeafNode, error) {
 	var buf bytes.Buffer
 	if err := m.Proof.Encode(&buf); err != nil {

--- a/universe/syncer.go
+++ b/universe/syncer.go
@@ -167,11 +167,11 @@ func (s *SimpleSyncer) syncRoot(ctx context.Context, remoteRoot BaseRoot,
 
 	// Otherwise, we'll need to perform a diff operation to find the set of
 	// keys we need to fetch.
-	remoteUniKeys, err := diffEngine.MintingKeys(ctx, uniID)
+	remoteUniKeys, err := diffEngine.UniverseLeafKeys(ctx, uniID)
 	if err != nil {
 		return err
 	}
-	localUniKeys, err := s.cfg.LocalDiffEngine.MintingKeys(ctx, uniID)
+	localUniKeys, err := s.cfg.LocalDiffEngine.UniverseLeafKeys(ctx, uniID)
 	if err != nil {
 		return err
 	}

--- a/universe/syncer.go
+++ b/universe/syncer.go
@@ -190,7 +190,7 @@ func (s *SimpleSyncer) syncRoot(ctx context.Context, remoteRoot BaseRoot,
 	// local registrar as they're fetched.
 	var (
 		fetchedLeaves = make(chan *IssuanceItem, len(keysToFetch))
-		newLeafProofs []*MintingLeaf
+		newLeafProofs []*Leaf
 		batchSyncEG   errgroup.Group
 	)
 
@@ -275,11 +275,11 @@ func (s *SimpleSyncer) syncRoot(ctx context.Context, remoteRoot BaseRoot,
 // batches and returns the new leaf proofs.
 func (s *SimpleSyncer) batchStreamNewItems(ctx context.Context,
 	uniID Identifier, fetchedLeaves chan *IssuanceItem,
-	numTotal int) ([]*MintingLeaf, error) {
+	numTotal int) ([]*Leaf, error) {
 
 	var (
 		numItems      int
-		newLeafProofs []*MintingLeaf
+		newLeafProofs []*Leaf
 	)
 	err := fn.CollectBatch(
 		ctx, fetchedLeaves, s.cfg.SyncBatchSize,
@@ -302,7 +302,7 @@ func (s *SimpleSyncer) batchStreamNewItems(ctx context.Context,
 				numItems, numTotal)
 
 			newLeaves := fn.Map(
-				batch, func(i *IssuanceItem) *MintingLeaf {
+				batch, func(i *IssuanceItem) *Leaf {
 					return i.Leaf
 				},
 			)

--- a/universe/syncer.go
+++ b/universe/syncer.go
@@ -205,7 +205,7 @@ func (s *SimpleSyncer) syncRoot(ctx context.Context, remoteRoot BaseRoot,
 	// Now that we know where the divergence is, we can fetch the issuance
 	// proofs from the remote party.
 	err = fn.ParSlice(
-		ctx, keysToFetch, func(ctx context.Context, key BaseKey) error {
+		ctx, keysToFetch, func(ctx context.Context, key LeafKey) error {
 			newProof, err := diffEngine.FetchIssuanceProof(
 				ctx, uniID, key,
 			)

--- a/universe_rpc_diff.go
+++ b/universe_rpc_diff.go
@@ -138,7 +138,7 @@ func (r *RpcUniverseDiff) MintingKeys(ctx context.Context,
 // of diff
 func (r *RpcUniverseDiff) FetchIssuanceProof(ctx context.Context,
 	id universe.Identifier,
-	key universe.LeafKey) ([]*universe.IssuanceProof, error) {
+	key universe.LeafKey) ([]*universe.Proof, error) {
 
 	uProofs, err := r.conn.QueryProof(ctx, &universerpc.UniverseKey{
 		Id:      marshalUniID(id),
@@ -171,14 +171,14 @@ func (r *RpcUniverseDiff) FetchIssuanceProof(ctx context.Context,
 		return nil, err
 	}
 
-	uniProof := &universe.IssuanceProof{
+	uniProof := &universe.Proof{
 		LeafKey:        key,
 		UniverseRoot:   uniRoot,
 		InclusionProof: inclusionProof,
 		Leaf:           assetLeaf,
 	}
 
-	return []*universe.IssuanceProof{uniProof}, nil
+	return []*universe.Proof{uniProof}, nil
 }
 
 // A compile time interface to ensure that RpcUniverseDiff implements the

--- a/universe_rpc_diff.go
+++ b/universe_rpc_diff.go
@@ -109,14 +109,14 @@ func (r *RpcUniverseDiff) RootNode(ctx context.Context,
 
 // MintingKeys returns all the keys inserted in the universe.
 func (r *RpcUniverseDiff) MintingKeys(ctx context.Context,
-	id universe.Identifier) ([]universe.BaseKey, error) {
+	id universe.Identifier) ([]universe.LeafKey, error) {
 
 	assetKeys, err := r.conn.AssetLeafKeys(ctx, marshalUniID(id))
 	if err != nil {
 		return nil, err
 	}
 
-	keys := make([]universe.BaseKey, len(assetKeys.AssetKeys))
+	keys := make([]universe.LeafKey, len(assetKeys.AssetKeys))
 	for i, key := range assetKeys.AssetKeys {
 		baseKey, err := unmarshalLeafKey(key)
 		if err != nil {
@@ -138,7 +138,7 @@ func (r *RpcUniverseDiff) MintingKeys(ctx context.Context,
 // of diff
 func (r *RpcUniverseDiff) FetchIssuanceProof(ctx context.Context,
 	id universe.Identifier,
-	key universe.BaseKey) ([]*universe.IssuanceProof, error) {
+	key universe.LeafKey) ([]*universe.IssuanceProof, error) {
 
 	uProofs, err := r.conn.QueryProof(ctx, &universerpc.UniverseKey{
 		Id:      marshalUniID(id),

--- a/universe_rpc_diff.go
+++ b/universe_rpc_diff.go
@@ -172,10 +172,10 @@ func (r *RpcUniverseDiff) FetchIssuanceProof(ctx context.Context,
 	}
 
 	uniProof := &universe.Proof{
-		LeafKey:        key,
-		UniverseRoot:   uniRoot,
-		InclusionProof: inclusionProof,
-		Leaf:           assetLeaf,
+		LeafKey:                key,
+		UniverseRoot:           uniRoot,
+		UniverseInclusionProof: inclusionProof,
+		Leaf:                   assetLeaf,
 	}
 
 	return []*universe.Proof{uniProof}, nil

--- a/universe_rpc_diff.go
+++ b/universe_rpc_diff.go
@@ -118,12 +118,12 @@ func (r *RpcUniverseDiff) MintingKeys(ctx context.Context,
 
 	keys := make([]universe.LeafKey, len(assetKeys.AssetKeys))
 	for i, key := range assetKeys.AssetKeys {
-		baseKey, err := unmarshalLeafKey(key)
+		leafKey, err := unmarshalLeafKey(key)
 		if err != nil {
 			return nil, err
 		}
 
-		keys[i] = baseKey
+		keys[i] = leafKey
 	}
 
 	return keys, nil

--- a/universe_rpc_diff.go
+++ b/universe_rpc_diff.go
@@ -172,7 +172,7 @@ func (r *RpcUniverseDiff) FetchIssuanceProof(ctx context.Context,
 	}
 
 	uniProof := &universe.IssuanceProof{
-		MintingKey:     key,
+		LeafKey:        key,
 		UniverseRoot:   uniRoot,
 		InclusionProof: inclusionProof,
 		Leaf:           assetLeaf,

--- a/universe_rpc_diff.go
+++ b/universe_rpc_diff.go
@@ -107,8 +107,8 @@ func (r *RpcUniverseDiff) RootNode(ctx context.Context,
 	return unmarshalUniverseRoot(universeRoot.AssetRoot)
 }
 
-// MintingKeys returns all the keys inserted in the universe.
-func (r *RpcUniverseDiff) MintingKeys(ctx context.Context,
+// UniverseLeafKeys returns all the keys inserted in the universe.
+func (r *RpcUniverseDiff) UniverseLeafKeys(ctx context.Context,
 	id universe.Identifier) ([]universe.LeafKey, error) {
 
 	assetKeys, err := r.conn.AssetLeafKeys(ctx, marshalUniID(id))

--- a/universe_rpc_registrar.go
+++ b/universe_rpc_registrar.go
@@ -82,7 +82,7 @@ func unmarshalIssuanceProof(uniKey *unirpc.UniverseKey,
 // that uses a remote Universe server as the Registry instance.
 func (r *RpcUniverseRegistrar) RegisterIssuance(ctx context.Context,
 	id universe.Identifier, key universe.LeafKey,
-	leaf *universe.MintingLeaf) (*universe.IssuanceProof, error) {
+	leaf *universe.Leaf) (*universe.IssuanceProof, error) {
 
 	// First, we'll parse the proofs and key into their RPC counterparts.
 	uniKey := &unirpc.UniverseKey{

--- a/universe_rpc_registrar.go
+++ b/universe_rpc_registrar.go
@@ -37,9 +37,9 @@ func NewRpcUniverseRegistrar(
 	}, nil
 }
 
-// unmarshalIssuanceProof unmarshals an issuance proof response into a struct
+// unmarshalIssuanceProof un-marshals an issuance proof response into a struct
 // usable by the universe package.
-func unmarshalIssuanceProof(ctx context.Context, uniKey *unirpc.UniverseKey,
+func unmarshalIssuanceProof(uniKey *unirpc.UniverseKey,
 	proofResp *unirpc.AssetProofResponse) (*universe.IssuanceProof, error) {
 
 	leafKey, err := unmarshalLeafKey(uniKey.LeafKey)
@@ -105,9 +105,9 @@ func (r *RpcUniverseRegistrar) RegisterIssuance(ctx context.Context,
 		return nil, err
 	}
 
-	// Finally, we'll map the response back into the IssuanceProof we
-	// expect as a response.
-	return unmarshalIssuanceProof(ctx, uniKey, proofResp)
+	// Finally, we'll map the response back into the IssuanceProof we expect
+	// as a response.
+	return unmarshalIssuanceProof(uniKey, proofResp)
 }
 
 // A compile time interface to ensure that RpcUniverseRegistrar implements the

--- a/universe_rpc_registrar.go
+++ b/universe_rpc_registrar.go
@@ -81,7 +81,7 @@ func unmarshalIssuanceProof(ctx context.Context, uniKey *unirpc.UniverseKey,
 // RegisterIssuance is an implementation of the universe.Registrar interface
 // that uses a remote Universe server as the Registry instance.
 func (r *RpcUniverseRegistrar) RegisterIssuance(ctx context.Context,
-	id universe.Identifier, key universe.BaseKey,
+	id universe.Identifier, key universe.LeafKey,
 	leaf *universe.MintingLeaf) (*universe.IssuanceProof, error) {
 
 	// First, we'll parse the proofs and key into their RPC counterparts.

--- a/universe_rpc_registrar.go
+++ b/universe_rpc_registrar.go
@@ -73,8 +73,8 @@ func unmarshalIssuanceProof(uniKey *unirpc.UniverseKey,
 			),
 			uint64(proofResp.UniverseRoot.MssmtRoot.RootSum),
 		),
-		InclusionProof: inclusionProof,
-		Leaf:           assetLeaf,
+		UniverseInclusionProof: inclusionProof,
+		Leaf:                   assetLeaf,
 	}, nil
 }
 

--- a/universe_rpc_registrar.go
+++ b/universe_rpc_registrar.go
@@ -66,7 +66,7 @@ func unmarshalIssuanceProof(uniKey *unirpc.UniverseKey,
 	}
 
 	return &universe.IssuanceProof{
-		MintingKey: leafKey,
+		LeafKey: leafKey,
 		UniverseRoot: mssmt.NewComputedBranch(
 			fn.ToArray[mssmt.NodeHash](
 				proofResp.UniverseRoot.MssmtRoot.RootHash,

--- a/universe_rpc_registrar.go
+++ b/universe_rpc_registrar.go
@@ -40,7 +40,7 @@ func NewRpcUniverseRegistrar(
 // unmarshalIssuanceProof un-marshals an issuance proof response into a struct
 // usable by the universe package.
 func unmarshalIssuanceProof(uniKey *unirpc.UniverseKey,
-	proofResp *unirpc.AssetProofResponse) (*universe.IssuanceProof, error) {
+	proofResp *unirpc.AssetProofResponse) (*universe.Proof, error) {
 
 	leafKey, err := unmarshalLeafKey(uniKey.LeafKey)
 	if err != nil {
@@ -65,7 +65,7 @@ func unmarshalIssuanceProof(uniKey *unirpc.UniverseKey,
 		return nil, err
 	}
 
-	return &universe.IssuanceProof{
+	return &universe.Proof{
 		LeafKey: leafKey,
 		UniverseRoot: mssmt.NewComputedBranch(
 			fn.ToArray[mssmt.NodeHash](
@@ -82,7 +82,7 @@ func unmarshalIssuanceProof(uniKey *unirpc.UniverseKey,
 // that uses a remote Universe server as the Registry instance.
 func (r *RpcUniverseRegistrar) RegisterIssuance(ctx context.Context,
 	id universe.Identifier, key universe.LeafKey,
-	leaf *universe.Leaf) (*universe.IssuanceProof, error) {
+	leaf *universe.Leaf) (*universe.Proof, error) {
 
 	// First, we'll parse the proofs and key into their RPC counterparts.
 	uniKey := &unirpc.UniverseKey{
@@ -105,7 +105,7 @@ func (r *RpcUniverseRegistrar) RegisterIssuance(ctx context.Context,
 		return nil, err
 	}
 
-	// Finally, we'll map the response back into the IssuanceProof we expect
+	// Finally, we'll map the response back into the Proof we expect
 	// as a response.
 	return unmarshalIssuanceProof(uniKey, proofResp)
 }

--- a/universe_rpc_registrar.go
+++ b/universe_rpc_registrar.go
@@ -42,7 +42,7 @@ func NewRpcUniverseRegistrar(
 func unmarshalIssuanceProof(ctx context.Context, uniKey *unirpc.UniverseKey,
 	proofResp *unirpc.AssetProofResponse) (*universe.IssuanceProof, error) {
 
-	baseKey, err := unmarshalLeafKey(uniKey.LeafKey)
+	leafKey, err := unmarshalLeafKey(uniKey.LeafKey)
 	if err != nil {
 		return nil, err
 	}
@@ -66,7 +66,7 @@ func unmarshalIssuanceProof(ctx context.Context, uniKey *unirpc.UniverseKey,
 	}
 
 	return &universe.IssuanceProof{
-		MintingKey: baseKey,
+		MintingKey: leafKey,
 		UniverseRoot: mssmt.NewComputedBranch(
 			fn.ToArray[mssmt.NodeHash](
 				proofResp.UniverseRoot.MssmtRoot.RootHash,


### PR DESCRIPTION
In this PR we change instances of "minting", "base", and "issuance" to more general terminology which will clarify that the code is also used for transition proofs (non-issuance).

Associated issue: https://github.com/lightninglabs/taproot-assets/issues/535
I may create additional PRs so I don't necessarily want this PR to close the above issue.