### PR TITLE
make: enable monitoring build tag by default for release builds

### DIFF
--- a/make/release_flags.mk
+++ b/make/release_flags.mk
@@ -20,7 +20,7 @@ linux-armv7 \
 linux-arm64 \
 windows-amd64
 
-RELEASE_TAGS = 
+RELEASE_TAGS = monitoring
 
 # One can either specify a git tag as the version suffix or one is generated
 # from the current date.


### PR DESCRIPTION
The official docker image and binary release build should have the Prometheus monitoring capability built in by default. We enable that by adding the `monitoring` tag to the list of release build tags.