### PR TITLE
tapd: allow configuring all connection params for Postgres

### DIFF
--- a/tapdb/postgres.go
+++ b/tapdb/postgres.go
@@ -79,7 +79,7 @@ func NewPostgresStore(cfg *PostgresConfig) (*PostgresStore, error) {
 
 	rawDb.SetMaxOpenConns(maxConns)
 	rawDb.SetMaxIdleConns(maxConns)
-	rawDb.SetConnMaxLifetime(connIdleLifetime)
+	rawDb.SetConnMaxLifetime(defaultConnMaxLifetime)
 
 	if !cfg.SkipMigrations {
 		// Now that the database is open, populate the database with

--- a/tapdb/sqlite.go
+++ b/tapdb/sqlite.go
@@ -33,7 +33,7 @@ const (
 
 	// defaultConnMaxLifetime is the maximum amount of time a connection can
 	// be reused for before it is closed.
-	defaultConnMaxLifetime = 5 * time.Minute
+	defaultConnMaxLifetime = 10 * time.Minute
 )
 
 // SqliteConfig holds all the config arguments needed to interact with our

--- a/tapdb/sqlite.go
+++ b/tapdb/sqlite.go
@@ -31,8 +31,9 @@ const (
 	// time.
 	defaultMaxConns = 25
 
-	// connIdleLifetime is the amount of time a connection can be idle.
-	connIdleLifetime = 5 * time.Minute
+	// defaultConnMaxLifetime is the maximum amount of time a connection can
+	// be reused for before it is closed.
+	defaultConnMaxLifetime = 5 * time.Minute
 )
 
 // SqliteConfig holds all the config arguments needed to interact with our
@@ -115,7 +116,7 @@ func NewSqliteStore(cfg *SqliteConfig) (*SqliteStore, error) {
 
 	db.SetMaxOpenConns(defaultMaxConns)
 	db.SetMaxIdleConns(defaultMaxConns)
-	db.SetConnMaxLifetime(connIdleLifetime)
+	db.SetConnMaxLifetime(defaultConnMaxLifetime)
 
 	if !cfg.SkipMigrations {
 		// Now that the database is open, populate the database with


### PR DESCRIPTION
We want to be able to specify the number of idle connections, and other lifetime parameters for Postgres as well.