### PR TITLE
tapgarden: fix races and deadlocks in caretaker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ COMMIT := $(shell git describe --tags --dirty)
 
 GOBUILD := GOEXPERIMENT=loopvar GO111MODULE=on go build -v
 GOINSTALL := GOEXPERIMENT=loopvar GO111MODULE=on go install -v
-GOTEST := GOEXPERIMENT=loopvar GO111MODULE=on go test 
+GOTEST := GOEXPERIMENT=loopvar GO111MODULE=on go test
 GOMOD := GO111MODULE=on go mod
 
 GOLIST := go list -deps $(PKG)/... | grep '$(PKG)'
@@ -168,7 +168,7 @@ unit-cover: $(GOACC_BIN)
 
 unit-race:
 	@$(call print, "Running unit race tests.")
-	env CGO_ENABLED=1 GORACE="history_size=7 halt_on_errors=1" $(GOLIST) | $(XARGS) env $(GOTEST) -race -test.timeout=20m
+	env CGO_ENABLED=1 GORACE="history_size=7 halt_on_errors=1" $(UNIT_RACE)
 
 itest: build-itest itest-only
 

--- a/fn/func.go
+++ b/fn/func.go
@@ -172,3 +172,20 @@ func First[T any](xs []*T, pred func(*T) bool) (*T, error) {
 
 	return nil, fmt.Errorf("no item found")
 }
+
+// Last returns the last item in the slice that matches the predicate, or an
+// error if none matches.
+func Last[T any](xs []*T, pred func(*T) bool) (*T, error) {
+	var matches []*T
+	for i := range xs {
+		if pred(xs[i]) {
+			matches = append(matches, xs[i])
+		}
+	}
+
+	if len(matches) == 0 {
+		return nil, fmt.Errorf("no item found")
+	}
+
+	return matches[len(matches)-1], nil
+}

--- a/make/testing_flags.mk
+++ b/make/testing_flags.mk
@@ -5,6 +5,7 @@ LOG_TAGS =
 TEST_FLAGS =
 ITEST_FLAGS = -logoutput
 COVER_PKG = $$(go list -deps -tags="$(DEV_TAGS)" ./... | grep '$(PKG)' | grep -v lnrpc)
+RACE_PKG = go list -deps -tags="$(DEV_TAGS)" ./... | grep '$(PKG)'
 COVER_HTML = go tool cover -html=coverage.txt -o coverage.html
 POSTGRES_START_DELAY = 5
 
@@ -19,6 +20,7 @@ ifneq ($(pkg),)
 UNITPKG := $(PKG)/$(pkg)
 UNIT_TARGETED = yes
 COVER_PKG = $(PKG)/$(pkg)
+RACE_PKG = $(PKG)/$(pkg)
 endif
 
 # If a specific unit test case is being target, construct test.run filter.
@@ -78,7 +80,7 @@ TEST_FLAGS += -test.timeout=$(timeout)
 else ifneq ($(optional),)
 TEST_FLAGS += -test.timeout=240m
 else
-TEST_FLAGS += -test.timeout=60m
+TEST_FLAGS += -test.timeout=20m
 endif
 
 GOLIST := go list -tags="$(DEV_TAGS)" -deps $(PKG)/... | grep '$(PKG)'| grep -v '/vendor/'

--- a/tapgarden/caretaker.go
+++ b/tapgarden/caretaker.go
@@ -166,6 +166,8 @@ func (b *BatchCaretaker) Start() error {
 func (b *BatchCaretaker) Stop() error {
 	var stopErr error
 	b.stopOnce.Do(func() {
+		log.Infof("BatchCaretaker(%x): Stopping", b.batchKey[:])
+
 		close(b.Quit)
 		b.Wg.Wait()
 	})
@@ -313,7 +315,7 @@ func (b *BatchCaretaker) assetCultivator() {
 		currentBatchState, BatchStateBroadcast,
 	)
 	if err != nil {
-		log.Errorf("unable to advance state machine: %v", err)
+		log.Errorf("Unable to advance state machine: %v", err)
 		b.cfg.BroadcastErrChan <- err
 		return
 	}

--- a/tapgarden/planter.go
+++ b/tapgarden/planter.go
@@ -91,8 +91,8 @@ type BatchKey = asset.SerializedKey
 
 // CancelResp is the response from a caretaker attempting to cancel a batch.
 type CancelResp struct {
-	finalState *BatchState
-	err        error
+	cancelAttempted bool
+	err             error
 }
 
 type stateRequest interface {
@@ -448,7 +448,7 @@ func (c *ChainPlanter) cancelMintingBatch(ctx context.Context,
 			// cancellation was possible and attempted. This means
 			// that the caretaker is shut down and the planter
 			// must delete it.
-			if cancelResp.finalState != nil {
+			if cancelResp.cancelAttempted {
 				delete(c.caretakers, batchKeySerialized)
 			}
 


### PR DESCRIPTION
Fixes #360 and #562 .

I found a few problems in the caretaker cancellation error reporting and cancellation, which manifested as an intermittent deadlock in the caretaker when running the minter tests under the race detector / with the `unit-race` target. The other test that revealed issues was deliberately causing failures in the caretaker as part of testing fee estimation, but that itest will be in a separate PR.

I verified these fixes locally by running 100 iterations of `TestBatchAssetIssuance` under standard conditions / with `make unit`, and under the race detector / with `make unit-race`.

One possible TODO is adding extra coverage for when the caretaker is cancelled, but I think the existing unit tests already cover the main partitions of before and after `BatchStateBroadcast`.