### PR TITLE
Add backoff procedure to universe RPC proof courier

### DIFF
--- a/itest/send_test.go
+++ b/itest/send_test.go
@@ -398,9 +398,10 @@ func testBasicSendPassiveAsset(t *harnessTest) {
 	test.WriteTestVectors(t.t, proof.RegtestTestVectorName, testVectors)
 }
 
-// testReattemptFailedAssetSend tests that a failed attempt at sending an asset
-// proof will be reattempted by the tapd node.
-func testReattemptFailedAssetSend(t *harnessTest) {
+// testReattemptFailedAssetSendHashmailCourier tests that a failed attempt at
+// sending an asset proof will be reattempted by the tapd node. This test
+// targets the hashmail courier.
+func testReattemptFailedAssetSendHashmailCourier(t *harnessTest) {
 	var (
 		ctxb = context.Background()
 		wg   sync.WaitGroup
@@ -444,10 +445,11 @@ func testReattemptFailedAssetSend(t *harnessTest) {
 			return false
 		}
 
-		// Default number of proof delivery attempts in tests is 3,
-		// therefore expect at least 2 backoff wait events
-		// (not waiting on first attempt).
-		expectedEventCount := 2
+		// Expected number of events is one less than the number of
+		// tries because the first attempt does not count as a backoff
+		// event.
+		nodeBackoffCfg := t.tapd.clientCfg.HashMailCourier.BackoffCfg
+		expectedEventCount := nodeBackoffCfg.NumTries - 1
 
 		// Context timeout scales with expected number of events.
 		timeout := time.Duration(expectedEventCount) *
@@ -485,6 +487,11 @@ func testReattemptFailedAssetSend(t *harnessTest) {
 
 	// Simulate a failed attempt at sending the asset proof by stopping
 	// the receiver node.
+	//
+	// The receiving tapd node does not return a proof received confirmation
+	// message via the universe RPC courier. We can simulate a proof
+	// transfer failure by stopping the courier service directly and not the
+	// receiving tapd node.
 	require.NoError(t.t, t.tapd.stop(false))
 
 	// Send asset and then mine to confirm the associated on-chain tx.

--- a/itest/send_test.go
+++ b/itest/send_test.go
@@ -109,6 +109,8 @@ func testBasicSendUnidirectional(t *harnessTest) {
 	require.NoError(t.t, err)
 
 	for i := 0; i < numSends; i++ {
+		t.t.Logf("Performing send procedure: %d", i)
+
 		// Deduct what we sent from the expected current number of
 		// units.
 		currentUnits -= numUnits

--- a/itest/test_list_on_test.go
+++ b/itest/test_list_on_test.go
@@ -59,6 +59,11 @@ var testCases = []*testCase{
 		proofCourierType: proof.HashmailCourierType,
 	},
 	{
+		name:             "reattempt failed asset send uni courier",
+		test:             testReattemptFailedAssetSendUniCourier,
+		proofCourierType: proof.UniverseRpcCourierType,
+	},
+	{
 		name:             "offline receiver eventually receives",
 		test:             testOfflineReceiverEventuallyReceives,
 		proofCourierType: proof.HashmailCourierType,

--- a/itest/test_list_on_test.go
+++ b/itest/test_list_on_test.go
@@ -54,8 +54,8 @@ var testCases = []*testCase{
 		proofCourierType: proof.HashmailCourierType,
 	},
 	{
-		name:             "reattempt failed asset send",
-		test:             testReattemptFailedAssetSend,
+		name:             "reattempt failed asset send hashmail courier",
+		test:             testReattemptFailedAssetSendHashmailCourier,
 		proofCourierType: proof.HashmailCourierType,
 	},
 	{

--- a/proof/courier.go
+++ b/proof/courier.go
@@ -528,6 +528,11 @@ func (e *BackoffExecError) Error() string {
 
 // BackoffCfg configures the behaviour of the proof delivery backoff procedure.
 type BackoffCfg struct {
+	// SkipInitDeliveryDelay is a flag that indicates whether we should skip
+	// the initial delay before attempting to deliver the proof to the
+	// receiver.
+	SkipInitDeliveryDelay bool
+
 	// BackoffResetWait is the amount of time we'll wait before
 	// resetting the backoff counter to its initial state.
 	BackoffResetWait time.Duration `long:"backoffresetwait" description:"The amount of time to wait before resetting the backoff counter."`
@@ -559,6 +564,12 @@ type BackoffHandler struct {
 // that we don't spam the courier service with proof delivery attempts.
 func (b *BackoffHandler) initialDelay(ctx context.Context,
 	proofLocator Locator) error {
+
+	// If the skip initial delivery delay flag is set, we'll skip the
+	// initial delay.
+	if b.cfg.SkipInitDeliveryDelay {
+		return nil
+	}
 
 	locatorHash, err := proofLocator.Hash()
 	if err != nil {

--- a/proof/courier.go
+++ b/proof/courier.go
@@ -807,6 +807,8 @@ func (h *HashMailCourier) DeliverProof(ctx context.Context,
 		// the proof over the stream.
 		//
 		// TODO(roasbeef): do ecies here
+		// (this ^ TODO relates to encrypting proofs for the receiver
+		// before uploading to the courier)
 		log.Infof("Sending receiver proof via sid=%x",
 			senderStreamID)
 		err = h.mailbox.WriteProof(

--- a/proof/courier.go
+++ b/proof/courier.go
@@ -533,6 +533,9 @@ type BackoffExecError struct {
 }
 
 func (e *BackoffExecError) Error() string {
+	if e.execErr == nil {
+		return "backoff exec error"
+	}
 	return fmt.Sprintf("backoff exec error: %s", e.execErr.Error())
 }
 


### PR DESCRIPTION
This PR extracts the backoff procedure from the hashmail proof courier and makes use of it in the universe RPC proof courier.

Fixes https://github.com/lightninglabs/taproot-assets/issues/512