### PR TITLE
build: fix github actions to ensure release artefacts are uploaded

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,7 +42,7 @@ jobs:
           name: tapd ${{ env.RELEASE_VERSION }}
           draft: true
           prerelease: false
-          files: tapd-${{ env.RELEASE_VERSION }}/*
+          files: taproot-assets-${{ env.RELEASE_VERSION }}/*
           body: |
             # Database Migrations
             TODO


### PR DESCRIPTION
The latest tag hit this error in the final phase of the build:
>  tapd-v0.3.2-beta.rc1/* not include valid file.

The actual release artefacts use the package name which is `taproot-assets` and not `tapd. So in this commit, we attempt to point it to the proper location in the work directory.