### PR TITLE
Ensure receiver node backoff retries finally succeed in asset send via universe proof courier

### DIFF
--- a/itest/universerpc_harness.go
+++ b/itest/universerpc_harness.go
@@ -43,7 +43,9 @@ func (h *UniverseRPCHarness) Start(_ chan error) error {
 
 // Stop stops the service.
 func (h *UniverseRPCHarness) Stop() error {
-	return h.service.stop(true)
+	// Don't delete temporary data on stop. This will allow us to cleanly
+	// restart the service mid-test.
+	return h.service.stop(false)
 }
 
 // Ensure that NewUniverseRPCHarness implements the proof.CourierHarness


### PR DESCRIPTION
Fixes https://github.com/lightninglabs/taproot-assets/issues/638

Before the changes introduced in this PR, the universe proof courier proof retrieval itest did not ensure that the proof was actually retrievable after multiple retrieval attempts were conducted. This PR ensures that the proof can actually be retrieved after repeated retrieval attempts using the backoff procedure.

This PR is ready for review.