### PR TITLE
make+vm: increase vm test coverage, improve the coverage target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ cmd/tapd/tapd
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+coverage.*
 
 # Sed backup files.
 *.bak
@@ -33,6 +34,8 @@ cmd/tapd/tapd
 # Editor configs.
 *.idea
 *.iml
+*.code-workspace
+.vscode/
 
 # Dependency directories (remove the comment below to include it)
 vendor/

--- a/Makefile
+++ b/Makefile
@@ -162,7 +162,7 @@ unit-trace:
 
 unit-cover: $(GOACC_BIN)
 	@$(call print, "Running unit coverage tests.")
-	$(GOACC_BIN) $(GOLIST_COVER)
+	$(GOACC); $(COVER_HTML)
 
 unit-race:
 	@$(call print, "Running unit race tests.")

--- a/make/testing_flags.mk
+++ b/make/testing_flags.mk
@@ -5,6 +5,7 @@ LOG_TAGS =
 TEST_FLAGS =
 ITEST_FLAGS = -logoutput
 COVER_PKG = $$(go list -deps -tags="$(DEV_TAGS)" ./... | grep '$(PKG)' | grep -v lnrpc)
+COVER_HTML = go tool cover -html=coverage.txt -o coverage.html
 POSTGRES_START_DELAY = 5
 
 # If rpc option is set also add all extra RPC tags to DEV_TAGS
@@ -111,6 +112,9 @@ endif
 
 # Construct the integration test command with the added build flags.
 ITEST_TAGS := $(DEV_TAGS) $(RPC_TAGS) integration itest $(backend)
+
+# Construct the coverage test command path with the added build flags.
+GOACC := $(GOACC_BIN) $(COVER_PKG) -- -tags="$(DEV_TAGS) $(LOG_TAGS)" $(TEST_FLAGS)
 
 # Construct the load test command with the added build flags.
 LOADTEST_TAGS := $(DEV_TAGS) $(RPC_TAGS) loadtest 

--- a/vm/testdata/vm_validation_generated.json
+++ b/vm/testdata/vm_validation_generated.json
@@ -33,17 +33,48 @@
       },
       "split_set": [],
       "input_set": [],
-      "comment": "collectible genesis"
+      "comment": "collectible group anchor"
     },
     {
       "asset": {
         "version": 0,
-        "genesis_first_prev_out": "7ae39d02db275a873cc0ea9b9ec18437f5198bb389ac728f5f4cacd9f5511802:2302292239",
-        "genesis_tag": "8afa3f85b8a62708caebbac880b5b89b93da53810164402104e648b6226a1b78",
-        "genesis_meta_hash": "8afa3f85b8a62708caebbac880b5b89b93da53810164402104e648b6226a1b78",
-        "genesis_output_index": 327692610,
+        "genesis_first_prev_out": "e17c02d5b55397b4926431624c583b0a7f201283b654043a6680d58fe8ba8f22:2674673580",
+        "genesis_tag": "3dbf8e7dcafc9e138647a4b44ed4bce964ed47f74aa594468ced323cb76f0d3f",
+        "genesis_meta_hash": "3dbf8e7dcafc9e138647a4b44ed4bce964ed47f74aa594468ced323cb76f0d3f",
+        "genesis_output_index": 2400003416,
+        "genesis_type": 1,
+        "amount": 1,
+        "lock_time": 0,
+        "relative_lock_time": 0,
+        "prev_witnesses": [
+          {
+            "prev_id": {
+              "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
+              "asset_id": "0000000000000000000000000000000000000000000000000000000000000000",
+              "script_key": "000000000000000000000000000000000000000000000000000000000000000000"
+            },
+            "tx_witness": null,
+            "split_commitment": null
+          }
+        ],
+        "split_commitment_root": null,
+        "script_version": 0,
+        "script_key": "02d68d2ed7ad27ef0c76178587dda47a7fc347abd8e4ace770089542cac06fe783",
+        "group_key": null
+      },
+      "split_set": [],
+      "input_set": [],
+      "comment": "collectible genesis"
+    },
+    {
+      "asset": {
+        "version": 1,
+        "genesis_first_prev_out": "505ec67aabc001e04cf3300698f9a8108c0c9bee7acf370641dfb5661b336077:3554031665",
+        "genesis_tag": "db07105dc31003620405da3b2169f5a910c9d0096e5e3ef1b570680746acd0cc",
+        "genesis_meta_hash": "db07105dc31003620405da3b2169f5a910c9d0096e5e3ef1b570680746acd0cc",
+        "genesis_output_index": 3407262265,
         "genesis_type": 0,
-        "amount": 3087187453,
+        "amount": 3105295895,
         "lock_time": 0,
         "relative_lock_time": 0,
         "prev_witnesses": [
@@ -54,17 +85,48 @@
               "script_key": "000000000000000000000000000000000000000000000000000000000000000000"
             },
             "tx_witness": [
-              "be6027ac2d3cef07abb355fee5e8786bb7e0841c1c3461af7deeb82161f93fd8092e12f3c15160267d7445cfb65efb48f1ac74b2895fa2de2e5b4467d3c6963d"
+              "0c4a4ec1534d41d01a77835902723fb02838c79abafecec4276d1e3300b9537dee611a50a49bcfb854801575fb44c085d1d9440931e78b989204a30265e0eeb6"
             ],
             "split_commitment": null
           }
         ],
         "split_commitment_root": null,
         "script_version": 0,
-        "script_key": "02e87a1d7a5ec816887dbb8e0b74692fcdaa6f59b9415a97ae16167abd5457ef8c",
+        "script_key": "02b150936bb693608c6b406e55bef96a47db3adc6bf9ae1a2e54e7c2304ad5c86f",
         "group_key": {
-          "group_key": "03cf23ad5fffb849e2060b104d9acff3f9ac48bc5cbe94fcfdaf1a5d1f3169ba4e"
+          "group_key": "035f1f7b77eabdf3f7c21d0305274a562e50e4c4908837e75af6dec76bb89af93c"
         }
+      },
+      "split_set": [],
+      "input_set": [],
+      "comment": "normal group anchor"
+    },
+    {
+      "asset": {
+        "version": 0,
+        "genesis_first_prev_out": "de77a649ba141d44d256987db903e70ab90059114dd94345252574f9217a93c9:2090483896",
+        "genesis_tag": "f6f4f8c0e70dbeebae7b14cdb9bc41033aa5baf40d45e24d72eac4a28e3ca030",
+        "genesis_meta_hash": "f6f4f8c0e70dbeebae7b14cdb9bc41033aa5baf40d45e24d72eac4a28e3ca030",
+        "genesis_output_index": 2816137693,
+        "genesis_type": 0,
+        "amount": 666691629,
+        "lock_time": 0,
+        "relative_lock_time": 0,
+        "prev_witnesses": [
+          {
+            "prev_id": {
+              "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
+              "asset_id": "0000000000000000000000000000000000000000000000000000000000000000",
+              "script_key": "000000000000000000000000000000000000000000000000000000000000000000"
+            },
+            "tx_witness": null,
+            "split_commitment": null
+          }
+        ],
+        "split_commitment_root": null,
+        "script_version": 0,
+        "script_key": "024a482bed16f280355faa94d728994b58be422456cc61a69ac32f82fe19f574f6",
+        "group_key": null
       },
       "split_set": [],
       "input_set": [],
@@ -73,10 +135,10 @@
     {
       "asset": {
         "version": 0,
-        "genesis_first_prev_out": "031a43ab6657fbb2a14ccdd7af4b8607a09f7b29df8f5522164965eb24ce99aa:1988458573",
-        "genesis_tag": "1c5b078143ee26a586ad23139d5041723470bf24a865837c9123461c41f5ff99",
-        "genesis_meta_hash": "1c5b078143ee26a586ad23139d5041723470bf24a865837c9123461c41f5ff99",
-        "genesis_output_index": 3920083314,
+        "genesis_first_prev_out": "e46d74010c77412cd004da190858f8c2b54e1aa93cce25ce839a88b0768a577a:551340839",
+        "genesis_tag": "b4ddb4aa3886cb5090940fc6d4cabe2153809e4ed60a0e2af07f1b2a6bb5a601",
+        "genesis_meta_hash": "b4ddb4aa3886cb5090940fc6d4cabe2153809e4ed60a0e2af07f1b2a6bb5a601",
+        "genesis_output_index": 1994093432,
         "genesis_type": 1,
         "amount": 1,
         "lock_time": 0,
@@ -85,20 +147,20 @@
           {
             "prev_id": {
               "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
-              "asset_id": "3295424c07f7b85a510e46fc238a523bfdfe7303d583e04bb076c68db49cf411",
-              "script_key": "025b35984db815e334f5563bdd7177a4fed63144cf58f2c74f5b3da72d42c0856c"
+              "asset_id": "00819c80f9b49489456a5606433821a39ba3b19cd7c37e680c58fb0b85f35bce",
+              "script_key": "0297af507e1ad79097bc05449cc0a5ece1408cd3b25e029f8dddef2abbe0c4a2e2"
             },
             "tx_witness": [
-              "a2dec0a746a2695a0d99be6383fbe45deac8d78d8b9d4caecd1e91d84e8ebf6df7e01aa260bee872eb6f84cd6668b4402cd97640677d1fe4909cb7f3107023ce"
+              "91a99a2643525a388aa89fd932b0ccda86c57fa6de852d818b3eff22609985ff4ece40978f3f39b8595b7e447f58ac4f03b2e1a7fd2b5805fe48df77f1fd2d8c"
             ],
             "split_commitment": null
           }
         ],
         "split_commitment_root": null,
         "script_version": 0,
-        "script_key": "02caff65bf22e13a37481b91ca02215e4543872f31ac1c41906ca64d6a5418dfa5",
+        "script_key": "02298325be051410d51c58fd37449f6aecdf0d4a81f717bff02df39e6299ae0bbd",
         "group_key": {
-          "group_key": "0277b2f873c4db93a77efec76b10030eb04bdb86021c6493da0af49e24336dd9a7"
+          "group_key": "024810dcbc686a5a1cf987d7a05050d4a75dc0f9a8c194056dbfe0c684125ee9ac"
         }
       },
       "split_set": [],
@@ -106,15 +168,15 @@
         {
           "prev_id": {
             "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
-            "asset_id": "3295424c07f7b85a510e46fc238a523bfdfe7303d583e04bb076c68db49cf411",
-            "script_key": "025b35984db815e334f5563bdd7177a4fed63144cf58f2c74f5b3da72d42c0856c"
+            "asset_id": "00819c80f9b49489456a5606433821a39ba3b19cd7c37e680c58fb0b85f35bce",
+            "script_key": "0297af507e1ad79097bc05449cc0a5ece1408cd3b25e029f8dddef2abbe0c4a2e2"
           },
           "asset": {
             "version": 0,
-            "genesis_first_prev_out": "031a43ab6657fbb2a14ccdd7af4b8607a09f7b29df8f5522164965eb24ce99aa:1988458573",
-            "genesis_tag": "1c5b078143ee26a586ad23139d5041723470bf24a865837c9123461c41f5ff99",
-            "genesis_meta_hash": "1c5b078143ee26a586ad23139d5041723470bf24a865837c9123461c41f5ff99",
-            "genesis_output_index": 3920083314,
+            "genesis_first_prev_out": "e46d74010c77412cd004da190858f8c2b54e1aa93cce25ce839a88b0768a577a:551340839",
+            "genesis_tag": "b4ddb4aa3886cb5090940fc6d4cabe2153809e4ed60a0e2af07f1b2a6bb5a601",
+            "genesis_meta_hash": "b4ddb4aa3886cb5090940fc6d4cabe2153809e4ed60a0e2af07f1b2a6bb5a601",
+            "genesis_output_index": 1994093432,
             "genesis_type": 1,
             "amount": 1,
             "lock_time": 0,
@@ -132,9 +194,9 @@
             ],
             "split_commitment_root": null,
             "script_version": 0,
-            "script_key": "025b35984db815e334f5563bdd7177a4fed63144cf58f2c74f5b3da72d42c0856c",
+            "script_key": "0297af507e1ad79097bc05449cc0a5ece1408cd3b25e029f8dddef2abbe0c4a2e2",
             "group_key": {
-              "group_key": "0277b2f873c4db93a77efec76b10030eb04bdb86021c6493da0af49e24336dd9a7"
+              "group_key": "024810dcbc686a5a1cf987d7a05050d4a75dc0f9a8c194056dbfe0c684125ee9ac"
             }
           }
         }
@@ -144,45 +206,45 @@
     {
       "asset": {
         "version": 1,
-        "genesis_first_prev_out": "da0504620310c35d1007dbc4098a7c7c50358b44e12d3329ab7af6400eb0ae91:3856427473",
-        "genesis_tag": "23e196c9dfff7fbaff4ffe94f4589733e563e19d3045aad3e226488ac02cca42",
-        "genesis_meta_hash": "23e196c9dfff7fbaff4ffe94f4589733e563e19d3045aad3e226488ac02cca42",
-        "genesis_output_index": 164677904,
+        "genesis_first_prev_out": "bdc33b93ffd26a2dfa6ca4fa0450cbcd2243b6d8e314b0255d3d05d286ad4dc0:1804420890",
+        "genesis_tag": "89078dc61f46494dccf403dad7f094170d2c3e29c198b0f341e284c4be8fa60c",
+        "genesis_meta_hash": "89078dc61f46494dccf403dad7f094170d2c3e29c198b0f341e284c4be8fa60c",
+        "genesis_output_index": 3505588838,
         "genesis_type": 0,
-        "amount": 2077694418,
+        "amount": 3702861593,
         "lock_time": 0,
         "relative_lock_time": 0,
         "prev_witnesses": [
           {
             "prev_id": {
               "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
-              "asset_id": "0305c136b7dd80131503b0431659f04526f87e1632dfaf000e990fbc57e9e6b0",
-              "script_key": "0290e890b331192e241b29d9ff916cdb85c53be4b3afee55028fa75307d8c86b41"
+              "asset_id": "3e9227ef7c15a9d79f93f84b08233b25d7e2449ae9a4c1b227d3ebaa6d2e0205",
+              "script_key": "0283604c0a3c90f7fe487026f2ba0232282e798b30adb293b6c434e7d8a1c4cde4"
             },
             "tx_witness": [
-              "68563c1630ff6b93a3749fbdc8bd10eee6778dd466f4c44d8101db824e276b22f1e6958abc790f47f9965356ea744e119225090084bb2faa645e2328e2362414"
+              "0307ad8c080951d007ff52debfe58efc1291903196402ece0524940d8f83d932515334590d8b5b2e9ba4cba40b603100308db28bce6adc83fb1268d03da54c0d"
             ],
             "split_commitment": null
           },
           {
             "prev_id": {
               "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
-              "asset_id": "c973b2f9fb2f4b2a05d13d2c8c517b661f5ed0f68bdef4d3b74836bdb6e7d246",
-              "script_key": "02a382379d9e1635e23369627a19c587e751e447f073dafc92bdcfb89630eccc6a"
+              "asset_id": "424e3cc1c2416827574d19cfa26ba914e19790ca5988042f603b23bd8a1c7b19",
+              "script_key": "0213dd526a78c665a56f254f116a74cfe76f83cf889b53b51a75cac39a8338cbb5"
             },
             "tx_witness": [
-              "edc2c4951995bc82659d090dc4f61f533f27b4e835a16e66cfbb5162c3c709eb331a6bf4ba3ea6c59a5206f8daa05d5b7754702e4e67b73efc6ccfe2467e0b02",
-              "20a354a15678381931fb574954a609244fc0b601830cac80bf6774882bfcf2e610ad56b2",
-              "c1a354a15678381931fb574954a609244fc0b601830cac80bf6774882bfcf2e610"
+              "53ac951644f42d3cf5fa5f901120be70fbd59ab0c4540b904cd4090ab21e0c81952d054097dd7d9f984119122c51c77ba3e6591358799541cbfed3dd95b53c4b",
+              "20addc7f12dbd79157ba5b5c248026e78c6d63256b9ce6a5b51e3b491016924f35ad56b2",
+              "c0addc7f12dbd79157ba5b5c248026e78c6d63256b9ce6a5b51e3b491016924f35"
             ],
             "split_commitment": null
           }
         ],
         "split_commitment_root": null,
         "script_version": 0,
-        "script_key": "022d7b674db8f92b92d7cefbea8dfce4b3c2f00c7b28d19b9bb6ce8b74b3a5bd06",
+        "script_key": "02feec768ea79229f57ca06b2c530c510af6cdce2fe26617ce6a3e59724c3df35c",
         "group_key": {
-          "group_key": "02db289a4f84e6edcc4dee256aa4f0304153e6e02677cfc5883e8fbd0c1e71ff79"
+          "group_key": "03cb111af8c479855843eb675e70909ad1c1e6bb3954703d3cbb2f902fe4bd0b46"
         }
       },
       "split_set": [],
@@ -190,52 +252,17 @@
         {
           "prev_id": {
             "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
-            "asset_id": "0305c136b7dd80131503b0431659f04526f87e1632dfaf000e990fbc57e9e6b0",
-            "script_key": "0290e890b331192e241b29d9ff916cdb85c53be4b3afee55028fa75307d8c86b41"
+            "asset_id": "424e3cc1c2416827574d19cfa26ba914e19790ca5988042f603b23bd8a1c7b19",
+            "script_key": "0213dd526a78c665a56f254f116a74cfe76f83cf889b53b51a75cac39a8338cbb5"
           },
           "asset": {
-            "version": 1,
-            "genesis_first_prev_out": "da0504620310c35d1007dbc4098a7c7c50358b44e12d3329ab7af6400eb0ae91:3856427473",
-            "genesis_tag": "23e196c9dfff7fbaff4ffe94f4589733e563e19d3045aad3e226488ac02cca42",
-            "genesis_meta_hash": "23e196c9dfff7fbaff4ffe94f4589733e563e19d3045aad3e226488ac02cca42",
-            "genesis_output_index": 164677904,
+            "version": 0,
+            "genesis_first_prev_out": "73da71923d29870a8360c826a1b37f3f931afd8b416421a5178ea14b1d2e9942:2232442454",
+            "genesis_tag": "b87b1615d512974fa4747dd1e17d02c9462a44fec150ca3a8f99cc1e4953365e",
+            "genesis_meta_hash": "b87b1615d512974fa4747dd1e17d02c9462a44fec150ca3a8f99cc1e4953365e",
+            "genesis_output_index": 1264367487,
             "genesis_type": 0,
-            "amount": 1752217074,
-            "lock_time": 0,
-            "relative_lock_time": 0,
-            "prev_witnesses": [
-              {
-                "prev_id": {
-                  "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
-                  "asset_id": "0000000000000000000000000000000000000000000000000000000000000000",
-                  "script_key": "000000000000000000000000000000000000000000000000000000000000000000"
-                },
-                "tx_witness": null,
-                "split_commitment": null
-              }
-            ],
-            "split_commitment_root": null,
-            "script_version": 0,
-            "script_key": "0290e890b331192e241b29d9ff916cdb85c53be4b3afee55028fa75307d8c86b41",
-            "group_key": {
-              "group_key": "02db289a4f84e6edcc4dee256aa4f0304153e6e02677cfc5883e8fbd0c1e71ff79"
-            }
-          }
-        },
-        {
-          "prev_id": {
-            "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
-            "asset_id": "c973b2f9fb2f4b2a05d13d2c8c517b661f5ed0f68bdef4d3b74836bdb6e7d246",
-            "script_key": "02a382379d9e1635e23369627a19c587e751e447f073dafc92bdcfb89630eccc6a"
-          },
-          "asset": {
-            "version": 1,
-            "genesis_first_prev_out": "d80f8784e7f8e35dc80a82dfe5aec24155b9170e16ee49c22554adf4f219a32f:2120591429",
-            "genesis_tag": "01c0ab7ac65e502d39b216cbc50e73a32eaf936401e2506bd8b82c30d346bc4b",
-            "genesis_meta_hash": "01c0ab7ac65e502d39b216cbc50e73a32eaf936401e2506bd8b82c30d346bc4b",
-            "genesis_output_index": 231487098,
-            "genesis_type": 0,
-            "amount": 325477344,
+            "amount": 3069508322,
             "lock_time": 0,
             "relative_lock_time": 6,
             "prev_witnesses": [
@@ -251,9 +278,44 @@
             ],
             "split_commitment_root": null,
             "script_version": 0,
-            "script_key": "02a382379d9e1635e23369627a19c587e751e447f073dafc92bdcfb89630eccc6a",
+            "script_key": "0213dd526a78c665a56f254f116a74cfe76f83cf889b53b51a75cac39a8338cbb5",
             "group_key": {
-              "group_key": "020e6a12617255f58b3c9c4184bd26cac12bdeddda89016240009d6a3886815cb6"
+              "group_key": "02538b10711cb713f14c83c68b379adf3245ebaf7d6b962e2df9c63937f6bd4bc2"
+            }
+          }
+        },
+        {
+          "prev_id": {
+            "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
+            "asset_id": "3e9227ef7c15a9d79f93f84b08233b25d7e2449ae9a4c1b227d3ebaa6d2e0205",
+            "script_key": "0283604c0a3c90f7fe487026f2ba0232282e798b30adb293b6c434e7d8a1c4cde4"
+          },
+          "asset": {
+            "version": 1,
+            "genesis_first_prev_out": "bdc33b93ffd26a2dfa6ca4fa0450cbcd2243b6d8e314b0255d3d05d286ad4dc0:1804420890",
+            "genesis_tag": "89078dc61f46494dccf403dad7f094170d2c3e29c198b0f341e284c4be8fa60c",
+            "genesis_meta_hash": "89078dc61f46494dccf403dad7f094170d2c3e29c198b0f341e284c4be8fa60c",
+            "genesis_output_index": 3505588838,
+            "genesis_type": 0,
+            "amount": 633353271,
+            "lock_time": 0,
+            "relative_lock_time": 0,
+            "prev_witnesses": [
+              {
+                "prev_id": {
+                  "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
+                  "asset_id": "0000000000000000000000000000000000000000000000000000000000000000",
+                  "script_key": "000000000000000000000000000000000000000000000000000000000000000000"
+                },
+                "tx_witness": null,
+                "split_commitment": null
+              }
+            ],
+            "split_commitment_root": null,
+            "script_version": 0,
+            "script_key": "0283604c0a3c90f7fe487026f2ba0232282e798b30adb293b6c434e7d8a1c4cde4",
+            "group_key": {
+              "group_key": "03cb111af8c479855843eb675e70909ad1c1e6bb3954703d3cbb2f902fe4bd0b46"
             }
           }
         }
@@ -263,10 +325,10 @@
     {
       "asset": {
         "version": 0,
-        "genesis_first_prev_out": "a644db2122649be16159cdf006e7309f035b88ab7f55666529f9370ff59da1d7:1571125468",
-        "genesis_tag": "da6745fba6a04c5c37c7ca35036f11732ce8bc27b48868611fc73c82a491bfab",
-        "genesis_meta_hash": "da6745fba6a04c5c37c7ca35036f11732ce8bc27b48868611fc73c82a491bfab",
-        "genesis_output_index": 2578299031,
+        "genesis_first_prev_out": "eaf52f276ebcbc40db544d2be2e904567a08fb7edb1a334f801bb1d81d09f54b:2648659725",
+        "genesis_tag": "93b2aed55b7d44b5b054f3f38e788e4fdf36e591568c41d1052cad0fcb68ca4c",
+        "genesis_meta_hash": "93b2aed55b7d44b5b054f3f38e788e4fdf36e591568c41d1052cad0fcb68ca4c",
+        "genesis_output_index": 1280700505,
         "genesis_type": 0,
         "amount": 1,
         "lock_time": 0,
@@ -275,40 +337,40 @@
           {
             "prev_id": {
               "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
-              "asset_id": "b26a1d1e24015ae0a7036fb6af252d5100a304d7b1e261992a653e37b250c80f",
-              "script_key": "0212727730101b62db3382a384360c3e5b4c0c553b995425ce57f10284d52d3b0b"
+              "asset_id": "7215055fc2aa585a2ae05beefc557a29c78551d3ef9d9c321d904bc711ba3d86",
+              "script_key": "02ab18bd09bc91f9cbe3df91853bc179e1e911ec2b14624a447bbfdffed228fc7b"
             },
             "tx_witness": [
-              "801ea6ba45f3482e8d02a13e78db0af8274410640e92436f0151939e34fdfc582788c13a5080073dd9070fda1ff3c6b5b33bef97ef7cc0a8f00927bc59b70527"
+              "8d340fc9d0691f5f2e3af5c03e5fb781ddcd5c0d86112e5ca8756098b09b1804460b6f228200fec8ea7f016d668a69ec69694a6c8b31df4f0c6a3a2765dfbbaf"
             ],
             "split_commitment": null
           }
         ],
         "split_commitment_root": {
-          "hash": "34c0bdc7fe60126cb199f155e46e00f84354c67cab3c3d339f52b9c2b422b9d8",
+          "hash": "837487b4bed03c7ff832382c49de9e9e4d186334066bdb023008b56b76e325ef",
           "sum": "3"
         },
         "script_version": 0,
-        "script_key": "0212727730101b62db3382a384360c3e5b4c0c553b995425ce57f10284d52d3b0b",
+        "script_key": "02ab18bd09bc91f9cbe3df91853bc179e1e911ec2b14624a447bbfdffed228fc7b",
         "group_key": {
-          "group_key": "02a359f7bd06079221f8d96d05352c6e8acaf3b585e47dc08ffd877eaf262ca5e5"
+          "group_key": "0225f784ed4c019043b53378437981526beec8a8dd0df58ff29b9be57bec2f87b8"
         }
       },
       "split_set": [
         {
           "key": {
             "output_index": 0,
-            "asset_id": "b26a1d1e24015ae0a7036fb6af252d5100a304d7b1e261992a653e37b250c80f",
-            "script_key": "0212727730101b62db3382a384360c3e5b4c0c553b995425ce57f10284d52d3b0b",
+            "asset_id": "7215055fc2aa585a2ae05beefc557a29c78551d3ef9d9c321d904bc711ba3d86",
+            "script_key": "02ab18bd09bc91f9cbe3df91853bc179e1e911ec2b14624a447bbfdffed228fc7b",
             "amount": 1
           },
           "value": {
             "asset": {
               "version": 0,
-              "genesis_first_prev_out": "a644db2122649be16159cdf006e7309f035b88ab7f55666529f9370ff59da1d7:1571125468",
-              "genesis_tag": "da6745fba6a04c5c37c7ca35036f11732ce8bc27b48868611fc73c82a491bfab",
-              "genesis_meta_hash": "da6745fba6a04c5c37c7ca35036f11732ce8bc27b48868611fc73c82a491bfab",
-              "genesis_output_index": 2578299031,
+              "genesis_first_prev_out": "eaf52f276ebcbc40db544d2be2e904567a08fb7edb1a334f801bb1d81d09f54b:2648659725",
+              "genesis_tag": "93b2aed55b7d44b5b054f3f38e788e4fdf36e591568c41d1052cad0fcb68ca4c",
+              "genesis_meta_hash": "93b2aed55b7d44b5b054f3f38e788e4fdf36e591568c41d1052cad0fcb68ca4c",
+              "genesis_output_index": 1280700505,
               "genesis_type": 0,
               "amount": 1,
               "lock_time": 0,
@@ -322,13 +384,13 @@
                   },
                   "tx_witness": null,
                   "split_commitment": {
-                    "proof": "0002c357442109f2de8b0a4d94cee619c25bd427fffdf069e3a45730c97637a5f7fd0000000000000001d6b99082d374f0e774f5b8cd4f2666035e5bd49d3be049d8304a336ff8c7ba610000000000000001ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff3f",
+                    "proof": "0002b7d11de3e9d3c87529f9aedfd04142fbeac12e9f83f8f2244885dc34545cd02e0000000000000001f08b3df584436f3fc953c44470c829be1ed070e27343f02bee35f922fca236f90000000000000001ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7b",
                     "root_asset": {
                       "version": 0,
-                      "genesis_first_prev_out": "a644db2122649be16159cdf006e7309f035b88ab7f55666529f9370ff59da1d7:1571125468",
-                      "genesis_tag": "da6745fba6a04c5c37c7ca35036f11732ce8bc27b48868611fc73c82a491bfab",
-                      "genesis_meta_hash": "da6745fba6a04c5c37c7ca35036f11732ce8bc27b48868611fc73c82a491bfab",
-                      "genesis_output_index": 2578299031,
+                      "genesis_first_prev_out": "eaf52f276ebcbc40db544d2be2e904567a08fb7edb1a334f801bb1d81d09f54b:2648659725",
+                      "genesis_tag": "93b2aed55b7d44b5b054f3f38e788e4fdf36e591568c41d1052cad0fcb68ca4c",
+                      "genesis_meta_hash": "93b2aed55b7d44b5b054f3f38e788e4fdf36e591568c41d1052cad0fcb68ca4c",
+                      "genesis_output_index": 1280700505,
                       "genesis_type": 0,
                       "amount": 1,
                       "lock_time": 0,
@@ -337,23 +399,23 @@
                         {
                           "prev_id": {
                             "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
-                            "asset_id": "b26a1d1e24015ae0a7036fb6af252d5100a304d7b1e261992a653e37b250c80f",
-                            "script_key": "0212727730101b62db3382a384360c3e5b4c0c553b995425ce57f10284d52d3b0b"
+                            "asset_id": "7215055fc2aa585a2ae05beefc557a29c78551d3ef9d9c321d904bc711ba3d86",
+                            "script_key": "02ab18bd09bc91f9cbe3df91853bc179e1e911ec2b14624a447bbfdffed228fc7b"
                           },
                           "tx_witness": [
-                            "801ea6ba45f3482e8d02a13e78db0af8274410640e92436f0151939e34fdfc582788c13a5080073dd9070fda1ff3c6b5b33bef97ef7cc0a8f00927bc59b70527"
+                            "8d340fc9d0691f5f2e3af5c03e5fb781ddcd5c0d86112e5ca8756098b09b1804460b6f228200fec8ea7f016d668a69ec69694a6c8b31df4f0c6a3a2765dfbbaf"
                           ],
                           "split_commitment": null
                         }
                       ],
                       "split_commitment_root": {
-                        "hash": "34c0bdc7fe60126cb199f155e46e00f84354c67cab3c3d339f52b9c2b422b9d8",
+                        "hash": "837487b4bed03c7ff832382c49de9e9e4d186334066bdb023008b56b76e325ef",
                         "sum": "3"
                       },
                       "script_version": 0,
-                      "script_key": "0212727730101b62db3382a384360c3e5b4c0c553b995425ce57f10284d52d3b0b",
+                      "script_key": "02ab18bd09bc91f9cbe3df91853bc179e1e911ec2b14624a447bbfdffed228fc7b",
                       "group_key": {
-                        "group_key": "02a359f7bd06079221f8d96d05352c6e8acaf3b585e47dc08ffd877eaf262ca5e5"
+                        "group_key": "0225f784ed4c019043b53378437981526beec8a8dd0df58ff29b9be57bec2f87b8"
                       }
                     }
                   }
@@ -361,9 +423,9 @@
               ],
               "split_commitment_root": null,
               "script_version": 0,
-              "script_key": "0212727730101b62db3382a384360c3e5b4c0c553b995425ce57f10284d52d3b0b",
+              "script_key": "02ab18bd09bc91f9cbe3df91853bc179e1e911ec2b14624a447bbfdffed228fc7b",
               "group_key": {
-                "group_key": "02a359f7bd06079221f8d96d05352c6e8acaf3b585e47dc08ffd877eaf262ca5e5"
+                "group_key": "0225f784ed4c019043b53378437981526beec8a8dd0df58ff29b9be57bec2f87b8"
               }
             },
             "output_index": 0
@@ -372,17 +434,17 @@
         {
           "key": {
             "output_index": 1,
-            "asset_id": "b26a1d1e24015ae0a7036fb6af252d5100a304d7b1e261992a653e37b250c80f",
-            "script_key": "02c70a2d41363605f378db363e6b3be6f04dd10a3b6eabfc24234fbaa0e6ef41f1",
+            "asset_id": "7215055fc2aa585a2ae05beefc557a29c78551d3ef9d9c321d904bc711ba3d86",
+            "script_key": "034c7d4b4dd143f1a1dd554ab1ca04fb844431e09252c42195943e7f6335de7292",
             "amount": 1
           },
           "value": {
             "asset": {
               "version": 0,
-              "genesis_first_prev_out": "a644db2122649be16159cdf006e7309f035b88ab7f55666529f9370ff59da1d7:1571125468",
-              "genesis_tag": "da6745fba6a04c5c37c7ca35036f11732ce8bc27b48868611fc73c82a491bfab",
-              "genesis_meta_hash": "da6745fba6a04c5c37c7ca35036f11732ce8bc27b48868611fc73c82a491bfab",
-              "genesis_output_index": 2578299031,
+              "genesis_first_prev_out": "eaf52f276ebcbc40db544d2be2e904567a08fb7edb1a334f801bb1d81d09f54b:2648659725",
+              "genesis_tag": "93b2aed55b7d44b5b054f3f38e788e4fdf36e591568c41d1052cad0fcb68ca4c",
+              "genesis_meta_hash": "93b2aed55b7d44b5b054f3f38e788e4fdf36e591568c41d1052cad0fcb68ca4c",
+              "genesis_output_index": 1280700505,
               "genesis_type": 0,
               "amount": 1,
               "lock_time": 0,
@@ -396,13 +458,13 @@
                   },
                   "tx_witness": null,
                   "split_commitment": {
-                    "proof": "000263e4ac003908ee9f613773594261b980ef9d3430cb95d42b09b03818a62c6dae0000000000000001d6b99082d374f0e774f5b8cd4f2666035e5bd49d3be049d8304a336ff8c7ba610000000000000001ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff3f",
+                    "proof": "0002b62ace00d00ed8d690ea6dc0e34d6412112ab4062ddc2f8eb1bb6f66d59cc0c40000000000000001f08b3df584436f3fc953c44470c829be1ed070e27343f02bee35f922fca236f90000000000000001ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7b",
                     "root_asset": {
                       "version": 0,
-                      "genesis_first_prev_out": "a644db2122649be16159cdf006e7309f035b88ab7f55666529f9370ff59da1d7:1571125468",
-                      "genesis_tag": "da6745fba6a04c5c37c7ca35036f11732ce8bc27b48868611fc73c82a491bfab",
-                      "genesis_meta_hash": "da6745fba6a04c5c37c7ca35036f11732ce8bc27b48868611fc73c82a491bfab",
-                      "genesis_output_index": 2578299031,
+                      "genesis_first_prev_out": "eaf52f276ebcbc40db544d2be2e904567a08fb7edb1a334f801bb1d81d09f54b:2648659725",
+                      "genesis_tag": "93b2aed55b7d44b5b054f3f38e788e4fdf36e591568c41d1052cad0fcb68ca4c",
+                      "genesis_meta_hash": "93b2aed55b7d44b5b054f3f38e788e4fdf36e591568c41d1052cad0fcb68ca4c",
+                      "genesis_output_index": 1280700505,
                       "genesis_type": 0,
                       "amount": 1,
                       "lock_time": 0,
@@ -411,23 +473,23 @@
                         {
                           "prev_id": {
                             "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
-                            "asset_id": "b26a1d1e24015ae0a7036fb6af252d5100a304d7b1e261992a653e37b250c80f",
-                            "script_key": "0212727730101b62db3382a384360c3e5b4c0c553b995425ce57f10284d52d3b0b"
+                            "asset_id": "7215055fc2aa585a2ae05beefc557a29c78551d3ef9d9c321d904bc711ba3d86",
+                            "script_key": "02ab18bd09bc91f9cbe3df91853bc179e1e911ec2b14624a447bbfdffed228fc7b"
                           },
                           "tx_witness": [
-                            "801ea6ba45f3482e8d02a13e78db0af8274410640e92436f0151939e34fdfc582788c13a5080073dd9070fda1ff3c6b5b33bef97ef7cc0a8f00927bc59b70527"
+                            "8d340fc9d0691f5f2e3af5c03e5fb781ddcd5c0d86112e5ca8756098b09b1804460b6f228200fec8ea7f016d668a69ec69694a6c8b31df4f0c6a3a2765dfbbaf"
                           ],
                           "split_commitment": null
                         }
                       ],
                       "split_commitment_root": {
-                        "hash": "34c0bdc7fe60126cb199f155e46e00f84354c67cab3c3d339f52b9c2b422b9d8",
+                        "hash": "837487b4bed03c7ff832382c49de9e9e4d186334066bdb023008b56b76e325ef",
                         "sum": "3"
                       },
                       "script_version": 0,
-                      "script_key": "0212727730101b62db3382a384360c3e5b4c0c553b995425ce57f10284d52d3b0b",
+                      "script_key": "02ab18bd09bc91f9cbe3df91853bc179e1e911ec2b14624a447bbfdffed228fc7b",
                       "group_key": {
-                        "group_key": "02a359f7bd06079221f8d96d05352c6e8acaf3b585e47dc08ffd877eaf262ca5e5"
+                        "group_key": "0225f784ed4c019043b53378437981526beec8a8dd0df58ff29b9be57bec2f87b8"
                       }
                     }
                   }
@@ -435,9 +497,9 @@
               ],
               "split_commitment_root": null,
               "script_version": 0,
-              "script_key": "02c70a2d41363605f378db363e6b3be6f04dd10a3b6eabfc24234fbaa0e6ef41f1",
+              "script_key": "024c7d4b4dd143f1a1dd554ab1ca04fb844431e09252c42195943e7f6335de7292",
               "group_key": {
-                "group_key": "02a359f7bd06079221f8d96d05352c6e8acaf3b585e47dc08ffd877eaf262ca5e5"
+                "group_key": "0225f784ed4c019043b53378437981526beec8a8dd0df58ff29b9be57bec2f87b8"
               }
             },
             "output_index": 1
@@ -446,17 +508,17 @@
         {
           "key": {
             "output_index": 2,
-            "asset_id": "b26a1d1e24015ae0a7036fb6af252d5100a304d7b1e261992a653e37b250c80f",
-            "script_key": "03c768175b26ac6503c4279427a20222d8af8c7fdc9337df1635255923bfa0ceef",
+            "asset_id": "7215055fc2aa585a2ae05beefc557a29c78551d3ef9d9c321d904bc711ba3d86",
+            "script_key": "0293a21538e1536021c43784edcaf324d92a20f3e995f1bc3cf10221ac51e21c1b",
             "amount": 1
           },
           "value": {
             "asset": {
               "version": 0,
-              "genesis_first_prev_out": "a644db2122649be16159cdf006e7309f035b88ab7f55666529f9370ff59da1d7:1571125468",
-              "genesis_tag": "da6745fba6a04c5c37c7ca35036f11732ce8bc27b48868611fc73c82a491bfab",
-              "genesis_meta_hash": "da6745fba6a04c5c37c7ca35036f11732ce8bc27b48868611fc73c82a491bfab",
-              "genesis_output_index": 2578299031,
+              "genesis_first_prev_out": "eaf52f276ebcbc40db544d2be2e904567a08fb7edb1a334f801bb1d81d09f54b:2648659725",
+              "genesis_tag": "93b2aed55b7d44b5b054f3f38e788e4fdf36e591568c41d1052cad0fcb68ca4c",
+              "genesis_meta_hash": "93b2aed55b7d44b5b054f3f38e788e4fdf36e591568c41d1052cad0fcb68ca4c",
+              "genesis_output_index": 1280700505,
               "genesis_type": 0,
               "amount": 1,
               "lock_time": 0,
@@ -470,13 +532,13 @@
                   },
                   "tx_witness": null,
                   "split_commitment": {
-                    "proof": "00011d435179b7a1c926d383e47879e5679b7403acbf175f3d46e07e955c566101160000000000000002ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7f",
+                    "proof": "0001b5e503fa1471ef96b20e74c5623db9696f65076fa0ff7b1dfdf66c55a1c90ff60000000000000002ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7f",
                     "root_asset": {
                       "version": 0,
-                      "genesis_first_prev_out": "a644db2122649be16159cdf006e7309f035b88ab7f55666529f9370ff59da1d7:1571125468",
-                      "genesis_tag": "da6745fba6a04c5c37c7ca35036f11732ce8bc27b48868611fc73c82a491bfab",
-                      "genesis_meta_hash": "da6745fba6a04c5c37c7ca35036f11732ce8bc27b48868611fc73c82a491bfab",
-                      "genesis_output_index": 2578299031,
+                      "genesis_first_prev_out": "eaf52f276ebcbc40db544d2be2e904567a08fb7edb1a334f801bb1d81d09f54b:2648659725",
+                      "genesis_tag": "93b2aed55b7d44b5b054f3f38e788e4fdf36e591568c41d1052cad0fcb68ca4c",
+                      "genesis_meta_hash": "93b2aed55b7d44b5b054f3f38e788e4fdf36e591568c41d1052cad0fcb68ca4c",
+                      "genesis_output_index": 1280700505,
                       "genesis_type": 0,
                       "amount": 1,
                       "lock_time": 0,
@@ -485,23 +547,23 @@
                         {
                           "prev_id": {
                             "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
-                            "asset_id": "b26a1d1e24015ae0a7036fb6af252d5100a304d7b1e261992a653e37b250c80f",
-                            "script_key": "0212727730101b62db3382a384360c3e5b4c0c553b995425ce57f10284d52d3b0b"
+                            "asset_id": "7215055fc2aa585a2ae05beefc557a29c78551d3ef9d9c321d904bc711ba3d86",
+                            "script_key": "02ab18bd09bc91f9cbe3df91853bc179e1e911ec2b14624a447bbfdffed228fc7b"
                           },
                           "tx_witness": [
-                            "801ea6ba45f3482e8d02a13e78db0af8274410640e92436f0151939e34fdfc582788c13a5080073dd9070fda1ff3c6b5b33bef97ef7cc0a8f00927bc59b70527"
+                            "8d340fc9d0691f5f2e3af5c03e5fb781ddcd5c0d86112e5ca8756098b09b1804460b6f228200fec8ea7f016d668a69ec69694a6c8b31df4f0c6a3a2765dfbbaf"
                           ],
                           "split_commitment": null
                         }
                       ],
                       "split_commitment_root": {
-                        "hash": "34c0bdc7fe60126cb199f155e46e00f84354c67cab3c3d339f52b9c2b422b9d8",
+                        "hash": "837487b4bed03c7ff832382c49de9e9e4d186334066bdb023008b56b76e325ef",
                         "sum": "3"
                       },
                       "script_version": 0,
-                      "script_key": "0212727730101b62db3382a384360c3e5b4c0c553b995425ce57f10284d52d3b0b",
+                      "script_key": "02ab18bd09bc91f9cbe3df91853bc179e1e911ec2b14624a447bbfdffed228fc7b",
                       "group_key": {
-                        "group_key": "02a359f7bd06079221f8d96d05352c6e8acaf3b585e47dc08ffd877eaf262ca5e5"
+                        "group_key": "0225f784ed4c019043b53378437981526beec8a8dd0df58ff29b9be57bec2f87b8"
                       }
                     }
                   }
@@ -509,9 +571,9 @@
               ],
               "split_commitment_root": null,
               "script_version": 0,
-              "script_key": "02c768175b26ac6503c4279427a20222d8af8c7fdc9337df1635255923bfa0ceef",
+              "script_key": "0293a21538e1536021c43784edcaf324d92a20f3e995f1bc3cf10221ac51e21c1b",
               "group_key": {
-                "group_key": "02a359f7bd06079221f8d96d05352c6e8acaf3b585e47dc08ffd877eaf262ca5e5"
+                "group_key": "0225f784ed4c019043b53378437981526beec8a8dd0df58ff29b9be57bec2f87b8"
               }
             },
             "output_index": 2
@@ -522,15 +584,15 @@
         {
           "prev_id": {
             "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
-            "asset_id": "b26a1d1e24015ae0a7036fb6af252d5100a304d7b1e261992a653e37b250c80f",
-            "script_key": "0212727730101b62db3382a384360c3e5b4c0c553b995425ce57f10284d52d3b0b"
+            "asset_id": "7215055fc2aa585a2ae05beefc557a29c78551d3ef9d9c321d904bc711ba3d86",
+            "script_key": "02ab18bd09bc91f9cbe3df91853bc179e1e911ec2b14624a447bbfdffed228fc7b"
           },
           "asset": {
             "version": 1,
-            "genesis_first_prev_out": "a644db2122649be16159cdf006e7309f035b88ab7f55666529f9370ff59da1d7:1571125468",
-            "genesis_tag": "da6745fba6a04c5c37c7ca35036f11732ce8bc27b48868611fc73c82a491bfab",
-            "genesis_meta_hash": "da6745fba6a04c5c37c7ca35036f11732ce8bc27b48868611fc73c82a491bfab",
-            "genesis_output_index": 2578299031,
+            "genesis_first_prev_out": "eaf52f276ebcbc40db544d2be2e904567a08fb7edb1a334f801bb1d81d09f54b:2648659725",
+            "genesis_tag": "93b2aed55b7d44b5b054f3f38e788e4fdf36e591568c41d1052cad0fcb68ca4c",
+            "genesis_meta_hash": "93b2aed55b7d44b5b054f3f38e788e4fdf36e591568c41d1052cad0fcb68ca4c",
+            "genesis_output_index": 1280700505,
             "genesis_type": 0,
             "amount": 3,
             "lock_time": 0,
@@ -548,9 +610,9 @@
             ],
             "split_commitment_root": null,
             "script_version": 0,
-            "script_key": "0212727730101b62db3382a384360c3e5b4c0c553b995425ce57f10284d52d3b0b",
+            "script_key": "02ab18bd09bc91f9cbe3df91853bc179e1e911ec2b14624a447bbfdffed228fc7b",
             "group_key": {
-              "group_key": "02a359f7bd06079221f8d96d05352c6e8acaf3b585e47dc08ffd877eaf262ca5e5"
+              "group_key": "0225f784ed4c019043b53378437981526beec8a8dd0df58ff29b9be57bec2f87b8"
             }
           }
         }
@@ -560,10 +622,10 @@
     {
       "asset": {
         "version": 0,
-        "genesis_first_prev_out": "a3e133383c18aca7775a5d96389b7f4de6089b2f436dc4f1950e929d89d34bc3:4267000691",
-        "genesis_tag": "d5a30dcca6e3aa2df04715d879279a96879a4f3690ac2025a60c7db15e0501eb",
-        "genesis_meta_hash": "d5a30dcca6e3aa2df04715d879279a96879a4f3690ac2025a60c7db15e0501eb",
-        "genesis_output_index": 788624889,
+        "genesis_first_prev_out": "a1a1e73548d41ce747221f59ab8439abb31b6529231f9da00312c3f6a02d3510:3114316200",
+        "genesis_tag": "7b805a072512a5e4cd274b7fd1fa23f830058208ff1a063b41039c74036b5b3d",
+        "genesis_meta_hash": "7b805a072512a5e4cd274b7fd1fa23f830058208ff1a063b41039c74036b5b3d",
+        "genesis_output_index": 4188993429,
         "genesis_type": 0,
         "amount": 0,
         "lock_time": 0,
@@ -572,40 +634,40 @@
           {
             "prev_id": {
               "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
-              "asset_id": "bea0cf68c9aed451bda14c4bb8e1805e0edfc2da182042e1b89e4c1d570fe453",
-              "script_key": "0257d433a93e96f30cf63c16e87094592152282695f47ae0393d56711234256a36"
+              "asset_id": "972bc026e4119244a7bf13aefb50b5408b68f5e4aaf4464d475bdb6f8fc1c27d",
+              "script_key": "026842347208033daff488ab98459bb8d84200f27b84895a67eb10ddcc45825842"
             },
             "tx_witness": [
-              "04a9c68848bf8abbcb191039a227757c807eebf4d71d97b380390b374818a2af9b66a6715cc0dd14dd4b0ebb0562bc536c3d29c164b55b9c4dcf69c6746517ad"
+              "84f827516d171de988dbd77fee535bd8ebbbb28e6ac04afc398b4efc1a1c9b67ffef71de6fa1cb0e39962096fa5aad40d8cfed3a4cf4ded1358030ff3bc8e751"
             ],
             "split_commitment": null
           }
         ],
         "split_commitment_root": {
-          "hash": "027ecffbf568d9af11d71632bc985bbf84ecb0296471ae4a59c23e30b2dc5007",
+          "hash": "c64129ac58db281e1da245dc7157aa0bbad2c0b92228dcbc118cbe971c0bb7d6",
           "sum": "3"
         },
         "script_version": 0,
         "script_key": "027c79b9b26e463895eef5679d8558942c86c4ad2233adef01bc3e6d540b3653fe",
         "group_key": {
-          "group_key": "0392b1c3484e017b01f33f8df5b0b23489890e64f47a921bd36db1922675cf8b73"
+          "group_key": "030ef243d558a74b21b0df3bcb0ecadb2e29d3b3ddaa32cc62a571e559bd44093a"
         }
       },
       "split_set": [
         {
           "key": {
             "output_index": 0,
-            "asset_id": "bea0cf68c9aed451bda14c4bb8e1805e0edfc2da182042e1b89e4c1d570fe453",
+            "asset_id": "972bc026e4119244a7bf13aefb50b5408b68f5e4aaf4464d475bdb6f8fc1c27d",
             "script_key": "027c79b9b26e463895eef5679d8558942c86c4ad2233adef01bc3e6d540b3653fe",
             "amount": 0
           },
           "value": {
             "asset": {
               "version": 0,
-              "genesis_first_prev_out": "a3e133383c18aca7775a5d96389b7f4de6089b2f436dc4f1950e929d89d34bc3:4267000691",
-              "genesis_tag": "d5a30dcca6e3aa2df04715d879279a96879a4f3690ac2025a60c7db15e0501eb",
-              "genesis_meta_hash": "d5a30dcca6e3aa2df04715d879279a96879a4f3690ac2025a60c7db15e0501eb",
-              "genesis_output_index": 788624889,
+              "genesis_first_prev_out": "a1a1e73548d41ce747221f59ab8439abb31b6529231f9da00312c3f6a02d3510:3114316200",
+              "genesis_tag": "7b805a072512a5e4cd274b7fd1fa23f830058208ff1a063b41039c74036b5b3d",
+              "genesis_meta_hash": "7b805a072512a5e4cd274b7fd1fa23f830058208ff1a063b41039c74036b5b3d",
+              "genesis_output_index": 4188993429,
               "genesis_type": 0,
               "amount": 0,
               "lock_time": 0,
@@ -619,13 +681,13 @@
                   },
                   "tx_witness": null,
                   "split_commitment": {
-                    "proof": "000101fc69d2f98ada742f14894525461af9a0c04ea48425434eca3a1c3229ccffa30000000000000003ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffdf",
+                    "proof": "00014358c4ad92d151aa79ea545cca5bdefaf1e672d4aff4133ec43a90fe30e050830000000000000003ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7f",
                     "root_asset": {
                       "version": 0,
-                      "genesis_first_prev_out": "a3e133383c18aca7775a5d96389b7f4de6089b2f436dc4f1950e929d89d34bc3:4267000691",
-                      "genesis_tag": "d5a30dcca6e3aa2df04715d879279a96879a4f3690ac2025a60c7db15e0501eb",
-                      "genesis_meta_hash": "d5a30dcca6e3aa2df04715d879279a96879a4f3690ac2025a60c7db15e0501eb",
-                      "genesis_output_index": 788624889,
+                      "genesis_first_prev_out": "a1a1e73548d41ce747221f59ab8439abb31b6529231f9da00312c3f6a02d3510:3114316200",
+                      "genesis_tag": "7b805a072512a5e4cd274b7fd1fa23f830058208ff1a063b41039c74036b5b3d",
+                      "genesis_meta_hash": "7b805a072512a5e4cd274b7fd1fa23f830058208ff1a063b41039c74036b5b3d",
+                      "genesis_output_index": 4188993429,
                       "genesis_type": 0,
                       "amount": 0,
                       "lock_time": 0,
@@ -634,23 +696,23 @@
                         {
                           "prev_id": {
                             "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
-                            "asset_id": "bea0cf68c9aed451bda14c4bb8e1805e0edfc2da182042e1b89e4c1d570fe453",
-                            "script_key": "0257d433a93e96f30cf63c16e87094592152282695f47ae0393d56711234256a36"
+                            "asset_id": "972bc026e4119244a7bf13aefb50b5408b68f5e4aaf4464d475bdb6f8fc1c27d",
+                            "script_key": "026842347208033daff488ab98459bb8d84200f27b84895a67eb10ddcc45825842"
                           },
                           "tx_witness": [
-                            "04a9c68848bf8abbcb191039a227757c807eebf4d71d97b380390b374818a2af9b66a6715cc0dd14dd4b0ebb0562bc536c3d29c164b55b9c4dcf69c6746517ad"
+                            "84f827516d171de988dbd77fee535bd8ebbbb28e6ac04afc398b4efc1a1c9b67ffef71de6fa1cb0e39962096fa5aad40d8cfed3a4cf4ded1358030ff3bc8e751"
                           ],
                           "split_commitment": null
                         }
                       ],
                       "split_commitment_root": {
-                        "hash": "027ecffbf568d9af11d71632bc985bbf84ecb0296471ae4a59c23e30b2dc5007",
+                        "hash": "c64129ac58db281e1da245dc7157aa0bbad2c0b92228dcbc118cbe971c0bb7d6",
                         "sum": "3"
                       },
                       "script_version": 0,
                       "script_key": "027c79b9b26e463895eef5679d8558942c86c4ad2233adef01bc3e6d540b3653fe",
                       "group_key": {
-                        "group_key": "0392b1c3484e017b01f33f8df5b0b23489890e64f47a921bd36db1922675cf8b73"
+                        "group_key": "030ef243d558a74b21b0df3bcb0ecadb2e29d3b3ddaa32cc62a571e559bd44093a"
                       }
                     }
                   }
@@ -660,7 +722,7 @@
               "script_version": 0,
               "script_key": "027c79b9b26e463895eef5679d8558942c86c4ad2233adef01bc3e6d540b3653fe",
               "group_key": {
-                "group_key": "0392b1c3484e017b01f33f8df5b0b23489890e64f47a921bd36db1922675cf8b73"
+                "group_key": "030ef243d558a74b21b0df3bcb0ecadb2e29d3b3ddaa32cc62a571e559bd44093a"
               }
             },
             "output_index": 0
@@ -669,17 +731,17 @@
         {
           "key": {
             "output_index": 1,
-            "asset_id": "bea0cf68c9aed451bda14c4bb8e1805e0edfc2da182042e1b89e4c1d570fe453",
-            "script_key": "02d84661bbf04e7e7829f5f924a467fac8ca07af7e2466a64485ee1bf2af331fc7",
+            "asset_id": "972bc026e4119244a7bf13aefb50b5408b68f5e4aaf4464d475bdb6f8fc1c27d",
+            "script_key": "0370c639fdd9485451a0f9d45c11bca1df48642786bbbed843b5f08bbd8e4d8ae0",
             "amount": 3
           },
           "value": {
             "asset": {
               "version": 0,
-              "genesis_first_prev_out": "a3e133383c18aca7775a5d96389b7f4de6089b2f436dc4f1950e929d89d34bc3:4267000691",
-              "genesis_tag": "d5a30dcca6e3aa2df04715d879279a96879a4f3690ac2025a60c7db15e0501eb",
-              "genesis_meta_hash": "d5a30dcca6e3aa2df04715d879279a96879a4f3690ac2025a60c7db15e0501eb",
-              "genesis_output_index": 788624889,
+              "genesis_first_prev_out": "a1a1e73548d41ce747221f59ab8439abb31b6529231f9da00312c3f6a02d3510:3114316200",
+              "genesis_tag": "7b805a072512a5e4cd274b7fd1fa23f830058208ff1a063b41039c74036b5b3d",
+              "genesis_meta_hash": "7b805a072512a5e4cd274b7fd1fa23f830058208ff1a063b41039c74036b5b3d",
+              "genesis_output_index": 4188993429,
               "genesis_type": 0,
               "amount": 3,
               "lock_time": 0,
@@ -693,13 +755,13 @@
                   },
                   "tx_witness": null,
                   "split_commitment": {
-                    "proof": "000164476dbfcedf40e6035a1c3daa680729bcac7fd01cc675678735ade1b77d29aa0000000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffdf",
+                    "proof": "000191c8c4757dd7b0e8b148263b107bd8965d5b48aa317576313e0a0c5996a0d8950000000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7f",
                     "root_asset": {
                       "version": 0,
-                      "genesis_first_prev_out": "a3e133383c18aca7775a5d96389b7f4de6089b2f436dc4f1950e929d89d34bc3:4267000691",
-                      "genesis_tag": "d5a30dcca6e3aa2df04715d879279a96879a4f3690ac2025a60c7db15e0501eb",
-                      "genesis_meta_hash": "d5a30dcca6e3aa2df04715d879279a96879a4f3690ac2025a60c7db15e0501eb",
-                      "genesis_output_index": 788624889,
+                      "genesis_first_prev_out": "a1a1e73548d41ce747221f59ab8439abb31b6529231f9da00312c3f6a02d3510:3114316200",
+                      "genesis_tag": "7b805a072512a5e4cd274b7fd1fa23f830058208ff1a063b41039c74036b5b3d",
+                      "genesis_meta_hash": "7b805a072512a5e4cd274b7fd1fa23f830058208ff1a063b41039c74036b5b3d",
+                      "genesis_output_index": 4188993429,
                       "genesis_type": 0,
                       "amount": 0,
                       "lock_time": 0,
@@ -708,23 +770,23 @@
                         {
                           "prev_id": {
                             "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
-                            "asset_id": "bea0cf68c9aed451bda14c4bb8e1805e0edfc2da182042e1b89e4c1d570fe453",
-                            "script_key": "0257d433a93e96f30cf63c16e87094592152282695f47ae0393d56711234256a36"
+                            "asset_id": "972bc026e4119244a7bf13aefb50b5408b68f5e4aaf4464d475bdb6f8fc1c27d",
+                            "script_key": "026842347208033daff488ab98459bb8d84200f27b84895a67eb10ddcc45825842"
                           },
                           "tx_witness": [
-                            "04a9c68848bf8abbcb191039a227757c807eebf4d71d97b380390b374818a2af9b66a6715cc0dd14dd4b0ebb0562bc536c3d29c164b55b9c4dcf69c6746517ad"
+                            "84f827516d171de988dbd77fee535bd8ebbbb28e6ac04afc398b4efc1a1c9b67ffef71de6fa1cb0e39962096fa5aad40d8cfed3a4cf4ded1358030ff3bc8e751"
                           ],
                           "split_commitment": null
                         }
                       ],
                       "split_commitment_root": {
-                        "hash": "027ecffbf568d9af11d71632bc985bbf84ecb0296471ae4a59c23e30b2dc5007",
+                        "hash": "c64129ac58db281e1da245dc7157aa0bbad2c0b92228dcbc118cbe971c0bb7d6",
                         "sum": "3"
                       },
                       "script_version": 0,
                       "script_key": "027c79b9b26e463895eef5679d8558942c86c4ad2233adef01bc3e6d540b3653fe",
                       "group_key": {
-                        "group_key": "0392b1c3484e017b01f33f8df5b0b23489890e64f47a921bd36db1922675cf8b73"
+                        "group_key": "030ef243d558a74b21b0df3bcb0ecadb2e29d3b3ddaa32cc62a571e559bd44093a"
                       }
                     }
                   }
@@ -732,9 +794,9 @@
               ],
               "split_commitment_root": null,
               "script_version": 0,
-              "script_key": "02d84661bbf04e7e7829f5f924a467fac8ca07af7e2466a64485ee1bf2af331fc7",
+              "script_key": "0270c639fdd9485451a0f9d45c11bca1df48642786bbbed843b5f08bbd8e4d8ae0",
               "group_key": {
-                "group_key": "0392b1c3484e017b01f33f8df5b0b23489890e64f47a921bd36db1922675cf8b73"
+                "group_key": "030ef243d558a74b21b0df3bcb0ecadb2e29d3b3ddaa32cc62a571e559bd44093a"
               }
             },
             "output_index": 1
@@ -745,15 +807,15 @@
         {
           "prev_id": {
             "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
-            "asset_id": "bea0cf68c9aed451bda14c4bb8e1805e0edfc2da182042e1b89e4c1d570fe453",
-            "script_key": "0257d433a93e96f30cf63c16e87094592152282695f47ae0393d56711234256a36"
+            "asset_id": "972bc026e4119244a7bf13aefb50b5408b68f5e4aaf4464d475bdb6f8fc1c27d",
+            "script_key": "026842347208033daff488ab98459bb8d84200f27b84895a67eb10ddcc45825842"
           },
           "asset": {
             "version": 1,
-            "genesis_first_prev_out": "a3e133383c18aca7775a5d96389b7f4de6089b2f436dc4f1950e929d89d34bc3:4267000691",
-            "genesis_tag": "d5a30dcca6e3aa2df04715d879279a96879a4f3690ac2025a60c7db15e0501eb",
-            "genesis_meta_hash": "d5a30dcca6e3aa2df04715d879279a96879a4f3690ac2025a60c7db15e0501eb",
-            "genesis_output_index": 788624889,
+            "genesis_first_prev_out": "a1a1e73548d41ce747221f59ab8439abb31b6529231f9da00312c3f6a02d3510:3114316200",
+            "genesis_tag": "7b805a072512a5e4cd274b7fd1fa23f830058208ff1a063b41039c74036b5b3d",
+            "genesis_meta_hash": "7b805a072512a5e4cd274b7fd1fa23f830058208ff1a063b41039c74036b5b3d",
+            "genesis_output_index": 4188993429,
             "genesis_type": 0,
             "amount": 3,
             "lock_time": 0,
@@ -771,9 +833,9 @@
             ],
             "split_commitment_root": null,
             "script_version": 0,
-            "script_key": "0257d433a93e96f30cf63c16e87094592152282695f47ae0393d56711234256a36",
+            "script_key": "026842347208033daff488ab98459bb8d84200f27b84895a67eb10ddcc45825842",
             "group_key": {
-              "group_key": "0392b1c3484e017b01f33f8df5b0b23489890e64f47a921bd36db1922675cf8b73"
+              "group_key": "030ef243d558a74b21b0df3bcb0ecadb2e29d3b3ddaa32cc62a571e559bd44093a"
             }
           }
         }
@@ -783,10 +845,10 @@
     {
       "asset": {
         "version": 0,
-        "genesis_first_prev_out": "c35cdf94a493708d7543a5e698ba897c46956067382511b464c0144f95107709:3683325250",
-        "genesis_tag": "746de44f3db6e3402e7873db7635516e87b33e4b412ba3df68544920f5ea27ec",
-        "genesis_meta_hash": "746de44f3db6e3402e7873db7635516e87b33e4b412ba3df68544920f5ea27ec",
-        "genesis_output_index": 1202112265,
+        "genesis_first_prev_out": "03ab48f2165ef91a08d63d68221442c1667a025b22f1597a8431737788e86ce9:3119091779",
+        "genesis_tag": "bdbf229fb25a9dca86d0ce46a278a45f5517bff2c049cc959a227dcdd3aca677",
+        "genesis_meta_hash": "bdbf229fb25a9dca86d0ce46a278a45f5517bff2c049cc959a227dcdd3aca677",
+        "genesis_output_index": 3870080487,
         "genesis_type": 1,
         "amount": 0,
         "lock_time": 0,
@@ -795,40 +857,40 @@
           {
             "prev_id": {
               "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
-              "asset_id": "b234ff862755ad8cfb0aa12c86789a532c3257650f50241db0cd147a1fbc5dbd",
-              "script_key": "02b30a2053a1f74f57367641db909e36617e47087e32c5b0fdc9dbeee12ea49347"
+              "asset_id": "a24ad0c3e9a9473164377d26a8a23a67f50c0754ce264c5c02a0b735ca90aa5c",
+              "script_key": "021d30da757e9b73f8d8f4e38a96525a73b4d502bb631c97827707530ab9e4bf43"
             },
             "tx_witness": [
-              "20cd282a9d8446f088b20cdf8ce6184fde5e7221249fd357bbb437d93915376d15ab749171531973a173f52c9a4238ba8d2489b7b455db9dc11fb8c0d927e068"
+              "8701841cf09788c7892f1ce0f1b0d336f596c1f19171ec62dd86839658311885f1b91dab6a43c760d7d904f0490f9f17f2c575b1789b2520fe78f1df23612e83"
             ],
             "split_commitment": null
           }
         ],
         "split_commitment_root": {
-          "hash": "5db2b8cbafec8408fc16527c9e65ca97fa4b12f69a2a5d7b313f526fc608e4ab",
+          "hash": "905b6f8f2005b1638314cc79920768d1da513b0231af719a73281c67b62fd353",
           "sum": "1"
         },
         "script_version": 0,
         "script_key": "027c79b9b26e463895eef5679d8558942c86c4ad2233adef01bc3e6d540b3653fe",
         "group_key": {
-          "group_key": "03bbfff5d427e719cf72b20bd7e5e97948ccc3a10674cda94435f5bb00c2921980"
+          "group_key": "03202febe066301d1da9bc2386f9e515047e8cb1e76ef4720a22b3a1be04e135bc"
         }
       },
       "split_set": [
         {
           "key": {
             "output_index": 0,
-            "asset_id": "b234ff862755ad8cfb0aa12c86789a532c3257650f50241db0cd147a1fbc5dbd",
+            "asset_id": "a24ad0c3e9a9473164377d26a8a23a67f50c0754ce264c5c02a0b735ca90aa5c",
             "script_key": "027c79b9b26e463895eef5679d8558942c86c4ad2233adef01bc3e6d540b3653fe",
             "amount": 0
           },
           "value": {
             "asset": {
               "version": 0,
-              "genesis_first_prev_out": "c35cdf94a493708d7543a5e698ba897c46956067382511b464c0144f95107709:3683325250",
-              "genesis_tag": "746de44f3db6e3402e7873db7635516e87b33e4b412ba3df68544920f5ea27ec",
-              "genesis_meta_hash": "746de44f3db6e3402e7873db7635516e87b33e4b412ba3df68544920f5ea27ec",
-              "genesis_output_index": 1202112265,
+              "genesis_first_prev_out": "03ab48f2165ef91a08d63d68221442c1667a025b22f1597a8431737788e86ce9:3119091779",
+              "genesis_tag": "bdbf229fb25a9dca86d0ce46a278a45f5517bff2c049cc959a227dcdd3aca677",
+              "genesis_meta_hash": "bdbf229fb25a9dca86d0ce46a278a45f5517bff2c049cc959a227dcdd3aca677",
+              "genesis_output_index": 3870080487,
               "genesis_type": 1,
               "amount": 0,
               "lock_time": 0,
@@ -842,13 +904,13 @@
                   },
                   "tx_witness": null,
                   "split_commitment": {
-                    "proof": "00017a2a4fa53c7f13851f367fd28f108ddf2c2b356ec5b14c3384e99b3853b3145e0000000000000001ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7f",
+                    "proof": "00010de4e79f84e97c4fb5e6c6ddb81aa4800fa081b7bed6f38b7d471d4b25ad35040000000000000001ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7f",
                     "root_asset": {
                       "version": 0,
-                      "genesis_first_prev_out": "c35cdf94a493708d7543a5e698ba897c46956067382511b464c0144f95107709:3683325250",
-                      "genesis_tag": "746de44f3db6e3402e7873db7635516e87b33e4b412ba3df68544920f5ea27ec",
-                      "genesis_meta_hash": "746de44f3db6e3402e7873db7635516e87b33e4b412ba3df68544920f5ea27ec",
-                      "genesis_output_index": 1202112265,
+                      "genesis_first_prev_out": "03ab48f2165ef91a08d63d68221442c1667a025b22f1597a8431737788e86ce9:3119091779",
+                      "genesis_tag": "bdbf229fb25a9dca86d0ce46a278a45f5517bff2c049cc959a227dcdd3aca677",
+                      "genesis_meta_hash": "bdbf229fb25a9dca86d0ce46a278a45f5517bff2c049cc959a227dcdd3aca677",
+                      "genesis_output_index": 3870080487,
                       "genesis_type": 1,
                       "amount": 0,
                       "lock_time": 0,
@@ -857,23 +919,23 @@
                         {
                           "prev_id": {
                             "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
-                            "asset_id": "b234ff862755ad8cfb0aa12c86789a532c3257650f50241db0cd147a1fbc5dbd",
-                            "script_key": "02b30a2053a1f74f57367641db909e36617e47087e32c5b0fdc9dbeee12ea49347"
+                            "asset_id": "a24ad0c3e9a9473164377d26a8a23a67f50c0754ce264c5c02a0b735ca90aa5c",
+                            "script_key": "021d30da757e9b73f8d8f4e38a96525a73b4d502bb631c97827707530ab9e4bf43"
                           },
                           "tx_witness": [
-                            "20cd282a9d8446f088b20cdf8ce6184fde5e7221249fd357bbb437d93915376d15ab749171531973a173f52c9a4238ba8d2489b7b455db9dc11fb8c0d927e068"
+                            "8701841cf09788c7892f1ce0f1b0d336f596c1f19171ec62dd86839658311885f1b91dab6a43c760d7d904f0490f9f17f2c575b1789b2520fe78f1df23612e83"
                           ],
                           "split_commitment": null
                         }
                       ],
                       "split_commitment_root": {
-                        "hash": "5db2b8cbafec8408fc16527c9e65ca97fa4b12f69a2a5d7b313f526fc608e4ab",
+                        "hash": "905b6f8f2005b1638314cc79920768d1da513b0231af719a73281c67b62fd353",
                         "sum": "1"
                       },
                       "script_version": 0,
                       "script_key": "027c79b9b26e463895eef5679d8558942c86c4ad2233adef01bc3e6d540b3653fe",
                       "group_key": {
-                        "group_key": "03bbfff5d427e719cf72b20bd7e5e97948ccc3a10674cda94435f5bb00c2921980"
+                        "group_key": "03202febe066301d1da9bc2386f9e515047e8cb1e76ef4720a22b3a1be04e135bc"
                       }
                     }
                   }
@@ -883,7 +945,7 @@
               "script_version": 0,
               "script_key": "027c79b9b26e463895eef5679d8558942c86c4ad2233adef01bc3e6d540b3653fe",
               "group_key": {
-                "group_key": "03bbfff5d427e719cf72b20bd7e5e97948ccc3a10674cda94435f5bb00c2921980"
+                "group_key": "03202febe066301d1da9bc2386f9e515047e8cb1e76ef4720a22b3a1be04e135bc"
               }
             },
             "output_index": 0
@@ -892,17 +954,17 @@
         {
           "key": {
             "output_index": 1,
-            "asset_id": "b234ff862755ad8cfb0aa12c86789a532c3257650f50241db0cd147a1fbc5dbd",
-            "script_key": "02f1f62f701caf4289b759b1fa1f179348c907a6dd06cbfc1020a32f8ecb115c7b",
+            "asset_id": "a24ad0c3e9a9473164377d26a8a23a67f50c0754ce264c5c02a0b735ca90aa5c",
+            "script_key": "0226847e0389e4aa03ba5e0bedc6e85989245f8049099ec8eaa283a49640cf3a82",
             "amount": 1
           },
           "value": {
             "asset": {
               "version": 0,
-              "genesis_first_prev_out": "c35cdf94a493708d7543a5e698ba897c46956067382511b464c0144f95107709:3683325250",
-              "genesis_tag": "746de44f3db6e3402e7873db7635516e87b33e4b412ba3df68544920f5ea27ec",
-              "genesis_meta_hash": "746de44f3db6e3402e7873db7635516e87b33e4b412ba3df68544920f5ea27ec",
-              "genesis_output_index": 1202112265,
+              "genesis_first_prev_out": "03ab48f2165ef91a08d63d68221442c1667a025b22f1597a8431737788e86ce9:3119091779",
+              "genesis_tag": "bdbf229fb25a9dca86d0ce46a278a45f5517bff2c049cc959a227dcdd3aca677",
+              "genesis_meta_hash": "bdbf229fb25a9dca86d0ce46a278a45f5517bff2c049cc959a227dcdd3aca677",
+              "genesis_output_index": 3870080487,
               "genesis_type": 1,
               "amount": 1,
               "lock_time": 0,
@@ -916,13 +978,13 @@
                   },
                   "tx_witness": null,
                   "split_commitment": {
-                    "proof": "000190ef4504f6d522e3ad14f5367d484adfc756c2fd8568d0a60930ae98e3afc3b60000000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7f",
+                    "proof": "000170bcbcce6e5f85f8b3c3e51c09e43d2895f37289dea93a38998d221f9326bc5f0000000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7f",
                     "root_asset": {
                       "version": 0,
-                      "genesis_first_prev_out": "c35cdf94a493708d7543a5e698ba897c46956067382511b464c0144f95107709:3683325250",
-                      "genesis_tag": "746de44f3db6e3402e7873db7635516e87b33e4b412ba3df68544920f5ea27ec",
-                      "genesis_meta_hash": "746de44f3db6e3402e7873db7635516e87b33e4b412ba3df68544920f5ea27ec",
-                      "genesis_output_index": 1202112265,
+                      "genesis_first_prev_out": "03ab48f2165ef91a08d63d68221442c1667a025b22f1597a8431737788e86ce9:3119091779",
+                      "genesis_tag": "bdbf229fb25a9dca86d0ce46a278a45f5517bff2c049cc959a227dcdd3aca677",
+                      "genesis_meta_hash": "bdbf229fb25a9dca86d0ce46a278a45f5517bff2c049cc959a227dcdd3aca677",
+                      "genesis_output_index": 3870080487,
                       "genesis_type": 1,
                       "amount": 0,
                       "lock_time": 0,
@@ -931,23 +993,23 @@
                         {
                           "prev_id": {
                             "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
-                            "asset_id": "b234ff862755ad8cfb0aa12c86789a532c3257650f50241db0cd147a1fbc5dbd",
-                            "script_key": "02b30a2053a1f74f57367641db909e36617e47087e32c5b0fdc9dbeee12ea49347"
+                            "asset_id": "a24ad0c3e9a9473164377d26a8a23a67f50c0754ce264c5c02a0b735ca90aa5c",
+                            "script_key": "021d30da757e9b73f8d8f4e38a96525a73b4d502bb631c97827707530ab9e4bf43"
                           },
                           "tx_witness": [
-                            "20cd282a9d8446f088b20cdf8ce6184fde5e7221249fd357bbb437d93915376d15ab749171531973a173f52c9a4238ba8d2489b7b455db9dc11fb8c0d927e068"
+                            "8701841cf09788c7892f1ce0f1b0d336f596c1f19171ec62dd86839658311885f1b91dab6a43c760d7d904f0490f9f17f2c575b1789b2520fe78f1df23612e83"
                           ],
                           "split_commitment": null
                         }
                       ],
                       "split_commitment_root": {
-                        "hash": "5db2b8cbafec8408fc16527c9e65ca97fa4b12f69a2a5d7b313f526fc608e4ab",
+                        "hash": "905b6f8f2005b1638314cc79920768d1da513b0231af719a73281c67b62fd353",
                         "sum": "1"
                       },
                       "script_version": 0,
                       "script_key": "027c79b9b26e463895eef5679d8558942c86c4ad2233adef01bc3e6d540b3653fe",
                       "group_key": {
-                        "group_key": "03bbfff5d427e719cf72b20bd7e5e97948ccc3a10674cda94435f5bb00c2921980"
+                        "group_key": "03202febe066301d1da9bc2386f9e515047e8cb1e76ef4720a22b3a1be04e135bc"
                       }
                     }
                   }
@@ -955,9 +1017,9 @@
               ],
               "split_commitment_root": null,
               "script_version": 0,
-              "script_key": "02f1f62f701caf4289b759b1fa1f179348c907a6dd06cbfc1020a32f8ecb115c7b",
+              "script_key": "0226847e0389e4aa03ba5e0bedc6e85989245f8049099ec8eaa283a49640cf3a82",
               "group_key": {
-                "group_key": "03bbfff5d427e719cf72b20bd7e5e97948ccc3a10674cda94435f5bb00c2921980"
+                "group_key": "03202febe066301d1da9bc2386f9e515047e8cb1e76ef4720a22b3a1be04e135bc"
               }
             },
             "output_index": 1
@@ -968,15 +1030,15 @@
         {
           "prev_id": {
             "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
-            "asset_id": "b234ff862755ad8cfb0aa12c86789a532c3257650f50241db0cd147a1fbc5dbd",
-            "script_key": "02b30a2053a1f74f57367641db909e36617e47087e32c5b0fdc9dbeee12ea49347"
+            "asset_id": "a24ad0c3e9a9473164377d26a8a23a67f50c0754ce264c5c02a0b735ca90aa5c",
+            "script_key": "021d30da757e9b73f8d8f4e38a96525a73b4d502bb631c97827707530ab9e4bf43"
           },
           "asset": {
-            "version": 0,
-            "genesis_first_prev_out": "c35cdf94a493708d7543a5e698ba897c46956067382511b464c0144f95107709:3683325250",
-            "genesis_tag": "746de44f3db6e3402e7873db7635516e87b33e4b412ba3df68544920f5ea27ec",
-            "genesis_meta_hash": "746de44f3db6e3402e7873db7635516e87b33e4b412ba3df68544920f5ea27ec",
-            "genesis_output_index": 1202112265,
+            "version": 1,
+            "genesis_first_prev_out": "03ab48f2165ef91a08d63d68221442c1667a025b22f1597a8431737788e86ce9:3119091779",
+            "genesis_tag": "bdbf229fb25a9dca86d0ce46a278a45f5517bff2c049cc959a227dcdd3aca677",
+            "genesis_meta_hash": "bdbf229fb25a9dca86d0ce46a278a45f5517bff2c049cc959a227dcdd3aca677",
+            "genesis_output_index": 3870080487,
             "genesis_type": 1,
             "amount": 1,
             "lock_time": 0,
@@ -994,9 +1056,9 @@
             ],
             "split_commitment_root": null,
             "script_version": 0,
-            "script_key": "02b30a2053a1f74f57367641db909e36617e47087e32c5b0fdc9dbeee12ea49347",
+            "script_key": "021d30da757e9b73f8d8f4e38a96525a73b4d502bb631c97827707530ab9e4bf43",
             "group_key": {
-              "group_key": "03bbfff5d427e719cf72b20bd7e5e97948ccc3a10674cda94435f5bb00c2921980"
+              "group_key": "03202febe066301d1da9bc2386f9e515047e8cb1e76ef4720a22b3a1be04e135bc"
             }
           }
         }

--- a/vm/testdata/vm_validation_generated_error_cases.json
+++ b/vm/testdata/vm_validation_generated_error_cases.json
@@ -4,10 +4,10 @@
     {
       "asset": {
         "version": 1,
-        "genesis_first_prev_out": "e17c02d5b55397b4926431624c583b0a7f201283b654043a6680d58fe8ba8f22:2674673580",
-        "genesis_tag": "3dbf8e7dcafc9e138647a4b44ed4bce964ed47f74aa594468ced323cb76f0d3f",
-        "genesis_meta_hash": "3dbf8e7dcafc9e138647a4b44ed4bce964ed47f74aa594468ced323cb76f0d3f",
-        "genesis_output_index": 2400003416,
+        "genesis_first_prev_out": "ab031f765a41e67230b027b7e0fc24541c3b6bd9c19e7792417fc3a82947a67e:1240912481",
+        "genesis_tag": "82caa9568e5b6fe9d8a9ddd9eb09277b92cef9046efa18500944cbe800a0b152",
+        "genesis_meta_hash": "82caa9568e5b6fe9d8a9ddd9eb09277b92cef9046efa18500944cbe800a0b152",
+        "genesis_output_index": 1154067264,
         "genesis_type": 1,
         "amount": 1,
         "lock_time": 0,
@@ -20,16 +20,16 @@
               "script_key": "000000000000000000000000000000000000000000000000000000000000000000"
             },
             "tx_witness": [
-              "5a59d223e448081749a28574d0dc646f10ae6d0ccd340e67ff19cf70de45294b4e9f03a37e3cb3820bb73407f28e3731c424ed43d5ab7041c10b1648770621b1"
+              "b3623de5e4cd170675607dcae34a492b954b760a6704887a97925df7fba3fac7f4d7ce5312fec37714f9ec3dd5e53a43838cfd8c323185961f0f126bf577f0d9"
             ],
             "split_commitment": null
           }
         ],
         "split_commitment_root": null,
         "script_version": 0,
-        "script_key": "02d68d2ed7ad27ef0c76178587dda47a7fc347abd8e4ace770089542cac06fe783",
+        "script_key": "023f72ea6b7de11b1f7e4410533fbed6c51f68e0de6dd4a0b29ca1ab188f9d68d8",
         "group_key": {
-          "group_key": "03d08f1961d1e326110a212fc9a710ce9c9007d049f315be78c6d8f436e4766e23"
+          "group_key": "02a38c0e898a695c68b893f425b73857b936fa6d1e133d8b2ef160f4e3b1c9a62a"
         }
       },
       "split_set": [],
@@ -42,10 +42,10 @@
           },
           "asset": {
             "version": 1,
-            "genesis_first_prev_out": "e17c02d5b55397b4926431624c583b0a7f201283b654043a6680d58fe8ba8f22:2674673580",
-            "genesis_tag": "3dbf8e7dcafc9e138647a4b44ed4bce964ed47f74aa594468ced323cb76f0d3f",
-            "genesis_meta_hash": "3dbf8e7dcafc9e138647a4b44ed4bce964ed47f74aa594468ced323cb76f0d3f",
-            "genesis_output_index": 2400003416,
+            "genesis_first_prev_out": "ab031f765a41e67230b027b7e0fc24541c3b6bd9c19e7792417fc3a82947a67e:1240912481",
+            "genesis_tag": "82caa9568e5b6fe9d8a9ddd9eb09277b92cef9046efa18500944cbe800a0b152",
+            "genesis_meta_hash": "82caa9568e5b6fe9d8a9ddd9eb09277b92cef9046efa18500944cbe800a0b152",
+            "genesis_output_index": 1154067264,
             "genesis_type": 1,
             "amount": 1,
             "lock_time": 0,
@@ -58,220 +58,64 @@
                   "script_key": "000000000000000000000000000000000000000000000000000000000000000000"
                 },
                 "tx_witness": [
-                  "5a59d223e448081749a28574d0dc646f10ae6d0ccd340e67ff19cf70de45294b4e9f03a37e3cb3820bb73407f28e3731c424ed43d5ab7041c10b1648770621b1"
+                  "b3623de5e4cd170675607dcae34a492b954b760a6704887a97925df7fba3fac7f4d7ce5312fec37714f9ec3dd5e53a43838cfd8c323185961f0f126bf577f0d9"
                 ],
                 "split_commitment": null
               }
             ],
             "split_commitment_root": null,
             "script_version": 0,
-            "script_key": "02d68d2ed7ad27ef0c76178587dda47a7fc347abd8e4ace770089542cac06fe783",
+            "script_key": "023f72ea6b7de11b1f7e4410533fbed6c51f68e0de6dd4a0b29ca1ab188f9d68d8",
             "group_key": {
-              "group_key": "03d08f1961d1e326110a212fc9a710ce9c9007d049f315be78c6d8f436e4766e23"
+              "group_key": "02a38c0e898a695c68b893f425b73857b936fa6d1e133d8b2ef160f4e3b1c9a62a"
             }
           }
         }
       ],
       "error": "invalid genesis state transition",
-      "comment": "invalid collectible genesis"
+      "comment": "invalid collectible group anchor"
     },
     {
       "asset": {
         "version": 0,
-        "genesis_first_prev_out": "abff4a8eb1ac99b757885ddb0efd7a84af6747c045d99121ebdd8f44c9ab40e6:527850049",
-        "genesis_tag": "7ea64729a861d2f6497a3235c37f4192779ec1d96b3b1c5424fce0b727b03072",
-        "genesis_meta_hash": "7ea64729a861d2f6497a3235c37f4192779ec1d96b3b1c5424fce0b727b03072",
-        "genesis_output_index": 2827658879,
-        "genesis_type": 0,
-        "amount": 0,
+        "genesis_first_prev_out": "0facd9f5511802781b6a22b648e604214064018153da939bb8b580c8ba3ffa8a:665237637",
+        "genesis_tag": "2f0fea1931a290220777a93143dfdcbfa68406e877073ff08834e197a4034aa4",
+        "genesis_meta_hash": "2f0fea1931a290220777a93143dfdcbfa68406e877073ff08834e197a4034aa4",
+        "genesis_output_index": 1921998668,
+        "genesis_type": 1,
+        "amount": 1,
         "lock_time": 0,
         "relative_lock_time": 0,
         "prev_witnesses": [
           {
             "prev_id": {
               "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
-              "asset_id": "65df486f36c688434ab61156e7ac785958aa51918a015bf213ae7017bdd44b6d",
-              "script_key": "02cfa0a85e956ec6abcb9537256a2c2a0f17a2a06807392d7727ce69f6b3c7b08c"
+              "asset_id": "0000000000000000000000000000000000000000000000000000000000000000",
+              "script_key": "000000000000000000000000000000000000000000000000000000000000000000"
             },
-            "tx_witness": [
-              "72d407e009f853a361d885670eac04e4ec81c6a1c3965deec7880d56118d845ee29a371eb32e27da855adfcc096286ab3ecdc324a2cdf0215ec670a17e99d051"
-            ],
+            "tx_witness": null,
             "split_commitment": null
           }
         ],
-        "split_commitment_root": {
-          "hash": "5cd89cc59083e44fb159ac1c0b4d09262716ac473dbbae8a41b792e0b20f4f1c",
-          "sum": "1"
-        },
+        "split_commitment_root": null,
         "script_version": 0,
-        "script_key": "027c79b9b26e463895eef5679d8558942c86c4ad2233adef01bc3e6d540b3653fe",
-        "group_key": {
-          "group_key": "03e07b85c5c3bd1425a4c95868f541e0b623a2469bef9a6f23c221219299f244d8"
-        }
+        "script_key": "0297198e8cd006ea177c6f4085f6418d63d16fed776a1db4fea72659698f593a00",
+        "group_key": null
       },
-      "split_set": [
-        {
-          "key": {
-            "output_index": 0,
-            "asset_id": "65df486f36c688434ab61156e7ac785958aa51918a015bf213ae7017bdd44b6d",
-            "script_key": "027c79b9b26e463895eef5679d8558942c86c4ad2233adef01bc3e6d540b3653fe",
-            "amount": 0
-          },
-          "value": {
-            "asset": {
-              "version": 0,
-              "genesis_first_prev_out": "abff4a8eb1ac99b757885ddb0efd7a84af6747c045d99121ebdd8f44c9ab40e6:527850049",
-              "genesis_tag": "7ea64729a861d2f6497a3235c37f4192779ec1d96b3b1c5424fce0b727b03072",
-              "genesis_meta_hash": "7ea64729a861d2f6497a3235c37f4192779ec1d96b3b1c5424fce0b727b03072",
-              "genesis_output_index": 2827658879,
-              "genesis_type": 1,
-              "amount": 0,
-              "lock_time": 0,
-              "relative_lock_time": 0,
-              "prev_witnesses": [
-                {
-                  "prev_id": {
-                    "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
-                    "asset_id": "0000000000000000000000000000000000000000000000000000000000000000",
-                    "script_key": "000000000000000000000000000000000000000000000000000000000000000000"
-                  },
-                  "tx_witness": null,
-                  "split_commitment": {
-                    "proof": "0001c26e59e62e28a92025ccbfab5d8ddf75a1bb6f54eec55c33decf37f17afb4d5e0000000000000001ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffbf",
-                    "root_asset": {
-                      "version": 0,
-                      "genesis_first_prev_out": "abff4a8eb1ac99b757885ddb0efd7a84af6747c045d99121ebdd8f44c9ab40e6:527850049",
-                      "genesis_tag": "7ea64729a861d2f6497a3235c37f4192779ec1d96b3b1c5424fce0b727b03072",
-                      "genesis_meta_hash": "7ea64729a861d2f6497a3235c37f4192779ec1d96b3b1c5424fce0b727b03072",
-                      "genesis_output_index": 2827658879,
-                      "genesis_type": 1,
-                      "amount": 0,
-                      "lock_time": 0,
-                      "relative_lock_time": 0,
-                      "prev_witnesses": [
-                        {
-                          "prev_id": {
-                            "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
-                            "asset_id": "65df486f36c688434ab61156e7ac785958aa51918a015bf213ae7017bdd44b6d",
-                            "script_key": "02cfa0a85e956ec6abcb9537256a2c2a0f17a2a06807392d7727ce69f6b3c7b08c"
-                          },
-                          "tx_witness": [
-                            "72d407e009f853a361d885670eac04e4ec81c6a1c3965deec7880d56118d845ee29a371eb32e27da855adfcc096286ab3ecdc324a2cdf0215ec670a17e99d051"
-                          ],
-                          "split_commitment": null
-                        }
-                      ],
-                      "split_commitment_root": {
-                        "hash": "5cd89cc59083e44fb159ac1c0b4d09262716ac473dbbae8a41b792e0b20f4f1c",
-                        "sum": "1"
-                      },
-                      "script_version": 0,
-                      "script_key": "027c79b9b26e463895eef5679d8558942c86c4ad2233adef01bc3e6d540b3653fe",
-                      "group_key": {
-                        "group_key": "03e07b85c5c3bd1425a4c95868f541e0b623a2469bef9a6f23c221219299f244d8"
-                      }
-                    }
-                  }
-                }
-              ],
-              "split_commitment_root": null,
-              "script_version": 0,
-              "script_key": "027c79b9b26e463895eef5679d8558942c86c4ad2233adef01bc3e6d540b3653fe",
-              "group_key": {
-                "group_key": "03e07b85c5c3bd1425a4c95868f541e0b623a2469bef9a6f23c221219299f244d8"
-              }
-            },
-            "output_index": 0
-          }
-        },
-        {
-          "key": {
-            "output_index": 1,
-            "asset_id": "65df486f36c688434ab61156e7ac785958aa51918a015bf213ae7017bdd44b6d",
-            "script_key": "0269ea8b776b7ab80612418f965950d663d319cf1abce0abccf9870ac7d9475559",
-            "amount": 1
-          },
-          "value": {
-            "asset": {
-              "version": 0,
-              "genesis_first_prev_out": "abff4a8eb1ac99b757885ddb0efd7a84af6747c045d99121ebdd8f44c9ab40e6:527850049",
-              "genesis_tag": "7ea64729a861d2f6497a3235c37f4192779ec1d96b3b1c5424fce0b727b03072",
-              "genesis_meta_hash": "7ea64729a861d2f6497a3235c37f4192779ec1d96b3b1c5424fce0b727b03072",
-              "genesis_output_index": 2827658879,
-              "genesis_type": 1,
-              "amount": 1,
-              "lock_time": 0,
-              "relative_lock_time": 0,
-              "prev_witnesses": [
-                {
-                  "prev_id": {
-                    "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
-                    "asset_id": "0000000000000000000000000000000000000000000000000000000000000000",
-                    "script_key": "000000000000000000000000000000000000000000000000000000000000000000"
-                  },
-                  "tx_witness": null,
-                  "split_commitment": {
-                    "proof": "0001b5ec3665a16f2f71624ccb00813b3e038193cd9e136441e2ea3c32efae61c74f0000000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffbf",
-                    "root_asset": {
-                      "version": 0,
-                      "genesis_first_prev_out": "abff4a8eb1ac99b757885ddb0efd7a84af6747c045d99121ebdd8f44c9ab40e6:527850049",
-                      "genesis_tag": "7ea64729a861d2f6497a3235c37f4192779ec1d96b3b1c5424fce0b727b03072",
-                      "genesis_meta_hash": "7ea64729a861d2f6497a3235c37f4192779ec1d96b3b1c5424fce0b727b03072",
-                      "genesis_output_index": 2827658879,
-                      "genesis_type": 1,
-                      "amount": 0,
-                      "lock_time": 0,
-                      "relative_lock_time": 0,
-                      "prev_witnesses": [
-                        {
-                          "prev_id": {
-                            "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
-                            "asset_id": "65df486f36c688434ab61156e7ac785958aa51918a015bf213ae7017bdd44b6d",
-                            "script_key": "02cfa0a85e956ec6abcb9537256a2c2a0f17a2a06807392d7727ce69f6b3c7b08c"
-                          },
-                          "tx_witness": [
-                            "72d407e009f853a361d885670eac04e4ec81c6a1c3965deec7880d56118d845ee29a371eb32e27da855adfcc096286ab3ecdc324a2cdf0215ec670a17e99d051"
-                          ],
-                          "split_commitment": null
-                        }
-                      ],
-                      "split_commitment_root": {
-                        "hash": "5cd89cc59083e44fb159ac1c0b4d09262716ac473dbbae8a41b792e0b20f4f1c",
-                        "sum": "1"
-                      },
-                      "script_version": 0,
-                      "script_key": "027c79b9b26e463895eef5679d8558942c86c4ad2233adef01bc3e6d540b3653fe",
-                      "group_key": {
-                        "group_key": "03e07b85c5c3bd1425a4c95868f541e0b623a2469bef9a6f23c221219299f244d8"
-                      }
-                    }
-                  }
-                }
-              ],
-              "split_commitment_root": null,
-              "script_version": 0,
-              "script_key": "0269ea8b776b7ab80612418f965950d663d319cf1abce0abccf9870ac7d9475559",
-              "group_key": {
-                "group_key": "03e07b85c5c3bd1425a4c95868f541e0b623a2469bef9a6f23c221219299f244d8"
-              }
-            },
-            "output_index": 1
-          }
-        }
-      ],
+      "split_set": [],
       "input_set": [
         {
           "prev_id": {
             "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
-            "asset_id": "65df486f36c688434ab61156e7ac785958aa51918a015bf213ae7017bdd44b6d",
-            "script_key": "02cfa0a85e956ec6abcb9537256a2c2a0f17a2a06807392d7727ce69f6b3c7b08c"
+            "asset_id": "0000000000000000000000000000000000000000000000000000000000000000",
+            "script_key": "000000000000000000000000000000000000000000000000000000000000000000"
           },
           "asset": {
-            "version": 1,
-            "genesis_first_prev_out": "abff4a8eb1ac99b757885ddb0efd7a84af6747c045d99121ebdd8f44c9ab40e6:527850049",
-            "genesis_tag": "7ea64729a861d2f6497a3235c37f4192779ec1d96b3b1c5424fce0b727b03072",
-            "genesis_meta_hash": "7ea64729a861d2f6497a3235c37f4192779ec1d96b3b1c5424fce0b727b03072",
-            "genesis_output_index": 2827658879,
+            "version": 0,
+            "genesis_first_prev_out": "0facd9f5511802781b6a22b648e604214064018153da939bb8b580c8ba3ffa8a:665237637",
+            "genesis_tag": "2f0fea1931a290220777a93143dfdcbfa68406e877073ff08834e197a4034aa4",
+            "genesis_meta_hash": "2f0fea1931a290220777a93143dfdcbfa68406e877073ff08834e197a4034aa4",
+            "genesis_output_index": 1921998668,
             "genesis_type": 1,
             "amount": 1,
             "lock_time": 0,
@@ -289,25 +133,23 @@
             ],
             "split_commitment_root": null,
             "script_version": 0,
-            "script_key": "02cfa0a85e956ec6abcb9537256a2c2a0f17a2a06807392d7727ce69f6b3c7b08c",
-            "group_key": {
-              "group_key": "03e07b85c5c3bd1425a4c95868f541e0b623a2469bef9a6f23c221219299f244d8"
-            }
+            "script_key": "0297198e8cd006ea177c6f4085f6418d63d16fed776a1db4fea72659698f593a00",
+            "group_key": null
           }
         }
       ],
-      "error": "invalid split asset type",
-      "comment": "invalid split collectible input"
+      "error": "invalid genesis state transition",
+      "comment": "invalid collectible genesis"
     },
     {
       "asset": {
         "version": 0,
-        "genesis_first_prev_out": "c9bf542b517f2b9a1d40367517c6beccfcba9075b05ee246c455bd0580d0564c:865175050",
-        "genesis_tag": "cde5e60c5ead6fc7ae77ba1d259b188a4b21c86fbc23d728b45347eada650af2",
-        "genesis_meta_hash": "cde5e60c5ead6fc7ae77ba1d259b188a4b21c86fbc23d728b45347eada650af2",
-        "genesis_output_index": 2905736656,
-        "genesis_type": 0,
-        "amount": 1312193189,
+        "genesis_first_prev_out": "91860a80d0564cf20a65daea4753b428d723bc6fc8214b8a189b251dba77aecd:1577903845",
+        "genesis_tag": "928a0f7de50be1a6dc1d5768e8537988fddce562e9b948c918bba3e933e5c400",
+        "genesis_meta_hash": "928a0f7de50be1a6dc1d5768e8537988fddce562e9b948c918bba3e933e5c400",
+        "genesis_output_index": 3293953285,
+        "genesis_type": 1,
+        "amount": 1,
         "lock_time": 0,
         "relative_lock_time": 0,
         "prev_witnesses": [
@@ -318,17 +160,369 @@
               "script_key": "000000000000000000000000000000000000000000000000000000000000000000"
             },
             "tx_witness": [
-              "6c53c1b89d7ad7a42c438dc62b9515e477620e759f698a09fa75adffe698a129dc3913ba1812397e45fc8178cb1533e40975df74cc68eb3c927240f078a45f4f"
+              "f01f4c59cdfeded75530bf58d6df7dee16f7b6ee7410d639284ea07bc5fd3edd5fb0cae40d19d03763209eb9d61042bb73c2178fa0631e7a467a6df46dd53134"
             ],
             "split_commitment": null
           }
         ],
         "split_commitment_root": null,
         "script_version": 0,
-        "script_key": "0244cdd6c73933c35f57259b5e569a36cca05e7b914b0c683d120d7d6416bf546d",
+        "script_key": "0299caff80c752766f57a3460b863ba93d725d5f660b9925d01be90b66be7af064",
+        "group_key": null
+      },
+      "split_set": [],
+      "input_set": [],
+      "error": "missing asset input(s)",
+      "comment": "collectible genesis invalid witness"
+    },
+    {
+      "asset": {
+        "version": 0,
+        "genesis_first_prev_out": "26ee4381075b1ccd2ab86ead7e74d4b80f63d487b8e5d22bd74362a7eb16922d:848831358",
+        "genesis_tag": "e685a591121966e031650d510354aa845580ff560760fd36514ca197c875f1d0",
+        "genesis_meta_hash": "e685a591121966e031650d510354aa845580ff560760fd36514ca197c875f1d0",
+        "genesis_output_index": 2635277229,
+        "genesis_type": 1,
+        "amount": 1,
+        "lock_time": 0,
+        "relative_lock_time": 0,
+        "prev_witnesses": [
+          {
+            "prev_id": {
+              "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
+              "asset_id": "0000000000000000000000000000000000000000000000000000000000000000",
+              "script_key": "000000000000000000000000000000000000000000000000000000000000000000"
+            },
+            "tx_witness": null,
+            "split_commitment": null
+          }
+        ],
+        "split_commitment_root": null,
+        "script_version": 0,
+        "script_key": "02b6d7c5c57cc52f95b8bdf8a828e145765c45cbf52f3a5c6ecec55aaf2a8aa81c",
         "group_key": {
-          "group_key": "0209bffc46f4e2edf4910ff1469068d41a0e84d588d02db5b9006a008a008c0dd6"
+          "group_key": "03c90ef7636738c0c0e013915b4f909bbfb969ad091c453cd36d9535c37db5e63d"
         }
+      },
+      "split_set": [],
+      "input_set": [],
+      "error": "invalid genesis state transition",
+      "comment": "collectible group anchor invalid witness"
+    },
+    {
+      "asset": {
+        "version": 0,
+        "genesis_first_prev_out": "c81caae74d2be64ed98e0fe27225c6794cbcafc208a0ac10745742f012c8d4bd:3448070931",
+        "genesis_tag": "c1dfc579b99ed9d20d573ad53171c8fef7f1f4e4613bb365b2ebb44f0ffb6907",
+        "genesis_meta_hash": "c1dfc579b99ed9d20d573ad53171c8fef7f1f4e4613bb365b2ebb44f0ffb6907",
+        "genesis_output_index": 3912334367,
+        "genesis_type": 0,
+        "amount": 0,
+        "lock_time": 0,
+        "relative_lock_time": 0,
+        "prev_witnesses": [
+          {
+            "prev_id": {
+              "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
+              "asset_id": "e0609966b92eca0713db410b458ce8094b58016b40bcaf32e29ea28dae82a6bc",
+              "script_key": "024c25fa5f861a81dc425778a9e01696795f79e1d8337fe9ead022aafdf8c373c1"
+            },
+            "tx_witness": [
+              "f21345c685804e28abbbd93131afd844ad33c14c83d931aab38cb8ef493128576496e637483656f37f9dcca8d5074259f257bc51795e1d54c86af71c37726272"
+            ],
+            "split_commitment": null
+          }
+        ],
+        "split_commitment_root": {
+          "hash": "f4809e49db0463d88d70be454feb3d93fba5479c2208ea84d04831906ace2118",
+          "sum": "1"
+        },
+        "script_version": 0,
+        "script_key": "027c79b9b26e463895eef5679d8558942c86c4ad2233adef01bc3e6d540b3653fe",
+        "group_key": {
+          "group_key": "03e4432f90617117fe6b72f30f8210950083ea641ab3e09f5db7cba78f0ddd2033"
+        }
+      },
+      "split_set": [
+        {
+          "key": {
+            "output_index": 0,
+            "asset_id": "e0609966b92eca0713db410b458ce8094b58016b40bcaf32e29ea28dae82a6bc",
+            "script_key": "027c79b9b26e463895eef5679d8558942c86c4ad2233adef01bc3e6d540b3653fe",
+            "amount": 0
+          },
+          "value": {
+            "asset": {
+              "version": 0,
+              "genesis_first_prev_out": "c81caae74d2be64ed98e0fe27225c6794cbcafc208a0ac10745742f012c8d4bd:3448070931",
+              "genesis_tag": "c1dfc579b99ed9d20d573ad53171c8fef7f1f4e4613bb365b2ebb44f0ffb6907",
+              "genesis_meta_hash": "c1dfc579b99ed9d20d573ad53171c8fef7f1f4e4613bb365b2ebb44f0ffb6907",
+              "genesis_output_index": 3912334367,
+              "genesis_type": 1,
+              "amount": 0,
+              "lock_time": 0,
+              "relative_lock_time": 0,
+              "prev_witnesses": [
+                {
+                  "prev_id": {
+                    "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
+                    "asset_id": "0000000000000000000000000000000000000000000000000000000000000000",
+                    "script_key": "000000000000000000000000000000000000000000000000000000000000000000"
+                  },
+                  "tx_witness": null,
+                  "split_commitment": {
+                    "proof": "0001d9dd564a9b575931b9d46f769d64f9d25b39d556511d9cc3998ca7b66b7213bd0000000000000001ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffbf",
+                    "root_asset": {
+                      "version": 0,
+                      "genesis_first_prev_out": "c81caae74d2be64ed98e0fe27225c6794cbcafc208a0ac10745742f012c8d4bd:3448070931",
+                      "genesis_tag": "c1dfc579b99ed9d20d573ad53171c8fef7f1f4e4613bb365b2ebb44f0ffb6907",
+                      "genesis_meta_hash": "c1dfc579b99ed9d20d573ad53171c8fef7f1f4e4613bb365b2ebb44f0ffb6907",
+                      "genesis_output_index": 3912334367,
+                      "genesis_type": 1,
+                      "amount": 0,
+                      "lock_time": 0,
+                      "relative_lock_time": 0,
+                      "prev_witnesses": [
+                        {
+                          "prev_id": {
+                            "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
+                            "asset_id": "e0609966b92eca0713db410b458ce8094b58016b40bcaf32e29ea28dae82a6bc",
+                            "script_key": "024c25fa5f861a81dc425778a9e01696795f79e1d8337fe9ead022aafdf8c373c1"
+                          },
+                          "tx_witness": [
+                            "f21345c685804e28abbbd93131afd844ad33c14c83d931aab38cb8ef493128576496e637483656f37f9dcca8d5074259f257bc51795e1d54c86af71c37726272"
+                          ],
+                          "split_commitment": null
+                        }
+                      ],
+                      "split_commitment_root": {
+                        "hash": "f4809e49db0463d88d70be454feb3d93fba5479c2208ea84d04831906ace2118",
+                        "sum": "1"
+                      },
+                      "script_version": 0,
+                      "script_key": "027c79b9b26e463895eef5679d8558942c86c4ad2233adef01bc3e6d540b3653fe",
+                      "group_key": {
+                        "group_key": "03e4432f90617117fe6b72f30f8210950083ea641ab3e09f5db7cba78f0ddd2033"
+                      }
+                    }
+                  }
+                }
+              ],
+              "split_commitment_root": null,
+              "script_version": 0,
+              "script_key": "027c79b9b26e463895eef5679d8558942c86c4ad2233adef01bc3e6d540b3653fe",
+              "group_key": {
+                "group_key": "03e4432f90617117fe6b72f30f8210950083ea641ab3e09f5db7cba78f0ddd2033"
+              }
+            },
+            "output_index": 0
+          }
+        },
+        {
+          "key": {
+            "output_index": 1,
+            "asset_id": "e0609966b92eca0713db410b458ce8094b58016b40bcaf32e29ea28dae82a6bc",
+            "script_key": "028ca46fc7785880fa367fb497fc53b0aded01b9929f3845483ac2d5b5efdb520f",
+            "amount": 1
+          },
+          "value": {
+            "asset": {
+              "version": 0,
+              "genesis_first_prev_out": "c81caae74d2be64ed98e0fe27225c6794cbcafc208a0ac10745742f012c8d4bd:3448070931",
+              "genesis_tag": "c1dfc579b99ed9d20d573ad53171c8fef7f1f4e4613bb365b2ebb44f0ffb6907",
+              "genesis_meta_hash": "c1dfc579b99ed9d20d573ad53171c8fef7f1f4e4613bb365b2ebb44f0ffb6907",
+              "genesis_output_index": 3912334367,
+              "genesis_type": 1,
+              "amount": 1,
+              "lock_time": 0,
+              "relative_lock_time": 0,
+              "prev_witnesses": [
+                {
+                  "prev_id": {
+                    "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
+                    "asset_id": "0000000000000000000000000000000000000000000000000000000000000000",
+                    "script_key": "000000000000000000000000000000000000000000000000000000000000000000"
+                  },
+                  "tx_witness": null,
+                  "split_commitment": {
+                    "proof": "000199bfb17a3ed908ab789b4d531a0058b18994b8d3cb15d8f0073147e274d81f930000000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffbf",
+                    "root_asset": {
+                      "version": 0,
+                      "genesis_first_prev_out": "c81caae74d2be64ed98e0fe27225c6794cbcafc208a0ac10745742f012c8d4bd:3448070931",
+                      "genesis_tag": "c1dfc579b99ed9d20d573ad53171c8fef7f1f4e4613bb365b2ebb44f0ffb6907",
+                      "genesis_meta_hash": "c1dfc579b99ed9d20d573ad53171c8fef7f1f4e4613bb365b2ebb44f0ffb6907",
+                      "genesis_output_index": 3912334367,
+                      "genesis_type": 1,
+                      "amount": 0,
+                      "lock_time": 0,
+                      "relative_lock_time": 0,
+                      "prev_witnesses": [
+                        {
+                          "prev_id": {
+                            "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
+                            "asset_id": "e0609966b92eca0713db410b458ce8094b58016b40bcaf32e29ea28dae82a6bc",
+                            "script_key": "024c25fa5f861a81dc425778a9e01696795f79e1d8337fe9ead022aafdf8c373c1"
+                          },
+                          "tx_witness": [
+                            "f21345c685804e28abbbd93131afd844ad33c14c83d931aab38cb8ef493128576496e637483656f37f9dcca8d5074259f257bc51795e1d54c86af71c37726272"
+                          ],
+                          "split_commitment": null
+                        }
+                      ],
+                      "split_commitment_root": {
+                        "hash": "f4809e49db0463d88d70be454feb3d93fba5479c2208ea84d04831906ace2118",
+                        "sum": "1"
+                      },
+                      "script_version": 0,
+                      "script_key": "027c79b9b26e463895eef5679d8558942c86c4ad2233adef01bc3e6d540b3653fe",
+                      "group_key": {
+                        "group_key": "03e4432f90617117fe6b72f30f8210950083ea641ab3e09f5db7cba78f0ddd2033"
+                      }
+                    }
+                  }
+                }
+              ],
+              "split_commitment_root": null,
+              "script_version": 0,
+              "script_key": "028ca46fc7785880fa367fb497fc53b0aded01b9929f3845483ac2d5b5efdb520f",
+              "group_key": {
+                "group_key": "03e4432f90617117fe6b72f30f8210950083ea641ab3e09f5db7cba78f0ddd2033"
+              }
+            },
+            "output_index": 1
+          }
+        }
+      ],
+      "input_set": [
+        {
+          "prev_id": {
+            "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
+            "asset_id": "e0609966b92eca0713db410b458ce8094b58016b40bcaf32e29ea28dae82a6bc",
+            "script_key": "024c25fa5f861a81dc425778a9e01696795f79e1d8337fe9ead022aafdf8c373c1"
+          },
+          "asset": {
+            "version": 0,
+            "genesis_first_prev_out": "c81caae74d2be64ed98e0fe27225c6794cbcafc208a0ac10745742f012c8d4bd:3448070931",
+            "genesis_tag": "c1dfc579b99ed9d20d573ad53171c8fef7f1f4e4613bb365b2ebb44f0ffb6907",
+            "genesis_meta_hash": "c1dfc579b99ed9d20d573ad53171c8fef7f1f4e4613bb365b2ebb44f0ffb6907",
+            "genesis_output_index": 3912334367,
+            "genesis_type": 1,
+            "amount": 1,
+            "lock_time": 0,
+            "relative_lock_time": 0,
+            "prev_witnesses": [
+              {
+                "prev_id": {
+                  "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
+                  "asset_id": "0000000000000000000000000000000000000000000000000000000000000000",
+                  "script_key": "000000000000000000000000000000000000000000000000000000000000000000"
+                },
+                "tx_witness": null,
+                "split_commitment": null
+              }
+            ],
+            "split_commitment_root": null,
+            "script_version": 0,
+            "script_key": "024c25fa5f861a81dc425778a9e01696795f79e1d8337fe9ead022aafdf8c373c1",
+            "group_key": {
+              "group_key": "03e4432f90617117fe6b72f30f8210950083ea641ab3e09f5db7cba78f0ddd2033"
+            }
+          }
+        }
+      ],
+      "error": "invalid split asset type",
+      "comment": "invalid split collectible input"
+    },
+    {
+      "asset": {
+        "version": 0,
+        "genesis_first_prev_out": "ff40d60c16baaa7cd182ec2d5fb458914041eeeaf601289223be14ff09ef3c48:4220064236",
+        "genesis_tag": "cd5961e19b642221db44a69497b8ad99408fe1e037c68bf7c5e5de1d2c681923",
+        "genesis_meta_hash": "cd5961e19b642221db44a69497b8ad99408fe1e037c68bf7c5e5de1d2c681923",
+        "genesis_output_index": 551640224,
+        "genesis_type": 0,
+        "amount": 2226950966,
+        "lock_time": 0,
+        "relative_lock_time": 0,
+        "prev_witnesses": [
+          {
+            "prev_id": {
+              "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
+              "asset_id": "0000000000000000000000000000000000000000000000000000000000000000",
+              "script_key": "000000000000000000000000000000000000000000000000000000000000000000"
+            },
+            "tx_witness": [
+              "dbeed8abf7eaf5b28f5440d0a6567a34d6e0e9a3d036311eb163c8c57c4445597ec08228b059d5cbfcf493ccd7310173b76a17c28d895c1d8b00b422074041d4"
+            ],
+            "split_commitment": null
+          }
+        ],
+        "split_commitment_root": null,
+        "script_version": 0,
+        "script_key": "022456f3a2664798a909fb245c3418cbdbc9b49d9a042950c0055eefb47d0aebe8",
+        "group_key": {
+          "group_key": "02d687a71acd8bddf4a0cde0380eea89a4cab74831ac91e14b321a1e83d43a7deb"
+        }
+      },
+      "split_set": [
+        {
+          "key": {
+            "output_index": 0,
+            "asset_id": "0000000000000000000000000000000000000000000000000000000000000000",
+            "script_key": "000000000000000000000000000000000000000000000000000000000000000000",
+            "amount": 0
+          },
+          "value": {
+            "asset": {
+              "version": 0,
+              "genesis_first_prev_out": "0000000000000000000000000000000000000000000000000000000000000000:0",
+              "genesis_tag": "",
+              "genesis_meta_hash": "0000000000000000000000000000000000000000000000000000000000000000",
+              "genesis_output_index": 0,
+              "genesis_type": 0,
+              "amount": 0,
+              "lock_time": 0,
+              "relative_lock_time": 0,
+              "prev_witnesses": null,
+              "split_commitment_root": null,
+              "script_version": 0,
+              "script_key": "",
+              "group_key": null
+            },
+            "output_index": 0
+          }
+        }
+      ],
+      "input_set": [],
+      "error": "invalid genesis state transition",
+      "comment": "invalid normal group anchor"
+    },
+    {
+      "asset": {
+        "version": 0,
+        "genesis_first_prev_out": "3c18aca7775a5d96389b7f4de6089b2f436dc4f1950e929d89d34bc3eb01055e:4267000691",
+        "genesis_tag": "13032a0bd5a30dcca6e3aa2df04715d879279a96879a4f3690ac2025a60c7db1",
+        "genesis_meta_hash": "13032a0bd5a30dcca6e3aa2df04715d879279a96879a4f3690ac2025a60c7db1",
+        "genesis_output_index": 1581425633,
+        "genesis_type": 0,
+        "amount": 3546960119,
+        "lock_time": 0,
+        "relative_lock_time": 0,
+        "prev_witnesses": [
+          {
+            "prev_id": {
+              "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
+              "asset_id": "0000000000000000000000000000000000000000000000000000000000000000",
+              "script_key": "000000000000000000000000000000000000000000000000000000000000000000"
+            },
+            "tx_witness": null,
+            "split_commitment": null
+          }
+        ],
+        "split_commitment_root": null,
+        "script_version": 0,
+        "script_key": "024dd0df00f2b494dc1ef9045ec850077a4704d218ec27e65617e0293cf4ca6e9a",
+        "group_key": null
       },
       "split_set": [
         {
@@ -366,10 +560,78 @@
     {
       "asset": {
         "version": 0,
-        "genesis_first_prev_out": "65fe5efb9ee48816ae54ddc325f8199dbfe353b9520118cc7166a839877df9b9:311845380",
-        "genesis_tag": "c35dd93515cefe0b002cee5e71c47935e281ebfc4b8b652b69ccb092e55a20f1",
-        "genesis_meta_hash": "c35dd93515cefe0b002cee5e71c47935e281ebfc4b8b652b69ccb092e55a20f1",
-        "genesis_output_index": 2356940289,
+        "genesis_first_prev_out": "7df9b9f1205ae592b0cc692b658b4bfceb81e23579c4715eee2c000b9c34adec:903437763",
+        "genesis_tag": "49a3d38540dc222969120ce80f2007cd42a708a721aa29987b45d4e428811984",
+        "genesis_meta_hash": "49a3d38540dc222969120ce80f2007cd42a708a721aa29987b45d4e428811984",
+        "genesis_output_index": 311845380,
+        "genesis_type": 0,
+        "amount": 2356940290,
+        "lock_time": 0,
+        "relative_lock_time": 0,
+        "prev_witnesses": [
+          {
+            "prev_id": {
+              "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
+              "asset_id": "0000000000000000000000000000000000000000000000000000000000000000",
+              "script_key": "000000000000000000000000000000000000000000000000000000000000000000"
+            },
+            "tx_witness": [
+              "bb9ad2c16ebbd7edbc41c7dc722d420784239f07ace344460f2fa823a4af938b5359c1b8167b3ad9e34e3abce80a13daa28176e6ab8c40e2502dbafb672d4fa7"
+            ],
+            "split_commitment": null
+          }
+        ],
+        "split_commitment_root": null,
+        "script_version": 0,
+        "script_key": "02bca0e389f046eb0e4a2292f35784336a0e579091bae236d27fb7097616c7eb22",
+        "group_key": null
+      },
+      "split_set": [],
+      "input_set": [],
+      "error": "missing asset input(s)",
+      "comment": "normal genesis invalid witness"
+    },
+    {
+      "asset": {
+        "version": 1,
+        "genesis_first_prev_out": "00efcc20aeaed4e9a843a70d56c818d73dc58438baf202fd5dff976108fa3463:3046907851",
+        "genesis_tag": "0027368b34f9c69776b4591532da1c5be68ef4eebe8cb8fa7dc5483fb70c2c89",
+        "genesis_meta_hash": "0027368b34f9c69776b4591532da1c5be68ef4eebe8cb8fa7dc5483fb70c2c89",
+        "genesis_output_index": 4074289298,
+        "genesis_type": 0,
+        "amount": 2112046729,
+        "lock_time": 0,
+        "relative_lock_time": 0,
+        "prev_witnesses": [
+          {
+            "prev_id": {
+              "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
+              "asset_id": "0000000000000000000000000000000000000000000000000000000000000000",
+              "script_key": "000000000000000000000000000000000000000000000000000000000000000000"
+            },
+            "tx_witness": null,
+            "split_commitment": null
+          }
+        ],
+        "split_commitment_root": null,
+        "script_version": 0,
+        "script_key": "02ce315fa9a3926f16f41bd8268750ffac43296ca9065530670ede3bba8781d45c",
+        "group_key": {
+          "group_key": "03737f6e29bdf44fd8162f0e92d74ad9b09e5e79c1e300b5e072fb14423cd41ddc"
+        }
+      },
+      "split_set": [],
+      "input_set": [],
+      "error": "invalid genesis state transition",
+      "comment": "normal group anchor invalid witness"
+    },
+    {
+      "asset": {
+        "version": 0,
+        "genesis_first_prev_out": "7be638ce6ac84d624c11cf3a797c6e353e1c8184b38c6f716af5a68cb22076b4:1423273655",
+        "genesis_tag": "fcd72aa176c0fcde9316f676fd527d9c42105b851639f09ea70533d26fc60cbe",
+        "genesis_meta_hash": "fcd72aa176c0fcde9316f676fd527d9c42105b851639f09ea70533d26fc60cbe",
+        "genesis_output_index": 130197170,
         "genesis_type": 0,
         "amount": 0,
         "lock_time": 0,
@@ -378,40 +640,40 @@
           {
             "prev_id": {
               "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
-              "asset_id": "09955b447c23172eb6648279aab6ea2de540a4d364d9702eed950430a1499ff3",
-              "script_key": "02207aebead63689daa973fcff2719cd33d60391c7f91a9605b8cb1fc7f9913ba7"
+              "asset_id": "8f8b190300631f97f27fb4f4eb9c17ab20f41ac7d0741186fea7413042a98c3f",
+              "script_key": "02eb1015d044964b28e09a30b2166498969e101b91482c251ab4068ec06886033b"
             },
             "tx_witness": [
-              "efbcd32f58e57a9f751926b51aa99e13f0754c40bf4aa221d6e49428ef7c43f78947a956145aae87481099f49b4cb2af7a7a6c6dccbf3d36c2da17434712d3ab"
+              "6d1eab42ed6e2ef1d8256f8f4deea9af7969c373eff1ed66efc38a132a88b73f92da4e917a5de3e0934879042b82842396aa3ebc09db007d1f3d08590fcf8431"
             ],
             "split_commitment": null
           }
         ],
         "split_commitment_root": {
-          "hash": "7d5dc24888a1632cb9b82400a323cc6478b917a3ab6f48af4b80a5d4c6139f96",
+          "hash": "8674e5c6ffd8efa0b96f1fc1a68da18968977378973ded5736940cefda5ef3fb",
           "sum": "3"
         },
         "script_version": 0,
-        "script_key": "02207aebead63689daa973fcff2719cd33d60391c7f91a9605b8cb1fc7f9913ba7",
+        "script_key": "02eb1015d044964b28e09a30b2166498969e101b91482c251ab4068ec06886033b",
         "group_key": {
-          "group_key": "031d5e8e09f0312ac5253afbbad7bb25eb26344cbb5876fac076b78da2a5162222"
+          "group_key": "024c315ba4e7267cfae6ed1d4452ddb7beadf759996dfa746222a2904641f8440f"
         }
       },
       "split_set": [
         {
           "key": {
             "output_index": 0,
-            "asset_id": "09955b447c23172eb6648279aab6ea2de540a4d364d9702eed950430a1499ff3",
+            "asset_id": "8f8b190300631f97f27fb4f4eb9c17ab20f41ac7d0741186fea7413042a98c3f",
             "script_key": "027c79b9b26e463895eef5679d8558942c86c4ad2233adef01bc3e6d540b3653fe",
             "amount": 0
           },
           "value": {
             "asset": {
               "version": 0,
-              "genesis_first_prev_out": "65fe5efb9ee48816ae54ddc325f8199dbfe353b9520118cc7166a839877df9b9:311845380",
-              "genesis_tag": "c35dd93515cefe0b002cee5e71c47935e281ebfc4b8b652b69ccb092e55a20f1",
-              "genesis_meta_hash": "c35dd93515cefe0b002cee5e71c47935e281ebfc4b8b652b69ccb092e55a20f1",
-              "genesis_output_index": 2356940289,
+              "genesis_first_prev_out": "7be638ce6ac84d624c11cf3a797c6e353e1c8184b38c6f716af5a68cb22076b4:1423273655",
+              "genesis_tag": "fcd72aa176c0fcde9316f676fd527d9c42105b851639f09ea70533d26fc60cbe",
+              "genesis_meta_hash": "fcd72aa176c0fcde9316f676fd527d9c42105b851639f09ea70533d26fc60cbe",
+              "genesis_output_index": 130197170,
               "genesis_type": 0,
               "amount": 0,
               "lock_time": 0,
@@ -425,13 +687,13 @@
                   },
                   "tx_witness": null,
                   "split_commitment": {
-                    "proof": "00011f8b2cdd185bdfdb0bd2b2026fda3b2f7016ce72fb27626e2e41a1f930a387440000000000000003ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffdf",
+                    "proof": "0001bbecf20d315cbadff5ec552bfa56292e2cb8e67fc9d45a700f359617b9be7c8b0000000000000003ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7f",
                     "root_asset": {
                       "version": 0,
-                      "genesis_first_prev_out": "65fe5efb9ee48816ae54ddc325f8199dbfe353b9520118cc7166a839877df9b9:311845380",
-                      "genesis_tag": "c35dd93515cefe0b002cee5e71c47935e281ebfc4b8b652b69ccb092e55a20f1",
-                      "genesis_meta_hash": "c35dd93515cefe0b002cee5e71c47935e281ebfc4b8b652b69ccb092e55a20f1",
-                      "genesis_output_index": 2356940289,
+                      "genesis_first_prev_out": "7be638ce6ac84d624c11cf3a797c6e353e1c8184b38c6f716af5a68cb22076b4:1423273655",
+                      "genesis_tag": "fcd72aa176c0fcde9316f676fd527d9c42105b851639f09ea70533d26fc60cbe",
+                      "genesis_meta_hash": "fcd72aa176c0fcde9316f676fd527d9c42105b851639f09ea70533d26fc60cbe",
+                      "genesis_output_index": 130197170,
                       "genesis_type": 0,
                       "amount": 0,
                       "lock_time": 0,
@@ -440,23 +702,23 @@
                         {
                           "prev_id": {
                             "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
-                            "asset_id": "09955b447c23172eb6648279aab6ea2de540a4d364d9702eed950430a1499ff3",
-                            "script_key": "02207aebead63689daa973fcff2719cd33d60391c7f91a9605b8cb1fc7f9913ba7"
+                            "asset_id": "8f8b190300631f97f27fb4f4eb9c17ab20f41ac7d0741186fea7413042a98c3f",
+                            "script_key": "02eb1015d044964b28e09a30b2166498969e101b91482c251ab4068ec06886033b"
                           },
                           "tx_witness": [
-                            "efbcd32f58e57a9f751926b51aa99e13f0754c40bf4aa221d6e49428ef7c43f78947a956145aae87481099f49b4cb2af7a7a6c6dccbf3d36c2da17434712d3ab"
+                            "6d1eab42ed6e2ef1d8256f8f4deea9af7969c373eff1ed66efc38a132a88b73f92da4e917a5de3e0934879042b82842396aa3ebc09db007d1f3d08590fcf8431"
                           ],
                           "split_commitment": null
                         }
                       ],
                       "split_commitment_root": {
-                        "hash": "7d5dc24888a1632cb9b82400a323cc6478b917a3ab6f48af4b80a5d4c6139f96",
+                        "hash": "8674e5c6ffd8efa0b96f1fc1a68da18968977378973ded5736940cefda5ef3fb",
                         "sum": "3"
                       },
                       "script_version": 0,
                       "script_key": "027c79b9b26e463895eef5679d8558942c86c4ad2233adef01bc3e6d540b3653fe",
                       "group_key": {
-                        "group_key": "031d5e8e09f0312ac5253afbbad7bb25eb26344cbb5876fac076b78da2a5162222"
+                        "group_key": "024c315ba4e7267cfae6ed1d4452ddb7beadf759996dfa746222a2904641f8440f"
                       }
                     }
                   }
@@ -466,7 +728,7 @@
               "script_version": 0,
               "script_key": "027c79b9b26e463895eef5679d8558942c86c4ad2233adef01bc3e6d540b3653fe",
               "group_key": {
-                "group_key": "031d5e8e09f0312ac5253afbbad7bb25eb26344cbb5876fac076b78da2a5162222"
+                "group_key": "024c315ba4e7267cfae6ed1d4452ddb7beadf759996dfa746222a2904641f8440f"
               }
             },
             "output_index": 0
@@ -475,17 +737,17 @@
         {
           "key": {
             "output_index": 1,
-            "asset_id": "09955b447c23172eb6648279aab6ea2de540a4d364d9702eed950430a1499ff3",
-            "script_key": "026b23cdec1433d9a8dda6a7de2d0037c300cce4cb88cc4163f95d03f4382c09a1",
+            "asset_id": "8f8b190300631f97f27fb4f4eb9c17ab20f41ac7d0741186fea7413042a98c3f",
+            "script_key": "0303ec8352545d715b02f28e44b7ca1634f93378bcaeae68e57e8adff32bf81800",
             "amount": 3
           },
           "value": {
             "asset": {
               "version": 0,
-              "genesis_first_prev_out": "65fe5efb9ee48816ae54ddc325f8199dbfe353b9520118cc7166a839877df9b9:311845380",
-              "genesis_tag": "c35dd93515cefe0b002cee5e71c47935e281ebfc4b8b652b69ccb092e55a20f1",
-              "genesis_meta_hash": "c35dd93515cefe0b002cee5e71c47935e281ebfc4b8b652b69ccb092e55a20f1",
-              "genesis_output_index": 2356940289,
+              "genesis_first_prev_out": "7be638ce6ac84d624c11cf3a797c6e353e1c8184b38c6f716af5a68cb22076b4:1423273655",
+              "genesis_tag": "fcd72aa176c0fcde9316f676fd527d9c42105b851639f09ea70533d26fc60cbe",
+              "genesis_meta_hash": "fcd72aa176c0fcde9316f676fd527d9c42105b851639f09ea70533d26fc60cbe",
+              "genesis_output_index": 130197170,
               "genesis_type": 0,
               "amount": 3,
               "lock_time": 0,
@@ -499,13 +761,13 @@
                   },
                   "tx_witness": null,
                   "split_commitment": {
-                    "proof": "000127b3bf4e69acb68e7842a29aaec782917caaf40645ffca11c99a783915282beb0000000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffdf",
+                    "proof": "00018ab3ed47a21756c89e981f07c288549eab28012bf76d77e0c91038928d5cccc00000000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7f",
                     "root_asset": {
                       "version": 0,
-                      "genesis_first_prev_out": "65fe5efb9ee48816ae54ddc325f8199dbfe353b9520118cc7166a839877df9b9:311845380",
-                      "genesis_tag": "c35dd93515cefe0b002cee5e71c47935e281ebfc4b8b652b69ccb092e55a20f1",
-                      "genesis_meta_hash": "c35dd93515cefe0b002cee5e71c47935e281ebfc4b8b652b69ccb092e55a20f1",
-                      "genesis_output_index": 2356940289,
+                      "genesis_first_prev_out": "7be638ce6ac84d624c11cf3a797c6e353e1c8184b38c6f716af5a68cb22076b4:1423273655",
+                      "genesis_tag": "fcd72aa176c0fcde9316f676fd527d9c42105b851639f09ea70533d26fc60cbe",
+                      "genesis_meta_hash": "fcd72aa176c0fcde9316f676fd527d9c42105b851639f09ea70533d26fc60cbe",
+                      "genesis_output_index": 130197170,
                       "genesis_type": 0,
                       "amount": 0,
                       "lock_time": 0,
@@ -514,23 +776,23 @@
                         {
                           "prev_id": {
                             "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
-                            "asset_id": "09955b447c23172eb6648279aab6ea2de540a4d364d9702eed950430a1499ff3",
-                            "script_key": "02207aebead63689daa973fcff2719cd33d60391c7f91a9605b8cb1fc7f9913ba7"
+                            "asset_id": "8f8b190300631f97f27fb4f4eb9c17ab20f41ac7d0741186fea7413042a98c3f",
+                            "script_key": "02eb1015d044964b28e09a30b2166498969e101b91482c251ab4068ec06886033b"
                           },
                           "tx_witness": [
-                            "efbcd32f58e57a9f751926b51aa99e13f0754c40bf4aa221d6e49428ef7c43f78947a956145aae87481099f49b4cb2af7a7a6c6dccbf3d36c2da17434712d3ab"
+                            "6d1eab42ed6e2ef1d8256f8f4deea9af7969c373eff1ed66efc38a132a88b73f92da4e917a5de3e0934879042b82842396aa3ebc09db007d1f3d08590fcf8431"
                           ],
                           "split_commitment": null
                         }
                       ],
                       "split_commitment_root": {
-                        "hash": "7d5dc24888a1632cb9b82400a323cc6478b917a3ab6f48af4b80a5d4c6139f96",
+                        "hash": "8674e5c6ffd8efa0b96f1fc1a68da18968977378973ded5736940cefda5ef3fb",
                         "sum": "3"
                       },
                       "script_version": 0,
                       "script_key": "027c79b9b26e463895eef5679d8558942c86c4ad2233adef01bc3e6d540b3653fe",
                       "group_key": {
-                        "group_key": "031d5e8e09f0312ac5253afbbad7bb25eb26344cbb5876fac076b78da2a5162222"
+                        "group_key": "024c315ba4e7267cfae6ed1d4452ddb7beadf759996dfa746222a2904641f8440f"
                       }
                     }
                   }
@@ -538,9 +800,9 @@
               ],
               "split_commitment_root": null,
               "script_version": 0,
-              "script_key": "026b23cdec1433d9a8dda6a7de2d0037c300cce4cb88cc4163f95d03f4382c09a1",
+              "script_key": "0203ec8352545d715b02f28e44b7ca1634f93378bcaeae68e57e8adff32bf81800",
               "group_key": {
-                "group_key": "031d5e8e09f0312ac5253afbbad7bb25eb26344cbb5876fac076b78da2a5162222"
+                "group_key": "024c315ba4e7267cfae6ed1d4452ddb7beadf759996dfa746222a2904641f8440f"
               }
             },
             "output_index": 1
@@ -551,15 +813,15 @@
         {
           "prev_id": {
             "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
-            "asset_id": "09955b447c23172eb6648279aab6ea2de540a4d364d9702eed950430a1499ff3",
-            "script_key": "02207aebead63689daa973fcff2719cd33d60391c7f91a9605b8cb1fc7f9913ba7"
+            "asset_id": "8f8b190300631f97f27fb4f4eb9c17ab20f41ac7d0741186fea7413042a98c3f",
+            "script_key": "02eb1015d044964b28e09a30b2166498969e101b91482c251ab4068ec06886033b"
           },
           "asset": {
-            "version": 1,
-            "genesis_first_prev_out": "65fe5efb9ee48816ae54ddc325f8199dbfe353b9520118cc7166a839877df9b9:311845380",
-            "genesis_tag": "c35dd93515cefe0b002cee5e71c47935e281ebfc4b8b652b69ccb092e55a20f1",
-            "genesis_meta_hash": "c35dd93515cefe0b002cee5e71c47935e281ebfc4b8b652b69ccb092e55a20f1",
-            "genesis_output_index": 2356940289,
+            "version": 0,
+            "genesis_first_prev_out": "7be638ce6ac84d624c11cf3a797c6e353e1c8184b38c6f716af5a68cb22076b4:1423273655",
+            "genesis_tag": "fcd72aa176c0fcde9316f676fd527d9c42105b851639f09ea70533d26fc60cbe",
+            "genesis_meta_hash": "fcd72aa176c0fcde9316f676fd527d9c42105b851639f09ea70533d26fc60cbe",
+            "genesis_output_index": 130197170,
             "genesis_type": 0,
             "amount": 3,
             "lock_time": 0,
@@ -577,9 +839,9 @@
             ],
             "split_commitment_root": null,
             "script_version": 0,
-            "script_key": "02207aebead63689daa973fcff2719cd33d60391c7f91a9605b8cb1fc7f9913ba7",
+            "script_key": "02eb1015d044964b28e09a30b2166498969e101b91482c251ab4068ec06886033b",
             "group_key": {
-              "group_key": "031d5e8e09f0312ac5253afbbad7bb25eb26344cbb5876fac076b78da2a5162222"
+              "group_key": "024c315ba4e7267cfae6ed1d4452ddb7beadf759996dfa746222a2904641f8440f"
             }
           }
         }
@@ -590,10 +852,10 @@
     {
       "asset": {
         "version": 0,
-        "genesis_first_prev_out": "2cb51337fe4f928e687e9533362384acf280b45806d18ff67de346885cddf294:1377792776",
-        "genesis_tag": "ccef002d82ca352592b8d8f2a8df3b0c35f15b9b370dca80d4ca8e9a133eb520",
-        "genesis_meta_hash": "ccef002d82ca352592b8d8f2a8df3b0c35f15b9b370dca80d4ca8e9a133eb520",
-        "genesis_output_index": 1451949430,
+        "genesis_first_prev_out": "0c666166bd67761366791f0b0847fb86fa18627c23f6f8d3c1d1476697468877:1580888861",
+        "genesis_tag": "99272490106ddf8683126f60d35772c6dfc744b0adbfd5dcf118c4f2b06cfaf0",
+        "genesis_meta_hash": "99272490106ddf8683126f60d35772c6dfc744b0adbfd5dcf118c4f2b06cfaf0",
+        "genesis_output_index": 3192606987,
         "genesis_type": 0,
         "amount": 0,
         "lock_time": 0,
@@ -602,40 +864,40 @@
           {
             "prev_id": {
               "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
-              "asset_id": "e871b4b6a293f14b6a57a410f1ec7e4a1829d553f2af165ce69545aa2d3da708",
-              "script_key": "02ec8a69b80a76df782dc293f8ce3100a8eb48fddc5f77245cc299e2ec828762fd"
+              "asset_id": "7a023dee7c51d8c392606a913bc7a540f2feaf0b948d7de57cff91050ccbe608",
+              "script_key": "02dcf6213bd4ed87c3200308af98581349ec45f7645abb4c1aed2449782e71a173"
             },
             "tx_witness": [
-              "c9fac6d39cd07740206a3edb4bf112025a4cba5d378dbd2a58699df99ada87c231d384e2965c9fcf2d37ab32319abd1b13d5b43423981a1122b43213f5c426c4"
+              "321e3846d410ce6c19e610adc5dcfa6a9f0f3d0acd666312d5092b5ecc5843be333c28a2f8489c04905360c531c1b3bf8bb8f1b196bfb647f9df56a082ef4ee8"
             ],
             "split_commitment": null
           }
         ],
         "split_commitment_root": {
-          "hash": "41536325cd431f32045404b4073341dfa19cbad2daa14ee52f2b2d51a409ef3f",
+          "hash": "f3d27cd62ca409189a54898494f16fbe49425fa0d2d87849cb2184f8c850002b",
           "sum": "3"
         },
         "script_version": 0,
         "script_key": "027c79b9b26e463895eef5679d8558942c86c4ad2233adef01bc3e6d540b3653fe",
         "group_key": {
-          "group_key": "02430e907416b82b273dff65737b84a8eb6426715770eff3251301343ff4bde645"
+          "group_key": "030862421d40ca98d44be159551d0dd5c35ca2a15c4ebef6f9776c929312aa7e01"
         }
       },
       "split_set": [
         {
           "key": {
             "output_index": 0,
-            "asset_id": "e871b4b6a293f14b6a57a410f1ec7e4a1829d553f2af165ce69545aa2d3da708",
+            "asset_id": "7a023dee7c51d8c392606a913bc7a540f2feaf0b948d7de57cff91050ccbe608",
             "script_key": "027c79b9b26e463895eef5679d8558942c86c4ad2233adef01bc3e6d540b3653fe",
             "amount": 0
           },
           "value": {
             "asset": {
               "version": 0,
-              "genesis_first_prev_out": "2cb51337fe4f928e687e9533362384acf280b45806d18ff67de346885cddf294:1377792776",
-              "genesis_tag": "ccef002d82ca352592b8d8f2a8df3b0c35f15b9b370dca80d4ca8e9a133eb520",
-              "genesis_meta_hash": "ccef002d82ca352592b8d8f2a8df3b0c35f15b9b370dca80d4ca8e9a133eb520",
-              "genesis_output_index": 1451949430,
+              "genesis_first_prev_out": "0c666166bd67761366791f0b0847fb86fa18627c23f6f8d3c1d1476697468877:1580888861",
+              "genesis_tag": "99272490106ddf8683126f60d35772c6dfc744b0adbfd5dcf118c4f2b06cfaf0",
+              "genesis_meta_hash": "99272490106ddf8683126f60d35772c6dfc744b0adbfd5dcf118c4f2b06cfaf0",
+              "genesis_output_index": 3192606987,
               "genesis_type": 0,
               "amount": 0,
               "lock_time": 0,
@@ -649,13 +911,13 @@
                   },
                   "tx_witness": null,
                   "split_commitment": {
-                    "proof": "0001e2368d672d7ad50c3a968cb7ca477ad64863153b6a15095f8fa300b30d39616e0000000000000003ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7f",
+                    "proof": "0001213910085e7da1d1dc32fba4e481f969467385ebfe7ec415e5373d91b3f99cb60000000000000003ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7f",
                     "root_asset": {
                       "version": 0,
-                      "genesis_first_prev_out": "2cb51337fe4f928e687e9533362384acf280b45806d18ff67de346885cddf294:1377792776",
-                      "genesis_tag": "ccef002d82ca352592b8d8f2a8df3b0c35f15b9b370dca80d4ca8e9a133eb520",
-                      "genesis_meta_hash": "ccef002d82ca352592b8d8f2a8df3b0c35f15b9b370dca80d4ca8e9a133eb520",
-                      "genesis_output_index": 1451949430,
+                      "genesis_first_prev_out": "0c666166bd67761366791f0b0847fb86fa18627c23f6f8d3c1d1476697468877:1580888861",
+                      "genesis_tag": "99272490106ddf8683126f60d35772c6dfc744b0adbfd5dcf118c4f2b06cfaf0",
+                      "genesis_meta_hash": "99272490106ddf8683126f60d35772c6dfc744b0adbfd5dcf118c4f2b06cfaf0",
+                      "genesis_output_index": 3192606987,
                       "genesis_type": 0,
                       "amount": 0,
                       "lock_time": 0,
@@ -664,23 +926,23 @@
                         {
                           "prev_id": {
                             "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
-                            "asset_id": "e871b4b6a293f14b6a57a410f1ec7e4a1829d553f2af165ce69545aa2d3da708",
-                            "script_key": "02ec8a69b80a76df782dc293f8ce3100a8eb48fddc5f77245cc299e2ec828762fd"
+                            "asset_id": "7a023dee7c51d8c392606a913bc7a540f2feaf0b948d7de57cff91050ccbe608",
+                            "script_key": "02dcf6213bd4ed87c3200308af98581349ec45f7645abb4c1aed2449782e71a173"
                           },
                           "tx_witness": [
-                            "c9fac6d39cd07740206a3edb4bf112025a4cba5d378dbd2a58699df99ada87c231d384e2965c9fcf2d37ab32319abd1b13d5b43423981a1122b43213f5c426c4"
+                            "321e3846d410ce6c19e610adc5dcfa6a9f0f3d0acd666312d5092b5ecc5843be333c28a2f8489c04905360c531c1b3bf8bb8f1b196bfb647f9df56a082ef4ee8"
                           ],
                           "split_commitment": null
                         }
                       ],
                       "split_commitment_root": {
-                        "hash": "41536325cd431f32045404b4073341dfa19cbad2daa14ee52f2b2d51a409ef3f",
+                        "hash": "f3d27cd62ca409189a54898494f16fbe49425fa0d2d87849cb2184f8c850002b",
                         "sum": "3"
                       },
                       "script_version": 0,
                       "script_key": "027c79b9b26e463895eef5679d8558942c86c4ad2233adef01bc3e6d540b3653fe",
                       "group_key": {
-                        "group_key": "02430e907416b82b273dff65737b84a8eb6426715770eff3251301343ff4bde645"
+                        "group_key": "030862421d40ca98d44be159551d0dd5c35ca2a15c4ebef6f9776c929312aa7e01"
                       }
                     }
                   }
@@ -688,9 +950,9 @@
               ],
               "split_commitment_root": null,
               "script_version": 0,
-              "script_key": "02ec8a69b80a76df782dc293f8ce3100a8eb48fddc5f77245cc299e2ec828762fd",
+              "script_key": "02dcf6213bd4ed87c3200308af98581349ec45f7645abb4c1aed2449782e71a173",
               "group_key": {
-                "group_key": "02430e907416b82b273dff65737b84a8eb6426715770eff3251301343ff4bde645"
+                "group_key": "030862421d40ca98d44be159551d0dd5c35ca2a15c4ebef6f9776c929312aa7e01"
               }
             },
             "output_index": 0
@@ -699,17 +961,17 @@
         {
           "key": {
             "output_index": 1,
-            "asset_id": "e871b4b6a293f14b6a57a410f1ec7e4a1829d553f2af165ce69545aa2d3da708",
-            "script_key": "025a93996c833ea834d12c1b69cfb3632ceb637070f2e700cd7b3a093c8a78b4b4",
+            "asset_id": "7a023dee7c51d8c392606a913bc7a540f2feaf0b948d7de57cff91050ccbe608",
+            "script_key": "0259319d60c9bb586e6944c82e81ddd86690c84b992df12070a16d6ee11cf6bc5c",
             "amount": 3
           },
           "value": {
             "asset": {
               "version": 0,
-              "genesis_first_prev_out": "2cb51337fe4f928e687e9533362384acf280b45806d18ff67de346885cddf294:1377792776",
-              "genesis_tag": "ccef002d82ca352592b8d8f2a8df3b0c35f15b9b370dca80d4ca8e9a133eb520",
-              "genesis_meta_hash": "ccef002d82ca352592b8d8f2a8df3b0c35f15b9b370dca80d4ca8e9a133eb520",
-              "genesis_output_index": 1451949430,
+              "genesis_first_prev_out": "0c666166bd67761366791f0b0847fb86fa18627c23f6f8d3c1d1476697468877:1580888861",
+              "genesis_tag": "99272490106ddf8683126f60d35772c6dfc744b0adbfd5dcf118c4f2b06cfaf0",
+              "genesis_meta_hash": "99272490106ddf8683126f60d35772c6dfc744b0adbfd5dcf118c4f2b06cfaf0",
+              "genesis_output_index": 3192606987,
               "genesis_type": 0,
               "amount": 3,
               "lock_time": 0,
@@ -723,13 +985,13 @@
                   },
                   "tx_witness": null,
                   "split_commitment": {
-                    "proof": "0001f9d46c413eaa0700193bf52f2eb23c26db7b631517abaecc13318011a0886a550000000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7f",
+                    "proof": "0001758d64984e8d3444e649545486053681fcbddec4e84c3683e2772c092898c09f0000000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7f",
                     "root_asset": {
                       "version": 0,
-                      "genesis_first_prev_out": "2cb51337fe4f928e687e9533362384acf280b45806d18ff67de346885cddf294:1377792776",
-                      "genesis_tag": "ccef002d82ca352592b8d8f2a8df3b0c35f15b9b370dca80d4ca8e9a133eb520",
-                      "genesis_meta_hash": "ccef002d82ca352592b8d8f2a8df3b0c35f15b9b370dca80d4ca8e9a133eb520",
-                      "genesis_output_index": 1451949430,
+                      "genesis_first_prev_out": "0c666166bd67761366791f0b0847fb86fa18627c23f6f8d3c1d1476697468877:1580888861",
+                      "genesis_tag": "99272490106ddf8683126f60d35772c6dfc744b0adbfd5dcf118c4f2b06cfaf0",
+                      "genesis_meta_hash": "99272490106ddf8683126f60d35772c6dfc744b0adbfd5dcf118c4f2b06cfaf0",
+                      "genesis_output_index": 3192606987,
                       "genesis_type": 0,
                       "amount": 0,
                       "lock_time": 0,
@@ -738,23 +1000,23 @@
                         {
                           "prev_id": {
                             "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
-                            "asset_id": "e871b4b6a293f14b6a57a410f1ec7e4a1829d553f2af165ce69545aa2d3da708",
-                            "script_key": "02ec8a69b80a76df782dc293f8ce3100a8eb48fddc5f77245cc299e2ec828762fd"
+                            "asset_id": "7a023dee7c51d8c392606a913bc7a540f2feaf0b948d7de57cff91050ccbe608",
+                            "script_key": "02dcf6213bd4ed87c3200308af98581349ec45f7645abb4c1aed2449782e71a173"
                           },
                           "tx_witness": [
-                            "c9fac6d39cd07740206a3edb4bf112025a4cba5d378dbd2a58699df99ada87c231d384e2965c9fcf2d37ab32319abd1b13d5b43423981a1122b43213f5c426c4"
+                            "321e3846d410ce6c19e610adc5dcfa6a9f0f3d0acd666312d5092b5ecc5843be333c28a2f8489c04905360c531c1b3bf8bb8f1b196bfb647f9df56a082ef4ee8"
                           ],
                           "split_commitment": null
                         }
                       ],
                       "split_commitment_root": {
-                        "hash": "41536325cd431f32045404b4073341dfa19cbad2daa14ee52f2b2d51a409ef3f",
+                        "hash": "f3d27cd62ca409189a54898494f16fbe49425fa0d2d87849cb2184f8c850002b",
                         "sum": "3"
                       },
                       "script_version": 0,
                       "script_key": "027c79b9b26e463895eef5679d8558942c86c4ad2233adef01bc3e6d540b3653fe",
                       "group_key": {
-                        "group_key": "02430e907416b82b273dff65737b84a8eb6426715770eff3251301343ff4bde645"
+                        "group_key": "030862421d40ca98d44be159551d0dd5c35ca2a15c4ebef6f9776c929312aa7e01"
                       }
                     }
                   }
@@ -762,9 +1024,9 @@
               ],
               "split_commitment_root": null,
               "script_version": 0,
-              "script_key": "025a93996c833ea834d12c1b69cfb3632ceb637070f2e700cd7b3a093c8a78b4b4",
+              "script_key": "0259319d60c9bb586e6944c82e81ddd86690c84b992df12070a16d6ee11cf6bc5c",
               "group_key": {
-                "group_key": "02430e907416b82b273dff65737b84a8eb6426715770eff3251301343ff4bde645"
+                "group_key": "030862421d40ca98d44be159551d0dd5c35ca2a15c4ebef6f9776c929312aa7e01"
               }
             },
             "output_index": 1
@@ -775,15 +1037,15 @@
         {
           "prev_id": {
             "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
-            "asset_id": "e871b4b6a293f14b6a57a410f1ec7e4a1829d553f2af165ce69545aa2d3da708",
-            "script_key": "02ec8a69b80a76df782dc293f8ce3100a8eb48fddc5f77245cc299e2ec828762fd"
+            "asset_id": "7a023dee7c51d8c392606a913bc7a540f2feaf0b948d7de57cff91050ccbe608",
+            "script_key": "02dcf6213bd4ed87c3200308af98581349ec45f7645abb4c1aed2449782e71a173"
           },
           "asset": {
             "version": 1,
-            "genesis_first_prev_out": "2cb51337fe4f928e687e9533362384acf280b45806d18ff67de346885cddf294:1377792776",
-            "genesis_tag": "ccef002d82ca352592b8d8f2a8df3b0c35f15b9b370dca80d4ca8e9a133eb520",
-            "genesis_meta_hash": "ccef002d82ca352592b8d8f2a8df3b0c35f15b9b370dca80d4ca8e9a133eb520",
-            "genesis_output_index": 1451949430,
+            "genesis_first_prev_out": "0c666166bd67761366791f0b0847fb86fa18627c23f6f8d3c1d1476697468877:1580888861",
+            "genesis_tag": "99272490106ddf8683126f60d35772c6dfc744b0adbfd5dcf118c4f2b06cfaf0",
+            "genesis_meta_hash": "99272490106ddf8683126f60d35772c6dfc744b0adbfd5dcf118c4f2b06cfaf0",
+            "genesis_output_index": 3192606987,
             "genesis_type": 0,
             "amount": 3,
             "lock_time": 0,
@@ -801,9 +1063,9 @@
             ],
             "split_commitment_root": null,
             "script_version": 0,
-            "script_key": "02ec8a69b80a76df782dc293f8ce3100a8eb48fddc5f77245cc299e2ec828762fd",
+            "script_key": "02dcf6213bd4ed87c3200308af98581349ec45f7645abb4c1aed2449782e71a173",
             "group_key": {
-              "group_key": "02430e907416b82b273dff65737b84a8eb6426715770eff3251301343ff4bde645"
+              "group_key": "030862421d40ca98d44be159551d0dd5c35ca2a15c4ebef6f9776c929312aa7e01"
             }
           }
         }

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -313,6 +313,12 @@ func (vm *Engine) Execute() error {
 		if len(vm.splitAssets) > 0 || len(vm.prevAssets) > 0 {
 			return newErrKind(ErrInvalidGenesisStateTransition)
 		}
+
+		// A genesis asset with a group key must have a witness before
+		// being validated.
+		if vm.newAsset.GroupKey != nil {
+			return newErrKind(ErrInvalidGenesisStateTransition)
+		}
 		return nil
 	}
 


### PR DESCRIPTION
Spinoff of #549.

Improves test coverage for the VM and ports Makefile improvements from LND that allow for measuring test coverage per-package and per-test-case.