### PR TITLE
tapcfg: allow using mainnet, enable universe proof courier by default

### DIFF
--- a/cmd/tapcli/main.go
+++ b/cmd/tapcli/main.go
@@ -293,7 +293,7 @@ func main() {
 			Name: "network, n",
 			Usage: "The network tapd is running on, e.g. " +
 				"mainnet, testnet, etc.",
-			Value: "mainnet",
+			Value: "testnet",
 		},
 		cli.BoolFlag{
 			Name:  "no-macaroons",

--- a/cmd/tapcli/main.go
+++ b/cmd/tapcli/main.go
@@ -219,7 +219,7 @@ func extractPathArgs(ctx *cli.Context) (string, string, error) {
 	// determine the correct path to the macaroon when not specified.
 	network := strings.ToLower(ctx.GlobalString("network"))
 	switch network {
-	case "testnet", "regtest", "simnet", "signet":
+	case "mainnet", "testnet", "regtest", "simnet", "signet":
 	default:
 		return "", "", fmt.Errorf("unknown network: %v", network)
 	}
@@ -234,7 +234,9 @@ func extractPathArgs(ctx *cli.Context) (string, string, error) {
 	// target the specified file.
 	var macPath string
 	if ctx.GlobalString("macaroonpath") != "" {
-		macPath = lncfg.CleanAndExpandPath(ctx.GlobalString("macaroonpath"))
+		macPath = lncfg.CleanAndExpandPath(ctx.GlobalString(
+			"macaroonpath",
+		))
 	} else {
 		// Otherwise, we'll go into the path:
 		// tapddir/data/<network> in order to fetch the
@@ -291,7 +293,7 @@ func main() {
 			Name: "network, n",
 			Usage: "The network tapd is running on, e.g. " +
 				"mainnet, testnet, etc.",
-			Value: "testnet",
+			Value: "mainnet",
 		},
 		cli.BoolFlag{
 			Name:  "no-macaroons",

--- a/tapcfg/config.go
+++ b/tapcfg/config.go
@@ -48,9 +48,12 @@ const (
 	defaultLetsEncryptDirname = "letsencrypt"
 	defaultLetsEncryptListen  = ":80"
 
+	defaultNetwork = "mainnet"
+
 	defaultMaxLogFiles    = 3
 	defaultMaxLogFileSize = 10
 
+	defaultMainnetFederationServer = "universe.lightning.finance:10029"
 	defaultTestnetFederationServer = "testnet.universe.lightning.finance:10029"
 
 	// DefaultAutogenValidity is the default validity of a self-signed
@@ -121,8 +124,6 @@ var (
 	// file.
 	DefaultConfigFile = filepath.Join(DefaultTapdDir, defaultConfigFileName)
 
-	defaultNetwork = "testnet"
-
 	defaultDataDir = filepath.Join(DefaultTapdDir, defaultDataDirname)
 	defaultLogDir  = filepath.Join(DefaultTapdDir, defaultLogDirname)
 
@@ -175,7 +176,7 @@ var (
 // ChainConfig houses the configuration options that govern which chain/network
 // we operate on.
 type ChainConfig struct {
-	Network string `long:"network" description:"network to run on" choice:"regtest" choice:"testnet" choice:"simnet" choice:"signet"`
+	Network string `long:"network" description:"network to run on" choice:"mainnet" choice:"regtest" choice:"testnet" choice:"simnet" choice:"signet"`
 
 	SigNetChallenge string `long:"signetchallenge" description:"Connect to a custom signet network defined by this challenge instead of using the global default signet test network -- Can be specified multiple times"`
 }
@@ -541,6 +542,8 @@ func ValidateConfig(cfg Config, cfgLogger btclog.Logger) (*Config, error) {
 	// network flags passed; assign active network params
 	// while we're at it.
 	switch cfg.ChainConf.Network {
+	case "mainnet":
+		cfg.ActiveNetParams = chaincfg.MainNetParams
 	case "testnet":
 		cfg.ActiveNetParams = chaincfg.TestNet3Params
 	case "regtest":

--- a/tapcfg/config.go
+++ b/tapcfg/config.go
@@ -72,6 +72,10 @@ const (
 	// proofs for asynchronous sends.
 	fallbackHashMailAddr = "mailbox.terminal.lightning.today:443"
 
+	// fallbackUniverseAddr is the fallback address we'll use to deliver
+	// proofs for asynchronous sends.
+	fallbackUniverseAddr = defaultMainnetFederationServer
+
 	// DatabaseBackendSqlite is the name of the SQLite database backend.
 	DatabaseBackendSqlite = "sqlite"
 
@@ -153,6 +157,12 @@ var (
 	// the SQLite database file.
 	defaultSqliteDatabasePath = filepath.Join(
 		defaultDataDir, defaultNetwork, defaultSqliteDatabaseFileName,
+	)
+
+	// defaultProofCourierAddr is the default proof courier address URI
+	// we'll use to deliver proofs for asynchronous sends.
+	defaultProofCourierAddr = fmt.Sprintf(
+		"%s://%s", proof.UniverseRpcCourierType, fallbackUniverseAddr,
 	)
 
 	// minimalCompatibleVersion is the minimum version and build tags
@@ -335,13 +345,11 @@ func DefaultConfig() Config {
 			Port:               5432,
 			MaxOpenConnections: 10,
 		},
-		LogWriter:            build.NewRotatingLogWriter(),
-		Prometheus:           monitoring.DefaultPrometheusConfig(),
-		BatchMintingInterval: defaultBatchMintingInterval,
-		ReOrgSafeDepth:       defaultReOrgSafeDepth,
-		DefaultProofCourierAddr: fmt.Sprintf(
-			"%s://%s", proof.HashmailCourierType, fallbackHashMailAddr,
-		),
+		LogWriter:               build.NewRotatingLogWriter(),
+		Prometheus:              monitoring.DefaultPrometheusConfig(),
+		BatchMintingInterval:    defaultBatchMintingInterval,
+		ReOrgSafeDepth:          defaultReOrgSafeDepth,
+		DefaultProofCourierAddr: defaultProofCourierAddr,
 		HashMailCourier: &proof.HashMailCourierCfg{
 			ReceiverAckTimeout: defaultProofTransferReceiverAckTimeout,
 			BackoffCfg: &proof.BackoffCfg{

--- a/tapcfg/config.go
+++ b/tapcfg/config.go
@@ -48,7 +48,7 @@ const (
 	defaultLetsEncryptDirname = "letsencrypt"
 	defaultLetsEncryptListen  = ":80"
 
-	defaultNetwork = "mainnet"
+	defaultNetwork = "testnet"
 
 	defaultMaxLogFiles    = 3
 	defaultMaxLogFileSize = 10

--- a/tapcfg/server.go
+++ b/tapcfg/server.go
@@ -35,7 +35,7 @@ type databaseBackend interface {
 // genServerConfig generates a server config from the given tapd config.
 //
 // NOTE: The RPCConfig and SignalInterceptor fields must be set by the caller
-// after genereting the server config.
+// after generating the server config.
 func genServerConfig(cfg *Config, cfgLogger btclog.Logger,
 	lndServices *lndclient.LndServices,
 	mainErrChan chan<- error) (*tap.Config, error) {
@@ -161,6 +161,46 @@ func genServerConfig(cfg *Config, cfgLogger btclog.Logger,
 		assetStore, proofFileStore,
 	)
 
+	federationMembers := cfg.Universe.FederationServers
+	switch cfg.ChainConf.Network {
+	case "mainnet":
+		cfgLogger.Infof("Configuring %v as initial Universe "+
+			"federation server", defaultMainnetFederationServer)
+
+		federationMembers = append(
+			federationMembers, defaultMainnetFederationServer,
+		)
+
+	case "testnet":
+		cfgLogger.Infof("Configuring %v as initial Universe "+
+			"federation server", defaultTestnetFederationServer)
+
+		federationMembers = append(
+			federationMembers, defaultTestnetFederationServer,
+		)
+
+		// For testnet, we need to overwrite the default universe proof
+		// courier address to use the testnet server.
+		if cfg.DefaultProofCourierAddr == defaultProofCourierAddr {
+			cfg.DefaultProofCourierAddr = fmt.Sprintf(
+				"%s://%s", proof.UniverseRpcCourierType,
+				fallbackUniverseAddr,
+			)
+		}
+
+	default:
+		// For any other network, such as regtest, we can't use a
+		// universe proof courier by default, as we don't know what
+		// server to pick. So if there is no explicit value set, we fall
+		// back to using the hashmail courier, which works in all cases.
+		if cfg.DefaultProofCourierAddr == defaultProofCourierAddr {
+			cfg.DefaultProofCourierAddr = fmt.Sprintf(
+				"%s://%s", proof.HashmailCourierType,
+				fallbackHashMailAddr,
+			)
+		}
+	}
+
 	// If no default proof courier address is set, use the fallback hashmail
 	// address.
 	fallbackHashmailCourierAddr := fmt.Sprintf(
@@ -185,10 +225,10 @@ func genServerConfig(cfg *Config, cfgLogger btclog.Logger,
 		}
 	}
 
-	var proofCourierCfg *proof.CourierCfg
 	// TODO(ffranr): This logic is leftover for integration tests which
 	//  do not yet enable a proof courier. Remove once all integration tests
 	//  support a proof courier.
+	var proofCourierCfg *proof.CourierCfg
 	if cfg.HashMailCourier != nil {
 		proofCourierCfg = &proof.CourierCfg{
 			ReceiverAckTimeout: cfg.HashMailCourier.ReceiverAckTimeout,
@@ -233,25 +273,6 @@ func genServerConfig(cfg *Config, cfgLogger btclog.Logger,
 		LocalRegistrar:      baseUni,
 		SyncBatchSize:       defaultUniverseSyncBatchSize,
 	})
-
-	federationMembers := cfg.Universe.FederationServers
-	switch cfg.ChainConf.Network {
-	case "mainnet":
-		cfgLogger.Infof("Configuring %v as initial Universe "+
-			"federation server", defaultMainnetFederationServer)
-
-		federationMembers = append(
-			federationMembers, defaultMainnetFederationServer,
-		)
-
-	case "testnet":
-		cfgLogger.Infof("Configuring %v as initial Universe "+
-			"federation server", defaultTestnetFederationServer)
-
-		federationMembers = append(
-			federationMembers, defaultTestnetFederationServer,
-		)
-	}
 
 	runtimeID := prand.Int63() // nolint:gosec
 	universeFederation := universe.NewFederationEnvoy(

--- a/tapcfg/server.go
+++ b/tapcfg/server.go
@@ -236,6 +236,14 @@ func genServerConfig(cfg *Config, cfgLogger btclog.Logger,
 
 	federationMembers := cfg.Universe.FederationServers
 	switch cfg.ChainConf.Network {
+	case "mainnet":
+		cfgLogger.Infof("Configuring %v as initial Universe "+
+			"federation server", defaultMainnetFederationServer)
+
+		federationMembers = append(
+			federationMembers, defaultMainnetFederationServer,
+		)
+
 	case "testnet":
 		cfgLogger.Infof("Configuring %v as initial Universe "+
 			"federation server", defaultTestnetFederationServer)

--- a/version.go
+++ b/version.go
@@ -42,10 +42,10 @@ const (
 	AppMajor uint = 0
 
 	// AppMinor defines the minor version of this binary.
-	AppMinor uint = 2
+	AppMinor uint = 3
 
 	// AppPatch defines the application patch for this binary.
-	AppPatch uint = 3
+	AppPatch uint = 0
 
 	// AppPreRelease MUST only contain characters from semanticAlphabet
 	// per the semantic versioning spec.


### PR DESCRIPTION
Depends on https://github.com/lightninglabs/taproot-assets/pull/564 for universe proofs to be synced.