### PR TITLE
universe: use debug logging when no sync needed

### DIFF
--- a/universe/syncer.go
+++ b/universe/syncer.go
@@ -169,7 +169,7 @@ func (s *SimpleSyncer) syncRoot(ctx context.Context, remoteRoot BaseRoot,
 
 	// If the local root matches the remote root, then we're done here.
 	case err == nil && mssmt.IsEqualNode(localRoot, remoteRoot):
-		log.Infof("Root for %v matches, no sync needed",
+		log.Debugf("Root for %v matches, no sync needed",
 			uniID.String())
 
 		return nil
@@ -329,7 +329,8 @@ func (s *SimpleSyncer) batchStreamNewItems(ctx context.Context,
 		ctx, fetchedLeaves, s.cfg.SyncBatchSize,
 		func(ctx context.Context, batch []*IssuanceItem) error {
 			numItems += len(batch)
-			log.Infof("UniverseRoot(%v): Inserting %d new leaves "+
+
+			log.Debugf("UniverseRoot(%v): Inserting %d new leaves "+
 				"(%d of %d)", uniID.String(), len(batch),
 				numItems, numTotal)
 
@@ -341,9 +342,11 @@ func (s *SimpleSyncer) batchStreamNewItems(ctx context.Context,
 					"issuance proofs: %w", err)
 			}
 
-			log.Infof("UniverseRoot(%v): Inserted %d new leaves "+
-				"(%d of %d)", uniID.String(), len(batch),
-				numItems, numTotal)
+			if len(batch) > 0 {
+				log.Infof("UniverseRoot(%v): Inserted %d new "+
+					"leaves (%d of %d)", uniID.String(),
+					len(batch), numItems, numTotal)
+			}
 
 			newLeaves := fn.Map(
 				batch, func(i *IssuanceItem) *Leaf {


### PR DESCRIPTION
In this commit, we cut down on the logging a no-op Universe sync needs. This cuts down on logs like:
```
2023-10-18 21:25:09.117 [INF] UNIV: Root for issuance-b14a8563de6112f7bb6c57f90eb0d84abcd745c32625a28d42467799dbf5294f matches, no sync needed
2023-10-18 21:25:09.118 [INF] UNIV: Root for issuance-a5b2e79a2b8668b5bd881331b13b44925a8ea0ce7a0b96bf319582c7ef133605 matches, no sync needed
2023-10-18 21:25:09.118 [INF] UNIV: Root for issuance-e455f0b659e9cf011cf070e330b2e9f12016dc2bae6010dacc490c4402fb6a8c matches, no sync needed
2023-10-18 21:25:09.119 [INF] UNIV: Root for issuance-787b019ce84cf262577a586dc131891db176bd066f97dbe5b31805a432f22dda matches, no sync needed
2023-10-18 21:25:09.119 [INF] UNIV: Root for issuance-bc810dbd27b8d12e9bdfaae391aaaf69afb637607e6037a27a7160dece013ac9 matches, no sync needed
2023-10-18 21:25:09.120 [INF] UNIV: Root for issuance-cb0a5f9c03bdf345df895c15befd0b83d68cfd0827ab584ca72d23bd704481ec matches, no sync needed
```