### PR TITLE
universe: stop syncer from syncing all known universes by default

### DIFF
--- a/tapdb/universe_federation.go
+++ b/tapdb/universe_federation.go
@@ -46,7 +46,7 @@ var (
 	defaultGlobalSyncConfigs = []*universe.FedGlobalSyncConfig{
 		{
 			ProofType:       universe.ProofTypeIssuance,
-			AllowSyncInsert: true,
+			AllowSyncInsert: false,
 			AllowSyncExport: true,
 		},
 		{


### PR DESCRIPTION
If a target set of universes is not specified the syncer will now sync universes which have associated specific sync configs, instead of all known universes.

Fixes https://github.com/lightninglabs/taproot-assets/issues/618