### PR TITLE
universe stats: only select issuance roots for asset related stats

### DIFF
--- a/fn/func.go
+++ b/fn/func.go
@@ -45,6 +45,21 @@ func Filter[T any](s []T, f func(T) bool) []T {
 	return output
 }
 
+// FilterMap applies the given predicate function to each element of the given
+// map and generates a new slice containing only the elements for which the
+// predicate returned true.
+func FilterMap[T any, K comparable](s map[K]T, f func(T) bool) []T {
+	output := make([]T, 0, len(s))
+
+	for _, x := range s {
+		if f(x) {
+			output = append(output, x)
+		}
+	}
+
+	return output
+}
+
 // MapErr applies the given fallible mapping function to each element of the
 // given slice and generates a new slice. This is identical to Map, but
 // returns early if any single mapping fails.

--- a/itest/loadtest/mint_batch_test.go
+++ b/itest/loadtest/mint_batch_test.go
@@ -127,7 +127,12 @@ func mintTest(t *testing.T, ctx context.Context, cfg *Config) {
 	// we asserted previously.
 	uniRoots, err := alice.AssetRoots(ctx, &unirpc.AssetRootRequest{})
 	require.NoError(t, err)
-	require.Len(t, uniRoots.UniverseRoots, groupCount)
+	issuanceRoots := fn.FilterMap(
+		uniRoots.UniverseRoots, func(root *unirpc.UniverseRoot) bool {
+			return root.Id.ProofType == unirpc.ProofType_PROOF_TYPE_ISSUANCE
+		},
+	)
+	require.Len(t, issuanceRoots, groupCount)
 
 	itest.AssertUniverseRoot(t, alice, groupBalance, nil, collectGroupKey)
 

--- a/tapdb/sqlc/migrations/000010_universe_stats.down.sql
+++ b/tapdb/sqlc/migrations/000010_universe_stats.down.sql
@@ -1,0 +1,2 @@
+-- This file is empty on purpose. There is nothing to roll back for this
+-- migration.

--- a/tapdb/sqlc/migrations/000010_universe_stats.up.sql
+++ b/tapdb/sqlc/migrations/000010_universe_stats.up.sql
@@ -1,0 +1,13 @@
+DROP VIEW universe_stats;
+
+CREATE VIEW universe_stats AS
+SELECT
+    COUNT(CASE WHEN u.event_type = 'SYNC' THEN 1 ELSE NULL END) AS total_asset_syncs,
+    COUNT(CASE WHEN u.event_type = 'NEW_PROOF' THEN 1 ELSE NULL END) AS total_asset_proofs,
+    roots.asset_id,
+    roots.group_key,
+    roots.proof_type
+FROM universe_events u
+JOIN universe_roots roots
+  ON u.universe_root_id = roots.id
+GROUP BY roots.asset_id, roots.group_key, roots.proof_type;

--- a/tapdb/sqlc/models.go
+++ b/tapdb/sqlc/models.go
@@ -312,4 +312,5 @@ type UniverseStat struct {
 	TotalAssetProofs int64
 	AssetID          []byte
 	GroupKey         []byte
+	ProofType        string
 }

--- a/tapdb/sqlc/universe.sql.go
+++ b/tapdb/sqlc/universe.sql.go
@@ -454,11 +454,14 @@ const queryUniverseAssetStats = `-- name: QueryUniverseAssetStats :many
 WITH asset_supply AS (
     SELECT SUM(nodes.sum) AS supply, gen.asset_id AS asset_id
     FROM universe_leaves leaves
+    JOIN universe_roots roots
+        ON leaves.universe_root_id = roots.id
     JOIN mssmt_nodes nodes
         ON leaves.leaf_node_key = nodes.key AND
            leaves.leaf_node_namespace = nodes.namespace
     JOIN genesis_info_view gen
         ON leaves.asset_genesis_id = gen.gen_asset_id
+    WHERE roots.proof_type = 'issuance'
     GROUP BY gen.asset_id
 ), group_supply AS (
     SELECT sum AS num_assets, uroots.group_key AS group_key
@@ -468,6 +471,7 @@ WITH asset_supply AS (
          nodes.namespace = roots.namespace
     JOIN universe_roots uroots
       ON roots.namespace = uroots.namespace_root
+    WHERE uroots.proof_type = 'issuance'
 ), asset_info AS (
     SELECT asset_supply.supply, group_supply.num_assets AS group_supply,
            gen.asset_id AS asset_id, 
@@ -500,6 +504,7 @@ SELECT asset_info.supply AS asset_supply,
 FROM asset_info
 JOIN universe_stats
     ON asset_info.asset_id = universe_stats.asset_id
+WHERE universe_stats.proof_type = 'issuance'
 ORDER BY
     CASE WHEN $1 = 'asset_id' AND $2 = 0 THEN
              asset_info.asset_id END ASC,


### PR DESCRIPTION
This fixes a bug where the output of `tapcli universe stats assets` would show weird duplicates because the query would also include transfer related universe roots.
This also fixes the load test to work with the latest version of the `main` branch.