### PR TITLE
tapdb: Federation DB fixes

### DIFF
--- a/tapdb/sqlc/migrations/000009_universe_configs.down.sql
+++ b/tapdb/sqlc/migrations/000009_universe_configs.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS federation_uni_sync_config;

--- a/tapdb/sqlc/migrations/000009_universe_configs.up.sql
+++ b/tapdb/sqlc/migrations/000009_universe_configs.up.sql
@@ -1,0 +1,35 @@
+DROP TABLE IF EXISTS federation_uni_sync_config;
+
+-- This table contains universe (asset/asset group) specific federation sync
+-- configuration.
+CREATE TABLE IF NOT EXISTS federation_uni_sync_config (
+    -- namespace is the string representation of the universe identifier, and
+    -- ensures that there are no duplicate configs.
+    namespace VARCHAR NOT NULL PRIMARY KEY,
+
+    -- This field contains the byte serialized ID of the asset to which this
+    -- configuration is applicable.
+    asset_id BLOB CHECK(length(asset_id) = 32) NULL,
+
+    -- This field contains the byte serialized compressed group key public key
+    -- of the asset group to which this configuration is applicable.
+    group_key BLOB CHECK(LENGTH(group_key) = 33) NULL,
+
+    -- This field is an enum representing the proof type stored in the given
+    -- universe.
+    proof_type TEXT NOT NULL CHECK(proof_type IN ('issuance', 'transfer')),
+
+    -- This field is a boolean that indicates whether or not the given universe
+    -- should accept remote proof insertion via federation sync.
+    allow_sync_insert BOOLEAN NOT NULL,
+
+    -- This field is a boolean that indicates whether or not the given universe
+    -- should accept remote proof export via federation sync.
+    allow_sync_export BOOLEAN NOT NULL,
+
+    -- Both the asset ID and group key cannot be null at the same time.
+    CHECK (
+        (asset_id IS NOT NULL AND group_key IS NULL) OR
+        (asset_id IS NULL AND group_key IS NOT NULL)
+    )
+);

--- a/tapdb/sqlc/models.go
+++ b/tapdb/sqlc/models.go
@@ -165,6 +165,7 @@ type FederationGlobalSyncConfig struct {
 }
 
 type FederationUniSyncConfig struct {
+	Namespace       string
 	AssetID         []byte
 	GroupKey        []byte
 	ProofType       string

--- a/tapdb/sqlc/queries/universe.sql
+++ b/tapdb/sqlc/queries/universe.sql
@@ -327,20 +327,22 @@ ON CONFLICT(proof_type)
 
 -- name: QueryFederationGlobalSyncConfigs :many
 SELECT proof_type, allow_sync_insert, allow_sync_export
-FROM federation_global_sync_config;
+FROM federation_global_sync_config
+ORDER BY proof_type;
 
 -- name: UpsertFederationUniSyncConfig :exec
 INSERT INTO federation_uni_sync_config  (
-    asset_id, group_key, proof_type, allow_sync_insert, allow_sync_export
+    namespace, asset_id, group_key, proof_type, allow_sync_insert, allow_sync_export
 )
 VALUES(
-    @asset_id, @group_key, @proof_type, @allow_sync_insert, @allow_sync_export
+    @namespace, @asset_id, @group_key, @proof_type, @allow_sync_insert, @allow_sync_export
 )
-ON CONFLICT(asset_id, group_key, proof_type)
+ON CONFLICT(namespace)
     DO UPDATE SET
     allow_sync_insert = @allow_sync_insert,
     allow_sync_export = @allow_sync_export;
 
 -- name: QueryFederationUniSyncConfigs :many
-SELECT asset_id, group_key, proof_type, allow_sync_insert, allow_sync_export
-FROM federation_uni_sync_config;
+SELECT namespace, asset_id, group_key, proof_type, allow_sync_insert, allow_sync_export
+FROM federation_uni_sync_config
+ORDER BY group_key NULLS LAST, asset_id NULLS LAST, proof_type;

--- a/tapdb/universe_federation.go
+++ b/tapdb/universe_federation.go
@@ -263,10 +263,8 @@ func (u *UniverseFederationDB) UpsertFederationSyncConfig(
 		}
 
 		// Upsert universe specific sync configs.
-		for i := range uniSyncConfigs {
+		for _, config := range uniSyncConfigs {
 			var (
-				config = uniSyncConfigs[i]
-
 				uniID        = config.UniverseID
 				groupPubKey  []byte
 				assetIDBytes []byte
@@ -285,6 +283,7 @@ func (u *UniverseFederationDB) UpsertFederationSyncConfig(
 
 			err := db.UpsertFederationUniSyncConfig(
 				ctx, UpsertFedUniSyncConfigParams{
+					Namespace:       uniID.String(),
 					AssetID:         assetIDBytes,
 					GroupKey:        groupPubKey,
 					ProofType:       uniID.ProofType.String(),
@@ -379,11 +378,9 @@ func (u *UniverseFederationDB) QueryFederationSyncConfigs(
 			[]*universe.FedUniSyncConfig, len(uniDbConfigs),
 		)
 
-		for i := range uniDbConfigs {
-			conf := uniDbConfigs[i]
-
+		for i, config := range uniDbConfigs {
 			proofType, err := universe.ParseStrProofType(
-				conf.ProofType,
+				config.ProofType,
 			)
 			if err != nil {
 				return err
@@ -391,8 +388,8 @@ func (u *UniverseFederationDB) QueryFederationSyncConfigs(
 
 			// Construct group key public key from bytes.
 			var pubKey *btcec.PublicKey
-			if conf.GroupKey != nil {
-				pubKey, err = btcec.ParsePubKey(conf.GroupKey)
+			if config.GroupKey != nil {
+				pubKey, err = btcec.ParsePubKey(config.GroupKey)
 				if err != nil {
 					return fmt.Errorf("unable to parse "+
 						"group key: %v", err)
@@ -401,7 +398,7 @@ func (u *UniverseFederationDB) QueryFederationSyncConfigs(
 
 			// Construct asset ID from bytes.
 			var assetID asset.ID
-			copy(assetID[:], conf.AssetID)
+			copy(assetID[:], config.AssetID)
 
 			uniID := universe.Identifier{
 				AssetID:   assetID,
@@ -411,8 +408,8 @@ func (u *UniverseFederationDB) QueryFederationSyncConfigs(
 
 			uniConfigs[i] = &universe.FedUniSyncConfig{
 				UniverseID:      uniID,
-				AllowSyncInsert: conf.AllowSyncInsert,
-				AllowSyncExport: conf.AllowSyncExport,
+				AllowSyncInsert: config.AllowSyncInsert,
+				AllowSyncExport: config.AllowSyncExport,
 			}
 		}
 		return nil


### PR DESCRIPTION
Fixes multiple issues with sync config load and store.

The first issue was the federation DB handle not returning the correct global config when the global config is modified for one proof type - this is resolved by loading the default config, and keying configs by proof type. Configs read from the DB then replace the default config with the matching proof type.

The second issue affected grouped assets, and led to group member asset IDs not being shown on the CLI.

The third issue was the UNIQUE constraint on universe sync configs not being enforced, since NULL values are distinct in UNIQUE constraints by default for SQLite and Postgres. This could lead to a bad configuration state with multiple entries for the same universe. This behavior is not configurable for SQLite, so extra columns were added that have a default value when one field of the universe ID is NULL. This should fix the DB constraint.