### PR TITLE
[1/2] custodian: look up proofs in local universe as well

### DIFF
--- a/fn/func.go
+++ b/fn/func.go
@@ -130,9 +130,33 @@ func All[T any](xs []T, pred func(T) bool) bool {
 	return true
 }
 
+// AllMapItems returns true if the passed predicate returns true for all items
+// in the map.
+func AllMapItems[T any, K comparable](xs map[K]T, pred func(T) bool) bool {
+	for i := range xs {
+		if !pred(xs[i]) {
+			return false
+		}
+	}
+
+	return true
+}
+
 // Any returns true if the passed predicate returns true for any item in the
 // slice.
 func Any[T any](xs []T, pred func(T) bool) bool {
+	for i := range xs {
+		if pred(xs[i]) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// AnyMapItem returns true if the passed predicate returns true for any item in
+// the map.
+func AnyMapItem[T any, K comparable](xs map[K]T, pred func(T) bool) bool {
 	for i := range xs {
 		if pred(xs[i]) {
 			return true
@@ -148,8 +172,28 @@ func NotAny[T any](xs []T, pred func(T) bool) bool {
 	return !Any(xs, pred)
 }
 
+// NotAnyMapItem returns true if the passed predicate returns false for all
+// items in the map.
+func NotAnyMapItem[T any, K comparable](xs map[K]T, pred func(T) bool) bool {
+	return !AnyMapItem(xs, pred)
+}
+
 // Count returns the number of items in the slice that match the predicate.
 func Count[T any](xs []T, pred func(T) bool) int {
+	var count int
+
+	for i := range xs {
+		if pred(xs[i]) {
+			count++
+		}
+	}
+
+	return count
+}
+
+// CountMapItems returns the number of items in the map that match the
+// predicate.
+func CountMapItems[T any, K comparable](xs map[K]T, pred func(T) bool) int {
 	var count int
 
 	for i := range xs {

--- a/fn/iter.go
+++ b/fn/iter.go
@@ -7,10 +7,8 @@ package fn
 // This function can be used instead of the normal range loop to ensure that a
 // loop scoping bug isn't introduced.
 func ForEachErr[T any](s []T, f func(T) error) error {
-	for _, item := range s {
-		item := item
-
-		if err := f(item); err != nil {
+	for i := range s {
+		if err := f(s[i]); err != nil {
 			return err
 		}
 	}
@@ -22,9 +20,17 @@ func ForEachErr[T any](s []T, f func(T) error) error {
 // This can be used to ensure that any normal for-loop don't run into bugs due
 // to loop variable scoping.
 func ForEach[T any](items []T, f func(T)) {
-	for _, item := range items {
-		item := item
-		f(item)
+	for i := range items {
+		f(items[i])
+	}
+}
+
+// ForEachMapItem is a generic implementation of a for-each (map with side
+// effects). This can be used to ensure that any normal for-loop don't run into
+// bugs due to loop variable scoping.
+func ForEachMapItem[T any, K comparable](items map[K]T, f func(T)) {
+	for i := range items {
+		f(items[i])
 	}
 }
 
@@ -35,6 +41,14 @@ func Enumerate[T any](items []T, f func(int, T)) {
 	for i := 0; i < len(items)-1; i++ {
 		item := items[i]
 		f(i, item)
+	}
+}
+
+// EnumerateMap is a generic enumeration function. The closure will be called
+// for each key and item in the passed-in map.
+func EnumerateMap[T any, K comparable](items map[K]T, f func(K, T)) {
+	for key := range items {
+		f(key, items[key])
 	}
 }
 

--- a/itest/test_list_on_test.go
+++ b/itest/test_list_on_test.go
@@ -184,6 +184,10 @@ var testCases = []*testCase{
 		test: testUniverseSync,
 	},
 	{
+		name: "universe sync manual insert",
+		test: testUniverseManualSync,
+	},
+	{
 		name: "universe federation",
 		test: testUniverseFederation,
 	},

--- a/itest/test_list_on_test.go
+++ b/itest/test_list_on_test.go
@@ -77,6 +77,10 @@ var testCases = []*testCase{
 		proofCourierType: proof.HashmailCourierType,
 	},
 	{
+		name: "addr send no proof courier with local universe import",
+		test: testSendNoCourierUniverseImport,
+	},
+	{
 		name:             "basic send passive asset",
 		test:             testBasicSendPassiveAsset,
 		proofCourierType: proof.HashmailCourierType,

--- a/itest/universe_test.go
+++ b/itest/universe_test.go
@@ -292,6 +292,88 @@ func testUniverseSync(t *harnessTest) {
 	)
 }
 
+// testUniverseManualSync tests that we're able to insert proofs manually into
+// a universe instead of using a full sync.
+func testUniverseManualSync(t *harnessTest) {
+	miner := t.lndHarness.Miner.Client
+
+	// First, we'll create out usual set of issuable assets.
+	rpcIssuableAssets := MintAssetsConfirmBatch(
+		t.t, miner, t.tapd, issuableAssets,
+	)
+
+	// With those assets created, we'll now create a new node that we'll
+	// use to exercise the manual Universe sync.
+	bob := setupTapdHarness(
+		t.t, t, t.lndHarness.Bob, t.universeServer,
+		func(params *tapdHarnessParams) {
+			params.noDefaultUniverseSync = true
+		},
+	)
+	defer func() {
+		require.NoError(t.t, bob.stop(!*noDelete))
+	}()
+
+	ctxb := context.Background()
+	ctxt, cancel := context.WithTimeout(ctxb, defaultWaitTimeout)
+	defer cancel()
+
+	// We now side load the issuance proof of our first asset into Bob's
+	// universe.
+	firstAsset := rpcIssuableAssets[0]
+	firstAssetGen := firstAsset.AssetGenesis
+	sendProofUniRPC(t, t.tapd, bob, firstAsset.ScriptKey, firstAssetGen)
+
+	// We should also be able to fetch an asset from Bob's Universe, and
+	// query for that asset with the compressed script key.
+	firstOutpoint, err := tap.UnmarshalOutpoint(
+		firstAsset.ChainAnchor.AnchorOutpoint,
+	)
+	require.NoError(t.t, err)
+
+	firstAssetProofQuery := unirpc.UniverseKey{
+		Id: &unirpc.ID{
+			Id: &unirpc.ID_GroupKey{
+				GroupKey: firstAsset.AssetGroup.TweakedGroupKey,
+			},
+			ProofType: unirpc.ProofType_PROOF_TYPE_ISSUANCE,
+		},
+		LeafKey: &unirpc.AssetKey{
+			Outpoint: &unirpc.AssetKey_Op{
+				Op: &unirpc.Outpoint{
+					HashStr: firstOutpoint.Hash.String(),
+					Index:   int32(firstOutpoint.Index),
+				},
+			},
+			ScriptKey: &unirpc.AssetKey_ScriptKeyBytes{
+				ScriptKeyBytes: firstAsset.ScriptKey,
+			},
+		},
+	}
+
+	// We should now be able to query for the asset proof.
+	_, err = bob.QueryProof(ctxt, &firstAssetProofQuery)
+	require.NoError(t.t, err)
+
+	// We should now also be able to fetch the meta data and group key for
+	// the asset.
+	metaData, err := bob.FetchAssetMeta(ctxt, &taprpc.FetchAssetMetaRequest{
+		Asset: &taprpc.FetchAssetMetaRequest_MetaHash{
+			MetaHash: firstAssetGen.MetaHash,
+		},
+	})
+	require.NoError(t.t, err)
+	require.Equal(t.t, firstAssetGen.MetaHash, metaData.MetaHash)
+
+	// We should be able to create a new address for the asset, since that
+	// requires us to know the full genesis and group key.
+	_, err = bob.NewAddr(ctxt, &taprpc.NewAddrRequest{
+		AssetId: firstAssetGen.AssetId,
+		Amt:     500,
+	})
+	require.NoError(t.t, err)
+}
+
 // unmarshalMerkleSumNode un-marshals a protobuf MerkleSumNode.
 func unmarshalMerkleSumNode(root *unirpc.MerkleSumNode) mssmt.Node {
 	var nodeHash mssmt.NodeHash

--- a/proof/archive.go
+++ b/proof/archive.go
@@ -125,7 +125,12 @@ type Archiver interface {
 // NotifyArchiver is an Archiver that also allows callers to subscribe to
 // notifications about new proofs being added to the archiver.
 type NotifyArchiver interface {
-	Archiver
+	// FetchProof fetches a proof for an asset uniquely identified by the
+	// passed Identifier. The returned blob is expected to be the encoded
+	// full proof file, containing the complete provenance of the asset.
+	//
+	// If a proof cannot be found, then ErrProofNotFound should be returned.
+	FetchProof(ctx context.Context, id Locator) (Blob, error)
 
 	fn.EventPublisher[Blob, []*Locator]
 }

--- a/proof/file.go
+++ b/proof/file.go
@@ -393,6 +393,26 @@ func (f *File) AppendProof(proof Proof) error {
 	return nil
 }
 
+// AppendProofRaw appends a raw proof to the file and calculates its chained
+// hash.
+func (f *File) AppendProofRaw(proof []byte) error {
+	if f.IsUnknownVersion() {
+		return ErrUnknownVersion
+	}
+
+	var prevHash [sha256.Size]byte
+	if !f.IsEmpty() {
+		prevHash = f.proofs[len(f.proofs)-1].hash
+	}
+
+	f.proofs = append(f.proofs, &hashedProof{
+		proofBytes: proof,
+		hash:       hashProof(proof, prevHash),
+	})
+
+	return nil
+}
+
 // ReplaceLastProof attempts to replace the last proof in the file with another
 // one, updating its chained hash in the process.
 func (f *File) ReplaceLastProof(proof Proof) error {

--- a/tapcfg/server.go
+++ b/tapcfg/server.go
@@ -327,6 +327,8 @@ func genServerConfig(cfg *Config, cfgLogger btclog.Logger,
 		TransferLog:    assetStore,
 	})
 
+	multiNotifier := proof.NewMultiArchiveNotifier(assetStore, multiverse)
+
 	return &tap.Config{
 		DebugLevel:   cfg.DebugLevel,
 		RuntimeID:    runtimeID,
@@ -361,7 +363,7 @@ func genServerConfig(cfg *Config, cfgLogger btclog.Logger,
 				),
 				AddrBook:               addrBook,
 				ProofArchive:           proofArchive,
-				ProofNotifier:          assetStore,
+				ProofNotifier:          multiNotifier,
 				ErrChan:                mainErrChan,
 				ProofCourierDispatcher: proofCourierDispatcher,
 				ProofRetrievalDelay:    cfg.CustodianProofRetrievalDelay, ProofWatcher: reOrgWatcher,

--- a/tapdb/multiverse.go
+++ b/tapdb/multiverse.go
@@ -1,6 +1,7 @@
 package tapdb
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"database/sql"
@@ -506,15 +507,23 @@ type MultiverseStore struct {
 	proofCache *proofCache
 
 	leafKeysCache *universeLeafCache
+
+	// transferProofDistributor is an event distributor that will be used to
+	// notify subscribers about new proof leaves that are added to the
+	// multiverse. This is used to notify the custodian about new incoming
+	// proofs. And since the custodian is only interested in transfer
+	// proofs, we only signal on transfer proofs.
+	transferProofDistributor *fn.EventDistributor[proof.Blob]
 }
 
 // NewMultiverseStore creates a new multiverse DB store handle.
 func NewMultiverseStore(db BatchedMultiverse) *MultiverseStore {
 	return &MultiverseStore{
-		db:            db,
-		rootNodeCache: newRootNodeCache(),
-		proofCache:    newProofCache(),
-		leafKeysCache: newUniverseLeafCache(),
+		db:                       db,
+		rootNodeCache:            newRootNodeCache(),
+		proofCache:               newProofCache(),
+		leafKeysCache:            newUniverseLeafCache(),
+		transferProofDistributor: fn.NewEventDistributor[proof.Blob](),
 	}
 }
 
@@ -893,6 +902,78 @@ func (b *MultiverseStore) FetchProofLeaf(ctx context.Context,
 	return proofs, nil
 }
 
+// FetchProof fetches a proof for an asset uniquely identified by the passed
+// Locator. The returned blob contains the encoded full proof file, representing
+// the complete provenance of the asset.
+//
+// If a proof cannot be found, then ErrProofNotFound is returned.
+//
+// NOTE: This is part of the proof.NotifyArchiver interface.
+func (b *MultiverseStore) FetchProof(ctx context.Context,
+	originLocator proof.Locator) (proof.Blob, error) {
+
+	// The universe only delivers a single proof at a time, so we need a
+	// callback that we can feed into proof.FetchProofProvenance to assemble
+	// the full proof file.
+	fetchProof := func(ctx context.Context, loc proof.Locator) (proof.Blob,
+		error) {
+
+		uniID := universe.Identifier{
+			AssetID:   *loc.AssetID,
+			GroupKey:  loc.GroupKey,
+			ProofType: universe.ProofTypeTransfer,
+		}
+		scriptKey := asset.NewScriptKey(&loc.ScriptKey)
+		leafKey := universe.LeafKey{
+			ScriptKey: &scriptKey,
+		}
+		if loc.OutPoint != nil {
+			leafKey.OutPoint = *loc.OutPoint
+		}
+
+		proofs, err := b.FetchProofLeaf(ctx, uniID, leafKey)
+		if errors.Is(err, universe.ErrNoUniverseProofFound) {
+			// If we didn't find a proof, maybe we arrived at the
+			// issuance proof, in which case we need to adjust the
+			// proof type.
+			uniID.ProofType = universe.ProofTypeIssuance
+			proofs, err = b.FetchProofLeaf(ctx, uniID, leafKey)
+
+			// If we still didn't find a proof, then we'll return
+			// the proof not found error, but the one from the proof
+			// package, not the universe package, as the Godoc for
+			// this method in the proof.NotifyArchiver states.
+			if errors.Is(err, universe.ErrNoUniverseProofFound) {
+				return nil, proof.ErrProofNotFound
+			}
+		}
+		if err != nil {
+			return nil, fmt.Errorf("error fetching proof from "+
+				"archive: %w", err)
+		}
+
+		if len(proofs) > 1 {
+			return nil, fmt.Errorf("expected only one proof, "+
+				"got %d", len(proofs))
+		}
+
+		return proofs[0].Leaf.RawProof, nil
+	}
+
+	file, err := proof.FetchProofProvenance(ctx, originLocator, fetchProof)
+	if err != nil {
+		return nil, fmt.Errorf("error fetching proof from archive: %w",
+			err)
+	}
+
+	var buf bytes.Buffer
+	if err := file.Encode(&buf); err != nil {
+		return nil, fmt.Errorf("error encoding proof file: %w", err)
+	}
+
+	return buf.Bytes(), nil
+}
+
 // UpsertProofLeaf upserts a proof leaf within the multiverse tree and the
 // universe tree that corresponds to the given key.
 func (b *MultiverseStore) UpsertProofLeaf(ctx context.Context,
@@ -929,6 +1010,14 @@ func (b *MultiverseStore) UpsertProofLeaf(ctx context.Context,
 	b.rootNodeCache.wipeCache()
 	b.proofCache.delProofsForAsset(id)
 	b.leafKeysCache.wipeCache(idStr)
+
+	// Notify subscribers about the new proof leaf, now that we're sure we
+	// have written it to the database. But we only care about transfer
+	// proofs, as the events are received by the custodian to finalize
+	// inbound transfers.
+	if id.ProofType == universe.ProofTypeTransfer {
+		b.transferProofDistributor.NotifySubscribers(leaf.RawProof)
+	}
 
 	return issuanceProof, nil
 }
@@ -975,6 +1064,18 @@ func (b *MultiverseStore) UpsertProofLeafBatch(ctx context.Context,
 	// TODO(roasbeef): want to write thru but then need db query again?
 
 	b.rootNodeCache.wipeCache()
+
+	// Notify subscribers about the new proof leaves, now that we're sure we
+	// have written them to the database. But we only care about transfer
+	// proofs, as the events are received by the custodian to finalize
+	// inbound transfers.
+	for idx := range items {
+		if items[idx].ID.ProofType == universe.ProofTypeTransfer {
+			b.transferProofDistributor.NotifySubscribers(
+				items[idx].Leaf.RawProof,
+			)
+		}
+	}
 
 	// Invalidate the root node cache for all the assets we just inserted.
 	idsToDelete := fn.NewSet(fn.Map(items, func(item *universe.Item) treeID {
@@ -1109,3 +1210,68 @@ func (b *MultiverseStore) FetchLeaves(ctx context.Context,
 
 	return leaves, nil
 }
+
+// RegisterSubscriber adds a new subscriber for receiving events. The
+// deliverExisting boolean indicates whether already existing items should be
+// sent to the NewItemCreated channel when the subscription is started. An
+// optional deliverFrom can be specified to indicate from which timestamp/index/
+// marker onward existing items should be delivered on startup. If deliverFrom
+// is nil/zero/empty then all existing items will be delivered.
+func (b *MultiverseStore) RegisterSubscriber(
+	receiver *fn.EventReceiver[proof.Blob], deliverExisting bool,
+	deliverFrom []*proof.Locator) error {
+
+	b.transferProofDistributor.RegisterSubscriber(receiver)
+
+	// No delivery of existing items requested, we're done here.
+	if !deliverExisting {
+		return nil
+	}
+
+	ctx := context.Background()
+	for _, loc := range deliverFrom {
+		if loc.AssetID == nil {
+			return fmt.Errorf("missing asset ID")
+		}
+
+		id := universe.Identifier{
+			AssetID:   *loc.AssetID,
+			GroupKey:  loc.GroupKey,
+			ProofType: universe.ProofTypeTransfer,
+		}
+		scriptKey := asset.NewScriptKey(&loc.ScriptKey)
+		key := universe.LeafKey{
+			ScriptKey: &scriptKey,
+		}
+
+		if loc.OutPoint != nil {
+			key.OutPoint = *loc.OutPoint
+		}
+
+		leaves, err := b.FetchProofLeaf(ctx, id, key)
+		if err != nil {
+			return err
+		}
+
+		// Deliver the found leaves to the new item queue of the
+		// subscriber.
+		for idx := range leaves {
+			rawProof := leaves[idx].Leaf.RawProof
+			receiver.NewItemCreated.ChanIn() <- rawProof
+		}
+	}
+
+	return nil
+}
+
+// RemoveSubscriber removes the given subscriber and also stops it from
+// processing events.
+func (b *MultiverseStore) RemoveSubscriber(
+	subscriber *fn.EventReceiver[proof.Blob]) error {
+
+	return b.transferProofDistributor.RemoveSubscriber(subscriber)
+}
+
+// A compile-time interface to ensure MultiverseStore meets the
+// proof.NotifyArchiver interface.
+var _ proof.NotifyArchiver = (*MultiverseStore)(nil)

--- a/tapdb/sqlc/querier.go
+++ b/tapdb/sqlc/querier.go
@@ -81,6 +81,7 @@ type Querier interface {
 	GenesisAssets(ctx context.Context) ([]GenesisAsset, error)
 	GenesisPoints(ctx context.Context) ([]GenesisPoint, error)
 	GetRootKey(ctx context.Context, id []byte) (Macaroon, error)
+	HasAssetProof(ctx context.Context, tweakedScriptKey []byte) (bool, error)
 	InsertAddr(ctx context.Context, arg InsertAddrParams) (int64, error)
 	InsertAssetSeedling(ctx context.Context, arg InsertAssetSeedlingParams) error
 	InsertAssetSeedlingIntoBatch(ctx context.Context, arg InsertAssetSeedlingIntoBatchParams) error

--- a/tapdb/sqlc/queries/assets.sql
+++ b/tapdb/sqlc/queries/assets.sql
@@ -690,6 +690,19 @@ FROM asset_proofs
 JOIN asset_info
     ON asset_info.asset_id = asset_proofs.asset_id;
 
+-- name: HasAssetProof :one
+WITH asset_info AS (
+    SELECT assets.asset_id
+    FROM assets
+    JOIN script_keys
+        ON assets.script_key_id = script_keys.script_key_id
+    WHERE script_keys.tweaked_script_key = $1
+)
+SELECT COUNT(asset_info.asset_id) > 0 as has_proof
+FROM asset_proofs
+JOIN asset_info
+    ON asset_info.asset_id = asset_proofs.asset_id;
+
 -- name: InsertAssetWitness :exec
 INSERT INTO asset_witnesses (
     asset_id, prev_out_point, prev_asset_id, prev_script_key, witness_stack,

--- a/tapdb/sqlutils_test.go
+++ b/tapdb/sqlutils_test.go
@@ -150,12 +150,26 @@ func (d *DbHandler) AddRandomAssetProof(t *testing.T) (*asset.Asset,
 	})
 	require.NoError(t, err, "unable to insert chain tx: %w", err)
 
+	// Before we insert the proof, we expect our backend to report it as not
+	// found.
+	proofLocator := proof.Locator{
+		ScriptKey: *testAsset.ScriptKey.PubKey,
+	}
+	found, err := assetStore.HasProof(ctx, proofLocator)
+	require.NoError(t, err)
+	require.False(t, found)
+
 	// With all our test data constructed, we'll now attempt to import the
 	// asset into the database.
 	require.NoError(t, assetStore.ImportProofs(
 		ctx, proof.MockHeaderVerifier, proof.MockGroupVerifier, false,
 		annotatedProof,
 	))
+
+	// Now the HasProof should return true.
+	found, err = assetStore.HasProof(ctx, proofLocator)
+	require.NoError(t, err)
+	require.True(t, found)
 
 	return testAsset, annotatedProof
 }

--- a/tapgarden/custodian.go
+++ b/tapgarden/custodian.go
@@ -1,7 +1,6 @@
 package tapgarden
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"strings"
@@ -626,6 +625,7 @@ func (c *Custodian) checkProofAvailable(event *address.Event) (bool, error) {
 		AssetID:   fn.Ptr(event.Addr.AssetID),
 		GroupKey:  event.Addr.GroupKey,
 		ScriptKey: event.Addr.ScriptKey,
+		OutPoint:  &event.Outpoint,
 	})
 	switch {
 	case errors.Is(err, proof.ErrProofNotFound):
@@ -636,15 +636,23 @@ func (c *Custodian) checkProofAvailable(event *address.Event) (bool, error) {
 			err)
 	}
 
-	file := proof.NewEmptyFile(proof.V0)
-	if err := file.Decode(bytes.NewReader(blob)); err != nil {
-		return false, fmt.Errorf("error decoding proof file: %w", err)
+	// At this point, we expect the proof to be a full file, containing the
+	// whole provenance chain (as required by implementers of the
+	// proof.NotifyArchiver.FetchProof() method). So if we don't we can't
+	// continue.
+	if !blob.IsFile() {
+		return false, fmt.Errorf("expected proof to be a full file, " +
+			"but got something else")
+	}
+
+	file, err := blob.AsFile()
+	if err != nil {
+		return false, fmt.Errorf("error extracting proof file: %w", err)
 	}
 
 	// Exit early on empty proof (shouldn't happen outside of test cases).
 	if file.IsEmpty() {
-		return false, fmt.Errorf("archive contained empty proof file: "+
-			"%w", err)
+		return false, fmt.Errorf("archive contained empty proof file")
 	}
 
 	lastProof, err := file.LastProof()
@@ -665,9 +673,92 @@ func (c *Custodian) checkProofAvailable(event *address.Event) (bool, error) {
 // and pending address event. If a proof successfully matches the desired state
 // of the address, that completes the inbound transfer of an asset.
 func (c *Custodian) mapProofToEvent(p proof.Blob) error {
-	file := proof.NewEmptyFile(proof.V0)
-	if err := file.Decode(bytes.NewReader(p)); err != nil {
-		return fmt.Errorf("error decoding proof file: %w", err)
+	// We arrive here if we are notified about a new proof. The notification
+	// interface allows that proof to be a single transition proof. So if
+	// we don't have a full file yet, we need to fetch it now. The
+	// proof.NotifyArchiver.FetchProof() method will return the full file as
+	// per its Godoc.
+	var (
+		proofBlob = p
+		lastProof *proof.Proof
+		err       error
+	)
+	if !p.IsFile() {
+		log.Debugf("Received single proof, inspecting if matches event")
+		lastProof, err = p.AsSingleProof()
+		if err != nil {
+			return fmt.Errorf("error decoding proof: %w", err)
+		}
+
+		// Before we go ahead and fetch the full file, let's make sure
+		// we are actually interested in this proof. We need to do this
+		// because we receive all transfer proofs inserted into the
+		// local universe here. So they could just be from a proof sync
+		// run and not actually be for an address we are interested in.
+		haveMatchingEvents := fn.AnyMapItem(
+			c.events, func(e *address.Event) bool {
+				return EventMatchesProof(e, lastProof)
+			},
+		)
+		if !haveMatchingEvents {
+			log.Debugf("Proof doesn't match any events, skipping.")
+			return nil
+		}
+
+		ctxt, cancel := c.WithCtxQuit()
+		defer cancel()
+
+		loc := proof.Locator{
+			AssetID:   fn.Ptr(lastProof.Asset.ID()),
+			ScriptKey: *lastProof.Asset.ScriptKey.PubKey,
+			OutPoint:  fn.Ptr(lastProof.OutPoint()),
+		}
+		if lastProof.Asset.GroupKey != nil {
+			loc.GroupKey = &lastProof.Asset.GroupKey.GroupPubKey
+		}
+
+		log.Debugf("Received single proof, fetching full file")
+		proofBlob, err = c.cfg.ProofNotifier.FetchProof(ctxt, loc)
+		if err != nil {
+			return fmt.Errorf("error fetching full proof file for "+
+				"event: %w", err)
+		}
+
+		// Do we already have this proof in our main archive? This
+		// should only be false if we got the notification from our
+		// local universe instead of the local proof archive (which the
+		// couriers use). This is mainly an optimization to make sure we
+		// don't unnecessarily overwrite the proofs in our main archive.
+		haveProof, err := c.cfg.ProofArchive.HasProof(ctxt, loc)
+		if err != nil {
+			return fmt.Errorf("error checking if proof is "+
+				"available: %w", err)
+		}
+
+		// We don't have the proof yet, or not in all backends, so we
+		// need to import it now.
+		if !haveProof {
+			headerVerifier := GenHeaderVerifier(
+				ctxt, c.cfg.ChainBridge,
+			)
+			err = c.cfg.ProofArchive.ImportProofs(
+				ctxt, headerVerifier, c.cfg.GroupVerifier,
+				false, &proof.AnnotatedProof{
+					Locator: loc,
+					Blob:    proofBlob,
+				},
+			)
+			if err != nil {
+				return fmt.Errorf("error importing proof "+
+					"file into main archive: %w", err)
+			}
+		}
+	}
+
+	// Now we can be sure we have a file.
+	file, err := proofBlob.AsFile()
+	if err != nil {
+		return fmt.Errorf("error extracting proof file: %w", err)
 	}
 
 	// Exit early on empty proof (shouldn't happen outside of test cases).
@@ -678,19 +769,22 @@ func (c *Custodian) mapProofToEvent(p proof.Blob) error {
 
 	// We got the proof from the multi archiver, which verifies it before
 	// giving it to us. So we don't have to verify them again and can
-	// directly look at the last state.
-	lastProof, err := file.LastProof()
-	if err != nil {
-		return fmt.Errorf("error fetching last proof: %w", err)
+	// directly look at the last state. We can skip extracting the last
+	// proof if we started out with a single proof in the first place, which
+	// we already parsed above.
+	if lastProof == nil {
+		lastProof, err = file.LastProof()
+		if err != nil {
+			return fmt.Errorf("error fetching last proof: %w", err)
+		}
 	}
-	log.Infof("Received new proof file, version=%d, num_proofs=%d",
-		file.Version, file.NumProofs())
+	log.Infof("Received new proof file for asset ID %s, version=%d,"+
+		"num_proofs=%d", lastProof.Asset.ID().String(), file.Version,
+		file.NumProofs())
 
 	// Check if any of our in-flight events match the last proof's state.
 	for _, event := range c.events {
-		if AddrMatchesAsset(event.Addr, &lastProof.Asset) &&
-			event.Outpoint == lastProof.OutPoint() {
-
+		if EventMatchesProof(event, lastProof) {
 			// Importing a proof already creates the asset in the
 			// database. Therefore, all we need to do is update the
 			// state of the address event to mark it as completed
@@ -843,4 +937,10 @@ func AddrMatchesAsset(addr *address.AddrWithKeyInfo, a *asset.Asset) bool {
 
 	return addr.AssetID == a.ID() && groupKeyEqual &&
 		addr.ScriptKey.IsEqual(a.ScriptKey.PubKey)
+}
+
+// EventMatchesProof returns true if the given event matches the given proof.
+func EventMatchesProof(event *address.Event, p *proof.Proof) bool {
+	return AddrMatchesAsset(event.Addr, &p.Asset) &&
+		event.Outpoint == p.OutPoint()
 }

--- a/tapgarden/mock.go
+++ b/tapgarden/mock.go
@@ -592,6 +592,12 @@ func (m *MockProofArchive) FetchProof(ctx context.Context,
 	return nil, nil
 }
 
+func (m *MockProofArchive) HasProof(ctx context.Context,
+	id proof.Locator) (bool, error) {
+
+	return false, nil
+}
+
 func (m *MockProofArchive) FetchProofs(ctx context.Context,
 	id asset.ID) ([]*proof.AnnotatedProof, error) {
 

--- a/tapgarden/re-org_watcher.go
+++ b/tapgarden/re-org_watcher.go
@@ -68,7 +68,7 @@ type ReOrgWatcherConfig struct {
 
 	// ProofArchive is the storage backend for proofs to which we store
 	// updated proofs.
-	ProofArchive proof.NotifyArchiver
+	ProofArchive proof.Archiver
 
 	// NonBuriedAssetFetcher is a function that returns all assets that are
 	// not yet sufficiently deep buried.


### PR DESCRIPTION
~Depends on https://github.com/lightninglabs/taproot-assets/pull/712.~

Fixes https://github.com/lightninglabs/taproot-assets/issues/578.

This PR updates the proof notification publish/subscribe mechanism in a way that allows us to pass in multiple proof sources to the custodian so it can detect incoming proofs from multiple sources.