### PR TITLE
multi: anchor fee test coverage

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,8 @@ require (
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.0.2
 	github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f
 	github.com/btcsuite/btcwallet v0.16.10-0.20231017144732-e3ff37491e9c
+	github.com/btcsuite/btcwallet/wallet/txrules v1.2.0
+	github.com/btcsuite/btcwallet/wallet/txsizes v1.2.3
 	github.com/caddyserver/certmagic v0.17.2
 	github.com/davecgh/go-spew v1.1.1
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1
@@ -60,8 +62,6 @@ require (
 	github.com/andybalholm/brotli v1.0.3 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/btcsuite/btcwallet/wallet/txauthor v1.3.2 // indirect
-	github.com/btcsuite/btcwallet/wallet/txrules v1.2.0 // indirect
-	github.com/btcsuite/btcwallet/wallet/txsizes v1.2.3 // indirect
 	github.com/btcsuite/btcwallet/walletdb v1.4.0 // indirect
 	github.com/btcsuite/btcwallet/wtxmgr v1.5.0 // indirect
 	github.com/btcsuite/go-socks v0.0.0-20170105172521-4720035b7bfd // indirect

--- a/itest/assertions.go
+++ b/itest/assertions.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/rpcclient"
 	"github.com/btcsuite/btcd/wire"
@@ -24,6 +25,7 @@ import (
 	"github.com/lightninglabs/taproot-assets/universe"
 	"github.com/lightningnetwork/lnd/lnrpc/chainrpc"
 	"github.com/lightningnetwork/lnd/lntest/wait"
+	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/maps"
 )
@@ -217,6 +219,75 @@ func AssertTxInBlock(t *testing.T, block *wire.MsgBlock,
 	require.Fail(t, "tx was not included in block")
 
 	return nil
+}
+
+// AssertTransferFeeRate checks that fee paid for the TX anchoring an asset
+// transfer is close to the expected fee for that TX, at a given fee rate.
+func AssertTransferFeeRate(t *testing.T, minerClient *rpcclient.Client,
+	transferResp *taprpc.SendAssetResponse, inputAmt int64,
+	feeRate chainfee.SatPerKWeight, roundFee bool) {
+
+	txid, err := chainhash.NewHash(transferResp.Transfer.AnchorTxHash)
+	require.NoError(t, err)
+
+	AssertFeeRate(t, minerClient, inputAmt, txid, feeRate, roundFee)
+}
+
+// AssertFeeRate checks that the fee paid for a given TX is close to the
+// expected fee for the same TX, at a given fee rate.
+func AssertFeeRate(t *testing.T, minerClient *rpcclient.Client, inputAmt int64,
+	txid *chainhash.Hash, feeRate chainfee.SatPerKWeight, roundFee bool) {
+
+	var (
+		outputValue                 float64
+		expectedFee, maxOverpayment btcutil.Amount
+		maxVsizeDifference          = int64(2)
+	)
+
+	verboseTx, err := minerClient.GetRawTransactionVerbose(txid)
+	require.NoError(t, err)
+
+	vsize := verboseTx.Vsize
+	for _, vout := range verboseTx.Vout {
+		outputValue += vout.Value
+	}
+
+	t.Logf("TX vsize of %d bytes", vsize)
+
+	btcOutputValue, err := btcutil.NewAmount(outputValue)
+	require.NoError(t, err)
+
+	actualFee := inputAmt - int64(btcOutputValue)
+
+	switch {
+	case roundFee:
+		// Replicate the rounding performed when calling `FundPsbt`.
+		feeSatPerVbyte := uint64(feeRate.FeePerKVByte()) / 1000
+		roundedFeeRate := chainfee.SatPerKVByte(
+			feeSatPerVbyte * 1000,
+		).FeePerKWeight()
+
+		expectedFee = roundedFeeRate.FeePerKVByte().
+			FeeForVSize(int64(vsize))
+		maxOverpayment = roundedFeeRate.FeePerKVByte().
+			FeeForVSize(maxVsizeDifference)
+
+	default:
+		expectedFee = feeRate.FeePerKVByte().
+			FeeForVSize(int64(vsize))
+		maxOverpayment = feeRate.FeePerKVByte().
+			FeeForVSize(maxVsizeDifference)
+	}
+
+	// The actual fee may be higher than the expected fee after
+	// confirmation, as the freighter makes a worst-case estimate of the TX
+	// vsize. The gap between these two fees should still be small.
+	require.GreaterOrEqual(t, actualFee, int64(expectedFee))
+
+	overpaidFee := actualFee - int64(expectedFee)
+	require.LessOrEqual(t, overpaidFee, int64(maxOverpayment))
+
+	t.Logf("Correct fee of %d sats", actualFee)
 }
 
 // WaitForBatchState polls until the planter has reached the desired state with

--- a/itest/assertions.go
+++ b/itest/assertions.go
@@ -640,16 +640,16 @@ func ConfirmAndAssertOutboundTransfer(t *testing.T,
 	expectedAmounts []uint64, currentTransferIdx,
 	numTransfers int) *wire.MsgBlock {
 
-	return ConfirmAndAssetOutboundTransferWithOutputs(
+	return ConfirmAndAssertOutboundTransferWithOutputs(
 		t, minerClient, sender, sendResp, assetID, expectedAmounts,
 		currentTransferIdx, numTransfers, 2,
 	)
 }
 
-// ConfirmAndAssetOutboundTransferWithOutputs makes sure the given outbound
+// ConfirmAndAssertOutboundTransferWithOutputs makes sure the given outbound
 // transfer has the correct state and number of outputs before confirming it and
 // then asserting the confirmed state with the node.
-func ConfirmAndAssetOutboundTransferWithOutputs(t *testing.T,
+func ConfirmAndAssertOutboundTransferWithOutputs(t *testing.T,
 	minerClient *rpcclient.Client, sender TapdClient,
 	sendResp *taprpc.SendAssetResponse, assetID []byte,
 	expectedAmounts []uint64, currentTransferIdx,

--- a/itest/burn_test.go
+++ b/itest/burn_test.go
@@ -99,7 +99,7 @@ func testBurnAssets(t *harnessTest) {
 		},
 	)
 	require.NoError(t.t, err)
-	ConfirmAndAssetOutboundTransferWithOutputs(
+	ConfirmAndAssertOutboundTransferWithOutputs(
 		t.t, minerClient, t.tapd, sendResp, simpleAssetGen.AssetId,
 		outputAmounts, 0, 1, numOutputs,
 	)

--- a/itest/fee_estimation_test.go
+++ b/itest/fee_estimation_test.go
@@ -1,0 +1,181 @@
+package itest
+
+import (
+	"context"
+
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/taproot-assets/taprpc"
+	"github.com/lightningnetwork/lnd/lnrpc"
+	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
+	"github.com/stretchr/testify/require"
+)
+
+// testFeeEstimation tests that we're able to spend outputs of various script
+// types, and that the fee estimator and TX size estimator used during asset
+// transfers are accurate.
+func testFeeEstimation(t *harnessTest) {
+	var (
+		// Make a ladder of UTXO values so use order is deterministic.
+		anchorAmounts = []int64{10000, 9990, 9980, 9970}
+
+		// The default feerate in the itests is 12.5 sat/vB, but we
+		// define it here explicitly to use for assertions.
+		defaultFeeRate   = chainfee.SatPerKWeight(3125)
+		higherFeeRate    = defaultFeeRate * 2
+		excessiveFeeRate = defaultFeeRate * 8
+		lowFeeRate       = chainfee.SatPerKWeight(500)
+
+		// We will mint assets using the largest NP2WKH output, and then
+		// use all three output types for transfers.
+		initialUTXOs = []*UTXORequest{
+			{
+				Type:   lnrpc.AddressType_NESTED_PUBKEY_HASH,
+				Amount: anchorAmounts[0],
+			},
+			{
+				Type:   lnrpc.AddressType_NESTED_PUBKEY_HASH,
+				Amount: anchorAmounts[1],
+			},
+			{
+				Type:   lnrpc.AddressType_WITNESS_PUBKEY_HASH,
+				Amount: anchorAmounts[2],
+			},
+			{
+				Type:   lnrpc.AddressType_TAPROOT_PUBKEY,
+				Amount: anchorAmounts[3],
+			},
+		}
+	)
+
+	ctxb := context.Background()
+	ctxt, cancel := context.WithTimeout(ctxb, defaultWaitTimeout)
+	defer cancel()
+
+	// Set the initial state of the wallet of the first node. The wallet
+	// state will reset at the end of this test.
+	SetNodeUTXOs(t, t.lndHarness.Alice, btcutil.Amount(1), initialUTXOs)
+	defer ResetNodeWallet(t, t.lndHarness.Alice)
+
+	// Mint some assets with a NP2WPKH input, which will give us an anchor
+	// output to spend for a transfer.
+	rpcAssets := MintAssetsConfirmBatch(
+		t.t, t.lndHarness.Miner.Client, t.tapd, simpleAssets,
+	)
+
+	// Check the final fee rate of the mint TX.
+	rpcMintOutpoint := rpcAssets[0].ChainAnchor.AnchorOutpoint
+	mintOutpoint, err := wire.NewOutPointFromString(rpcMintOutpoint)
+	require.NoError(t.t, err)
+
+	// We check the minting TX with a rounded fee rate as the minter does
+	// not adjust the fee rate of the TX after it was funded by our backing
+	// wallet.
+	AssertFeeRate(
+		t.t, t.lndHarness.Miner.Client, anchorAmounts[0],
+		&mintOutpoint.Hash, defaultFeeRate, true,
+	)
+
+	// Split the normal asset to create a transfer with two anchor outputs.
+	normalAssetId := rpcAssets[0].AssetGenesis.AssetId
+	splitAmount := rpcAssets[0].Amount / 2
+	addr, err := t.tapd.NewAddr(
+		ctxt, &taprpc.NewAddrRequest{
+			AssetId: normalAssetId,
+			Amt:     splitAmount,
+		},
+	)
+	require.NoError(t.t, err)
+
+	AssertAddrCreated(t.t, t.tapd, rpcAssets[0], addr)
+	sendResp := sendAssetsToAddr(t, t.tapd, addr)
+
+	transferIdx := 0
+	ConfirmAndAssertOutboundTransfer(
+		t.t, t.lndHarness.Miner.Client, t.tapd, sendResp, normalAssetId,
+		[]uint64{splitAmount, splitAmount}, transferIdx, transferIdx+1,
+	)
+	transferIdx += 1
+	AssertNonInteractiveRecvComplete(t.t, t.tapd, transferIdx)
+
+	sendInputAmt := anchorAmounts[1] + 1000
+	AssertTransferFeeRate(
+		t.t, t.lndHarness.Miner.Client, sendResp, sendInputAmt,
+		defaultFeeRate, false,
+	)
+
+	// Double the fee rate to 25 sat/vB before performing another transfer.
+	t.lndHarness.SetFeeEstimateWithConf(higherFeeRate, 6)
+
+	secondSplitAmount := splitAmount / 2
+	addr2, err := t.tapd.NewAddr(
+		ctxt, &taprpc.NewAddrRequest{
+			AssetId: normalAssetId,
+			Amt:     secondSplitAmount,
+		},
+	)
+	require.NoError(t.t, err)
+
+	AssertAddrCreated(t.t, t.tapd, rpcAssets[0], addr2)
+	sendResp = sendAssetsToAddr(t, t.tapd, addr2)
+
+	ConfirmAndAssertOutboundTransfer(
+		t.t, t.lndHarness.Miner.Client, t.tapd, sendResp, normalAssetId,
+		[]uint64{secondSplitAmount, secondSplitAmount},
+		transferIdx, transferIdx+1,
+	)
+	transferIdx += 1
+	AssertNonInteractiveRecvComplete(t.t, t.tapd, transferIdx)
+
+	sendInputAmt = anchorAmounts[2] + 1000
+	AssertTransferFeeRate(
+		t.t, t.lndHarness.Miner.Client, sendResp, sendInputAmt,
+		higherFeeRate, false,
+	)
+
+	// If we quadruple the fee rate, the freighter should fail during input
+	// selection.
+	t.lndHarness.SetFeeEstimateWithConf(excessiveFeeRate, 6)
+
+	thirdSplitAmount := splitAmount / 4
+	addr3, err := t.tapd.NewAddr(
+		ctxt, &taprpc.NewAddrRequest{
+			AssetId: normalAssetId,
+			Amt:     thirdSplitAmount,
+		},
+	)
+	require.NoError(t.t, err)
+
+	AssertAddrCreated(t.t, t.tapd, rpcAssets[0], addr3)
+	_, err = t.tapd.SendAsset(ctxt, &taprpc.SendAssetRequest{
+		TapAddrs: []string{addr3.Encoded},
+	})
+	require.ErrorContains(t.t, err, "insufficient funds available")
+
+	// The transfer should also be rejected if the manually-specified
+	// feerate fails the sanity check against the fee estimator's fee floor
+	// of 253 sat/kw, or 1.012 sat/vB.
+	_, err = t.tapd.SendAsset(ctxt, &taprpc.SendAssetRequest{
+		TapAddrs: []string{addr3.Encoded},
+		FeeRate:  uint32(chainfee.FeePerKwFloor) - 1,
+	})
+	require.ErrorContains(t.t, err, "manual fee rate below floor")
+	// After failure at the high feerate, we should still be able to make a
+	// transfer at a very low feerate.
+	t.lndHarness.SetFeeEstimateWithConf(lowFeeRate, 6)
+	sendResp = sendAssetsToAddr(t, t.tapd, addr3)
+
+	ConfirmAndAssertOutboundTransfer(
+		t.t, t.lndHarness.Miner.Client, t.tapd, sendResp, normalAssetId,
+		[]uint64{thirdSplitAmount, thirdSplitAmount},
+		transferIdx, transferIdx+1,
+	)
+	transferIdx += 1
+	AssertNonInteractiveRecvComplete(t.t, t.tapd, transferIdx)
+
+	sendInputAmt = anchorAmounts[3] + 1000
+	AssertTransferFeeRate(
+		t.t, t.lndHarness.Miner.Client, sendResp, sendInputAmt,
+		lowFeeRate, false,
+	)
+}

--- a/itest/psbt_test.go
+++ b/itest/psbt_test.go
@@ -425,7 +425,7 @@ func runPsbtInteractiveFullValueSendTest(ctxt context.Context, t *harnessTest,
 			numOutputs = 2
 			amounts = []uint64{fullAmt, 0}
 		}
-		ConfirmAndAssetOutboundTransferWithOutputs(
+		ConfirmAndAssertOutboundTransferWithOutputs(
 			t.t, t.lndHarness.Miner.Client, sender,
 			sendResp, genInfo.AssetId, amounts, i/2, (i/2)+1,
 			numOutputs,
@@ -637,7 +637,7 @@ func runPsbtInteractiveSplitSendTest(ctxt context.Context, t *harnessTest,
 		require.NoError(t.t, err)
 
 		numOutputs := 2
-		ConfirmAndAssetOutboundTransferWithOutputs(
+		ConfirmAndAssertOutboundTransferWithOutputs(
 			t.t, t.lndHarness.Miner.Client, sender,
 			sendResp, genInfo.AssetId,
 			[]uint64{sendAmt, changeAmt}, i/2, (i/2)+1,
@@ -761,7 +761,7 @@ func testPsbtInteractiveTapscriptSibling(t *harnessTest) {
 	)
 	require.NoError(t.t, err)
 
-	ConfirmAndAssetOutboundTransferWithOutputs(
+	ConfirmAndAssertOutboundTransferWithOutputs(
 		t.t, t.lndHarness.Miner.Client, alice, sendResp,
 		genInfo.AssetId, []uint64{sendAmt, changeAmt}, 0, 1, 2,
 	)
@@ -908,7 +908,7 @@ func testPsbtMultiSend(t *harnessTest) {
 	// addresses (sharing an anchor output) and 1 for the change. So there
 	// are 4 BTC anchor outputs but 5 asset transfer outputs.
 	numOutputs := 5
-	ConfirmAndAssetOutboundTransferWithOutputs(
+	ConfirmAndAssertOutboundTransferWithOutputs(
 		t.t, t.lndHarness.Miner.Client, sender, sendResp,
 		genInfo.AssetId, outputAmounts, 0, 1, numOutputs,
 	)
@@ -1079,7 +1079,7 @@ func testMultiInputPsbtSingleAssetID(t *harnessTest) {
 		numTransfers       = 1
 		numOutputs         = 1
 	)
-	ConfirmAndAssetOutboundTransferWithOutputs(
+	ConfirmAndAssertOutboundTransferWithOutputs(
 		t.t, t.lndHarness.Miner.Client, secondaryTapd,
 		sendResp, genInfo.AssetId,
 		[]uint64{sendAmt}, currentTransferIdx, numTransfers,

--- a/itest/send_test.go
+++ b/itest/send_test.go
@@ -1320,7 +1320,7 @@ func testSendMultipleCoins(t *harnessTest) {
 	// We created 5 addresses in our first node now, so we can initiate the
 	// transfer to send the coins back to our wallet in 5 pieces now.
 	sendResp := sendAssetsToAddr(t, t.tapd, addrs...)
-	ConfirmAndAssetOutboundTransferWithOutputs(
+	ConfirmAndAssertOutboundTransferWithOutputs(
 		t.t, t.lndHarness.Miner.Client, t.tapd, sendResp,
 		genInfo.AssetId, []uint64{
 			0, unitsPerPart, unitsPerPart, unitsPerPart,

--- a/itest/test_list_on_test.go
+++ b/itest/test_list_on_test.go
@@ -184,6 +184,10 @@ var testCases = []*testCase{
 		test: testUniverseFederation,
 	},
 	{
+		name: "fee estimation",
+		test: testFeeEstimation,
+	},
+	{
 		name: "get info",
 		test: testGetInfo,
 	},

--- a/tapfreighter/wallet.go
+++ b/tapfreighter/wallet.go
@@ -18,6 +18,7 @@ import (
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcwallet/wallet/txrules"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/lightninglabs/taproot-assets/address"
 	"github.com/lightninglabs/taproot-assets/asset"
@@ -28,7 +29,6 @@ import (
 	"github.com/lightninglabs/taproot-assets/tapgarden"
 	"github.com/lightninglabs/taproot-assets/tappsbt"
 	"github.com/lightninglabs/taproot-assets/tapscript"
-	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
 )
@@ -1654,61 +1654,30 @@ func addAnchorPsbtInputs(btcPkt *psbt.Packet, vPkt *tappsbt.VPacket,
 	}
 
 	// Now that we've added an extra input, we'll want to re-calculate the
-	// total weight of the transaction, so we can ensure we're paying
-	// enough in fees.
-	var (
-		weightEstimator     input.TxWeightEstimator
-		inputAmt, outputAmt int64
+	// total vsize of the transaction and the necessary fee at the desired
+	// fee rate.
+	inputScripts := make([][]byte, 0, len(btcPkt.Inputs))
+	for inputIdx, input := range btcPkt.Inputs {
+		if input.WitnessUtxo == nil {
+			return fmt.Errorf("PSBT input %d doesn't specify "+
+				"witness UTXO, which is not supported",
+				inputIdx)
+		}
+
+		if len(input.WitnessUtxo.PkScript) == 0 {
+			return fmt.Errorf("input %d on psbt missing "+
+				"pkscript", inputIdx)
+		}
+
+		inputScripts = append(inputScripts, input.WitnessUtxo.PkScript)
+	}
+
+	estimatedSize, requiredFee := tapscript.EstimateFee(
+		inputScripts, btcPkt.UnsignedTx.TxOut, feeRate,
 	)
-	for _, pIn := range btcPkt.Inputs {
-		inputAmt += pIn.WitnessUtxo.Value
-
-		inputPkScript := pIn.WitnessUtxo.PkScript
-		switch {
-		case txscript.IsPayToWitnessPubKeyHash(inputPkScript):
-			weightEstimator.AddP2WKHInput()
-
-		case txscript.IsPayToScriptHash(inputPkScript):
-			weightEstimator.AddNestedP2WKHInput()
-
-		case txscript.IsPayToTaproot(inputPkScript):
-			weightEstimator.AddTaprootKeySpendInput(
-				txscript.SigHashDefault,
-			)
-		default:
-			return fmt.Errorf("unknown pkScript: %x",
-				inputPkScript)
-		}
-	}
-	for _, txOut := range btcPkt.UnsignedTx.TxOut {
-		outputAmt += txOut.Value
-
-		addrType, _, _, err := txscript.ExtractPkScriptAddrs(
-			txOut.PkScript, params,
-		)
-		if err != nil {
-			return err
-		}
-
-		switch addrType {
-		case txscript.WitnessV0PubKeyHashTy:
-			weightEstimator.AddP2WKHOutput()
-
-		case txscript.WitnessV0ScriptHashTy:
-			weightEstimator.AddP2WSHOutput()
-
-		case txscript.WitnessV1TaprootTy:
-			weightEstimator.AddP2TROutput()
-		default:
-			return fmt.Errorf("unknown pkscript: %x",
-				txOut.PkScript)
-		}
-	}
-
-	// With this, we can now calculate the total fee we need to pay. We'll
-	// also make sure to round up the required fee to the floor.
-	totalWeight := int64(weightEstimator.Weight())
-	requiredFee := feeRate.FeeForWeight(totalWeight)
+	log.Infof("Estimated TX vsize: %d", estimatedSize)
+	log.Infof("TX required fee before change adjustment: %d at feerate "+
+		"%d sat/vB", requiredFee, feeRate.FeePerKVByte()/1000)
 
 	// Given the current fee (which doesn't account for our input) and the
 	// total fee we want to pay, we'll adjust the wallet's change output
@@ -1729,8 +1698,8 @@ func addAnchorPsbtInputs(btcPkt *psbt.Packet, vPkt *tappsbt.VPacket,
 	// The fee may exceed the total value of the change output, which means
 	// this spend is impossible with the given inputs and fee rate.
 	if changeValue-feeDelta < 0 {
-		return fmt.Errorf("fee of %d sats exceeds change amount of %d"+
-			"sats", requiredFee, changeValue)
+		return fmt.Errorf("fee exceeds change amount: (fee=%d, "+
+			"change=%d) ", requiredFee, changeValue)
 	}
 
 	btcPkt.UnsignedTx.TxOut[lastIdx].Value -= feeDelta

--- a/tapscript/send.go
+++ b/tapscript/send.go
@@ -115,14 +115,14 @@ var (
 	)
 )
 
-// createDummyOutput creates a new Bitcoin transaction output that is later
+// CreateDummyOutput creates a new Bitcoin transaction output that is later
 // used to embed a Taproot Asset commitment.
-func createDummyOutput() *wire.TxOut {
+func CreateDummyOutput() *wire.TxOut {
 	// The dummy PkScript is the same size as an encoded P2TR output and has
 	// a valid P2TR prefix.
 	newOutput := wire.TxOut{
 		Value:    int64(DummyAmtSats),
-		PkScript: GenesisDummyScript,
+		PkScript: bytes.Clone(GenesisDummyScript),
 	}
 	return &newOutput
 }
@@ -1029,7 +1029,7 @@ func CreateAnchorTx(outputs []*tappsbt.VOutput) (*psbt.Packet, error) {
 
 	txTemplate := wire.NewMsgTx(2)
 	for i := uint32(0); i < maxOutputIndex; i++ {
-		txTemplate.AddTxOut(createDummyOutput())
+		txTemplate.AddTxOut(CreateDummyOutput())
 	}
 
 	spendPkt, err := psbt.NewFromUnsignedTx(txTemplate)

--- a/tapscript/util.go
+++ b/tapscript/util.go
@@ -3,9 +3,13 @@ package tapscript
 import (
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcwallet/wallet/txsizes"
 	"github.com/lightninglabs/taproot-assets/commitment"
+	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
 )
 
 // PayToAddrScript constructs a P2TR script that embeds a Taproot Asset
@@ -30,4 +34,41 @@ func PayToTaprootScript(taprootKey *btcec.PublicKey) ([]byte, error) {
 		AddOp(txscript.OP_1).
 		AddData(schnorr.SerializePubKey(taprootKey)).
 		Script()
+}
+
+// EstimateFee provides a worst-case fee and vsize estimate for a transaction
+// built from the given inputs and outputs. This mirrors the fee estimation
+// implemented in btcwallet/wallet/txauthor/author.go:NewUnsignedTransaction()
+// EstimateFee assumes that a change output (or a dummy output for change) is
+// included in the set of given outputs.
+func EstimateFee(inputScripts [][]byte, outputs []*wire.TxOut,
+	feeRate chainfee.SatPerKWeight) (int, btcutil.Amount) {
+
+	// Count the types of input scripts.
+	var nested, p2wpkh, p2tr, p2pkh int
+	for _, pkScript := range inputScripts {
+		switch {
+		// If this is a p2sh output, we assume this is a
+		// nested P2WKH.
+		case txscript.IsPayToScriptHash(pkScript):
+			nested++
+		case txscript.IsPayToWitnessPubKeyHash(pkScript):
+			p2wpkh++
+		case txscript.IsPayToTaproot(pkScript):
+			p2tr++
+		default:
+			p2pkh++
+		}
+	}
+
+	// The change output is already in the set of given outputs, so we don't
+	// need to account for an additional output.
+	maxSignedSize := txsizes.EstimateVirtualSize(
+		p2pkh, p2tr, p2wpkh, nested, outputs, 0,
+	)
+	maxRequiredFee := feeRate.FeePerKVByte().FeeForVSize(
+		int64(maxSignedSize),
+	)
+
+	return maxSignedSize, maxRequiredFee
 }


### PR DESCRIPTION
Fixes #671 

Verifies fixes for various issues with fee estimation.

There are also some issues with cleaning up caretaker state if the caretaker returns an error, which is not recoverable from inside the caretaker.

Batch finalization could be manually reattempted by the user.

Also added extra logging of fee rates and transaction weights.

Should also change units exposed to the user.

> In line with our other software, this flag could be called `--sat_per_vbyte` and be measured in sat/vB. We use the term `fee_rate` a bit differently in LND.