### PR TITLE
tapcli: expose universe sync config settings

### DIFF
--- a/fn/iter.go
+++ b/fn/iter.go
@@ -37,3 +37,15 @@ func Enumerate[T any](items []T, f func(int, T)) {
 		f(i, item)
 	}
 }
+
+// MakeSlice is a generic function short hand for making a slice out of a set
+// of elements. This can be used to avoid having to specify the type of the
+// slice as well as the types of the elements.
+func MakeSlice[T any](items ...T) []T {
+	ts := make([]T, len(items))
+	for i, item := range items {
+		ts[i] = item
+	}
+
+	return ts
+}

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -2758,6 +2758,10 @@ func unmarshalAssetSyncConfig(
 	config *unirpc.AssetFederationSyncConfig) (*universe.FedUniSyncConfig,
 	error) {
 
+	if config == nil {
+		return nil, fmt.Errorf("empty universe sync config")
+	}
+
 	// Parse the universe ID from the RPC form.
 	uniID, err := UnmarshalUniID(config.Id)
 	if err != nil {

--- a/tapdb/universe_federation_test.go
+++ b/tapdb/universe_federation_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/lightninglabs/taproot-assets/fn"
 	"github.com/lightninglabs/taproot-assets/tapdb/sqlc"
 	"github.com/lightninglabs/taproot-assets/universe"
 	"github.com/lightningnetwork/lnd/clock"
@@ -111,4 +112,70 @@ func TestFederationConfigDefault(t *testing.T) {
 	globalConfig, _, err := fedDB.QueryFederationSyncConfigs(ctx)
 	require.NoError(t, err)
 	require.Equal(t, defaultGlobalSyncConfigs, globalConfig)
+}
+
+// TestFederationGlobalConfigCRUD tests that we're able to properly update the
+// global and local federation configs.
+func TestFederationGlobalConfigCRUD(t *testing.T) {
+	t.Parallel()
+
+	testClock := clock.NewTestClock(time.Now())
+	fedDB, _ := newTestFederationDb(t, testClock)
+
+	ctx := context.Background()
+
+	// First, we'll add a new global config, but just for the issuance
+	// proof type.
+	newGlobalProof := fn.MakeSlice(&universe.FedGlobalSyncConfig{
+		ProofType:       universe.ProofTypeIssuance,
+		AllowSyncInsert: true,
+		AllowSyncExport: true,
+	})
+
+	err := fedDB.UpsertFederationSyncConfig(
+		ctx, newGlobalProof, nil,
+	)
+	require.NoError(t, err)
+
+	// If we query for the global config, then we should get the issuance
+	// proof type we just modified, and also the existing global config for
+	// transfer proof type.
+	expectedCfgs := append(
+		newGlobalProof, defaultGlobalSyncConfigs[1],
+	)
+
+	dbGlobalCfg, _, err := fedDB.QueryFederationSyncConfigs(ctx)
+	require.NoError(t, err)
+
+	require.Equal(t, expectedCfgs, dbGlobalCfg)
+
+	// Next, make the same modification, but for the transfer proof type.
+	newGlobalTransfer := fn.MakeSlice(&universe.FedGlobalSyncConfig{
+		ProofType:       universe.ProofTypeTransfer,
+		AllowSyncInsert: true,
+		AllowSyncExport: true,
+	})
+	err = fedDB.UpsertFederationSyncConfig(
+		ctx, newGlobalTransfer, nil,
+	)
+	require.NoError(t, err)
+
+	dbGlobalCfg, _, err = fedDB.QueryFederationSyncConfigs(ctx)
+	require.NoError(t, err)
+
+	expectedCfgs = append(newGlobalProof, newGlobalTransfer...)
+	require.Equal(t, expectedCfgs, dbGlobalCfg)
+
+	// Finally, we should be able to update them both in the same txn.
+	for _, cfg := range expectedCfgs {
+		cfg.AllowSyncInsert = false
+		cfg.AllowSyncExport = false
+	}
+
+	err = fedDB.UpsertFederationSyncConfig(ctx, expectedCfgs, nil)
+	require.NoError(t, err)
+
+	dbGlobalCfg, _, err = fedDB.QueryFederationSyncConfigs(ctx)
+	require.NoError(t, err)
+	require.Equal(t, expectedCfgs, dbGlobalCfg)
 }


### PR DESCRIPTION
Fixes https://github.com/lightninglabs/taproot-assets/issues/566.

In draft as still needs some manual testing.

Would also like to add a universe federation config info command before merge.

Intended supported usage would be to set the insert or export bools independently (one or both at the same time), and only modify the config for a single scope at a time (global config or config for a specific asset).