### PR TITLE
Fix instances of `time.Now()` which should be set to UTC

### DIFF
--- a/tapdb/universe_stats.go
+++ b/tapdb/universe_stats.go
@@ -137,7 +137,7 @@ func (u *UniverseStats) LogSyncEvent(ctx context.Context,
 		}
 
 		return db.InsertNewSyncEvent(ctx, NewSyncEvent{
-			EventTime:      u.clock.Now(),
+			EventTime:      u.clock.Now().UTC(),
 			EventTimestamp: u.clock.Now().UTC().Unix(),
 			AssetID:        uniID.AssetID[:],
 			GroupKeyXOnly:  groupKeyXOnly,
@@ -162,7 +162,7 @@ func (u *UniverseStats) LogSyncEvents(ctx context.Context,
 			}
 
 			err := db.InsertNewSyncEvent(ctx, NewSyncEvent{
-				EventTime:      u.clock.Now(),
+				EventTime:      u.clock.Now().UTC(),
 				EventTimestamp: u.clock.Now().UTC().Unix(),
 				AssetID:        uniID.AssetID[:],
 				GroupKeyXOnly:  groupKeyXOnly,
@@ -188,7 +188,7 @@ func (u *UniverseStats) LogNewProofEvent(ctx context.Context,
 		}
 
 		return db.InsertNewProofEvent(ctx, NewProofEvent{
-			EventTime:      u.clock.Now(),
+			EventTime:      u.clock.Now().UTC(),
 			EventTimestamp: u.clock.Now().UTC().Unix(),
 			AssetID:        uniID.AssetID[:],
 			GroupKeyXOnly:  groupKeyXOnly,
@@ -212,7 +212,7 @@ func (u *UniverseStats) LogNewProofEvents(ctx context.Context,
 			}
 
 			err := db.InsertNewProofEvent(ctx, NewProofEvent{
-				EventTime:      u.clock.Now(),
+				EventTime:      u.clock.Now().UTC(),
 				EventTimestamp: u.clock.Now().UTC().Unix(),
 				AssetID:        uniID.AssetID[:],
 				GroupKeyXOnly:  groupKeyXOnly,

--- a/tapdb/universe_stats_test.go
+++ b/tapdb/universe_stats_test.go
@@ -109,7 +109,7 @@ func TestUniverseStatsEvents(t *testing.T) {
 
 	db := NewTestDB(t)
 
-	yesterday := time.Now().Add(-24 * time.Hour)
+	yesterday := time.Now().UTC().Add(-24 * time.Hour)
 	testClock := clock.NewTestClock(yesterday)
 	statsDB, _ := newUniverseStatsWithDB(db.BaseDB, testClock)
 


### PR DESCRIPTION
Closes https://github.com/lightninglabs/taproot-assets/issues/541

I have confirmed that the failing unit test now passes.

I think we should enforce UTC location in `clock.NewTestClock` (LND). Thoughts on this @guggero ?