### PR TITLE
misc: group key testing

### DIFF
--- a/asset/asset.go
+++ b/asset/asset.go
@@ -513,7 +513,7 @@ type GroupKeyReveal struct {
 func (g *GroupKeyReveal) GroupPubKey(assetID ID) (*btcec.PublicKey, error) {
 	rawKey, err := g.RawKey.ToPubKey()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("group reveal raw key invalid: %w", err)
 	}
 
 	return GroupPubKey(rawKey, assetID[:], g.TapscriptRoot)
@@ -812,6 +812,10 @@ func DeriveGroupKey(genSigner GenesisSigner, genBuilder GenesisTxBuilder,
 
 	if !newAsset.HasGenesisWitness() {
 		return nil, fmt.Errorf("asset is not a genesis asset")
+	}
+
+	if newAsset.GroupKey != nil {
+		return nil, fmt.Errorf("asset already has group key")
 	}
 
 	if initialGen.Type != newAsset.Type {

--- a/asset/asset.go
+++ b/asset/asset.go
@@ -1208,9 +1208,10 @@ func (a *Asset) Copy() *Asset {
 
 	if a.GroupKey != nil {
 		assetCopy.GroupKey = &GroupKey{
-			RawKey:      a.GroupKey.RawKey,
-			GroupPubKey: a.GroupKey.GroupPubKey,
-			Witness:     a.GroupKey.Witness,
+			RawKey:        a.GroupKey.RawKey,
+			GroupPubKey:   a.GroupKey.GroupPubKey,
+			TapscriptRoot: a.GroupKey.TapscriptRoot,
+			Witness:       a.GroupKey.Witness,
 		}
 	}
 

--- a/asset/mock.go
+++ b/asset/mock.go
@@ -175,7 +175,7 @@ func (m *MockGroupTxBuilder) BuildGenesisTx(newAsset *Asset) (*wire.MsgTx,
 	// First, we check that the passed asset is a genesis grouped asset
 	// that has no group witness.
 	if !newAsset.NeedsGenesisWitnessForGroup() {
-		return nil, nil, fmt.Errorf("asset is not a genesis grouped" +
+		return nil, nil, fmt.Errorf("asset is not a genesis grouped " +
 			"asset")
 	}
 

--- a/asset/mock.go
+++ b/asset/mock.go
@@ -323,6 +323,16 @@ func RandID(t testing.TB) ID {
 	return a
 }
 
+// RandAssetType creates a random asset type.
+func RandAssetType(t testing.TB) Type {
+	isCollectible := test.RandBool()
+	if isCollectible {
+		return Collectible
+	}
+
+	return Normal
+}
+
 // NewAssetNoErr creates an asset and fails the test if asset creation fails.
 func NewAssetNoErr(t testing.TB, gen Genesis, amt, locktime, relocktime uint64,
 	scriptKey ScriptKey, groupKey *GroupKey, opts ...NewAssetOpt) *Asset {

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/btcsuite/btcwallet v0.16.10-0.20231017144732-e3ff37491e9c
 	github.com/caddyserver/certmagic v0.17.2
 	github.com/davecgh/go-spew v1.1.1
+	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1
 	github.com/go-errors/errors v1.0.1
 	github.com/golang-migrate/migrate/v4 v4.16.1
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0
@@ -74,7 +75,6 @@ require (
 	github.com/coreos/go-systemd/v22 v22.3.2 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.0 // indirect
 	github.com/decred/dcrd/crypto/blake256 v1.0.0 // indirect
-	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1 // indirect
 	github.com/decred/dcrd/lru v1.0.0 // indirect
 	github.com/docker/cli v20.10.17+incompatible // indirect
 	github.com/docker/docker v20.10.24+incompatible // indirect

--- a/proof/append_test.go
+++ b/proof/append_test.go
@@ -110,7 +110,7 @@ func runAppendTransitionTest(t *testing.T, assetType asset.Type, amt uint64,
 
 	// Start with a minted genesis asset.
 	genesisProof, senderPrivKey := genRandomGenesisWithProof(
-		t, assetType, &amt, nil, true, nil, nil, assetVersion,
+		t, assetType, &amt, nil, true, nil, nil, nil, nil, assetVersion,
 	)
 	genesisBlob, err := EncodeAsProofFile(&genesisProof)
 	require.NoError(t, err)

--- a/proof/proof.go
+++ b/proof/proof.go
@@ -56,7 +56,7 @@ var (
 	// proof for a genesis asset has a non-zero meta hash, but doesn't have
 	// a meta reveal.
 	ErrGenesisRevealMetaRevealRequired = errors.New("genesis meta reveal " +
-		"reveal required")
+		"required")
 
 	// ErrGenesisRevealMetaHashMismatch is an error returned if an asset
 	// proof for a genesis asset has a genesis reveal where the meta hash
@@ -69,12 +69,6 @@ var (
 	// doesn't match the proof TLV field.
 	ErrGenesisRevealOutputIndexMismatch = errors.New("genesis reveal " +
 		"output index mismatch")
-
-	// ErrGenesisRevealTypeMismatch is an error returned if an asset proof
-	// for a genesis asset has a genesis reveal where the asset type doesn't
-	// match the proof TLV field.
-	ErrGenesisRevealTypeMismatch = errors.New("genesis reveal type " +
-		"mismatch")
 
 	// ErrNonGenesisAssetWithGroupKeyReveal is an error returned if an asset
 	// proof for a non-genesis asset contains a group key reveal.

--- a/tapscript/mint.go
+++ b/tapscript/mint.go
@@ -20,7 +20,7 @@ func BuildGenesisTx(newAsset *asset.Asset) (*wire.MsgTx,
 	// First, we check that the passed asset is a genesis grouped asset
 	// that has no group witness.
 	if !newAsset.NeedsGenesisWitnessForGroup() {
-		return nil, nil, fmt.Errorf("asset is not a genesis grouped" +
+		return nil, nil, fmt.Errorf("asset is not a genesis grouped " +
 			"asset")
 	}
 

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -54,9 +54,10 @@ func randAsset(t *testing.T, assetType asset.Type,
 	protoAsset := asset.RandAssetWithValues(t, genesis, nil, scriptKey)
 	groupKey := asset.RandGroupKey(t, genesis, protoAsset)
 
-	fullAsset := protoAsset.Copy()
-	fullAsset.GroupKey = groupKey
-	return fullAsset
+	return asset.NewAssetNoErr(
+		t, genesis, protoAsset.Amount, protoAsset.LockTime,
+		protoAsset.RelativeLockTime, scriptKey, groupKey,
+	)
 }
 
 func genTaprootKeySpend(t *testing.T, privKey btcec.PrivateKey,


### PR DESCRIPTION
Spun out of #549 . Adds a few test cases related to group key handling following the group key derivation algorithm changes and storage changes that were included in 0.3.0. We also remove some clearly-redunant error checking in proof validation.

Coverage for `asset` increases by 3.6% to 70.8%, for `tapdb` an increase of 0.2% to 66.1%, and for `proof` an increase of 0.4% to 56.1%.