### PR TITLE
loadtest: add support for push metrics

### DIFF
--- a/itest/loadtest/config.go
+++ b/itest/loadtest/config.go
@@ -44,6 +44,14 @@ type BitcoinConfig struct {
 	TLSPath  string `long:"tlspath" description:"Path to btcd's TLS certificate, if TLS is enabled"`
 }
 
+// PrometheusGatewayConfig defines exported config options for connecting to the
+// Prometheus PushGateway.
+type PrometheusGatewayConfig struct {
+	Enabled bool   `long:"enabled" description:"Enable pushing metrics to Prometheus PushGateway"`
+	Host    string `long:"host" description:"Prometheus PushGateway host address"`
+	Port    int    `long:"port" description:"Prometheus PushGateway port"`
+}
+
 // Config holds the main configuration for the performance testing binary.
 type Config struct {
 	// TestCases is a comma separated list of test cases that will be
@@ -80,6 +88,9 @@ type Config struct {
 
 	// TestTimeout is the timeout for each test.
 	TestTimeout time.Duration `long:"test-timeout" description:"the timeout for each test"`
+
+	// PrometheusGateway is the configuration for the Prometheus PushGateway.
+	PrometheusGateway *PrometheusGatewayConfig `group:"prometheus-gateway" namespace:"prometheus-gateway" description:"Prometheus PushGateway configuration"`
 }
 
 // DefaultConfig returns the default configuration for the performance testing
@@ -102,6 +113,11 @@ func DefaultConfig() Config {
 		SendType:         taprpc.AssetType_COLLECTIBLE,
 		TestSuiteTimeout: defaultSuiteTimeout,
 		TestTimeout:      defaultTestTimeout,
+		PrometheusGateway: &PrometheusGatewayConfig{
+			Enabled: false,
+			Host:    "localhost",
+			Port:    9091,
+		},
 	}
 }
 

--- a/itest/loadtest/config.go
+++ b/itest/loadtest/config.go
@@ -1,6 +1,7 @@
 package loadtest
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/jessevdk/go-flags"
@@ -50,6 +51,7 @@ type PrometheusGatewayConfig struct {
 	Enabled bool   `long:"enabled" description:"Enable pushing metrics to Prometheus PushGateway"`
 	Host    string `long:"host" description:"Prometheus PushGateway host address"`
 	Port    int    `long:"port" description:"Prometheus PushGateway port"`
+	PushURL string
 }
 
 // Config holds the main configuration for the performance testing binary.
@@ -154,5 +156,25 @@ func LoadConfig() (*Config, error) {
 // of it with sane defaults.
 func ValidateConfig(cfg Config) (*Config, error) {
 	// TODO (positiveblue): add validation logic.
+
+	// Validate Prometheus PushGateway configuration.
+	if cfg.PrometheusGateway.Enabled {
+		gatewayHost := cfg.PrometheusGateway.Host
+		gatewayPort := cfg.PrometheusGateway.Port
+
+		if gatewayHost == "" {
+			return nil, fmt.Errorf("gateway hostname may not be empty")
+		}
+
+		if gatewayPort == 0 {
+			return nil, fmt.Errorf("gateway port is not set")
+		}
+
+		// Construct the endpoint for Prometheus PushGateway.
+		cfg.PrometheusGateway.PushURL = fmt.Sprintf(
+			"%s:%d", gatewayHost, gatewayPort,
+		)
+	}
+
 	return &cfg, nil
 }

--- a/itest/loadtest/load_test.go
+++ b/itest/loadtest/load_test.go
@@ -4,7 +4,6 @@ package loadtest
 
 import (
 	"context"
-	"strconv"
 	"testing"
 	"time"
 
@@ -86,10 +85,7 @@ func TestPerformance(t *testing.T) {
 			testDuration.WithLabelValues(tc.name).Set(duration)
 
 			// Create a new pusher to push the metrics.
-			pushURL := cfg.PrometheusGateway.Host + ":" +
-				strconv.Itoa(cfg.PrometheusGateway.Port)
-
-			pusher := push.New(pushURL, "load_test").
+			pusher := push.New(cfg.PrometheusGateway.PushURL, "load_test").
 				Collector(testDuration).
 				Grouping("test_case", tc.name)
 


### PR DESCRIPTION
Equip the test orchestrator with the ability to push metrics on execution time to a configurable remote prometheus push gateway.

Related to: https://github.com/lightninglabs/taproot-assets/pull/662 (`loadtest` metrics vs. `tapd` metrics)