### PR TITLE
taprpc: add missing cli autogen docs

### DIFF
--- a/cmd/tapcli/assets.go
+++ b/cmd/tapcli/assets.go
@@ -261,8 +261,8 @@ var finalizeBatchCommand = cli.Command{
 		},
 		cli.Uint64Flag{
 			Name: feeRateName,
-			Usage: "if set, the fee rate in sat/kw to use for the" +
-				"minting transaction",
+			Usage: "if set, the fee rate in sat/kw to use for " +
+				"the minting transaction",
 		},
 	},
 	Action: finalizeBatch,
@@ -531,8 +531,8 @@ var sendAssetsCommand = cli.Command{
 		},
 		cli.Uint64Flag{
 			Name: feeRateName,
-			Usage: "if set, the fee rate in sat/kw to use for the" +
-				"anchor transaction",
+			Usage: "if set, the fee rate in sat/kw to use for " +
+				"the anchor transaction",
 		},
 		// TODO(roasbeef): add arg for file name to write sender proof
 		// blob

--- a/cmd/tapcli/universe.go
+++ b/cmd/tapcli/universe.go
@@ -783,13 +783,13 @@ var (
 		},
 		cli.StringFlag{
 			Name: proofInsertName,
-			Usage: "if true, remote Universes can push proofs to" +
+			Usage: "if true, remote Universes can push proofs to " +
 				"the local Universe",
 		},
 		cli.StringFlag{
 			Name: proofExportName,
-			Usage: "if true, remote Universes can pull proofs from" +
-				"the local Universe",
+			Usage: "if true, remote Universes can pull proofs " +
+				"from the local Universe",
 		},
 	}
 )
@@ -1166,8 +1166,8 @@ func universeFederationGetConfigInfo(ctx *cli.Context) error {
 	}
 
 	if scope == "global" {
-		return fmt.Errorf("cannot specify global scope and a specific" +
-			"asset")
+		return fmt.Errorf("cannot specify global scope and a " +
+			"specific asset")
 	}
 
 	return printLocalConfig()

--- a/taprpc/assetwalletrpc/assetwallet.proto
+++ b/taprpc/assetwalletrpc/assetwallet.proto
@@ -49,7 +49,7 @@ service AssetWallet {
     */
     rpc NextScriptKey (NextScriptKeyRequest) returns (NextScriptKeyResponse);
 
-    /*
+    /* tapcli: `proofs proveownership`
     ProveAssetOwnership creates an ownership proof embedded in an asset
     transition proof. That ownership proof is a signed virtual transaction
     spending the asset with a valid witness to prove the prover owns the keys
@@ -58,7 +58,7 @@ service AssetWallet {
     rpc ProveAssetOwnership (ProveAssetOwnershipRequest)
         returns (ProveAssetOwnershipResponse);
 
-    /*
+    /* tapcli: `proofs verifyownership`
     VerifyAssetOwnership verifies the asset ownership proof embedded in the
     given transition proof of an asset and returns true if the proof is valid.
     */

--- a/taprpc/assetwalletrpc/assetwallet.swagger.json
+++ b/taprpc/assetwalletrpc/assetwallet.swagger.json
@@ -51,7 +51,7 @@
     },
     "/v1/taproot-assets/wallet/ownership/prove": {
       "post": {
-        "summary": "ProveAssetOwnership creates an ownership proof embedded in an asset\ntransition proof. That ownership proof is a signed virtual transaction\nspending the asset with a valid witness to prove the prover owns the keys\nthat can spend the asset.",
+        "summary": "tapcli: `proofs proveownership`\nProveAssetOwnership creates an ownership proof embedded in an asset\ntransition proof. That ownership proof is a signed virtual transaction\nspending the asset with a valid witness to prove the prover owns the keys\nthat can spend the asset.",
         "operationId": "AssetWallet_ProveAssetOwnership",
         "responses": {
           "200": {
@@ -84,7 +84,7 @@
     },
     "/v1/taproot-assets/wallet/ownership/verify": {
       "post": {
-        "summary": "VerifyAssetOwnership verifies the asset ownership proof embedded in the\ngiven transition proof of an asset and returns true if the proof is valid.",
+        "summary": "tapcli: `proofs verifyownership`\nVerifyAssetOwnership verifies the asset ownership proof embedded in the\ngiven transition proof of an asset and returns true if the proof is valid.",
         "operationId": "AssetWallet_VerifyAssetOwnership",
         "responses": {
           "200": {

--- a/taprpc/assetwalletrpc/assetwallet_grpc.pb.go
+++ b/taprpc/assetwalletrpc/assetwallet_grpc.pb.go
@@ -42,11 +42,13 @@ type AssetWalletClient interface {
 	// key) and stores them both in the database to make sure they are identified
 	// as local keys later on when importing proofs.
 	NextScriptKey(ctx context.Context, in *NextScriptKeyRequest, opts ...grpc.CallOption) (*NextScriptKeyResponse, error)
+	// tapcli: `proofs proveownership`
 	// ProveAssetOwnership creates an ownership proof embedded in an asset
 	// transition proof. That ownership proof is a signed virtual transaction
 	// spending the asset with a valid witness to prove the prover owns the keys
 	// that can spend the asset.
 	ProveAssetOwnership(ctx context.Context, in *ProveAssetOwnershipRequest, opts ...grpc.CallOption) (*ProveAssetOwnershipResponse, error)
+	// tapcli: `proofs verifyownership`
 	// VerifyAssetOwnership verifies the asset ownership proof embedded in the
 	// given transition proof of an asset and returns true if the proof is valid.
 	VerifyAssetOwnership(ctx context.Context, in *VerifyAssetOwnershipRequest, opts ...grpc.CallOption) (*VerifyAssetOwnershipResponse, error)
@@ -162,11 +164,13 @@ type AssetWalletServer interface {
 	// key) and stores them both in the database to make sure they are identified
 	// as local keys later on when importing proofs.
 	NextScriptKey(context.Context, *NextScriptKeyRequest) (*NextScriptKeyResponse, error)
+	// tapcli: `proofs proveownership`
 	// ProveAssetOwnership creates an ownership proof embedded in an asset
 	// transition proof. That ownership proof is a signed virtual transaction
 	// spending the asset with a valid witness to prove the prover owns the keys
 	// that can spend the asset.
 	ProveAssetOwnership(context.Context, *ProveAssetOwnershipRequest) (*ProveAssetOwnershipResponse, error)
+	// tapcli: `proofs verifyownership`
 	// VerifyAssetOwnership verifies the asset ownership proof embedded in the
 	// given transition proof of an asset and returns true if the proof is valid.
 	VerifyAssetOwnership(context.Context, *VerifyAssetOwnershipRequest) (*VerifyAssetOwnershipResponse, error)

--- a/taprpc/taprootassets.proto
+++ b/taprpc/taprootassets.proto
@@ -123,7 +123,7 @@ service TaprootAssets {
     rpc SubscribeReceiveAssetEventNtfns (SubscribeReceiveAssetEventNtfnsRequest)
         returns (stream ReceiveAssetEvent);
 
-    /*
+    /* tapcli: `assets meta`
     FetchAssetMeta allows a caller to fetch the reveal meta data for an asset
     either by the asset ID for that asset, or a meta hash.
     */

--- a/taprpc/taprootassets.swagger.json
+++ b/taprpc/taprootassets.swagger.json
@@ -293,7 +293,7 @@
     },
     "/v1/taproot-assets/assets/meta/asset-id/{asset_id_str}": {
       "get": {
-        "summary": "FetchAssetMeta allows a caller to fetch the reveal meta data for an asset\neither by the asset ID for that asset, or a meta hash.",
+        "summary": "tapcli: `assets meta`\nFetchAssetMeta allows a caller to fetch the reveal meta data for an asset\neither by the asset ID for that asset, or a meta hash.",
         "operationId": "TaprootAssets_FetchAssetMeta",
         "responses": {
           "200": {
@@ -348,7 +348,7 @@
     },
     "/v1/taproot-assets/assets/meta/hash/{meta_hash_str}": {
       "get": {
-        "summary": "FetchAssetMeta allows a caller to fetch the reveal meta data for an asset\neither by the asset ID for that asset, or a meta hash.",
+        "summary": "tapcli: `assets meta`\nFetchAssetMeta allows a caller to fetch the reveal meta data for an asset\neither by the asset ID for that asset, or a meta hash.",
         "operationId": "TaprootAssets_FetchAssetMeta2",
         "responses": {
           "200": {

--- a/taprpc/taprootassets_grpc.pb.go
+++ b/taprpc/taprootassets_grpc.pb.go
@@ -94,6 +94,7 @@ type TaprootAssetsClient interface {
 	// SubscribeReceiveAssetEventNtfns registers a subscription to the event
 	// notification stream which relates to the asset receive process.
 	SubscribeReceiveAssetEventNtfns(ctx context.Context, in *SubscribeReceiveAssetEventNtfnsRequest, opts ...grpc.CallOption) (TaprootAssets_SubscribeReceiveAssetEventNtfnsClient, error)
+	// tapcli: `assets meta`
 	// FetchAssetMeta allows a caller to fetch the reveal meta data for an asset
 	// either by the asset ID for that asset, or a meta hash.
 	FetchAssetMeta(ctx context.Context, in *FetchAssetMetaRequest, opts ...grpc.CallOption) (*AssetMeta, error)
@@ -413,6 +414,7 @@ type TaprootAssetsServer interface {
 	// SubscribeReceiveAssetEventNtfns registers a subscription to the event
 	// notification stream which relates to the asset receive process.
 	SubscribeReceiveAssetEventNtfns(*SubscribeReceiveAssetEventNtfnsRequest, TaprootAssets_SubscribeReceiveAssetEventNtfnsServer) error
+	// tapcli: `assets meta`
 	// FetchAssetMeta allows a caller to fetch the reveal meta data for an asset
 	// either by the asset ID for that asset, or a meta hash.
 	FetchAssetMeta(context.Context, *FetchAssetMetaRequest) (*AssetMeta, error)

--- a/taprpc/universerpc/universe.proto
+++ b/taprpc/universerpc/universe.proto
@@ -134,7 +134,7 @@ service Universe {
     rpc SetFederationSyncConfig (SetFederationSyncConfigRequest)
         returns (SetFederationSyncConfigResponse);
 
-    /*
+    /* tapcli: `universe federation config info`
     QueryFederationSyncConfig queries the universe federation sync configuration
     settings.
     */

--- a/taprpc/universerpc/universe.swagger.json
+++ b/taprpc/universerpc/universe.swagger.json
@@ -1212,7 +1212,7 @@
     },
     "/v1/taproot-assets/universe/sync/config": {
       "get": {
-        "summary": "QueryFederationSyncConfig queries the universe federation sync configuration\nsettings.",
+        "summary": "tapcli: `universe federation config info`\nQueryFederationSyncConfig queries the universe federation sync configuration\nsettings.",
         "operationId": "Universe_QueryFederationSyncConfig",
         "responses": {
           "200": {

--- a/taprpc/universerpc/universe_grpc.pb.go
+++ b/taprpc/universerpc/universe_grpc.pb.go
@@ -101,6 +101,7 @@ type UniverseClient interface {
 	// SetFederationSyncConfig sets the configuration of the universe federation
 	// sync.
 	SetFederationSyncConfig(ctx context.Context, in *SetFederationSyncConfigRequest, opts ...grpc.CallOption) (*SetFederationSyncConfigResponse, error)
+	// tapcli: `universe federation config info`
 	// QueryFederationSyncConfig queries the universe federation sync configuration
 	// settings.
 	QueryFederationSyncConfig(ctx context.Context, in *QueryFederationSyncConfigRequest, opts ...grpc.CallOption) (*QueryFederationSyncConfigResponse, error)
@@ -354,6 +355,7 @@ type UniverseServer interface {
 	// SetFederationSyncConfig sets the configuration of the universe federation
 	// sync.
 	SetFederationSyncConfig(context.Context, *SetFederationSyncConfigRequest) (*SetFederationSyncConfigResponse, error)
+	// tapcli: `universe federation config info`
 	// QueryFederationSyncConfig queries the universe federation sync configuration
 	// settings.
 	QueryFederationSyncConfig(context.Context, *QueryFederationSyncConfigRequest) (*QueryFederationSyncConfigResponse, error)


### PR DESCRIPTION
Adds some missing tags in the proto files that prevented parts of our API docs page from showing CLI commands when one exists.

Right now this page, https://lightning.engineering/api-docs/api/taproot-assets/taproot-assets/fetch-asset-meta , shows no `Shell` example even though the command exists.

Also fixes some help comments.

I don't think we can easily add a lint for these comments since some RPC endpoints intentionally don't have a matching CLI cmd, like the PSBT endpoints.