### PR TITLE
universe: fix log entry when sync fails

### DIFF
--- a/universe/auto_syncer.go
+++ b/universe/auto_syncer.go
@@ -473,7 +473,7 @@ func (f *FederationEnvoy) SyncServers(serverAddrs []ServerAddr) error {
 		err := f.syncServerState(ctx, serverAddr, *syncConfigs)
 		if err != nil {
 			log.Warnf("encountered an error whilst syncing with "+
-				"server=%v: %w", spew.Sdump(serverAddr), err)
+				"server=%v: %v", spew.Sdump(serverAddr), err)
 		}
 		return nil
 	}

--- a/universe/base.go
+++ b/universe/base.go
@@ -127,7 +127,7 @@ type RootNodesQuery struct {
 func (a *Archive) RootNodes(ctx context.Context,
 	q RootNodesQuery) ([]Root, error) {
 
-	log.Debugf("Fetching all known Universe roots (with_amounts_by_id=%v"+
+	log.Tracef("Fetching all known Universe roots (with_amounts_by_id=%v"+
 		", sort_direction=%v, offset=%v, limit=%v)", q.WithAmountsById,
 		q.SortDirection, q.Offset, q.Limit)
 


### PR DESCRIPTION
In this commit, we fix a bug that would cause a log entry to be garbled when we try to sync with a Universe, but it fails. Before this commit, we used `%w`, which should only be used when _creating_ a new error, not logging one.