### PR TITLE
Federation envoy re-attempts sync push for issuance proofs

### DIFF
--- a/itest/tapd_harness.go
+++ b/itest/tapd_harness.go
@@ -100,6 +100,10 @@ type harnessOpts struct {
 	proofCourier                 proof.CourierHarness
 	custodianProofRetrievalDelay *time.Duration
 	addrAssetSyncerDisable       bool
+
+	// fedSyncTickerInterval is the interval at which the federation envoy
+	// sync ticker will fire.
+	fedSyncTickerInterval *time.Duration
 }
 
 type harnessOption func(*harnessOpts)
@@ -240,6 +244,10 @@ func newTapdHarness(t *testing.T, ht *harnessTest, cfg tapdConfig,
 	finalCfg.CustodianProofRetrievalDelay = defaultProofRetrievalDelay
 	if opts.custodianProofRetrievalDelay != nil {
 		finalCfg.CustodianProofRetrievalDelay = *opts.custodianProofRetrievalDelay
+	}
+
+	if opts.fedSyncTickerInterval != nil {
+		finalCfg.Universe.SyncInterval = *opts.fedSyncTickerInterval
 	}
 
 	return &tapdHarness{

--- a/itest/test_harness.go
+++ b/itest/test_harness.go
@@ -366,6 +366,10 @@ type tapdHarnessParams struct {
 	// synced from the above node.
 	startupSyncNumAssets int
 
+	// fedSyncTickerInterval is the interval at which the federation envoy
+	// sync ticker will fire.
+	fedSyncTickerInterval *time.Duration
+
 	// noDefaultUniverseSync indicates whether the default universe server
 	// should be added as a federation server or not.
 	noDefaultUniverseSync bool
@@ -402,6 +406,7 @@ func setupTapdHarness(t *testing.T, ht *harnessTest,
 		ho.proofCourier = selectedProofCourier
 		ho.custodianProofRetrievalDelay = params.custodianProofRetrievalDelay
 		ho.addrAssetSyncerDisable = params.addrAssetSyncerDisable
+		ho.fedSyncTickerInterval = params.fedSyncTickerInterval
 	}
 
 	tapdHarness, err := newTapdHarness(t, ht, tapdConfig{

--- a/itest/test_list_on_test.go
+++ b/itest/test_list_on_test.go
@@ -195,6 +195,10 @@ var testCases = []*testCase{
 		name: "universe pagination simple",
 		test: testUniversePaginationSimple,
 	},
+	{
+		name: "mint proof repeat fed sync attempt",
+		test: testMintProofRepeatFedSyncAttempt,
+	},
 }
 
 var optionalTestCases = []*testCase{

--- a/itest/universe_federation_test.go
+++ b/itest/universe_federation_test.go
@@ -1,0 +1,99 @@
+package itest
+
+import (
+	"context"
+	"time"
+
+	"github.com/lightninglabs/taproot-assets/taprpc/mintrpc"
+	unirpc "github.com/lightninglabs/taproot-assets/taprpc/universerpc"
+	"github.com/stretchr/testify/require"
+)
+
+// testMintProofRepeatFedSyncAttempt tests that the minting node will retry
+// pushing the minting proofs to the federation server peer node, if the peer
+// node is offline at the time of the initial sync attempt.
+func testMintProofRepeatFedSyncAttempt(t *harnessTest) {
+	// Create a new minting node, without hooking it up to any existing
+	// Universe server. We will also set the sync ticker to 4 second, so
+	// that we can test that the proof push sync is retried and eventually
+	// succeeds after the fed server peer node reappears online.
+	syncTickerInterval := 4 * time.Second
+	mintingNode := setupTapdHarness(
+		t.t, t, t.lndHarness.Bob, nil,
+		func(params *tapdHarnessParams) {
+			params.fedSyncTickerInterval = &syncTickerInterval
+			params.noDefaultUniverseSync = true
+		},
+	)
+	defer func() {
+		require.NoError(t.t, mintingNode.stop(!*noDelete))
+	}()
+
+	// We'll use the main node as our federation universe server
+	// counterparty.
+	fedServerNode := t.tapd
+
+	// Keep a reference to the fed server node RPC host address, so that we
+	// can assert that it has not changed after the restart. This is
+	// important, because the minting node will be retrying the proof push
+	// to this address.
+	fedServerNodeRpcHost := fedServerNode.rpcHost()
+
+	// Register the fedServerNode as a federation universe server with the
+	// minting node.
+	ctxb := context.Background()
+	ctxt, cancel := context.WithTimeout(ctxb, defaultWaitTimeout)
+	defer cancel()
+
+	_, err := mintingNode.AddFederationServer(
+		ctxt, &unirpc.AddFederationServerRequest{
+			Servers: []*unirpc.UniverseFederationServer{
+				{
+					Host: fedServerNodeRpcHost,
+				},
+			},
+		},
+	)
+	require.NoError(t.t, err)
+
+	// Assert that the fed server node has not seen any asset proofs.
+	AssertUniverseStats(t.t, fedServerNode, 0, 0, 0)
+
+	// Stop the federation server peer node, so that it does not receive the
+	// newly minted asset proofs immediately upon minting.
+	t.Logf("Stopping fed server tapd node")
+	require.NoError(t.t, fedServerNode.stop(false))
+
+	// Now that federation peer node is inactive, we'll mint some assets.
+	t.Logf("Minting assets on minting node")
+	rpcAssets := MintAssetsConfirmBatch(
+		t.t, t.lndHarness.Miner.Client, mintingNode,
+		[]*mintrpc.MintAssetRequest{
+			simpleAssets[0], issuableAssets[0],
+		},
+	)
+	require.Len(t.t, rpcAssets, 2)
+
+	t.lndHarness.MineBlocks(7)
+
+	// Wait for the minting node to attempt (and fail) to push the minting
+	// proofs to the fed peer node. We wait some multiple of the sync ticker
+	// interval to ensure that the minting node has had time to retry the
+	// proof push sync.
+	time.Sleep(syncTickerInterval * 2)
+
+	// Start the federation server peer node. The federation envoy component
+	// of our minting node should currently be retrying the proof push sync
+	// with the federation peer at each tick.
+	t.Logf("Start (previously stopped) fed server tapd node")
+	err = fedServerNode.start(false)
+	require.NoError(t.t, err)
+
+	// Ensure that the federation server node RPC host address has not
+	// changed after the restart. If it has, then the minting node will be
+	// retrying the proof push to the wrong address.
+	require.Equal(t.t, fedServerNodeRpcHost, fedServerNode.rpcHost())
+
+	t.Logf("Assert that fed peer node has seen the asset minting proofs")
+	AssertUniverseStats(t.t, fedServerNode, 2, 2, 1)
+}

--- a/tapdb/assets_store_test.go
+++ b/tapdb/assets_store_test.go
@@ -246,105 +246,17 @@ func assertAssetEqual(t *testing.T, a, b *asset.Asset) {
 func TestImportAssetProof(t *testing.T) {
 	t.Parallel()
 
-	// First, we'll create a new instance of the database.
-	_, assetStore, db := newAssetStore(t)
+	var (
+		ctxb = context.Background()
 
-	// Next, we'll make a new random asset that also has a few inputs with
-	// dummy witness information.
-	testAsset := randAsset(t)
+		dbHandle   = NewDbHandle(t)
+		assetStore = dbHandle.AssetStore
+	)
 
-	assetRoot, err := commitment.NewAssetCommitment(testAsset)
-	require.NoError(t, err)
-
-	taprootAssetRoot, err := commitment.NewTapCommitment(assetRoot)
-	require.NoError(t, err)
-
-	// With our asset created, we can now create the AnnotatedProof we use
-	// to import assets into the database.
-	var blockHash chainhash.Hash
-	_, err = rand.Read(blockHash[:])
-	require.NoError(t, err)
-
-	anchorTx := wire.NewMsgTx(2)
-	anchorTx.AddTxIn(&wire.TxIn{})
-	anchorTx.AddTxOut(&wire.TxOut{
-		PkScript: bytes.Repeat([]byte{0x01}, 34),
-		Value:    10,
-	})
-
+	// Add a random asset and corresponding proof into the database.
+	testAsset, testProof := dbHandle.AddRandomAssetProof(t)
 	assetID := testAsset.ID()
-	anchorPoint := wire.OutPoint{
-		Hash:  anchorTx.TxHash(),
-		Index: 0,
-	}
-	initialBlob := bytes.Repeat([]byte{0x0}, 100)
-	updatedBlob := bytes.Repeat([]byte{0x77}, 100)
-	testProof := &proof.AnnotatedProof{
-		Locator: proof.Locator{
-			AssetID:   &assetID,
-			ScriptKey: *testAsset.ScriptKey.PubKey,
-		},
-		Blob: initialBlob,
-		AssetSnapshot: &proof.AssetSnapshot{
-			Asset:             testAsset,
-			OutPoint:          anchorPoint,
-			AnchorBlockHash:   blockHash,
-			AnchorBlockHeight: test.RandInt[uint32](),
-			AnchorTxIndex:     test.RandInt[uint32](),
-			AnchorTx:          anchorTx,
-			OutputIndex:       0,
-			InternalKey:       test.RandPubKey(t),
-			ScriptRoot:        taprootAssetRoot,
-		},
-	}
-	if testAsset.GroupKey != nil {
-		testProof.GroupKey = &testAsset.GroupKey.GroupPubKey
-	}
-
-	// We'll now insert the internal key information as well as the script
-	// key ahead of time to reflect the address creation that happens
-	// elsewhere.
-	ctxb := context.Background()
-	_, err = db.UpsertInternalKey(ctxb, InternalKey{
-		RawKey:    testProof.InternalKey.SerializeCompressed(),
-		KeyFamily: test.RandInt[int32](),
-		KeyIndex:  test.RandInt[int32](),
-	})
-	require.NoError(t, err)
-	rawScriptKeyID, err := db.UpsertInternalKey(ctxb, InternalKey{
-		RawKey:    testAsset.ScriptKey.RawKey.PubKey.SerializeCompressed(),
-		KeyFamily: int32(testAsset.ScriptKey.RawKey.Family),
-		KeyIndex:  int32(testAsset.ScriptKey.RawKey.Index),
-	})
-	require.NoError(t, err)
-	_, err = db.UpsertScriptKey(ctxb, NewScriptKey{
-		InternalKeyID:    rawScriptKeyID,
-		TweakedScriptKey: testAsset.ScriptKey.PubKey.SerializeCompressed(),
-		Tweak:            nil,
-	})
-	require.NoError(t, err)
-
-	// We'll add the chain transaction of the proof now to simulate a
-	// batched transfer on a higher layer.
-	var anchorTxBuf bytes.Buffer
-	err = testProof.AnchorTx.Serialize(&anchorTxBuf)
-	require.NoError(t, err)
-	anchorTXID := testProof.AnchorTx.TxHash()
-	_, err = db.UpsertChainTx(ctxb, ChainTxParams{
-		Txid:        anchorTXID[:],
-		RawTx:       anchorTxBuf.Bytes(),
-		BlockHeight: sqlInt32(testProof.AnchorBlockHeight),
-		BlockHash:   testProof.AnchorBlockHash[:],
-		TxIndex:     sqlInt32(testProof.AnchorTxIndex),
-	})
-	require.NoError(t, err, "unable to insert chain tx: %w", err)
-
-	// With all our test data constructed, we'll now attempt to import the
-	// asset into the database.
-	require.NoError(t, assetStore.ImportProofs(
-		ctxb, proof.MockHeaderVerifier, proof.MockGroupVerifier, false,
-		testProof,
-	))
+	initialBlob := testProof.Blob
 
 	// We should now be able to retrieve the set of all assets inserted on
 	// disk.
@@ -371,7 +283,7 @@ func TestImportAssetProof(t *testing.T) {
 		ScriptKey: *testAsset.ScriptKey.PubKey,
 	})
 	require.NoError(t, err)
-	require.Equal(t, initialBlob, []byte(currentBlob))
+	require.Equal(t, initialBlob, currentBlob)
 
 	// We should also be able to fetch the created asset above based on
 	// either the asset ID, or key group via the main coin selection
@@ -391,6 +303,8 @@ func TestImportAssetProof(t *testing.T) {
 
 	// We'll now attempt to overwrite the proof with one that has different
 	// block information (simulating a re-org).
+	updatedBlob := bytes.Repeat([]byte{0x77}, 100)
+
 	testProof.AnchorBlockHash = chainhash.Hash{12, 34, 56}
 	testProof.AnchorBlockHeight = 1234
 	testProof.AnchorTxIndex = 5678

--- a/tapdb/sqlc/migrations/000013_universe_fed_proof_sync_log.down.sql
+++ b/tapdb/sqlc/migrations/000013_universe_fed_proof_sync_log.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS federation_proof_sync_log_unique_index_proof_leaf_id_servers_id;
+DROP TABLE IF EXISTS federation_proof_sync_log;

--- a/tapdb/sqlc/migrations/000013_universe_fed_proof_sync_log.up.sql
+++ b/tapdb/sqlc/migrations/000013_universe_fed_proof_sync_log.up.sql
@@ -1,0 +1,36 @@
+-- This table stores the log of federation universe proof sync attempts. Rows
+-- in this table are specific to a given proof leaf, server, and sync direction.
+CREATE TABLE IF NOT EXISTS federation_proof_sync_log (
+    id BIGINT PRIMARY KEY,
+
+    -- The status of the proof sync attempt.
+    status TEXT NOT NULL CHECK(status IN ('pending', 'complete')),
+
+    -- The timestamp of when the log entry for the associated proof was last
+    -- updated.
+    timestamp TIMESTAMP NOT NULL,
+
+    -- The number of attempts that have been made to sync the proof.
+    attempt_counter BIGINT NOT NULL DEFAULT 0,
+
+    -- The direction of the proof sync attempt.
+    sync_direction TEXT NOT NULL CHECK(sync_direction IN ('push', 'pull')),
+
+    -- The ID of the subject proof leaf.
+    proof_leaf_id BIGINT NOT NULL REFERENCES universe_leaves(id),
+
+    -- The ID of the universe that the proof leaf belongs to.
+    universe_root_id BIGINT NOT NULL REFERENCES universe_roots(id),
+
+    -- The ID of the server that the proof will be/was synced to.
+    servers_id BIGINT NOT NULL REFERENCES universe_servers(id)
+);
+
+-- Create a unique index on table federation_proof_sync_log
+CREATE UNIQUE INDEX federation_proof_sync_log_unique_index_proof_leaf_id_servers_id
+ON federation_proof_sync_log (
+    sync_direction,
+    proof_leaf_id,
+    universe_root_id,
+    servers_id
+);

--- a/tapdb/sqlc/models.go
+++ b/tapdb/sqlc/models.go
@@ -164,6 +164,17 @@ type FederationGlobalSyncConfig struct {
 	AllowSyncExport bool
 }
 
+type FederationProofSyncLog struct {
+	ID             int64
+	Status         string
+	Timestamp      time.Time
+	AttemptCounter int64
+	SyncDirection  string
+	ProofLeafID    int64
+	UniverseRootID int64
+	ServersID      int64
+}
+
 type FederationUniSyncConfig struct {
 	Namespace       string
 	AssetID         []byte

--- a/tapdb/sqlc/querier.go
+++ b/tapdb/sqlc/querier.go
@@ -25,6 +25,7 @@ type Querier interface {
 	DeleteAllNodes(ctx context.Context, namespace string) (int64, error)
 	DeleteAssetWitnesses(ctx context.Context, assetID int64) error
 	DeleteExpiredUTXOLeases(ctx context.Context, now sql.NullTime) error
+	DeleteFederationProofSyncLog(ctx context.Context, arg DeleteFederationProofSyncLogParams) error
 	DeleteManagedUTXO(ctx context.Context, outpoint []byte) error
 	DeleteNode(ctx context.Context, arg DeleteNodeParams) (int64, error)
 	DeleteRoot(ctx context.Context, namespace string) (int64, error)

--- a/tapdb/sqlc/querier.go
+++ b/tapdb/sqlc/querier.go
@@ -121,6 +121,9 @@ type Querier interface {
 	QueryAssets(ctx context.Context, arg QueryAssetsParams) ([]QueryAssetsRow, error)
 	QueryEventIDs(ctx context.Context, arg QueryEventIDsParams) ([]QueryEventIDsRow, error)
 	QueryFederationGlobalSyncConfigs(ctx context.Context) ([]FederationGlobalSyncConfig, error)
+	// Join on mssmt_nodes to get leaf related fields.
+	// Join on genesis_info_view to get leaf related fields.
+	QueryFederationProofSyncLog(ctx context.Context, arg QueryFederationProofSyncLogParams) ([]QueryFederationProofSyncLogRow, error)
 	QueryFederationUniSyncConfigs(ctx context.Context) ([]FederationUniSyncConfig, error)
 	QueryPassiveAssets(ctx context.Context, transferID int64) ([]QueryPassiveAssetsRow, error)
 	QueryProofTransferAttempts(ctx context.Context, arg QueryProofTransferAttemptsParams) ([]time.Time, error)
@@ -145,6 +148,7 @@ type Querier interface {
 	UpsertAssetProof(ctx context.Context, arg UpsertAssetProofParams) error
 	UpsertChainTx(ctx context.Context, arg UpsertChainTxParams) (int64, error)
 	UpsertFederationGlobalSyncConfig(ctx context.Context, arg UpsertFederationGlobalSyncConfigParams) error
+	UpsertFederationProofSyncLog(ctx context.Context, arg UpsertFederationProofSyncLogParams) (int64, error)
 	UpsertFederationUniSyncConfig(ctx context.Context, arg UpsertFederationUniSyncConfigParams) error
 	UpsertGenesisAsset(ctx context.Context, arg UpsertGenesisAssetParams) (int64, error)
 	UpsertGenesisPoint(ctx context.Context, prevOut []byte) (int64, error)

--- a/tapdb/sqlc/querier.go
+++ b/tapdb/sqlc/querier.go
@@ -94,7 +94,6 @@ type Querier interface {
 	InsertPassiveAsset(ctx context.Context, arg InsertPassiveAssetParams) error
 	InsertRootKey(ctx context.Context, arg InsertRootKeyParams) error
 	InsertUniverseServer(ctx context.Context, arg InsertUniverseServerParams) error
-	ListUniverseServers(ctx context.Context) ([]UniverseServer, error)
 	LogProofTransferAttempt(ctx context.Context, arg LogProofTransferAttemptParams) error
 	LogServerSync(ctx context.Context, arg LogServerSyncParams) error
 	NewMintingBatch(ctx context.Context, arg NewMintingBatchParams) error
@@ -129,6 +128,7 @@ type Querier interface {
 	// root, simplifies queries
 	QueryUniverseAssetStats(ctx context.Context, arg QueryUniverseAssetStatsParams) ([]QueryUniverseAssetStatsRow, error)
 	QueryUniverseLeaves(ctx context.Context, arg QueryUniverseLeavesParams) ([]QueryUniverseLeavesRow, error)
+	QueryUniverseServers(ctx context.Context, arg QueryUniverseServersParams) ([]UniverseServer, error)
 	QueryUniverseStats(ctx context.Context) (QueryUniverseStatsRow, error)
 	ReAnchorPassiveAssets(ctx context.Context, arg ReAnchorPassiveAssetsParams) error
 	SetAddrManaged(ctx context.Context, arg SetAddrManagedParams) error

--- a/tapdb/sqlc/queries/universe.sql
+++ b/tapdb/sqlc/queries/universe.sql
@@ -115,8 +115,11 @@ UPDATE universe_servers
 SET last_sync_time = @new_sync_time
 WHERE server_host = @target_server;
 
--- name: ListUniverseServers :many
-SELECT * FROM universe_servers;
+-- name: QueryUniverseServers :many
+SELECT * FROM universe_servers
+WHERE (id = sqlc.narg('id') OR sqlc.narg('id') IS NULL) AND
+      (server_host = sqlc.narg('server_host')
+           OR sqlc.narg('server_host') IS NULL);
 
 -- name: InsertNewSyncEvent :exec
 WITH group_key_root_id AS (

--- a/tapdb/sqlc/queries/universe.sql
+++ b/tapdb/sqlc/queries/universe.sql
@@ -461,3 +461,23 @@ WHERE (log.sync_direction = sqlc.narg('sync_direction')
         AND
       (leaf.script_key_bytes = sqlc.narg('leaf_script_key_bytes')
            OR sqlc.narg('leaf_script_key_bytes') IS NULL);
+
+-- name: DeleteFederationProofSyncLog :exec
+WITH selected_server_id AS (
+    -- Select the server ids from the universe_servers table for the specified
+    -- hosts.
+    SELECT id
+    FROM universe_servers
+    WHERE
+        (server_host = sqlc.narg('server_host')
+            OR sqlc.narg('server_host') IS NULL)
+)
+DELETE FROM federation_proof_sync_log
+WHERE
+    servers_id IN (SELECT id FROM selected_server_id) AND
+    (status = sqlc.narg('status')
+        OR sqlc.narg('status') IS NULL) AND
+    (timestamp >= sqlc.narg('min_timestamp')
+        OR sqlc.narg('min_timestamp') IS NULL) AND
+    (attempt_counter >= sqlc.narg('min_attempt_counter')
+        OR sqlc.narg('min_attempt_counter') IS NULL);

--- a/tapdb/sqlc/universe.sql.go
+++ b/tapdb/sqlc/universe.sql.go
@@ -402,6 +402,134 @@ func (q *Queries) QueryFederationGlobalSyncConfigs(ctx context.Context) ([]Feder
 	return items, nil
 }
 
+const queryFederationProofSyncLog = `-- name: QueryFederationProofSyncLog :many
+SELECT
+    log.id, status, timestamp, sync_direction, attempt_counter,
+
+    -- Select fields from the universe_servers table.
+    server.id as server_id,
+    server.server_host,
+
+    -- Select universe leaf related fields.
+    leaf.minting_point as leaf_minting_point_bytes,
+    leaf.script_key_bytes as leaf_script_key_bytes,
+    mssmt_node.value as leaf_genesis_proof,
+    genesis.gen_asset_id as leaf_gen_asset_id,
+    genesis.asset_id as leaf_asset_id,
+
+    -- Select fields from the universe_roots table.
+    root.asset_id as uni_asset_id,
+    root.group_key as uni_group_key,
+    root.proof_type as uni_proof_type
+
+FROM federation_proof_sync_log as log
+
+JOIN universe_leaves as leaf
+    ON leaf.id = log.proof_leaf_id
+
+JOIN mssmt_nodes mssmt_node
+     ON leaf.leaf_node_key = mssmt_node.key AND
+        leaf.leaf_node_namespace = mssmt_node.namespace
+
+JOIN genesis_info_view genesis
+     ON leaf.asset_genesis_id = genesis.gen_asset_id
+
+JOIN universe_servers as server
+    ON server.id = log.servers_id
+
+JOIN universe_roots as root
+    ON root.id = log.universe_root_id
+
+WHERE (log.sync_direction = $1
+           OR $1 IS NULL)
+        AND
+      (log.status = $2 OR $2 IS NULL)
+        AND
+
+      -- Universe leaves WHERE clauses.
+      (leaf.leaf_node_namespace = $3
+           OR $3 IS NULL)
+        AND
+      (leaf.minting_point = $4
+           OR $4 IS NULL)
+        AND
+      (leaf.script_key_bytes = $5
+           OR $5 IS NULL)
+`
+
+type QueryFederationProofSyncLogParams struct {
+	SyncDirection         sql.NullString
+	Status                sql.NullString
+	LeafNamespace         sql.NullString
+	LeafMintingPointBytes []byte
+	LeafScriptKeyBytes    []byte
+}
+
+type QueryFederationProofSyncLogRow struct {
+	ID                    int64
+	Status                string
+	Timestamp             time.Time
+	SyncDirection         string
+	AttemptCounter        int64
+	ServerID              int64
+	ServerHost            string
+	LeafMintingPointBytes []byte
+	LeafScriptKeyBytes    []byte
+	LeafGenesisProof      []byte
+	LeafGenAssetID        int64
+	LeafAssetID           []byte
+	UniAssetID            []byte
+	UniGroupKey           []byte
+	UniProofType          string
+}
+
+// Join on mssmt_nodes to get leaf related fields.
+// Join on genesis_info_view to get leaf related fields.
+func (q *Queries) QueryFederationProofSyncLog(ctx context.Context, arg QueryFederationProofSyncLogParams) ([]QueryFederationProofSyncLogRow, error) {
+	rows, err := q.db.QueryContext(ctx, queryFederationProofSyncLog,
+		arg.SyncDirection,
+		arg.Status,
+		arg.LeafNamespace,
+		arg.LeafMintingPointBytes,
+		arg.LeafScriptKeyBytes,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []QueryFederationProofSyncLogRow
+	for rows.Next() {
+		var i QueryFederationProofSyncLogRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.Status,
+			&i.Timestamp,
+			&i.SyncDirection,
+			&i.AttemptCounter,
+			&i.ServerID,
+			&i.ServerHost,
+			&i.LeafMintingPointBytes,
+			&i.LeafScriptKeyBytes,
+			&i.LeafGenesisProof,
+			&i.LeafGenAssetID,
+			&i.LeafAssetID,
+			&i.UniAssetID,
+			&i.UniGroupKey,
+			&i.UniProofType,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const queryFederationUniSyncConfigs = `-- name: QueryFederationUniSyncConfigs :many
 SELECT namespace, asset_id, group_key, proof_type, allow_sync_insert, allow_sync_export
 FROM federation_uni_sync_config
@@ -875,6 +1003,76 @@ type UpsertFederationGlobalSyncConfigParams struct {
 func (q *Queries) UpsertFederationGlobalSyncConfig(ctx context.Context, arg UpsertFederationGlobalSyncConfigParams) error {
 	_, err := q.db.ExecContext(ctx, upsertFederationGlobalSyncConfig, arg.ProofType, arg.AllowSyncInsert, arg.AllowSyncExport)
 	return err
+}
+
+const upsertFederationProofSyncLog = `-- name: UpsertFederationProofSyncLog :one
+INSERT INTO federation_proof_sync_log as log (
+    status, timestamp, sync_direction, proof_leaf_id, universe_root_id,
+    servers_id
+) VALUES (
+    $1, $2, $3,
+    (
+        -- Select the leaf id from the universe_leaves table.
+        SELECT id
+        FROM universe_leaves
+        WHERE leaf_node_namespace = $4
+            AND minting_point = $5
+            AND script_key_bytes = $6
+        LIMIT 1
+    ),
+    (
+        -- Select the universe root id from the universe_roots table.
+        SELECT id
+        FROM universe_roots
+        WHERE namespace_root = $7
+        LIMIT 1
+    ),
+    (
+        -- Select the server id from the universe_servers table.
+        SELECT id
+        FROM universe_servers
+        WHERE server_host = $8
+        LIMIT 1
+    )
+) ON CONFLICT (sync_direction, proof_leaf_id, universe_root_id, servers_id)
+DO UPDATE SET
+    status = EXCLUDED.status,
+    timestamp = EXCLUDED.timestamp,
+    -- Increment the attempt counter.
+    attempt_counter = CASE
+       WHEN $9 = true THEN log.attempt_counter + 1
+       ELSE log.attempt_counter
+    END
+RETURNING id
+`
+
+type UpsertFederationProofSyncLogParams struct {
+	Status                 string
+	Timestamp              time.Time
+	SyncDirection          string
+	LeafNamespace          string
+	LeafMintingPointBytes  []byte
+	LeafScriptKeyBytes     []byte
+	UniverseIDNamespace    string
+	ServerHost             string
+	BumpSyncAttemptCounter interface{}
+}
+
+func (q *Queries) UpsertFederationProofSyncLog(ctx context.Context, arg UpsertFederationProofSyncLogParams) (int64, error) {
+	row := q.db.QueryRowContext(ctx, upsertFederationProofSyncLog,
+		arg.Status,
+		arg.Timestamp,
+		arg.SyncDirection,
+		arg.LeafNamespace,
+		arg.LeafMintingPointBytes,
+		arg.LeafScriptKeyBytes,
+		arg.UniverseIDNamespace,
+		arg.ServerHost,
+		arg.BumpSyncAttemptCounter,
+	)
+	var id int64
+	err := row.Scan(&id)
+	return id, err
 }
 
 const upsertFederationUniSyncConfig = `-- name: UpsertFederationUniSyncConfig :exec

--- a/tapdb/sqlite.go
+++ b/tapdb/sqlite.go
@@ -160,11 +160,11 @@ func NewSqliteStore(cfg *SqliteConfig) (*SqliteStore, error) {
 func NewTestSqliteDB(t *testing.T) *SqliteStore {
 	t.Helper()
 
-	t.Logf("Creating new SQLite DB for testing")
+	dbFileName := filepath.Join(t.TempDir(), "tmp.db")
+	t.Logf("Creating new SQLite DB for testing: %s", dbFileName)
 
 	// TODO(roasbeef): if we pass :memory: for the file name, then we get
 	// an in mem version to speed up tests
-	dbFileName := filepath.Join(t.TempDir(), "tmp.db")
 	sqlDB, err := NewSqliteStore(&SqliteConfig{
 		DatabaseFileName: dbFileName,
 		SkipMigrations:   false,

--- a/tapdb/sqlutils_test.go
+++ b/tapdb/sqlutils_test.go
@@ -1,0 +1,77 @@
+package tapdb
+
+import (
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/lightninglabs/taproot-assets/tapdb/sqlc"
+	"github.com/lightningnetwork/lnd/clock"
+)
+
+// DbHandler is a helper struct that contains all the database stores.
+type DbHandler struct {
+	// UniverseFederationStore is a handle to the universe federation store.
+	UniverseFederationStore *UniverseFederationDB
+
+	// MultiverseStore is a handle to the multiverse store.
+	MultiverseStore *MultiverseStore
+
+	// AssetMintingStore is a handle to the pending (minting) assets store.
+	AssetMintingStore *AssetMintingStore
+
+	// AssetStore is a handle to the active assets store.
+	AssetStore *AssetStore
+
+	// DirectQuery is a handle to the underlying database that can be used
+	// to query the database directly.
+	DirectQuery sqlc.Querier
+}
+
+// NewDbHandle creates a new store and query handle to the test database.
+func NewDbHandle(t *testing.T) *DbHandler {
+	// Create a new test database.
+	db := NewTestDB(t)
+
+	testClock := clock.NewTestClock(time.Now())
+
+	// Gain a handle to the pending (minting) universe federation store.
+	universeServerTxCreator := NewTransactionExecutor(
+		db, func(tx *sql.Tx) UniverseServerStore {
+			return db.WithTx(tx)
+		},
+	)
+	fedStore := NewUniverseFederationDB(universeServerTxCreator, testClock)
+
+	// Gain a handle to the multiverse store.
+	multiverseTxCreator := NewTransactionExecutor(db,
+		func(tx *sql.Tx) BaseMultiverseStore {
+			return db.WithTx(tx)
+		},
+	)
+	multiverseStore := NewMultiverseStore(multiverseTxCreator)
+
+	// Gain a handle to the pending (minting) assets store.
+	assetMintingDB := NewTransactionExecutor(
+		db, func(tx *sql.Tx) PendingAssetStore {
+			return db.WithTx(tx)
+		},
+	)
+	assetMintingStore := NewAssetMintingStore(assetMintingDB)
+
+	// Gain a handle to the active assets store.
+	assetsDB := NewTransactionExecutor(
+		db, func(tx *sql.Tx) ActiveAssetsStore {
+			return db.WithTx(tx)
+		},
+	)
+	activeAssetsStore := NewAssetStore(assetsDB, testClock)
+
+	return &DbHandler{
+		UniverseFederationStore: fedStore,
+		MultiverseStore:         multiverseStore,
+		AssetMintingStore:       assetMintingStore,
+		AssetStore:              activeAssetsStore,
+		DirectQuery:             db,
+	}
+}

--- a/tapdb/universe_federation.go
+++ b/tapdb/universe_federation.go
@@ -40,6 +40,9 @@ type (
 	// FedUniSyncConfigs is the universe specific federation sync config
 	// returned from a query.
 	FedUniSyncConfigs = sqlc.FederationUniSyncConfig
+
+	// QueryUniServersParams is used to query for universe servers.
+	QueryUniServersParams = sqlc.QueryUniverseServersParams
 )
 
 var (
@@ -97,8 +100,10 @@ type UniverseServerStore interface {
 	// LogServerSync marks that a server was just synced in the DB.
 	LogServerSync(ctx context.Context, arg sqlc.LogServerSyncParams) error
 
-	// ListUniverseServers returns the total set of all universe servers.
-	ListUniverseServers(ctx context.Context) ([]sqlc.UniverseServer, error)
+	// QueryUniverseServers returns a set of universe servers.
+	QueryUniverseServers(ctx context.Context,
+		arg sqlc.QueryUniverseServersParams) ([]sqlc.UniverseServer,
+		error)
 }
 
 // UniverseFederationOptions is the database tx object for the universe server store.
@@ -174,7 +179,9 @@ func (u *UniverseFederationDB) UniverseServers(
 
 	readTx := NewUniverseFederationReadTx()
 	dbErr := u.db.ExecTx(ctx, &readTx, func(db UniverseServerStore) error {
-		servers, err := db.ListUniverseServers(ctx)
+		servers, err := db.QueryUniverseServers(
+			ctx, QueryUniServersParams{},
+		)
 		if err != nil {
 			return err
 		}

--- a/tapdb/universe_federation.go
+++ b/tapdb/universe_federation.go
@@ -1,7 +1,9 @@
 package tapdb
 
 import (
+	"bytes"
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 	"sort"
@@ -9,8 +11,11 @@ import (
 	"time"
 
 	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/taproot-assets/asset"
 	"github.com/lightninglabs/taproot-assets/fn"
+	"github.com/lightninglabs/taproot-assets/proof"
 	"github.com/lightninglabs/taproot-assets/tapdb/sqlc"
 	"github.com/lightninglabs/taproot-assets/universe"
 	"github.com/lightningnetwork/lnd/clock"
@@ -19,6 +24,17 @@ import (
 )
 
 type (
+	// UpsertFedProofSyncLogParams is used to upsert federation proof sync
+	// logs.
+	UpsertFedProofSyncLogParams = sqlc.UpsertFederationProofSyncLogParams
+
+	// QueryFedProofSyncLogParams is used to query for federation proof sync
+	// logs.
+	QueryFedProofSyncLogParams = sqlc.QueryFederationProofSyncLogParams
+
+	// ProofSyncLogEntry is a single entry from the proof sync log.
+	ProofSyncLogEntry = sqlc.QueryFederationProofSyncLogRow
+
 	// NewUniverseServer is used to create a new universe server.
 	NewUniverseServer = sqlc.InsertUniverseServerParams
 
@@ -62,6 +78,22 @@ var (
 	}
 )
 
+// FederationProofSyncLogStore is used to log the sync status of individual
+// universe proofs.
+type FederationProofSyncLogStore interface {
+	BaseUniverseStore
+
+	// UpsertFederationProofSyncLog upserts a proof sync log entry for a
+	// given proof leaf and server.
+	UpsertFederationProofSyncLog(ctx context.Context,
+		arg UpsertFedProofSyncLogParams) (int64, error)
+
+	// QueryFederationProofSyncLog returns the set of proof sync logs for a
+	// given proof leaf.
+	QueryFederationProofSyncLog(ctx context.Context,
+		arg QueryFedProofSyncLogParams) ([]ProofSyncLogEntry, error)
+}
+
 // FederationSyncConfigStore is used to manage the set of Universe servers as
 // part of a federation.
 type FederationSyncConfigStore interface {
@@ -90,6 +122,7 @@ type FederationSyncConfigStore interface {
 // of a federation.
 type UniverseServerStore interface {
 	FederationSyncConfigStore
+	FederationProofSyncLogStore
 
 	// InsertUniverseServer inserts a new universe server in to the DB.
 	InsertUniverseServer(ctx context.Context, arg NewUniverseServer) error
@@ -266,6 +299,270 @@ func (u *UniverseFederationDB) LogNewSyncs(ctx context.Context,
 			})
 		})
 	})
+}
+
+// UpsertFederationProofSyncLog upserts a federation proof sync log entry for a
+// given universe server and proof.
+func (u *UniverseFederationDB) UpsertFederationProofSyncLog(
+	ctx context.Context, uniID universe.Identifier,
+	leafKey universe.LeafKey, addr universe.ServerAddr,
+	syncDirection universe.SyncDirection,
+	syncStatus universe.ProofSyncStatus,
+	bumpSyncAttemptCounter bool) (int64, error) {
+
+	// Encode the leaf key outpoint as bytes. We'll use this to look up the
+	// leaf ID in the DB.
+	leafKeyOutpointBytes, err := encodeOutpoint(leafKey.OutPoint)
+	if err != nil {
+		return 0, err
+	}
+
+	// Encode the leaf script key pub key as bytes. We'll use this to look
+	// up the leaf ID in the DB.
+	scriptKeyPubKeyBytes := schnorr.SerializePubKey(
+		leafKey.ScriptKey.PubKey,
+	)
+
+	var (
+		writeTx UniverseFederationOptions
+		logID   int64
+	)
+
+	err = u.db.ExecTx(ctx, &writeTx, func(db UniverseServerStore) error {
+		params := UpsertFedProofSyncLogParams{
+			Status:                 string(syncStatus),
+			Timestamp:              time.Now().UTC(),
+			SyncDirection:          string(syncDirection),
+			UniverseIDNamespace:    uniID.String(),
+			LeafNamespace:          uniID.String(),
+			LeafMintingPointBytes:  leafKeyOutpointBytes,
+			LeafScriptKeyBytes:     scriptKeyPubKeyBytes,
+			ServerHost:             addr.HostStr(),
+			BumpSyncAttemptCounter: bumpSyncAttemptCounter,
+		}
+		logID, err = db.UpsertFederationProofSyncLog(ctx, params)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
+
+	return logID, err
+}
+
+// QueryFederationProofSyncLog queries the federation proof sync log and returns
+// the log entries which correspond to the given universe proof leaf.
+func (u *UniverseFederationDB) QueryFederationProofSyncLog(
+	ctx context.Context, uniID universe.Identifier,
+	leafKey universe.LeafKey,
+	syncDirection universe.SyncDirection,
+	syncStatus universe.ProofSyncStatus) ([]*universe.ProofSyncLogEntry,
+	error) {
+
+	// Encode the leaf key outpoint as bytes. We'll use this to look up the
+	// leaf ID in the DB.
+	leafKeyOutpointBytes, err := encodeOutpoint(leafKey.OutPoint)
+	if err != nil {
+		return nil, err
+	}
+
+	// Encode the leaf script key pub key as bytes. We'll use this to look
+	// up the leaf ID in the DB.
+	scriptKeyPubKeyBytes := schnorr.SerializePubKey(
+		leafKey.ScriptKey.PubKey,
+	)
+
+	var (
+		readTx        = NewUniverseFederationReadTx()
+		proofSyncLogs []*universe.ProofSyncLogEntry
+	)
+
+	err = u.db.ExecTx(ctx, &readTx, func(db UniverseServerStore) error {
+		params := QueryFedProofSyncLogParams{
+			SyncDirection:         sqlStr(string(syncDirection)),
+			Status:                sqlStr(string(syncStatus)),
+			LeafNamespace:         sqlStr(uniID.String()),
+			LeafMintingPointBytes: leafKeyOutpointBytes,
+			LeafScriptKeyBytes:    scriptKeyPubKeyBytes,
+		}
+		logEntries, err := db.QueryFederationProofSyncLog(ctx, params)
+
+		// Parse database proof sync logs. Multiple log entries may
+		// exist for a given leaf because each log entry is unique to a
+		// server.
+		proofSyncLogs = make(
+			[]*universe.ProofSyncLogEntry, 0, len(logEntries),
+		)
+		for idx := range logEntries {
+			entry := logEntries[idx]
+
+			parsedLogEntry, err := fetchProofSyncLogEntry(
+				ctx, entry, db,
+			)
+			if err != nil {
+				return err
+			}
+
+			proofSyncLogs = append(proofSyncLogs, parsedLogEntry)
+		}
+
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return proofSyncLogs, nil
+}
+
+// FetchPendingProofsSyncLog queries the federation proof sync log and returns
+// all log entries with sync status pending.
+func (u *UniverseFederationDB) FetchPendingProofsSyncLog(ctx context.Context,
+	syncDirection *universe.SyncDirection) ([]*universe.ProofSyncLogEntry,
+	error) {
+
+	var (
+		readTx        = NewUniverseFederationReadTx()
+		proofSyncLogs []*universe.ProofSyncLogEntry
+	)
+
+	err := u.db.ExecTx(ctx, &readTx, func(db UniverseServerStore) error {
+		// If the sync direction is not set, then we'll query for all
+		// pending proof sync log entries.
+		var sqlSyncDirection sql.NullString
+		if syncDirection != nil {
+			sqlSyncDirection = sqlStr(string(*syncDirection))
+		}
+
+		sqlProofSyncStatus := sqlStr(
+			string(universe.ProofSyncStatusPending),
+		)
+
+		params := QueryFedProofSyncLogParams{
+			SyncDirection: sqlSyncDirection,
+			Status:        sqlProofSyncStatus,
+		}
+		logEntries, err := db.QueryFederationProofSyncLog(ctx, params)
+		if err != nil {
+			return fmt.Errorf("unable to query proof sync log: %w",
+				err)
+		}
+
+		// Parse log entries from database row.
+		proofSyncLogs = make(
+			[]*universe.ProofSyncLogEntry, 0, len(logEntries),
+		)
+		for idx := range logEntries {
+			entry := logEntries[idx]
+
+			parsedLogEntry, err := fetchProofSyncLogEntry(
+				ctx, entry, db,
+			)
+			if err != nil {
+				return err
+			}
+
+			proofSyncLogs = append(proofSyncLogs, parsedLogEntry)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return proofSyncLogs, nil
+}
+
+// fetchProofSyncLogEntry returns a proof sync log entry given a DB row.
+func fetchProofSyncLogEntry(ctx context.Context, entry ProofSyncLogEntry,
+	dbTx UniverseServerStore) (*universe.ProofSyncLogEntry, error) {
+
+	// Fetch asset genesis for the leaf.
+	leafAssetGen, err := fetchGenesis(ctx, dbTx, entry.LeafGenAssetID)
+	if err != nil {
+		return nil, err
+	}
+
+	// We only need to obtain the asset at this point, so we'll do a sparse
+	// decode here to decode only the asset record.
+	var leafAsset asset.Asset
+	assetRecord := proof.AssetLeafRecord(&leafAsset)
+	err = proof.SparseDecode(
+		bytes.NewReader(entry.LeafGenesisProof), assetRecord,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("unable to decode proof: %w", err)
+	}
+
+	leaf := &universe.Leaf{
+		GenesisWithGroup: universe.GenesisWithGroup{
+			Genesis:  leafAssetGen,
+			GroupKey: leafAsset.GroupKey,
+		},
+		RawProof: entry.LeafGenesisProof,
+		Asset:    &leafAsset,
+		Amt:      leafAsset.Amount,
+	}
+
+	// Parse leaf key from leaf DB row.
+	scriptKeyPub, err := schnorr.ParsePubKey(
+		entry.LeafScriptKeyBytes,
+	)
+	if err != nil {
+		return nil, err
+	}
+	scriptKey := asset.NewScriptKey(scriptKeyPub)
+
+	var outPoint wire.OutPoint
+	err = readOutPoint(
+		bytes.NewReader(entry.LeafMintingPointBytes), 0, 0,
+		&outPoint,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	leafKey := universe.LeafKey{
+		OutPoint:  outPoint,
+		ScriptKey: &scriptKey,
+	}
+
+	// Parse server address from DB row.
+	serverAddr := universe.NewServerAddr(entry.ServerID, entry.ServerHost)
+
+	// Parse proof sync status directly from the DB row.
+	status, err := universe.ParseStrProofSyncStatus(entry.Status)
+	if err != nil {
+		return nil, err
+	}
+
+	// Parse proof sync direction directly from the DB row.
+	direction, err := universe.ParseStrSyncDirection(entry.SyncDirection)
+	if err != nil {
+		return nil, err
+	}
+
+	uniID, err := universe.NewUniIDFromRawArgs(
+		entry.UniAssetID, entry.UniGroupKey,
+		entry.UniProofType,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &universe.ProofSyncLogEntry{
+		Timestamp:      entry.Timestamp,
+		SyncStatus:     status,
+		SyncDirection:  direction,
+		AttemptCounter: entry.AttemptCounter,
+		ServerAddr:     serverAddr,
+
+		UniID:   uniID,
+		LeafKey: leafKey,
+		Leaf:    *leaf,
+	}, nil
 }
 
 // UpsertFederationSyncConfig upserts both the global and universe specific

--- a/tapdb/universe_test.go
+++ b/tapdb/universe_test.go
@@ -129,7 +129,12 @@ func randLeafKey(t *testing.T) universe.LeafKey {
 	}
 }
 
-func randProof(t *testing.T) *proof.Proof {
+func randProof(t *testing.T, argAsset *asset.Asset) *proof.Proof {
+	proofAsset := *asset.RandAsset(t, asset.Normal)
+	if argAsset != nil {
+		proofAsset = *argAsset
+	}
+
 	return &proof.Proof{
 		PrevOut: wire.OutPoint{},
 		BlockHeader: wire.BlockHeader{
@@ -142,7 +147,7 @@ func randProof(t *testing.T) *proof.Proof {
 			}},
 		},
 		TxMerkleProof: proof.TxMerkleProof{},
-		Asset:         *asset.RandAsset(t, asset.Normal),
+		Asset:         proofAsset,
 		InclusionProof: proof.TaprootProof{
 			InternalKey: test.RandPubKey(t),
 		},
@@ -152,7 +157,7 @@ func randProof(t *testing.T) *proof.Proof {
 func randMintingLeaf(t *testing.T, assetGen asset.Genesis,
 	groupKey *btcec.PublicKey) universe.Leaf {
 
-	randProof := randProof(t)
+	randProof := randProof(t, nil)
 
 	leaf := universe.Leaf{
 		GenesisWithGroup: universe.GenesisWithGroup{
@@ -320,7 +325,7 @@ func TestUniverseIssuanceProofs(t *testing.T) {
 		testLeaf := &testLeaves[idx]
 
 		var proofBuf bytes.Buffer
-		randProof := randProof(t)
+		randProof := randProof(t, nil)
 		require.NoError(t, randProof.Encode(&proofBuf))
 
 		testLeaf.Leaf.RawProof = proofBuf.Bytes()

--- a/tapgarden/caretaker.go
+++ b/tapgarden/caretaker.go
@@ -1179,6 +1179,11 @@ func (b *BatchCaretaker) storeMintingProof(ctx context.Context,
 		ID:   uniID,
 		Key:  leafKey,
 		Leaf: mintingLeaf,
+
+		// We set this to true to indicate that we would like the syncer
+		// to log and reattempt (in the event of a failure) to push sync
+		// this proof leaf.
+		LogProofSync: true,
 	}, nil
 }
 

--- a/universe/auto_syncer.go
+++ b/universe/auto_syncer.go
@@ -71,8 +71,12 @@ type FederationPushReq struct {
 	// Leaf is the new leaf to add.
 	Leaf *Leaf
 
+	// resp is a channel that will be sent the asset issuance/transfer
+	// proof and corresponding universe/multiverse inclusion proofs if the
+	// federation proof push was successful.
 	resp chan *Proof
-	err  chan error
+
+	err chan error
 }
 
 // FederationProofBatchPushReq is used to push out a batch of universe proof
@@ -97,8 +101,12 @@ type FederationEnvoy struct {
 
 	stopOnce sync.Once
 
+	// pushRequests is a channel that will be sent new requests to push out
+	// proof leaves to the federation.
 	pushRequests chan *FederationPushReq
 
+	// batchPushRequests is a channel that will be sent new requests to push
+	// out batch proof leaves to the federation.
 	batchPushRequests chan *FederationProofBatchPushReq
 }
 

--- a/universe/auto_syncer.go
+++ b/universe/auto_syncer.go
@@ -76,6 +76,12 @@ type FederationPushReq struct {
 	// federation proof push was successful.
 	resp chan *Proof
 
+	// LogProofSync is a boolean that indicates, if true, that the proof
+	// leaf sync attempt should be logged and actively managed to ensure
+	// that the federation push procedure is repeated in the event of a
+	// failure.
+	LogProofSync bool
+
 	err chan error
 }
 
@@ -227,53 +233,161 @@ func (f *FederationEnvoy) syncServerState(ctx context.Context,
 	return nil
 }
 
-// pushProofToFederation attempts to push out a new proof to the current
-// federation in parallel.
-func (f *FederationEnvoy) pushProofToFederation(uniID Identifier, key LeafKey,
-	leaf *Leaf) {
+// pushProofToServer attempts to push out a new proof to the target server.
+func (f *FederationEnvoy) pushProofToServer(ctx context.Context,
+	uniID Identifier, key LeafKey, leaf *Leaf, addr ServerAddr) error {
 
-	// Fetch all universe servers in our federation.
-	fedServers, err := f.tryFetchServers()
-	if err != nil || len(fedServers) == 0 {
-		return
+	remoteUniverseServer, err := f.cfg.NewRemoteRegistrar(addr)
+	if err != nil {
+		return fmt.Errorf("cannot push proof unable to connect "+
+			"to remote server(%v): %w", addr.HostStr(), err)
 	}
 
-	log.Infof("Pushing new proof to %v federation members, proof_key=%v",
-		len(fedServers), spew.Sdump(key))
+	_, err = remoteUniverseServer.UpsertProofLeaf(
+		ctx, uniID, key, leaf,
+	)
+	if err != nil {
+		return fmt.Errorf("cannot push proof to remote "+
+			"server(%v): %w", addr.HostStr(), err)
+	}
 
-	ctx, cancel := f.WithCtxQuitNoTimeout()
-	defer cancel()
+	return nil
+}
+
+// pushProofToServerLogged attempts to push out a new proof to the target
+// server, and logs the sync attempt.
+func (f *FederationEnvoy) pushProofToServerLogged(ctx context.Context,
+	uniID Identifier, key LeafKey, leaf *Leaf, addr ServerAddr) error {
+
+	// Ensure that we have a pending sync log entry for this
+	// leaf and server pair. This will allow us to handle all
+	// pending syncs in the event of a restart or at a different
+	// point in the envoy.
+	_, err := f.cfg.FederationDB.UpsertFederationProofSyncLog(
+		ctx, uniID, key, addr, SyncDirectionPush,
+		ProofSyncStatusPending, true,
+	)
+	if err != nil {
+		return fmt.Errorf("unable to log proof sync as pending: %w",
+			err)
+	}
+
+	// Push the proof to the remote server.
+	err = f.pushProofToServer(ctx, uniID, key, leaf, addr)
+	if err != nil {
+		return fmt.Errorf("cannot push proof to remote server(%v): %w",
+			addr.HostStr(), err)
+	}
+
+	// We did not encounter an error in our proof push
+	// attempt. Log the proof sync attempt as complete.
+	_, err = f.cfg.FederationDB.UpsertFederationProofSyncLog(
+		ctx, uniID, key, addr, SyncDirectionPush,
+		ProofSyncStatusComplete, false,
+	)
+	if err != nil {
+		return fmt.Errorf("unable to log proof sync attempt: %w", err)
+	}
+
+	return nil
+}
+
+// pushProofToFederation attempts to push out a new proof to the current
+// federation in parallel.
+func (f *FederationEnvoy) pushProofToFederation(ctx context.Context,
+	uniID Identifier, key LeafKey, leaf *Leaf, fedServers []ServerAddr,
+	logProofSync bool) {
+
+	log.Infof("Pushing proof to %v federation members, proof_key=%v",
+		len(fedServers), spew.Sdump(key))
 
 	// To push a new proof out, we'll attempt to dial to the remote
 	// registrar, then will attempt to push the new proof directly to the
 	// register.
 	pushNewProof := func(ctx context.Context, addr ServerAddr) error {
-		remoteUniverseServer, err := f.cfg.NewRemoteRegistrar(addr)
-		if err != nil {
-			log.Warnf("cannot push proof unable to connect "+
-				"to remote server(%v): %v", addr.HostStr(),
-				err)
+		// If we are logging proof sync attempts, we will use the
+		// logged version of the push function.
+		if logProofSync {
+			err := f.pushProofToServerLogged(
+				ctx, uniID, key, leaf, addr,
+			)
+			if err != nil {
+				log.Warnf("Cannot push proof via logged "+
+					"server push: %v", err)
+			}
+
 			return nil
 		}
 
-		_, err = remoteUniverseServer.UpsertProofLeaf(
-			ctx, uniID, key, leaf,
-		)
+		// If we are not logging proof sync attempts, we will use the
+		// non-logged version of the push function.
+		err := f.pushProofToServer(ctx, uniID, key, leaf, addr)
 		if err != nil {
-			log.Warnf("cannot push proof to remote "+
-				"server(%v): %v", addr.HostStr(), err)
+			log.Warnf("Cannot push proof: %v", err)
 		}
+
 		return nil
 	}
 
 	// To conclude, we'll attempt to push the new proof to all the universe
 	// servers in parallel.
-	err = fn.ParSlice(ctx, fedServers, pushNewProof)
+	err := fn.ParSlice(ctx, fedServers, pushNewProof)
 	if err != nil {
 		// TODO(roasbeef): retry in the background until successful?
 		log.Errorf("unable to push proof to federation: %v", err)
 		return
 	}
+}
+
+// filterProofSyncPending filters out servers that have already been synced
+// with for the given leaf.
+func (f *FederationEnvoy) filterProofSyncPending(fedServers []ServerAddr,
+	uniID Identifier, key LeafKey) ([]ServerAddr, error) {
+
+	// If there are no servers to filter, then we'll return early. This
+	// saves from querying the database unnecessarily.
+	if len(fedServers) == 0 {
+		return nil, nil
+	}
+
+	ctx, cancel := f.WithCtxQuit()
+	defer cancel()
+
+	// Select all sync push complete log entries for the given universe
+	// leaf. If there are any servers which are sync complete within this
+	// log set, we will filter them out of our target server set.
+	logs, err := f.cfg.FederationDB.QueryFederationProofSyncLog(
+		ctx, uniID, key, SyncDirectionPush,
+		ProofSyncStatusComplete,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("unable to query federation sync log: %w",
+			err)
+	}
+
+	// Construct a map of servers that have already been synced with for the
+	// given leaf.
+	syncedServers := make(map[string]struct{})
+	for idx := range logs {
+		logEntry := logs[idx]
+		syncedServers[logEntry.ServerAddr.HostStr()] = struct{}{}
+	}
+
+	// Filter out servers that we've already pushed to.
+	filteredFedServers := fn.Filter(fedServers, func(a ServerAddr) bool {
+		// Filter out servers that have a log entry with sync status
+		// complete.
+		if _, ok := syncedServers[a.HostStr()]; ok {
+			return false
+		}
+
+		// By this point we haven't found logs corresponding to the
+		// given server, we will therefore return true and include the
+		// server as a sync target for the given leaf.
+		return true
+	})
+
+	return filteredFedServers, nil
 }
 
 // syncer is the main goroutine that's responsible for interacting with the
@@ -289,12 +403,24 @@ func (f *FederationEnvoy) syncer() {
 	syncTicker := time.NewTicker(f.cfg.SyncInterval)
 	defer syncTicker.Stop()
 
+	// We'll use a timeout that's slightly less than the sync interval to
+	// help avoid ticking into a new sync event before the previous event
+	// has finished.
+	syncContextTimeout := f.cfg.SyncInterval - 1*time.Second
+	if syncContextTimeout < 0 {
+		// If the sync interval is less than a second, then we'll use
+		// the sync interval as the timeout.
+		syncContextTimeout = f.cfg.SyncInterval
+	}
+
 	for {
 		select {
 		// A new sync event has just been triggered, so we'll attempt
 		// to synchronize state with all the active universe servers in
 		// the federation.
 		case <-syncTicker.C:
+			log.Debug("Federation envoy handling new tick event")
+
 			// Error propagation is handled in tryFetchServers, we
 			// only need to exit here.
 			fedServers, err := f.tryFetchServers()
@@ -313,11 +439,60 @@ func (f *FederationEnvoy) syncer() {
 				continue
 			}
 
+			// After we've synced with the federation, we'll
+			// attempt to push out any pending proofs that we
+			// haven't yet completed.
+			ctxFetchLog, cancelFetchLog := f.WithCtxQuitNoTimeout()
+			syncDirection := SyncDirectionPush
+			db := f.cfg.FederationDB
+			logEntries, err := db.FetchPendingProofsSyncLog(
+				ctxFetchLog, &syncDirection,
+			)
+			cancelFetchLog()
+			if err != nil {
+				log.Warnf("unable to query pending push "+
+					"sync log: %w", err)
+				continue
+			}
+
+			if len(logEntries) > 0 {
+				log.Debugf("Handling pending proof sync log "+
+					"entries (entries_count=%d)",
+					len(logEntries))
+			}
+
+			// TODO(ffranr): Take account of any new servers that
+			//  have been added since the last time we populated the
+			//  log for a given proof leaf. Pending proof sync log
+			//  entries are only relevant for the set of servers
+			//  that existed at the time the log entry was created.
+			//  If a new server is added, then we should create a
+			//  new log entry for the new server.
+
+			for idx := range logEntries {
+				entry := logEntries[idx]
+
+				servers := []ServerAddr{
+					entry.ServerAddr,
+				}
+
+				ctxPush, cancelPush :=
+					f.CtxBlockingCustomTimeout(
+						syncContextTimeout,
+					)
+				f.pushProofToFederation(
+					ctxPush, entry.UniID, entry.LeafKey,
+					&entry.Leaf, servers, true,
+				)
+				cancelPush()
+			}
+
 		// A new push request has just arrived. We'll perform a
 		// asynchronous registration with the local Universe registrar,
 		// then push it out in an async manner to the federation
 		// members.
 		case pushReq := <-f.pushRequests:
+			log.Debug("Federation envoy handling push request")
 			ctx, cancel := f.WithCtxQuit()
 
 			// First, we'll attempt to registrar the proof leaf with
@@ -341,13 +516,53 @@ func (f *FederationEnvoy) syncer() {
 			// proof out to the federation in the background.
 			pushReq.resp <- newProof
 
-			// With the response sent above, we'll push this out to
-			// all the Universe servers in the background.
-			go f.pushProofToFederation(
-				pushReq.ID, pushReq.Key, pushReq.Leaf,
+			// Fetch all universe servers in our federation.
+			fedServers, err := f.tryFetchServers()
+			if err != nil {
+				err := fmt.Errorf("unable to fetch "+
+					"federation servers: %w", err)
+				log.Warnf(err.Error())
+				pushReq.err <- err
+				continue
+			}
+
+			if len(fedServers) == 0 {
+				log.Warnf("could not find any federation " +
+					"servers")
+				continue
+			}
+
+			if pushReq.LogProofSync {
+				// We are attempting to sync using the
+				// logged proof sync procedure. We will
+				// therefore narrow down the set of target
+				// servers based on the sync log. Only servers
+				// that are not yet push sync complete will be
+				// targeted.
+				fedServers, err = f.filterProofSyncPending(
+					fedServers, pushReq.ID, pushReq.Key,
+				)
+				if err != nil {
+					log.Warnf("failed to filter " +
+						"federation servers")
+					continue
+				}
+			}
+
+			// With the response sent above, we'll push this
+			// out to all the Universe servers in the
+			// background.
+			ctxPush, cancelPush := f.WithCtxQuitNoTimeout()
+			f.pushProofToFederation(
+				ctxPush, pushReq.ID, pushReq.Key,
+				pushReq.Leaf, fedServers,
+				pushReq.LogProofSync,
 			)
+			cancelPush()
 
 		case pushReq := <-f.batchPushRequests:
+			log.Debug("Federation envoy handling batch push " +
+				"request")
 			ctx, cancel := f.WithCtxQuitNoTimeout()
 
 			// First, we'll attempt to registrar the proof leaf with
@@ -370,16 +585,34 @@ func (f *FederationEnvoy) syncer() {
 			// we'll return back to the caller.
 			pushReq.resp <- struct{}{}
 
+			// Fetch all universe servers in our federation.
+			fedServers, err := f.tryFetchServers()
+			if err != nil {
+				err := fmt.Errorf("unable to fetch "+
+					"federation servers: %w", err)
+				log.Warnf(err.Error())
+				pushReq.err <- err
+				continue
+			}
+
+			if len(fedServers) == 0 {
+				log.Warnf("could not find any federation " +
+					"servers")
+				continue
+			}
+
 			// With the response sent above, we'll push this out to
 			// all the Universe servers in the background.
-			go func() {
-				for idx := range pushReq.Batch {
-					item := pushReq.Batch[idx]
-					f.pushProofToFederation(
-						item.ID, item.Key, item.Leaf,
-					)
-				}
-			}()
+			ctxPush, cancelPush := f.WithCtxQuitNoTimeout()
+			for idx := range pushReq.Batch {
+				item := pushReq.Batch[idx]
+
+				f.pushProofToFederation(
+					ctxPush, item.ID, item.Key, item.Leaf,
+					fedServers, item.LogProofSync,
+				)
+			}
+			cancelPush()
 
 		case <-f.Quit:
 			return
@@ -395,12 +628,18 @@ func (f *FederationEnvoy) syncer() {
 func (f *FederationEnvoy) UpsertProofLeaf(_ context.Context, id Identifier,
 	key LeafKey, leaf *Leaf) (*Proof, error) {
 
+	// If we're attempting to push an issuance proof, then we'll ensure
+	// that we track the sync attempt to ensure that we retry in the event
+	// of a failure.
+	logProofSync := id.ProofType == ProofTypeIssuance
+
 	pushReq := &FederationPushReq{
-		ID:   id,
-		Key:  key,
-		Leaf: leaf,
-		resp: make(chan *Proof, 1),
-		err:  make(chan error, 1),
+		ID:           id,
+		Key:          key,
+		Leaf:         leaf,
+		LogProofSync: logProofSync,
+		resp:         make(chan *Proof, 1),
+		err:          make(chan error, 1),
 	}
 
 	if !fn.SendOrQuit(f.pushRequests, pushReq, f.Quit) {

--- a/universe/auto_syncer.go
+++ b/universe/auto_syncer.go
@@ -287,7 +287,7 @@ func (f *FederationEnvoy) syncer() {
 		// to synchronize state with all the active universe servers in
 		// the federation.
 		case <-syncTicker.C:
-			// Error propogation is handled in tryFetchServers, we
+			// Error propagation is handled in tryFetchServers, we
 			// only need to exit here.
 			fedServers, err := f.tryFetchServers()
 			if err != nil {

--- a/universe/interface.go
+++ b/universe/interface.go
@@ -859,6 +859,10 @@ type FederationProofSyncLog interface {
 	// returns all log entries with sync status pending.
 	FetchPendingProofsSyncLog(ctx context.Context,
 		syncDirection *SyncDirection) ([]*ProofSyncLogEntry, error)
+
+	// DeleteProofsSyncLogEntries deletes proof sync log entries.
+	DeleteProofsSyncLogEntries(ctx context.Context,
+		servers ...ServerAddr) error
 }
 
 // FederationDB is used for CRUD operations related to federation logs and

--- a/universe/interface.go
+++ b/universe/interface.go
@@ -84,6 +84,26 @@ func (i *Identifier) StringForLog() string {
 		i.String(), i.AssetID[:], groupKey, i.ProofType)
 }
 
+// NewUniIDFromAsset creates a new universe ID from an asset.
+func NewUniIDFromAsset(a asset.Asset) Identifier {
+	proofType := ProofTypeTransfer
+	if a.IsGenesisAsset() {
+		proofType = ProofTypeIssuance
+	}
+
+	if a.GroupKey != nil {
+		return Identifier{
+			GroupKey:  &a.GroupKey.GroupPubKey,
+			ProofType: proofType,
+		}
+	}
+
+	return Identifier{
+		AssetID:   a.ID(),
+		ProofType: proofType,
+	}
+}
+
 // NewUniIDFromRawArgs creates a new universe ID from the raw arguments. The
 // asset ID bytes and group key bytes are mutually exclusive. If the group key
 // bytes are set, then the asset ID bytes will be ignored.

--- a/universe/interface.go
+++ b/universe/interface.go
@@ -757,10 +757,109 @@ type FederationSyncConfigDB interface {
 		uniSyncConfigs []*FedUniSyncConfig) error
 }
 
-// FederationDB is used for CRUD operations related to federation sync config
-// and tracked servers.
+// SyncDirection is the direction of a proof sync.
+type SyncDirection string
+
+const (
+	// SyncDirectionPush indicates that the sync is a push sync (from the local
+	// server to the remote server).
+	SyncDirectionPush SyncDirection = "push"
+
+	// SyncDirectionPull indicates that the sync is a pull sync (from the remote
+	// server to the local server).
+	SyncDirectionPull SyncDirection = "pull"
+)
+
+// ParseStrSyncDirection parses a string into a SyncDirection.
+func ParseStrSyncDirection(s string) (SyncDirection, error) {
+	switch s {
+	case string(SyncDirectionPush):
+		return SyncDirectionPush, nil
+	case string(SyncDirectionPull):
+		return SyncDirectionPull, nil
+	default:
+		return "", fmt.Errorf("unknown sync direction: %v", s)
+	}
+}
+
+// ProofSyncStatus is the status of a proof sync.
+type ProofSyncStatus string
+
+const (
+	// ProofSyncStatusPending indicates that the sync is pending.
+	ProofSyncStatusPending ProofSyncStatus = "pending"
+
+	// ProofSyncStatusComplete indicates that the sync is complete.
+	ProofSyncStatusComplete ProofSyncStatus = "complete"
+)
+
+// ParseStrProofSyncStatus parses a string into a ProofSyncStatus.
+func ParseStrProofSyncStatus(s string) (ProofSyncStatus, error) {
+	switch s {
+	case string(ProofSyncStatusPending):
+		return ProofSyncStatusPending, nil
+	case string(ProofSyncStatusComplete):
+		return ProofSyncStatusComplete, nil
+	default:
+		return "", fmt.Errorf("unknown proof sync status: %v", s)
+	}
+}
+
+// ProofSyncLogEntry is a log entry for a proof sync.
+type ProofSyncLogEntry struct {
+	// Timestamp is the timestamp of the log entry.
+	Timestamp time.Time
+
+	// SyncStatus is the status of the sync.
+	SyncStatus ProofSyncStatus
+
+	// SyncDirection is the direction of the sync.
+	SyncDirection SyncDirection
+
+	// AttemptCounter is the number of times the sync has been attempted.
+	AttemptCounter int64
+
+	// ServerAddr is the address of the sync counterparty server.
+	ServerAddr ServerAddr
+
+	// UniID is the identifier of the universe associated with the sync event.
+	UniID Identifier
+
+	// LeafKey is the leaf key associated with the sync event.
+	LeafKey LeafKey
+
+	// Leaf is the leaf associated with the sync event.
+	Leaf Leaf
+}
+
+// FederationProofSyncLog is used for CRUD operations relating to the federation
+// proof sync log.
+type FederationProofSyncLog interface {
+	// UpsertFederationProofSyncLog upserts a federation proof sync log
+	// entry for a given universe server and proof.
+	UpsertFederationProofSyncLog(ctx context.Context, uniID Identifier,
+		leafKey LeafKey, addr ServerAddr, syncDirection SyncDirection,
+		syncStatus ProofSyncStatus,
+		bumpSyncAttemptCounter bool) (int64, error)
+
+	// QueryFederationProofSyncLog queries the federation proof sync log and
+	// returns the log entries which correspond to the given universe proof
+	// leaf.
+	QueryFederationProofSyncLog(ctx context.Context, uniID Identifier,
+		leafKey LeafKey, syncDirection SyncDirection,
+		syncStatus ProofSyncStatus) ([]*ProofSyncLogEntry, error)
+
+	// FetchPendingProofsSyncLog queries the federation proof sync log and
+	// returns all log entries with sync status pending.
+	FetchPendingProofsSyncLog(ctx context.Context,
+		syncDirection *SyncDirection) ([]*ProofSyncLogEntry, error)
+}
+
+// FederationDB is used for CRUD operations related to federation logs and
+// configuration.
 type FederationDB interface {
 	FederationLog
+	FederationProofSyncLog
 	FederationSyncConfigDB
 }
 

--- a/universe/interface.go
+++ b/universe/interface.go
@@ -397,6 +397,12 @@ type Item struct {
 
 	// MetaReveal is the meta reveal associated with the given proof leaf.
 	MetaReveal *proof.MetaReveal
+
+	// LogProofSync is a boolean that indicates, if true, that the proof
+	// leaf sync attempt should be logged and actively managed to ensure
+	// that the federation push procedure is repeated in the event of a
+	// failure.
+	LogProofSync bool
 }
 
 // BatchRegistrar is an interface that allows a caller to register a batch of


### PR DESCRIPTION
Closes https://github.com/lightninglabs/taproot-assets/issues/526

This PR adds a new SQL table which logs the federation sync status of select proofs. In this PR we use the new table to log and re-attempt failed asset issuance proof push sync events.

The federation envoy is modified such that tick events kick-off syncing for pending proofs found in the new log table.

I would be happy to receive reviews to double check that I'm on the right track with these changes.

This PR is currently missing tests.