### PR TITLE
tapdb: populate proof type when fetching uni roots

### DIFF
--- a/tapdb/multiverse.go
+++ b/tapdb/multiverse.go
@@ -152,6 +152,15 @@ func (b *MultiverseStore) RootNodes(
 				groupedAssets map[asset.ID]uint64
 			)
 
+			// Parse universe proof type and populate the universe
+			// ID.
+			id.ProofType, err = universe.ParseStrProofType(
+				dbRoot.ProofType,
+			)
+			if err != nil {
+				return err
+			}
+
 			if dbRoot.AssetID != nil {
 				copy(id.AssetID[:], dbRoot.AssetID)
 			}
@@ -187,15 +196,6 @@ func (b *MultiverseStore) RootNodes(
 				groupedAssets = map[asset.ID]uint64{
 					id.AssetID: uint64(dbRoot.RootSum),
 				}
-			}
-
-			// Parse universe proof type and populate the universe
-			// ID.
-			id.ProofType, err = universe.ParseStrProofType(
-				dbRoot.ProofType,
-			)
-			if err != nil {
-				return err
 			}
 
 			var nodeHash mssmt.NodeHash


### PR DESCRIPTION
In this commit, we fix an issue that prevented the display of asset IDs for asset group members. The unpopulated proof type field led the following query for universe leaves to fail.