### PR TITLE
asset: update parsing to return error if unknown odd type encountered

### DIFF
--- a/asset/asset.go
+++ b/asset/asset.go
@@ -1343,7 +1343,8 @@ func (a *Asset) Decode(r io.Reader) error {
 	if err != nil {
 		return err
 	}
-	return stream.Decode(r)
+
+	return TlvStrictDecode(stream, r, KnownAssetLeafTypes)
 }
 
 // Leaf returns the asset encoded as a MS-SMT leaf node.

--- a/asset/records_test.go
+++ b/asset/records_test.go
@@ -1,0 +1,66 @@
+package asset
+
+import (
+	"testing"
+
+	"github.com/lightninglabs/taproot-assets/fn"
+	"github.com/lightningnetwork/lnd/tlv"
+	"github.com/stretchr/testify/require"
+)
+
+// TestTlvStrictDecode tests that the strict decoding of TLV records works as
+// expected.
+func TestTlvStrictDecode(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		parsedTypes tlv.TypeMap
+		knownTypes  fn.Set[tlv.Type]
+		err         error
+	}{
+		// No unknown types.
+		{
+			parsedTypes: tlv.TypeMap{
+				0: []byte{},
+				2: []byte{},
+			},
+			knownTypes: fn.NewSet[tlv.Type](0, 2),
+			err:        nil,
+		},
+
+		// Unknown type, but even.
+		{
+			parsedTypes: tlv.TypeMap{
+				0: []byte{},
+				2: []byte{},
+				4: []byte{},
+			},
+			knownTypes: fn.NewSet[tlv.Type](0, 2),
+			err:        nil,
+		},
+
+		// Unknown odd type, error.
+		{
+			parsedTypes: tlv.TypeMap{
+				0: []byte{},
+				2: []byte{},
+				5: []byte{},
+			},
+			knownTypes: fn.NewSet[tlv.Type](0, 2),
+			err: ErrUnknownType{
+				UnknownType: 5,
+				ValueBytes:  []byte{},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+
+		require.Equal(t,
+			testCase.err,
+			AssertNoUnkownTypes(
+				testCase.parsedTypes, testCase.knownTypes,
+			),
+		)
+	}
+}


### PR DESCRIPTION
In this commit, as a follow up to the recent even/odd type split, we add some helper functions to assert that when we decode an asset TLV stream, we bail out if we find any unknown types.