### PR TITLE
tapcfg: fix defaults for testnet universe courier

### DIFF
--- a/cmd/tapcli/universe.go
+++ b/cmd/tapcli/universe.go
@@ -520,6 +520,12 @@ var universeSyncCommand = cli.Command{
 			Name:  groupKeyName,
 			Usage: "the group key of sync with the universe",
 		},
+		cli.StringFlag{
+			Name: proofTypeName,
+			Usage: "the type of proof to sync either 'issuance' " +
+				"or 'transfer'",
+			Value: universe.ProofTypeIssuance.String(),
+		},
 	},
 	Action: universeSync,
 }

--- a/tapcfg/config.go
+++ b/tapcfg/config.go
@@ -74,7 +74,7 @@ const (
 
 	// fallbackUniverseAddr is the fallback address we'll use to deliver
 	// proofs for asynchronous sends.
-	fallbackUniverseAddr = defaultMainnetFederationServer
+	fallbackUniverseAddr = defaultTestnetFederationServer
 
 	// DatabaseBackendSqlite is the name of the SQLite database backend.
 	DatabaseBackendSqlite = "sqlite"

--- a/tapcfg/server.go
+++ b/tapcfg/server.go
@@ -171,6 +171,15 @@ func genServerConfig(cfg *Config, cfgLogger btclog.Logger,
 			federationMembers, defaultMainnetFederationServer,
 		)
 
+		// For mainnet, we need to overwrite the default universe proof
+		// courier address to use the mainnet server.
+		if cfg.DefaultProofCourierAddr == defaultProofCourierAddr {
+			cfg.DefaultProofCourierAddr = fmt.Sprintf(
+				"%s://%s", proof.UniverseRpcCourierType,
+				defaultMainnetFederationServer,
+			)
+		}
+
 	case "testnet":
 		cfgLogger.Infof("Configuring %v as initial Universe "+
 			"federation server", defaultTestnetFederationServer)
@@ -179,20 +188,12 @@ func genServerConfig(cfg *Config, cfgLogger btclog.Logger,
 			federationMembers, defaultTestnetFederationServer,
 		)
 
-		// For testnet, we need to overwrite the default universe proof
-		// courier address to use the testnet server.
-		if cfg.DefaultProofCourierAddr == defaultProofCourierAddr {
-			cfg.DefaultProofCourierAddr = fmt.Sprintf(
-				"%s://%s", proof.UniverseRpcCourierType,
-				fallbackUniverseAddr,
-			)
-		}
-
 	default:
 		// For any other network, such as regtest, we can't use a
 		// universe proof courier by default, as we don't know what
-		// server to pick. So if there is no explicit value set, we fall
-		// back to using the hashmail courier, which works in all cases.
+		// server to pick. So if there is no explicit value set, we
+		// fall back to using the hashmail courier, which works in all
+		// cases.
 		if cfg.DefaultProofCourierAddr == defaultProofCourierAddr {
 			cfg.DefaultProofCourierAddr = fmt.Sprintf(
 				"%s://%s", proof.HashmailCourierType,

--- a/tapdb/universe_federation.go
+++ b/tapdb/universe_federation.go
@@ -45,7 +45,7 @@ var (
 	defaultGlobalSyncConfigs = []*universe.FedGlobalSyncConfig{
 		{
 			ProofType:       universe.ProofTypeIssuance,
-			AllowSyncInsert: false,
+			AllowSyncInsert: true,
 			AllowSyncExport: false,
 		},
 		{

--- a/tapdb/universe_federation.go
+++ b/tapdb/universe_federation.go
@@ -45,12 +45,12 @@ var (
 		{
 			ProofType:       universe.ProofTypeIssuance,
 			AllowSyncInsert: true,
-			AllowSyncExport: false,
+			AllowSyncExport: true,
 		},
 		{
 			ProofType:       universe.ProofTypeTransfer,
 			AllowSyncInsert: false,
-			AllowSyncExport: false,
+			AllowSyncExport: true,
 		},
 	}
 )

--- a/tapdb/universe_federation.go
+++ b/tapdb/universe_federation.go
@@ -2,7 +2,6 @@ package tapdb
 
 import (
 	"context"
-	"database/sql"
 	"errors"
 	"fmt"
 	"time"
@@ -319,7 +318,7 @@ func (u *UniverseFederationDB) QueryFederationSyncConfigs(
 			ctx,
 		)
 		switch {
-		case errors.Is(err, sql.ErrNoRows):
+		case globalDbConfigs == nil:
 			// If the query does not return any rows then a global
 			// config for each proof type has not yet been set. We
 			// will return a default config for each proof type.

--- a/tapdb/universe_federation_test.go
+++ b/tapdb/universe_federation_test.go
@@ -95,3 +95,20 @@ func TestUniverseFederationCRUD(t *testing.T) {
 	err = fedDB.LogNewSyncs(ctx, addrToUpdate)
 	require.NoError(t, err)
 }
+
+// TestFederationConfigDefault tests that we're able to fetch the default
+// federation config.
+func TestFederationConfigDefault(t *testing.T) {
+	t.Parallel()
+
+	testClock := clock.NewTestClock(time.Now())
+	fedDB, _ := newTestFederationDb(t, testClock)
+
+	ctx := context.Background()
+
+	// If we try to fetch the default config without any added, we should
+	// should get the default config.
+	globalConfig, _, err := fedDB.QueryFederationSyncConfigs(ctx)
+	require.NoError(t, err)
+	require.Equal(t, defaultGlobalSyncConfigs, globalConfig)
+}


### PR DESCRIPTION
When we made testnet the default, the default config logic wasn't updated to properly implement the fallback logic. As a result, on testnet, the mainnet courier was still being used.