### PR TITLE
workflows: fix release name

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,7 +39,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ env.RELEASE_VERSION }}
-          name: tapd ${{ env.RELEASE_VERSION }}
+          name: ${{ env.RELEASE_VERSION }}
           draft: true
           prerelease: false
           files: taproot-assets-${{ env.RELEASE_VERSION }}/*


### PR DESCRIPTION
Release name should be `Taproot Assets v...` rather than `tapd v...`.