### PR TITLE
multi: attempt to fix issue of high number of TCP connections by explicitly closing connections and implementing an idle timer

### DIFF
--- a/server.go
+++ b/server.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	proxy "github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/lightninglabs/lndclient"
@@ -21,6 +22,7 @@ import (
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/macaroons"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/keepalive"
 	"gopkg.in/macaroon-bakery.v2/bakery"
 )
 
@@ -268,6 +270,12 @@ func (s *Server) RunUntilShutdown(mainErrChan <-chan error) error {
 	)
 	serverOpts = append(serverOpts, rpcServerOpts...)
 	serverOpts = append(serverOpts, ServerMaxMsgReceiveSize)
+
+	keepAliveParams := keepalive.ServerParameters{
+		MaxConnectionIdle: time.Minute * 2,
+	}
+
+	serverOpts = append(serverOpts, grpc.KeepaliveParams(keepAliveParams))
 
 	grpcServer := grpc.NewServer(serverOpts...)
 	defer grpcServer.Stop()

--- a/tapfreighter/chain_porter.go
+++ b/tapfreighter/chain_porter.go
@@ -671,6 +671,8 @@ func (p *ChainPorter) transferReceiverProof(pkg *sendPackage) error {
 				"service handle: %w", err)
 		}
 
+		defer courier.Close()
+
 		// Update courier events subscribers before attempting to
 		// deliver proof.
 		p.subscriberMtx.Lock()

--- a/universe/auto_syncer.go
+++ b/universe/auto_syncer.go
@@ -175,6 +175,11 @@ func (f *FederationEnvoy) Start() error {
 	return nil
 }
 
+// Close frees up any ephemeral resources allocated by the envoy.
+func (f *FederationEnvoy) Close() error {
+	return nil
+}
+
 // Stop stops all active goroutines.
 func (f *FederationEnvoy) Stop() error {
 	f.stopOnce.Do(func() {

--- a/universe/auto_syncer.go
+++ b/universe/auto_syncer.go
@@ -243,6 +243,8 @@ func (f *FederationEnvoy) pushProofToServer(ctx context.Context,
 			"to remote server(%v): %w", addr.HostStr(), err)
 	}
 
+	defer remoteUniverseServer.Close()
+
 	_, err = remoteUniverseServer.UpsertProofLeaf(
 		ctx, uniID, key, leaf,
 	)

--- a/universe/base.go
+++ b/universe/base.go
@@ -71,6 +71,11 @@ func NewArchive(cfg ArchiveConfig) *Archive {
 	return a
 }
 
+// Close closes the archive, stopping all goroutines and freeing all resources.
+func (a *Archive) Close() error {
+	return nil
+}
+
 // fetchUniverse returns the base universe instance for the passed identifier.
 // The universe will be loaded in on demand if it has not been seen before.
 func (a *Archive) fetchUniverse(id Identifier) BaseBackend {

--- a/universe/interface.go
+++ b/universe/interface.go
@@ -401,6 +401,9 @@ type Registrar interface {
 	// UpsertProofLeaf upserts a proof leaf within the target universe tree.
 	UpsertProofLeaf(ctx context.Context, id Identifier, key LeafKey,
 		leaf *Leaf) (*Proof, error)
+
+	// Close is used to shutdown the active registrar instance.
+	Close() error
 }
 
 // Item contains the data fields necessary to insert/update a proof leaf
@@ -605,6 +608,9 @@ type DiffEngine interface {
 	// of diff
 	FetchProofLeaf(ctx context.Context, id Identifier,
 		key LeafKey) ([]*Proof, error)
+
+	// Close is used to shutdown the active diff engine instance.
+	Close() error
 }
 
 // Commitment is an on chain universe commitment. This includes the merkle

--- a/universe/syncer.go
+++ b/universe/syncer.go
@@ -462,6 +462,8 @@ func (s *SimpleSyncer) SyncUniverse(ctx context.Context, host ServerAddr,
 			"engine: %w", err)
 	}
 
+	defer diffEngine.Close()
+
 	// With the engine created, we can now sync the local Universe with the
 	// remote instance.
 	return s.executeSync(ctx, diffEngine, syncType, syncConfigs, idsToSync)

--- a/universe/syncer.go
+++ b/universe/syncer.go
@@ -461,7 +461,6 @@ func (s *SimpleSyncer) SyncUniverse(ctx context.Context, host ServerAddr,
 		return nil, fmt.Errorf("unable to create remote diff "+
 			"engine: %w", err)
 	}
-
 	defer diffEngine.Close()
 
 	// With the engine created, we can now sync the local Universe with the

--- a/universe_rpc_diff.go
+++ b/universe_rpc_diff.go
@@ -15,7 +15,7 @@ import (
 // RpcUniverseDiff is an implementation of the universe.DiffEngine interface
 // that uses an RPC connection to target Universe.
 type RpcUniverseDiff struct {
-	conn unirpc.UniverseClient
+	conn *universeClientConn
 }
 
 // NewRpcUniverseDiff creates a new RpcUniverseDiff instance that dials out to
@@ -208,6 +208,17 @@ func (r *RpcUniverseDiff) FetchProofLeaf(ctx context.Context,
 	}
 
 	return []*universe.Proof{uniProof}, nil
+}
+
+// Close closes the underlying RPC connection to the remote universe server.
+func (r *RpcUniverseDiff) Close() error {
+	if err := r.conn.Close(); err != nil {
+		tapdLog.Warnf("unable to close universe RPC "+
+			"connection: %v", err)
+		return err
+	}
+
+	return nil
 }
 
 // A compile time interface to ensure that RpcUniverseDiff implements the


### PR DESCRIPTION
On the instance we've run, we've been seeing a very high number of active TCP connections at any given time. After tweaking some Aperture related settings, it seems that the issue is with our own gRPC server, and the way we make outbound connections. 

This PR implements to fixes to attempt to mitigate this issue:
   * Close out any outbound connections we make (courier, gRPC syncing, etc) once we're done. 
   * Add a default idle timer that'll close out connections that haven't received any requests/responses after an interval of time. 