### PR TITLE
Universe events stats handle universe identity proof type

### DIFF
--- a/itest/loadtest/mint_batch_test.go
+++ b/itest/loadtest/mint_batch_test.go
@@ -137,6 +137,7 @@ func mintTest(t *testing.T, ctx context.Context, cfg *Config) {
 		Id: &unirpc.ID_GroupKey{
 			GroupKey: collectGroupKey[1:],
 		},
+		ProofType: unirpc.ProofType_PROOF_TYPE_ISSUANCE,
 	}
 	uniLeaves, err := alice.AssetLeaves(ctx, &collectUniID)
 	require.NoError(t, err)

--- a/itest/mint_batch_stress_test.go
+++ b/itest/mint_batch_stress_test.go
@@ -191,6 +191,7 @@ func mintBatchStressTest(
 		Id: &unirpc.ID_GroupKey{
 			GroupKey: collectGroupKey[1:],
 		},
+		ProofType: unirpc.ProofType_PROOF_TYPE_ISSUANCE,
 	}
 	uniLeaves, err := alice.AssetLeaves(ctx, &collectUniID)
 	require.NoError(t, err)

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -3200,9 +3200,8 @@ func (r *rpcServer) QueryProof(ctx context.Context,
 		return nil, err
 	}
 
-	rpcsLog.Debugf("[QueryProof]: fetching proof at "+
-		"(universeID=%x, leafKey=%x)", universeID,
-		leafKey.UniverseKey())
+	rpcsLog.Debugf("[QueryProof]: fetching proof at (universeID=%v, "+
+		"leafKey=%x)", universeID, leafKey.UniverseKey())
 
 	// Keep a record of whether the proof type was specified by the client.
 	unspecifiedArgProofType :=
@@ -3237,14 +3236,14 @@ func (r *rpcServer) QueryProof(ctx context.Context,
 		)
 		if err != nil {
 			rpcsLog.Debugf("[QueryProof]: error querying for "+
-				"proof at (universeID=%x, leafKey=%x)",
+				"proof at (universeID=%v, leafKey=%x)",
 				universeID, leafKey.UniverseKey())
 			return nil, err
 		}
 	}
 	if err != nil {
 		rpcsLog.Debugf("[QueryProof]: error querying for proof at "+
-			"(universeID=%x, leafKey=%x)", universeID,
+			"(universeID=%v, leafKey=%x)", universeID,
 			leafKey.UniverseKey())
 		return nil, err
 	}
@@ -3253,9 +3252,8 @@ func (r *rpcServer) QueryProof(ctx context.Context,
 	// not be fully specified
 	proof := proofs[0]
 
-	rpcsLog.Debugf("[QueryProof]: found proof at "+
-		"(universeID=%x, leafKey=%x)", universeID,
-		leafKey.UniverseKey())
+	rpcsLog.Debugf("[QueryProof]: found proof at (universeID=%v, "+
+		"leafKey=%x)", universeID, leafKey.UniverseKey())
 
 	return r.marshalIssuanceProof(ctx, req, proof)
 }
@@ -3328,7 +3326,7 @@ func (r *rpcServer) InsertProof(ctx context.Context,
 	}
 
 	rpcsLog.Debugf("[InsertProof]: inserting proof at "+
-		"(universeID=%x, leafKey=%x)", universeID,
+		"(universeID=%v, leafKey=%x)", universeID,
 		leafKey.UniverseKey())
 
 	newUniverseState, err := r.cfg.BaseUniverse.RegisterIssuance(

--- a/tapdb/sqlc/migrations/000007_universe.up.sql
+++ b/tapdb/sqlc/migrations/000007_universe.up.sql
@@ -80,11 +80,10 @@ CREATE VIEW universe_stats AS
         COUNT(CASE WHEN u.event_type = 'SYNC' THEN 1 ELSE NULL END) AS total_asset_syncs,
         COUNT(CASE WHEN u.event_type = 'NEW_PROOF' THEN 1 ELSE NULL END) AS total_asset_proofs,
         roots.asset_id,
-        roots.group_key,
-        roots.namespace_root
+        roots.group_key
     FROM universe_events u
     JOIN universe_roots roots ON u.universe_root_id = roots.id
-    GROUP BY roots.asset_id, roots.group_key, roots.namespace_root;
+    GROUP BY roots.asset_id, roots.group_key;
 
 -- This table contains global configuration for universe federation syncing.
 CREATE TABLE IF NOT EXISTS federation_global_sync_config (

--- a/tapdb/sqlc/models.go
+++ b/tapdb/sqlc/models.go
@@ -311,5 +311,4 @@ type UniverseStat struct {
 	TotalAssetProofs int64
 	AssetID          []byte
 	GroupKey         []byte
-	NamespaceRoot    string
 }

--- a/tapdb/sqlc/queries/universe.sql
+++ b/tapdb/sqlc/queries/universe.sql
@@ -142,14 +142,18 @@ INSERT INTO universe_events (
 -- name: InsertNewProofEvent :exec
 WITH group_key_root_id AS (
     SELECT id
-    FROM universe_roots
+    FROM universe_roots roots
     WHERE group_key = @group_key_x_only
+        AND roots.proof_type = @proof_type
 ), asset_id_root_id AS (
     SELECT leaves.universe_root_id AS id
     FROM universe_leaves leaves
-             JOIN genesis_info_view gen
-                  ON leaves.asset_genesis_id = gen.gen_asset_id
+    JOIN universe_roots roots
+        ON leaves.universe_root_id = roots.id
+    JOIN genesis_info_view gen
+        ON leaves.asset_genesis_id = gen.gen_asset_id
     WHERE gen.asset_id = @asset_id
+        AND roots.proof_type = @proof_type
     LIMIT 1
 )
 INSERT INTO universe_events (

--- a/tapdb/sqlc/queries/universe.sql
+++ b/tapdb/sqlc/queries/universe.sql
@@ -113,14 +113,18 @@ SELECT * FROM universe_servers;
 -- name: InsertNewSyncEvent :exec
 WITH group_key_root_id AS (
     SELECT id
-    FROM universe_roots
+    FROM universe_roots roots
     WHERE group_key = @group_key_x_only
+      AND roots.proof_type = @proof_type
 ), asset_id_root_id AS (
     SELECT leaves.universe_root_id AS id
     FROM universe_leaves leaves
+    JOIN universe_roots roots
+        ON leaves.universe_root_id = roots.id
     JOIN genesis_info_view gen
         ON leaves.asset_genesis_id = gen.gen_asset_id
-    WHERE gen.asset_id = @asset_id 
+    WHERE gen.asset_id = @asset_id
+        AND roots.proof_type = @proof_type
     LIMIT 1
 )
 INSERT INTO universe_events (

--- a/tapdb/sqlc/universe.sql.go
+++ b/tapdb/sqlc/universe.sql.go
@@ -136,14 +136,18 @@ func (q *Queries) FetchUniverseRoot(ctx context.Context, namespace string) (Fetc
 const insertNewProofEvent = `-- name: InsertNewProofEvent :exec
 WITH group_key_root_id AS (
     SELECT id
-    FROM universe_roots
+    FROM universe_roots roots
     WHERE group_key = $1
+        AND roots.proof_type = $4
 ), asset_id_root_id AS (
     SELECT leaves.universe_root_id AS id
     FROM universe_leaves leaves
-             JOIN genesis_info_view gen
-                  ON leaves.asset_genesis_id = gen.gen_asset_id
-    WHERE gen.asset_id = $4
+    JOIN universe_roots roots
+        ON leaves.universe_root_id = roots.id
+    JOIN genesis_info_view gen
+        ON leaves.asset_genesis_id = gen.gen_asset_id
+    WHERE gen.asset_id = $5
+        AND roots.proof_type = $4
     LIMIT 1
 )
 INSERT INTO universe_events (
@@ -163,6 +167,7 @@ type InsertNewProofEventParams struct {
 	GroupKeyXOnly  interface{}
 	EventTime      time.Time
 	EventTimestamp int64
+	ProofType      string
 	AssetID        []byte
 }
 
@@ -171,6 +176,7 @@ func (q *Queries) InsertNewProofEvent(ctx context.Context, arg InsertNewProofEve
 		arg.GroupKeyXOnly,
 		arg.EventTime,
 		arg.EventTimestamp,
+		arg.ProofType,
 		arg.AssetID,
 	)
 	return err

--- a/tapdb/sqlc/universe.sql.go
+++ b/tapdb/sqlc/universe.sql.go
@@ -179,14 +179,18 @@ func (q *Queries) InsertNewProofEvent(ctx context.Context, arg InsertNewProofEve
 const insertNewSyncEvent = `-- name: InsertNewSyncEvent :exec
 WITH group_key_root_id AS (
     SELECT id
-    FROM universe_roots
+    FROM universe_roots roots
     WHERE group_key = $1
+      AND roots.proof_type = $4
 ), asset_id_root_id AS (
     SELECT leaves.universe_root_id AS id
     FROM universe_leaves leaves
+    JOIN universe_roots roots
+        ON leaves.universe_root_id = roots.id
     JOIN genesis_info_view gen
         ON leaves.asset_genesis_id = gen.gen_asset_id
-    WHERE gen.asset_id = $4 
+    WHERE gen.asset_id = $5
+        AND roots.proof_type = $4
     LIMIT 1
 )
 INSERT INTO universe_events (
@@ -206,6 +210,7 @@ type InsertNewSyncEventParams struct {
 	GroupKeyXOnly  interface{}
 	EventTime      time.Time
 	EventTimestamp int64
+	ProofType      string
 	AssetID        []byte
 }
 
@@ -214,6 +219,7 @@ func (q *Queries) InsertNewSyncEvent(ctx context.Context, arg InsertNewSyncEvent
 		arg.GroupKeyXOnly,
 		arg.EventTime,
 		arg.EventTimestamp,
+		arg.ProofType,
 		arg.AssetID,
 	)
 	return err

--- a/tapdb/universe_stats.go
+++ b/tapdb/universe_stats.go
@@ -193,6 +193,7 @@ func (u *UniverseStats) LogNewProofEvent(ctx context.Context,
 			EventTimestamp: u.clock.Now().UTC().Unix(),
 			AssetID:        uniID.AssetID[:],
 			GroupKeyXOnly:  groupKeyXOnly,
+			ProofType:      uniID.ProofType.String(),
 		})
 	})
 }
@@ -217,6 +218,7 @@ func (u *UniverseStats) LogNewProofEvents(ctx context.Context,
 				EventTimestamp: u.clock.Now().UTC().Unix(),
 				AssetID:        uniID.AssetID[:],
 				GroupKeyXOnly:  groupKeyXOnly,
+				ProofType:      uniID.ProofType.String(),
 			})
 			if err != nil {
 				return err

--- a/tapdb/universe_stats.go
+++ b/tapdb/universe_stats.go
@@ -140,6 +140,7 @@ func (u *UniverseStats) LogSyncEvent(ctx context.Context,
 			EventTimestamp: u.clock.Now().UTC().Unix(),
 			AssetID:        uniID.AssetID[:],
 			GroupKeyXOnly:  groupKeyXOnly,
+			ProofType:      uniID.ProofType.String(),
 		})
 	})
 }
@@ -165,6 +166,7 @@ func (u *UniverseStats) LogSyncEvents(ctx context.Context,
 				EventTimestamp: u.clock.Now().UTC().Unix(),
 				AssetID:        uniID.AssetID[:],
 				GroupKeyXOnly:  groupKeyXOnly,
+				ProofType:      uniID.ProofType.String(),
 			})
 			if err != nil {
 				return err


### PR DESCRIPTION
Depends on https://github.com/lightninglabs/taproot-assets/pull/540 . Do not merge this PR before merging https://github.com/lightninglabs/taproot-assets/pull/540 I've converted this PR to draft until all parent PRs have been merged.

This PR adds universe identity proof type support to universe events stats database SQL statements.