### PR TITLE
monitoring: add assetCollector for asset related metrics

### DIFF
--- a/monitoring/asset_collector.go
+++ b/monitoring/asset_collector.go
@@ -1,0 +1,107 @@
+package monitoring
+
+import (
+	"context"
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	assetCollectorName = "asset"
+
+	numAssetsMintedMetric = "num_assets_minted"
+)
+
+type assetCollector struct {
+	collectMx sync.Mutex
+
+	cfg *PrometheusConfig
+
+	numAssetsMinted prometheus.Gauge
+}
+
+func newAssetCollector(cfg *PrometheusConfig) *assetCollector {
+	return &assetCollector{
+		cfg: cfg,
+		numAssetsMinted: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Name: numAssetsMintedMetric,
+				Help: "Total number of assets minted",
+			}),
+	}
+}
+
+func (a *assetCollector) Name() string {
+	return assetCollectorName
+}
+
+// Describe sends the super-set of all possible descriptors of metrics
+// collected by this Collector to the provided channel and returns once the
+// last descriptor has been sent.
+//
+// NOTE: Part of the prometheus.Collector interface.
+func (a *assetCollector) Describe(ch chan<- *prometheus.Desc) {
+	log.Infof("Asset Collector Describe()")
+	a.collectMx.Lock()
+	defer a.collectMx.Unlock()
+
+	a.numAssetsMinted.Describe(ch)
+}
+
+// Collect is called by the Prometheus registry when collecting metrics.
+//
+// NOTE: Part of the prometheus.Collector interface.
+func (a *assetCollector) Collect(ch chan<- prometheus.Metric) {
+	log.Infof("Asset Collector Collect()")
+	a.collectMx.Lock()
+	defer a.collectMx.Unlock()
+
+	if a.cfg == nil {
+		log.Error("cfg is nil")
+		return
+	}
+
+	if a.cfg.UniverseStats == nil {
+		log.Error("UniverseStats is nil")
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), dbTimeout)
+	defer cancel()
+
+	universeStats, err := a.cfg.UniverseStats.AggregateSyncStats(ctx)
+	if err != nil {
+		log.Errorf("unable to get aggregate universe stats: %v", err)
+		return
+	}
+
+	numAssets := universeStats.NumTotalAssets
+	a.numAssetsMinted.Set(float64(numAssets))
+
+	a.numAssetsMinted.Collect(ch)
+}
+
+func (a *assetCollector) RegisterMetricFuncs() error {
+	log.Infof("Asset Collector: Register Metric Funcs")
+	err := prometheus.Register(a)
+	if err != nil {
+		log.Errorf("Error registering asset collector: %v", err)
+		return err
+	}
+
+	log.Infof("Asset Collector: Register Metric Funcs Finished")
+	return nil
+}
+
+var _ MetricGroup = (*assetCollector)(nil)
+
+func init() {
+	metricsMtx.Lock()
+	defer metricsMtx.Unlock()
+	metricGroups[assetCollectorName] = func(cfg *PrometheusConfig) (
+		MetricGroup, error) {
+
+		return newAssetCollector(cfg), nil
+	}
+}

--- a/monitoring/config.go
+++ b/monitoring/config.go
@@ -1,6 +1,9 @@
 package monitoring
 
-import "google.golang.org/grpc"
+import (
+	"github.com/lightninglabs/taproot-assets/universe"
+	"google.golang.org/grpc"
+)
 
 // PrometheusConfig is the set of configuration data that specifies if
 // Prometheus metric exporting is activated, and if so the listening address of
@@ -16,6 +19,9 @@ type PrometheusConfig struct {
 	// RPCServer is a pointer to the main RPC server. We use this to export
 	// generic RPC metrics to monitor the health of the service.
 	RPCServer *grpc.Server
+
+	// UniverseStats ...
+	UniverseStats universe.Telemetry
 
 	// PerfHistograms indicates if the additional histogram information for
 	// latency, and handling time of gRPC calls should be enabled. This

--- a/monitoring/interface.go
+++ b/monitoring/interface.go
@@ -5,7 +5,7 @@ import "github.com/prometheus/client_golang/prometheus"
 // metricGroupFactory is a factory method that given the primary prometheus
 // config, will create a new MetricGroup that will be managed by the main
 // PrometheusExporter.
-type metricGroupFactory func(*PrometheusConfig) (MetricGroup, error)
+type metricGroupFactory func(*PrometheusConfig, *prometheus.Registry) (MetricGroup, error)
 
 // MetricGroup is the primary interface of this package. The main exporter (in
 // this case the PrometheusExporter), will manage these directly, ensuring that

--- a/monitoring/prometheus.go
+++ b/monitoring/prometheus.go
@@ -34,6 +34,11 @@ var (
 	serverMetrics *grpc_prometheus.ServerMetrics
 )
 
+const (
+	// dbTimeout is the default database timeout.
+	dbTimeout = 20 * time.Second
+)
+
 // PrometheusExporter is a metric exporter that uses Prometheus directly. The
 // internal server will interact with this struct in order to export relevant
 // metrics.

--- a/server.go
+++ b/server.go
@@ -313,6 +313,9 @@ func (s *Server) RunUntilShutdown(mainErrChan <-chan error) error {
 		// configuration.
 		s.cfg.Prometheus.RPCServer = grpcServer
 
+		// Provide Prometheus collectors with access to Universe stats.
+		s.cfg.Prometheus.UniverseStats = s.cfg.UniverseStats
+
 		promExporter, err := monitoring.NewPrometheusExporter(
 			&s.cfg.Prometheus,
 		)

--- a/server.go
+++ b/server.go
@@ -324,13 +324,14 @@ func (s *Server) RunUntilShutdown(mainErrChan <-chan error) error {
 				err)
 		}
 
-		srvrLog.Infof("Prometheus exporter server listening on %v",
-			s.cfg.Prometheus.ListenAddr)
-
 		if err := promExporter.Start(); err != nil {
 			return mkErr("Unable to start prometheus exporter: %v",
 				err)
 		}
+
+		srvrLog.Infof("Prometheus exporter server listening on %v",
+			s.cfg.Prometheus.ListenAddr)
+
 	}
 
 	srvrLog.Infof("Taproot Asset Daemon fully active!")


### PR DESCRIPTION
Enable custom metric for # of minted assets. In the future we will expand this to include additional metrics of interest.

There seems to be some change to the `universe stats` RPC, upon which the reporting of # of minted assets presently relies. The RPC will not reflect recent changes immediately, but does seem to eventually become consistent.
```bash
/ # tapcli --network=regtest --tapddir=/data universe stats
{
    "num_total_assets": "0",
    "num_total_groups": "0",
    "num_total_syncs": "0",
    "num_total_proofs": "0"
}
... some time later
/ # tapcli --network=regtest --tapddir=/data universe stats
{
    "num_total_assets": "8",
    "num_total_groups": "8",
    "num_total_syncs": "0",
    "num_total_proofs": "466"
}
```
NOTE: This is more or less a mirror of how [`subasta`](https://github.com/lightninglabs/subasta/blob/master/monitoring/account_collector.go) sets things up.

TODO:
- Check into whether there have been any changes to the functionality of the `universe stats` RPC and whether a new approach will need to be taken here.

Partially Addresses: https://github.com/lightninglabs/lightning-infra/issues/990
