### PR TITLE
loadtest: add multi send test

### DIFF
--- a/itest/loadtest/config.go
+++ b/itest/loadtest/config.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/jessevdk/go-flags"
+	"github.com/lightninglabs/taproot-assets/taprpc"
 )
 
 const (
@@ -58,9 +59,21 @@ type Config struct {
 	// Bitcoin is the configuration for the bitcoin backend.
 	Bitcoin *BitcoinConfig `group:"bitcoin" namespace:"bitcoin" long:"bitcoin" description:"bitcoin client configuration"`
 
-	// BatchSize is the number of assets to mint in a single batch. This is only
-	// relevant for some test cases.
-	BatchSize int `long:"batch-size" description:"the number of assets to mint in a single batch"`
+	// BatchSize is the number of assets to mint in a single batch. This is
+	// only relevant for the mint test.
+	BatchSize int `long:"mint-test-batch-size" description:"the number of assets to mint in a single batch; only relevant for the mint test"`
+
+	// NumSends is the number of asset sends to perform. This is only
+	// relevant for the send test.
+	NumSends int `long:"send-test-num-sends" description:"the number of send operations to perform; only relevant for the send test"`
+
+	// NumAssets is the number of assets to send in each send operation.
+	// This is only relevant for the send test.
+	NumAssets uint64 `long:"send-test-num-assets" description:"the number of assets to send in each send operation; only relevant for the send test"`
+
+	// SendType is the type of asset to attempt to send. This is only
+	// relevant for the send test.
+	SendType taprpc.AssetType `long:"send-test-send-type" description:"the type of asset to attempt to send; only relevant for the send test"`
 
 	// TestSuiteTimeout is the timeout for the entire test suite.
 	TestSuiteTimeout time.Duration `long:"test-suite-timeout" description:"the timeout for the entire test suite"`
@@ -84,6 +97,9 @@ func DefaultConfig() Config {
 			},
 		},
 		BatchSize:        100,
+		NumSends:         50,
+		NumAssets:        1, // We only mint collectibles.
+		SendType:         taprpc.AssetType_COLLECTIBLE,
 		TestSuiteTimeout: defaultSuiteTimeout,
 		TestTimeout:      defaultTestTimeout,
 	}

--- a/itest/loadtest/config.go
+++ b/itest/loadtest/config.go
@@ -73,7 +73,6 @@ type Config struct {
 // binary.
 func DefaultConfig() Config {
 	return Config{
-		TestCases: []string{"mint_batch_stress"},
 		Alice: &User{
 			Tapd: &TapConfig{
 				Name: "alice",
@@ -95,21 +94,11 @@ func DefaultConfig() Config {
 //
 // The configuration proceeds as follows:
 //  1. Start with a default config with sane settings
-//  2. Pre-parse the command line to check for an alternative config file
-//  3. Load configuration file overwriting defaults with any specified options
-//  4. Parse CLI options and overwrite/add any specified options
+//  2. Load configuration file overwriting defaults with any specified options
 func LoadConfig() (*Config, error) {
-	// Pre-parse the command line options to pick up an alternative config
-	// file.
-	preCfg := DefaultConfig()
-	if _, err := flags.Parse(&preCfg); err != nil {
-		return nil, err
-	}
-
-	// Next, load any additional configuration options from the file.
-	cfg := preCfg
+	// First, load any additional configuration options from the file.
+	cfg := DefaultConfig()
 	fileParser := flags.NewParser(&cfg, flags.Default)
-
 	err := flags.NewIniParser(fileParser).ParseFile(defaultConfigPath)
 	if err != nil {
 		// If it's a parsing related error, then we'll return
@@ -118,13 +107,6 @@ func LoadConfig() (*Config, error) {
 		if _, ok := err.(*flags.IniError); ok { //nolint:gosimple
 			return nil, err
 		}
-	}
-
-	// Finally, parse the remaining command line options again to ensure
-	// they take precedence.
-	flagParser := flags.NewParser(&cfg, flags.Default)
-	if _, err := flagParser.Parse(); err != nil {
-		return nil, err
 	}
 
 	// Make sure everything we just loaded makes sense.

--- a/itest/loadtest/load_test.go
+++ b/itest/loadtest/load_test.go
@@ -9,6 +9,18 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type testCase struct {
+	name string
+	fn   func(t *testing.T, ctx context.Context, cfg *Config)
+}
+
+var loadTestCases = []testCase{
+	{
+		name: "mint_batch_stress",
+		fn:   execMintBatchStressTest,
+	},
+}
+
 // TestPerformance executes the configured performance tests.
 func TestPerformance(t *testing.T) {
 	cfg, err := LoadConfig()
@@ -18,23 +30,44 @@ func TestPerformance(t *testing.T) {
 	ctxt, cancel := context.WithTimeout(ctxb, cfg.TestSuiteTimeout)
 	defer cancel()
 
-	for _, testCase := range cfg.TestCases {
-		execTestCase(t, ctxt, testCase, cfg)
+	for _, tc := range loadTestCases {
+		tc := tc
+
+		if !shouldRunCase(tc.name, cfg.TestCases) {
+			t.Logf("Not running test case '%s' as not configured",
+				tc.name)
+
+			continue
+		}
+
+		success := t.Run(tc.name, func(tt *testing.T) {
+			ctxt, cancel := context.WithTimeout(
+				ctxt, cfg.TestTimeout,
+			)
+			defer cancel()
+
+			tc.fn(t, ctxt, cfg)
+		})
+		if !success {
+			t.Fatalf("test case %v failed", tc.name)
+		}
 	}
 }
 
-// execTestCase is the method in charge of executing a single test case.
-func execTestCase(t *testing.T, ctx context.Context, testName string,
-	cfg *Config) {
-
-	ctxt, cancel := context.WithTimeout(ctx, cfg.TestTimeout)
-	defer cancel()
-
-	switch testName {
-	case "mint_batch_stress":
-		execMintBatchStressTest(t, ctxt, cfg)
-
-	default:
-		require.Fail(t, "unknown test case: %v", testName)
+// shouldRunCase returns true if the given test case should be run. This will
+// return true if the config file does not specify any test cases. In that case
+// we can select the test cases to run using the command line
+// (-test.run="TestPerformance/test_case_name")
+func shouldRunCase(name string, configuredCases []string) bool {
+	if len(configuredCases) == 0 {
+		return true
 	}
+
+	for _, c := range configuredCases {
+		if c == name {
+			return true
+		}
+	}
+
+	return false
 }

--- a/itest/loadtest/load_test.go
+++ b/itest/loadtest/load_test.go
@@ -16,8 +16,8 @@ type testCase struct {
 
 var loadTestCases = []testCase{
 	{
-		name: "mint_batch_stress",
-		fn:   execMintBatchStressTest,
+		name: "mint",
+		fn:   mintTest,
 	},
 }
 

--- a/itest/loadtest/load_test.go
+++ b/itest/loadtest/load_test.go
@@ -19,6 +19,10 @@ var loadTestCases = []testCase{
 		name: "mint",
 		fn:   mintTest,
 	},
+	{
+		name: "send",
+		fn:   sendTest,
+	},
 }
 
 // TestPerformance executes the configured performance tests.

--- a/itest/loadtest/send_test.go
+++ b/itest/loadtest/send_test.go
@@ -1,0 +1,129 @@
+package loadtest
+
+import (
+	"context"
+	prand "math/rand"
+	"testing"
+
+	"github.com/btcsuite/btcd/rpcclient"
+	"github.com/lightninglabs/taproot-assets/itest"
+	"github.com/lightninglabs/taproot-assets/taprpc"
+	"github.com/lightningnetwork/lnd/lntest/wait"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	statusDetected  = taprpc.AddrEventStatus_ADDR_EVENT_STATUS_TRANSACTION_DETECTED
+	statusCompleted = taprpc.AddrEventStatus_ADDR_EVENT_STATUS_COMPLETED
+)
+
+// sendTest checks that we are able to send assets between the two nodes.
+func sendTest(t *testing.T, ctx context.Context, cfg *Config) {
+	// Start by initializing all our client connections.
+	alice, bob, bitcoinClient := initClients(t, ctx, cfg)
+
+	ctxb := context.Background()
+	ctxt, cancel := context.WithTimeout(ctxb, cfg.TestTimeout)
+	defer cancel()
+
+	t.Logf("Running send test, sending %d asset(s) of type %v %d times",
+		cfg.NumAssets, cfg.SendType, cfg.NumSends)
+	for i := 1; i <= cfg.NumSends; i++ {
+		send, receive, ok := pickSendNode(
+			t, ctx, cfg.NumAssets, cfg.SendType, alice, bob,
+		)
+		if !ok {
+			t.Fatalf("Aborting send test at attempt %d of %d as "+
+				"no node has enough balance to send %d "+
+				"assets of type %v", i, cfg.NumSends,
+				cfg.NumAssets, cfg.SendType)
+			return
+		}
+
+		sendAssets(
+			t, ctxt, cfg.NumAssets, cfg.SendType, send, receive,
+			bitcoinClient,
+		)
+
+		t.Logf("Finished %d of %d send operations", i, cfg.NumSends)
+	}
+}
+
+// sendAsset sends the given number of assets of the given type from the given
+// node to the other node.
+func sendAssets(t *testing.T, ctx context.Context, numAssets uint64,
+	assetType taprpc.AssetType, send, receive *rpcClient,
+	bitcoinClient *rpcclient.Client) {
+
+	// Query the asset we'll be sending, so we can assert some things about
+	// it later.
+	sendAsset := send.assetIDWithBalance(t, ctx, numAssets, assetType)
+	t.Logf("Sending %d asset(s) with ID %x from %v to %v", numAssets,
+		sendAsset.AssetGenesis.AssetId, send.cfg.Name, receive.cfg.Name)
+
+	// Let's create an address on the receiving node and make sure it's
+	// created correctly.
+	addr, err := receive.NewAddr(ctx, &taprpc.NewAddrRequest{
+		AssetId: sendAsset.AssetGenesis.AssetId,
+		Amt:     numAssets,
+	})
+	require.NoError(t, err)
+	itest.AssertAddrCreated(t, receive, sendAsset, addr)
+
+	// Before we send the asset, we record the existing transfers on the
+	// sending node, so we can easily select the new transfer once it
+	// appears.
+	transfersBefore := send.listTransfersSince(t, ctx, nil)
+
+	// Initiate the send now.
+	_, err = send.SendAsset(ctx, &taprpc.SendAssetRequest{
+		TapAddrs: []string{addr.Encoded},
+	})
+	require.NoError(t, err)
+
+	// Wait for the transfer to appear on the sending node.
+	require.Eventually(t, func() bool {
+		newTransfers := send.listTransfersSince(t, ctx, transfersBefore)
+		return len(newTransfers) == 1
+	}, defaultTimeout, wait.PollInterval)
+
+	// And for it to be detected on the receiving node.
+	itest.AssertAddrEvent(t, receive, addr, 1, statusDetected)
+
+	// Mine a block to confirm the transfer.
+	itest.MineBlocks(t, bitcoinClient, 1, 1)
+
+	// Now the transfer should go to completed eventually.
+	itest.AssertAddrEvent(t, receive, addr, 1, statusCompleted)
+}
+
+// pickSendNode picks a node at random, checks whether it has enough assets of
+// the given type, and returns it. The second return value is the other node,
+// which will be the receiving node. The boolean argument returns true if there
+// is a node with sufficient balance. If that is false, the test should be
+// skipped.
+func pickSendNode(t *testing.T, ctx context.Context, minBalance uint64,
+	assetType taprpc.AssetType, a, b *rpcClient) (*rpcClient, *rpcClient,
+	bool) {
+
+	send, receive := a, b
+	if prand.Intn(1) == 0 {
+		send, receive = b, a
+	}
+
+	// Check if the randomly picked send node has enough balance.
+	if send.assetIDWithBalance(t, ctx, minBalance, assetType) != nil {
+		return send, receive, true
+	}
+
+	// If we get here, the send node doesn't have enough balance. We'll try
+	// the other one.
+	send, receive = receive, send
+	if send.assetIDWithBalance(t, ctx, minBalance, assetType) != nil {
+		return send, receive, true
+	}
+
+	// None of the nodes have enough balance. We can't run the send test
+	// currently.
+	return nil, nil, false
+}


### PR DESCRIPTION
Fixes https://github.com/lightninglabs/taproot-assets/issues/469.

Depends on https://github.com/lightninglabs/taproot-assets/pull/556.

This is the last piece to address our initial requirements for the load test.

cc @calvinrzachman:

I changed some things around and it's now possible to either specify a test case in the config (`test-case=xxx`, if you don't specify anything, all two tests will run) or in the command line (`-test.run="TestPerformance/send"`).
There are a couple of new test specific settings we can specify (and I renamed the `batch-size` config to `mint-test-batch-size`).
Here are the default values for these new config values:

```
mint-test-batch-size=200
send-test-num-sends=50
send-test-num-assets=1
send-test-send-type=1
```