### PR TITLE
address: optimistic asset sync

### DIFF
--- a/address/book.go
+++ b/address/book.go
@@ -70,6 +70,19 @@ type QueryParams struct {
 	UnmanagedOnly bool
 }
 
+// AssetSyncer is an interface that allows the address.Book to look up asset
+// genesis and group information from both the local asset store and assets
+// known to universe servers in our federation.
+type AssetSyncer interface {
+	// SyncAssetInfo queries the universes in our federation for genesis
+	// and asset group information about the given asset ID.
+	SyncAssetInfo(ctx context.Context, assetID *asset.ID) error
+
+	// EnableAssetSync updates the sync config for the given asset so that
+	// we sync future issuance proofs.
+	EnableAssetSync(ctx context.Context, groupInfo *asset.AssetGroup) error
+}
+
 // Storage is the main storage interface for the address book.
 type Storage interface {
 	EventStorage
@@ -131,6 +144,10 @@ type KeyRing interface {
 type BookConfig struct {
 	// Store holds the set of created addresses.
 	Store Storage
+
+	// Syncer allows the address.Book to sync issuance information for
+	// assets from universe servers in our federation.
+	Syncer AssetSyncer
 
 	// KeyRing points to an active key ring instance.
 	KeyRing KeyRing

--- a/address/book.go
+++ b/address/book.go
@@ -2,12 +2,14 @@ package address
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/url"
 	"sync"
 	"time"
 
 	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/lndclient"
 	"github.com/lightninglabs/taproot-assets/asset"
@@ -188,6 +190,64 @@ func NewBook(cfg BookConfig) *Book {
 	}
 }
 
+// queryAssetInfo attempts to locate asset genesis information by querying
+// geneses already known to this node. If asset issuance was not previously
+// verified, we then query universes in our federation for issuance proofs.
+func (b *Book) queryAssetInfo(ctx context.Context,
+	id asset.ID) (*asset.AssetGroup, error) {
+
+	// Check if we know of this asset ID already.
+	assetGroup, err := b.cfg.Store.QueryAssetGroup(ctx, id)
+	switch {
+	case assetGroup != nil:
+		return assetGroup, nil
+
+	// Asset lookup failed gracefully; continue to asset lookup using the
+	// AssetSyncer if enabled.
+	case errors.Is(err, ErrAssetGroupUnknown):
+		if b.cfg.Syncer == nil {
+			return nil, ErrAssetGroupUnknown
+		}
+
+	case err != nil:
+		return nil, err
+	}
+
+	log.Debugf("asset %v is unknown, attempting to bootstrap", id.String())
+
+	// Use the AssetSyncer to query our universe federation for the asset.
+	err = b.cfg.Syncer.SyncAssetInfo(ctx, &id)
+	if err != nil {
+		return nil, err
+	}
+
+	// The asset genesis info may have been synced from a universe
+	// server; query for the asset ID again.
+	assetGroup, err = b.cfg.Store.QueryAssetGroup(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+
+	log.Debugf("bootstrap succeeded for asset %v", id.String())
+
+	// If the asset was found after sync, and has an asset group, update our
+	// universe sync config to ensure that we sync future issuance proofs.
+	// Ungrouped assets will have no new issuance proofs so do not need a
+	// universe sync config at all.
+	if assetGroup.GroupKey != nil {
+		log.Debugf("enabling asset sync for asset group %x",
+			schnorr.SerializePubKey(
+				&assetGroup.GroupKey.GroupPubKey,
+			))
+		err = b.cfg.Syncer.EnableAssetSync(ctx, assetGroup)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return assetGroup, nil
+}
+
 // NewAddress creates a new Taproot Asset address based on the input parameters.
 func (b *Book) NewAddress(ctx context.Context, assetID asset.ID, amount uint64,
 	tapscriptSibling *commitment.TapscriptPreimage,
@@ -195,8 +255,8 @@ func (b *Book) NewAddress(ctx context.Context, assetID asset.ID, amount uint64,
 ) (*AddrWithKeyInfo, error) {
 
 	// Before we proceed and make new keys, make sure that we actually know
-	// of this asset ID already.
-	if _, err := b.cfg.Store.QueryAssetGroup(ctx, assetID); err != nil {
+	// of this asset ID, or can import it.
+	if _, err := b.queryAssetInfo(ctx, assetID); err != nil {
 		return nil, fmt.Errorf("unable to make address for unknown "+
 			"asset %x: %w", assetID[:], err)
 	}
@@ -234,7 +294,7 @@ func (b *Book) NewAddressWithKeys(ctx context.Context, assetID asset.ID,
 	// Before we proceed, we'll make sure that the asset group is known to
 	// the local store. Otherwise, we can't make an address as we haven't
 	// bootstrapped it.
-	assetGroup, err := b.cfg.Store.QueryAssetGroup(ctx, assetID)
+	assetGroup, err := b.queryAssetInfo(ctx, assetID)
 	if err != nil {
 		return nil, err
 	}

--- a/address/log.go
+++ b/address/log.go
@@ -1,0 +1,26 @@
+package address
+
+import (
+	"github.com/btcsuite/btclog"
+)
+
+// Subsystem defines the logging code for this subsystem.
+const Subsystem = "ADDR"
+
+// log is a logger that is initialized with no output filters.  This
+// means the package will not perform any logging by default until the caller
+// requests it.
+var log = btclog.Disabled
+
+// DisableLog disables all library log output.  Logging output is disabled
+// by default until UseLogger is called.
+func DisableLog() {
+	UseLogger(btclog.Disabled)
+}
+
+// UseLogger uses a specified Logger to output package logging info.
+// This should be used in preference to SetLogWriter if the caller is also
+// using btclog.
+func UseLogger(logger btclog.Logger) {
+	log = logger
+}

--- a/config.go
+++ b/config.go
@@ -100,6 +100,11 @@ type Config struct {
 
 	AddrBook *address.Book
 
+	// AddrBookDisableSyncer is a flag which, if true, will prevent the
+	// daemon from trying to sync issuance proofs for unknown assets when
+	// creating an address.
+	AddrBookDisableSyncer bool
+
 	DefaultProofCourierAddr *url.URL
 
 	ProofArchive proof.Archiver

--- a/itest/test_harness.go
+++ b/itest/test_harness.go
@@ -325,6 +325,10 @@ type tapdHarnessParams struct {
 	// an ack from the proof receiver.
 	proofReceiverAckTimeout *time.Duration
 
+	// addrAssetSyncerDisable is a flag that determines if the address book
+	// will try and bootstrap unknown assets on address creation.
+	addrAssetSyncerDisable bool
+
 	// expectErrExit indicates whether tapd is expected to exit with an
 	// error.
 	expectErrExit bool
@@ -363,12 +367,18 @@ func setupTapdHarness(t *testing.T, ht *harnessTest,
 		selectedProofCourier = params.proofCourier
 	}
 
+	harnessOpts := func(ho *harnessOpts) {
+		ho.proofSendBackoffCfg = params.proofSendBackoffCfg
+		ho.proofReceiverAckTimeout = params.proofReceiverAckTimeout
+		ho.proofCourier = selectedProofCourier
+		ho.addrAssetSyncerDisable = params.addrAssetSyncerDisable
+	}
+
 	tapdHarness, err := newTapdHarness(
 		t, ht, tapdConfig{
 			NetParams: harnessNetParams,
 			LndNode:   node,
-		}, selectedProofCourier,
-		params.proofSendBackoffCfg, params.proofReceiverAckTimeout,
+		}, harnessOpts,
 	)
 	require.NoError(t, err)
 

--- a/itest/test_list_on_test.go
+++ b/itest/test_list_on_test.go
@@ -39,6 +39,10 @@ var testCases = []*testCase{
 		test: testReOrgMintAndSend,
 	},
 	{
+		name: "address syncer",
+		test: testAddressAssetSyncer,
+	},
+	{
 		name:             "basic send unidirectional",
 		test:             testBasicSendUnidirectional,
 		proofCourierType: proof.HashmailCourierType,

--- a/itest/test_list_on_test.go
+++ b/itest/test_list_on_test.go
@@ -23,6 +23,10 @@ var testCases = []*testCase{
 		name: "multi address",
 		test: testMultiAddress,
 	},
+	{
+		name: "address syncer",
+		test: testAddressAssetSyncer,
+	},
 	// For some (yet unknown) reason, the Postgres itest is much more flaky
 	// if the re-org tests run last. So we run them toward the beginning to
 	// reduce the flakiness of the Postgres itest.
@@ -37,10 +41,6 @@ var testCases = []*testCase{
 	{
 		name: "re-org mint and send",
 		test: testReOrgMintAndSend,
-	},
-	{
-		name: "address syncer",
-		test: testAddressAssetSyncer,
 	},
 	{
 		name:             "basic send unidirectional",

--- a/itest/universerpc_harness.go
+++ b/itest/universerpc_harness.go
@@ -26,7 +26,7 @@ func NewUniverseRPCHarness(t *testing.T, ht *harnessTest,
 		t, ht, tapdConfig{
 			NetParams: harnessNetParams,
 			LndNode:   lndHarness,
-		}, nil, nil, nil,
+		},
 	)
 	require.NoError(t, err)
 

--- a/log.go
+++ b/log.go
@@ -2,6 +2,7 @@ package taprootassets
 
 import (
 	"github.com/btcsuite/btclog"
+	"github.com/lightninglabs/taproot-assets/address"
 	"github.com/lightninglabs/taproot-assets/commitment"
 	"github.com/lightninglabs/taproot-assets/monitoring"
 	"github.com/lightninglabs/taproot-assets/proof"
@@ -97,6 +98,7 @@ func SetupLoggers(root *build.RotatingLogWriter, interceptor signal.Interceptor)
 	)
 	AddSubLogger(root, proof.Subsystem, interceptor, proof.UseLogger)
 	AddSubLogger(root, tapdb.Subsystem, interceptor, tapdb.UseLogger)
+	AddSubLogger(root, address.Subsystem, interceptor, address.UseLogger)
 	AddSubLogger(
 		root, tapscript.Subsystem, interceptor, tapscript.UseLogger,
 	)

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -2957,13 +2957,84 @@ func (r *rpcServer) QueryAssetRoots(ctx context.Context,
 			"given universe")
 	}
 
-	issuanceRoot, err := r.cfg.UniverseArchive.RootNode(ctx, universeID)
+	// Query for both a issaunce and transfer universe root.
+	assetRoots, err := r.queryAssetProofRoots(ctx, universeID)
 	if err != nil {
+		return nil, err
+	}
+
+	// If no roots were found and the universe ID had no group key, the
+	// asset may be a grouped asset.
+	mayBeGrouped := assetRoots.IssuanceRoot.Id == nil &&
+		assetRoots.TransferRoot.Id == nil && universeID.GroupKey == nil
+
+	// We already found some universe roots, or the original
+	// request was for an asset group. Return the roots we have.
+	if !mayBeGrouped {
+		return assetRoots, nil
+	}
+
+	// Query for a matching asset group, and fetch the matching universe
+	// roots if we find a group.
+	groupedAssetID := universeID.AssetID
+	rpcsLog.Debugf("No roots found for asset %v, checking if this "+
+		"asset is part of a group", groupedAssetID.String())
+
+	assetGroup, err := r.cfg.TapAddrBook.QueryAssetGroup(
+		ctx, groupedAssetID,
+	)
+
+	switch {
+	// No asset info was found; we will return empty universe roots.
+	case errors.Is(err, address.ErrAssetGroupUnknown):
+		return assetRoots, nil
+
+	case err != nil:
+		return nil, fmt.Errorf("asset group lookup failed: %w",
+			err)
+
+	// We found the correct group for this asset; fetch the universe
+	// roots for the group.
+	case assetGroup.GroupKey != nil:
+		foundGroupKey := &assetGroup.GroupPubKey
+		groupUniID := universe.Identifier{
+			GroupKey:  foundGroupKey,
+			ProofType: universe.ProofTypeIssuance,
+		}
+
+		rpcsLog.Debugf("Found group %x for asset %v",
+			foundGroupKey.SerializeCompressed(),
+			groupedAssetID.String())
+
+		assetRoots, err := r.queryAssetProofRoots(ctx, groupUniID)
+		if err != nil {
+			return nil, err
+		}
+
+		return assetRoots, nil
+
+	// The asset has no group; we will return empty universe roots.
+	default:
+		return assetRoots, nil
+	}
+}
+
+// queryAssetProofRoots attempts to locate the current Universe root for a
+// specific asset, for both proof types. The asset can be identified by its
+// asset ID or group key.
+func (r *rpcServer) queryAssetProofRoots(ctx context.Context,
+	id universe.Identifier) (*unirpc.QueryRootResponse, error) {
+
+	var issuanceRootRPC, transferRootRPC *unirpc.UniverseRoot
+	uniID := id
+
+	issuanceRoot, issuanceErr := r.cfg.UniverseArchive.RootNode(ctx, uniID)
+	if issuanceErr != nil {
 		// Do not return at this point if the error only indicates that
 		// the root wasn't found. We'll try to find the transfer root
 		// below.
-		if !errors.Is(err, universe.ErrNoUniverseRoot) {
-			return nil, err
+		if !errors.Is(issuanceErr, universe.ErrNoUniverseRoot) {
+			return nil, issuanceErr
 		}
 	}
 
@@ -2974,21 +3045,21 @@ func (r *rpcServer) QueryAssetRoots(ctx context.Context,
 
 	// Attempt to retrieve the transfer universe root.
 	rpcsLog.Debugf("Querying for asset (group) transfer universe root "+
-		"for %v", spew.Sdump(universeID))
+		"for %v", spew.Sdump(uniID))
 
-	universeID.ProofType = universe.ProofTypeTransfer
+	uniID.ProofType = universe.ProofTypeTransfer
 
-	transferRoot, err := r.cfg.UniverseArchive.RootNode(ctx, universeID)
-	if err != nil {
+	transferRoot, transferErr := r.cfg.UniverseArchive.RootNode(ctx, uniID)
+	if transferErr != nil {
 		// Do not return at this point if the error only indicates that
 		// the root wasn't found. We may have found the issuance root
 		// above.
-		if !errors.Is(err, universe.ErrNoUniverseRoot) {
-			return nil, err
+		if !errors.Is(transferErr, universe.ErrNoUniverseRoot) {
+			return nil, transferErr
 		}
 	}
 
-	transferRootRPC, err := marshalUniverseRoot(transferRoot)
+	transferRootRPC, err = marshalUniverseRoot(transferRoot)
 	if err != nil {
 		return nil, err
 	}

--- a/tapcfg/config.go
+++ b/tapcfg/config.go
@@ -253,6 +253,12 @@ type UniverseConfig struct {
 	PublicAccess bool `long:"public-access" description:"If true, and the Universe server is on a public interface, valid proof from remote parties will be accepted, and proofs will be queryable by remote parties. This applies to federation syncing as well as RPC insert and query."`
 }
 
+// AddressConfig is the config that houses any address Book related config
+// values.
+type AddrBookConfig struct {
+	DisableSyncer bool `long:"disable-syncer" description:"If true, tapd will not try to sync issuance proofs for unknown assets when creating an address."`
+}
+
 // Config is the main config for the tapd cli command.
 type Config struct {
 	ShowVersion bool `long:"version" description:"Display version information and exit"`
@@ -288,6 +294,8 @@ type Config struct {
 	Postgres        *tapdb.PostgresConfig `group:"postgres" namespace:"postgres"`
 
 	Universe *UniverseConfig `group:"universe" namespace:"universe"`
+
+	AddrBook *AddrBookConfig `group:"address" namespace:"address"`
 
 	Prometheus monitoring.PrometheusConfig `group:"prometheus" namespace:"prometheus"`
 
@@ -361,6 +369,9 @@ func DefaultConfig() Config {
 		},
 		Universe: &UniverseConfig{
 			SyncInterval: defaultUniverseSyncInterval,
+		},
+		AddrBook: &AddrBookConfig{
+			DisableSyncer: false,
 		},
 	}
 }

--- a/tapcfg/server.go
+++ b/tapcfg/server.go
@@ -98,13 +98,6 @@ func genServerConfig(cfg *Config, cfgLogger btclog.Logger,
 	walletAnchor := tap.NewLndRpcWalletAnchor(lndServices)
 	chainBridge := tap.NewLndRpcChainBridge(lndServices)
 
-	addrBook := address.NewBook(address.BookConfig{
-		Store:        tapdbAddrBook,
-		StoreTimeout: tapdb.DefaultStoreTimeout,
-		KeyRing:      keyRing,
-		Chain:        tapChainParams,
-	})
-
 	assetStore := tapdb.NewAssetStore(assetDB, defaultClock)
 
 	uniDB := tapdb.NewTransactionExecutor(
@@ -300,6 +293,15 @@ func genServerConfig(cfg *Config, cfgLogger btclog.Logger,
 			ErrChan: mainErrChan,
 		},
 	)
+
+	addrBookConfig := address.BookConfig{
+		Store:        tapdbAddrBook,
+		Syncer:       universeFederation,
+		StoreTimeout: tapdb.DefaultStoreTimeout,
+		KeyRing:      keyRing,
+		Chain:        tapChainParams,
+	}
+	addrBook := address.NewBook(addrBookConfig)
 
 	virtualTxSigner := tap.NewLndRpcVirtualTxSigner(lndServices)
 	coinSelect := tapfreighter.NewCoinSelect(assetStore)

--- a/tapcfg/server.go
+++ b/tapcfg/server.go
@@ -301,6 +301,9 @@ func genServerConfig(cfg *Config, cfgLogger btclog.Logger,
 		KeyRing:      keyRing,
 		Chain:        tapChainParams,
 	}
+	if cfg.AddrBook.DisableSyncer {
+		addrBookConfig.Syncer = nil
+	}
 	addrBook := address.NewBook(addrBookConfig)
 
 	virtualTxSigner := tap.NewLndRpcVirtualTxSigner(lndServices)
@@ -358,6 +361,7 @@ func genServerConfig(cfg *Config, cfgLogger btclog.Logger,
 		),
 		ChainBridge:             chainBridge,
 		AddrBook:                addrBook,
+		AddrBookDisableSyncer:   cfg.AddrBook.DisableSyncer,
 		DefaultProofCourierAddr: proofCourierAddr.Url(),
 		ProofArchive:            proofArchive,
 		AssetWallet:             assetWallet,

--- a/universe/auto_syncer.go
+++ b/universe/auto_syncer.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	"github.com/davecgh/go-spew/spew"
+	"github.com/lightninglabs/taproot-assets/address"
+	"github.com/lightninglabs/taproot-assets/asset"
 	"github.com/lightninglabs/taproot-assets/fn"
 )
 
@@ -100,6 +102,10 @@ type FederationEnvoy struct {
 	batchPushRequests chan *FederationProofBatchPushReq
 }
 
+// A compile-time check to ensure that FederationEnvoy meets the
+// address.AssetSyncer interface.
+var _ address.AssetSyncer = (*FederationEnvoy)(nil)
+
 // NewFederationEnvoy creates a new federation envoy from the passed config.
 func NewFederationEnvoy(cfg FederationConfig) *FederationEnvoy {
 	return &FederationEnvoy{
@@ -170,16 +176,6 @@ func (f *FederationEnvoy) Stop() error {
 	return nil
 }
 
-// reportErr sends a new error result back to the main error channel.
-func (f *FederationEnvoy) reportErr(err error) {
-	log.Errorf(err.Error())
-
-	select {
-	case f.cfg.ErrChan <- err:
-	case <-f.Quit:
-	}
-}
-
 // syncServerState attempts to sync Universe state with the target server.
 // If the sync is successful (even if no diff is generated), then a new sync
 // event will be logged.
@@ -228,27 +224,16 @@ func (f *FederationEnvoy) syncServerState(ctx context.Context,
 func (f *FederationEnvoy) pushProofToFederation(uniID Identifier, key LeafKey,
 	leaf *Leaf) {
 
-	ctx, cancel := f.WithCtxQuit()
-	defer cancel()
-
-	fedServers, err := f.cfg.FederationDB.UniverseServers(
-		ctx,
-	)
-	if err != nil {
-		err := fmt.Errorf("unable to fetch set of universe "+
-			"servers: %v", err)
-		f.reportErr(err)
-		return
-	}
-
-	if len(fedServers) == 0 {
+	// Fetch all universe servers in our federation.
+	fedServers, err := f.tryFetchServers()
+	if err != nil || len(fedServers) == 0 {
 		return
 	}
 
 	log.Infof("Pushing new proof to %v federation members, proof_key=%v",
 		len(fedServers), spew.Sdump(key))
 
-	ctx, cancel = f.WithCtxQuitNoTimeout()
+	ctx, cancel := f.WithCtxQuitNoTimeout()
 	defer cancel()
 
 	// To push a new proof out, we'll attempt to dial to the remote
@@ -302,20 +287,12 @@ func (f *FederationEnvoy) syncer() {
 		// to synchronize state with all the active universe servers in
 		// the federation.
 		case <-syncTicker.C:
-			ctx, cancel := f.WithCtxQuit()
-
-			fedServers, err := f.cfg.FederationDB.UniverseServers(
-				ctx,
-			)
+			// Error propogation is handled in tryFetchServers, we
+			// only need to exit here.
+			fedServers, err := f.tryFetchServers()
 			if err != nil {
-				cancel()
-
-				err := fmt.Errorf("unable to fetch set of "+
-					"universe servers: %v", err)
-				f.reportErr(err)
 				return
 			}
-			cancel()
 
 			log.Infof("Synchronizing with %v federation members",
 				len(fedServers))
@@ -528,6 +505,128 @@ func (f *FederationEnvoy) SetAllowPublicAccess() error {
 
 	return f.cfg.FederationDB.UpsertFederationSyncConfig(
 		ctx, globalSyncConfigs, nil,
+	)
+}
+
+// tryFetchServers attempts to fetch the set of universe servers in the
+// federation.
+func (f *FederationEnvoy) tryFetchServers() ([]ServerAddr, error) {
+	ctx, cancel := f.WithCtxQuit()
+
+	fedServers, err := f.cfg.FederationDB.UniverseServers(
+		ctx,
+	)
+	if err != nil {
+		log.Warnf("unable to fetch set of universe servers: %v", err)
+	}
+	cancel()
+
+	return fedServers, nil
+}
+
+// SyncAssetInfo queries the universes in our federation for genesis and asset
+// group information about the given asset ID.
+func (f *FederationEnvoy) SyncAssetInfo(ctx context.Context,
+	assetID *asset.ID) error {
+
+	if assetID == nil {
+		return fmt.Errorf("no asset ID provided")
+	}
+
+	// Fetch the set of universe servers in our federation.
+	fedServers, err := f.tryFetchServers()
+	if err != nil {
+		return err
+	}
+
+	assetConfig := FedUniSyncConfig{
+		UniverseID: Identifier{
+			AssetID:   *assetID,
+			ProofType: ProofTypeIssuance,
+		},
+		AllowSyncInsert: true,
+		AllowSyncExport: false,
+	}
+	fullConfig := SyncConfigs{
+		UniSyncConfigs: []*FedUniSyncConfig{&assetConfig},
+	}
+	// We'll sync with Universe servers in parallel and collect the diffs
+	// from any successful syncs. There can only be one diff per server, as
+	// we're only syncing one universe root.
+	returnedSyncDiffs := make(chan AssetSyncDiff, len(fedServers))
+
+	// To fetch information about the asset, we only need to sync with the
+	// remote universe. Asset group import and verification is handled as
+	// part of the universe sync.
+	syncFromUni := func(ctxs context.Context, addr ServerAddr) error {
+		syncDiff, err := f.cfg.UniverseSyncer.SyncUniverse(
+			ctxs, addr, SyncIssuance, fullConfig,
+		)
+
+		// Sync failures are expected from Universe servers that do not
+		// have a relevant universe root.
+		if err != nil {
+			log.Debugf("asset lookup for %v failed with remote"+
+				"server: %v", assetID.String(), addr.HostStr())
+			return nil
+		}
+
+		// There should only be one sync diff since we're only syncing
+		// one universe root.
+		if syncDiff != nil {
+			if len(syncDiff) != 1 {
+				log.Debugf("unexpected number of sync diffs: "+
+					"%v", len(syncDiff))
+				return nil
+			}
+
+			returnedSyncDiffs <- syncDiff[0]
+		}
+
+		return nil
+	}
+
+	// Sync with the federation Universe servers in parallel.
+	err = fn.ParSlice(ctx, fedServers, syncFromUni)
+	if err != nil {
+		// We should never receive a non-nil error from the sync above.
+		log.Errorf("unable to perform asset lookup with federation: "+
+			"%v", err)
+		return err
+	}
+
+	syncDiffs := fn.Collect(returnedSyncDiffs)
+	log.Infof("Synced new Universe leaves for asset %v, diff_size=%v",
+		assetID.String(), len(syncDiffs))
+
+	// TODO(jhb): Log successful syncs?
+	if len(syncDiffs) == 0 {
+		return fmt.Errorf("asset lookup failed for asset: %v",
+			assetID.String())
+	}
+
+	return nil
+}
+
+// EnableAssetSync updates the sync config for the given asset to that we sync
+// future issuance proofs.
+func (f *FederationEnvoy) EnableAssetSync(ctx context.Context,
+	groupInfo *asset.AssetGroup) error {
+
+	// Construct the universe config to match the given asset.
+	uniID := FedUniSyncConfig{
+		UniverseID: Identifier{
+			ProofType: ProofTypeIssuance,
+			GroupKey:  &groupInfo.GroupKey.GroupPubKey,
+		},
+		AllowSyncInsert: true,
+		AllowSyncExport: true,
+	}
+
+	// We know there is no existing config for this asset, so we don't need
+	// to read an existing config before upserting the config above.
+	return f.cfg.FederationDB.UpsertFederationSyncConfig(
+		ctx, nil, []*FedUniSyncConfig{&uniID},
 	)
 }
 


### PR DESCRIPTION
Fixes #620.

This PR adds support for creating addresses for assets that  a node has not bootstrapped or synced. If the asset info is not found, the node tries to sync asset info from all members of their universe federation. If the asset info is found, this asset is also added to the universe sync config to keep track of future possible issuance.

This helps address the UX changes from switching global sync to opt-in, since you can also make an address for an asset that's a member of an asset group, without having bootstrapped the asset group creation itself.

A related change is that the `QueryAssetRoots` RPC will now try and look up an asset group for a given universe ID, iff the ID specified an asset ID and no other roots were found. This is what allows a user to bootstrap an asset group without knowing the group key.

TODOs:

- [x] extend itest to cover a grouped asset and verify asset universe config changes + sync behavior with the config changes