### PR TITLE
Add asset group burn itest, logging, and missing error handling

### DIFF
--- a/itest/test_list_on_test.go
+++ b/itest/test_list_on_test.go
@@ -188,6 +188,10 @@ var testCases = []*testCase{
 		test: testBurnAssets,
 	},
 	{
+		name: "burn grouped assets",
+		test: testBurnGroupedAssets,
+	},
+	{
 		name: "federation sync config",
 		test: testFederationSyncConfig,
 	},

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -2092,8 +2092,18 @@ func (r *rpcServer) BurnAsset(ctx context.Context,
 
 	var groupKey *btcec.PublicKey
 	assetGroup, err := r.cfg.TapAddrBook.QueryAssetGroup(ctx, assetID)
-	if err == nil && assetGroup.GroupKey != nil {
+	switch {
+	case err == nil && assetGroup.GroupKey != nil:
+		// We found the asset group, so we can use the group key to
+		// burn the asset.
 		groupKey = &assetGroup.GroupPubKey
+	case errors.Is(err, address.ErrAssetGroupUnknown):
+		// We don't know the asset group, so we'll try to burn the
+		// asset using the asset ID only.
+		rpcsLog.Debug("Asset group key not found, asset may not be " +
+			"part of a group")
+	case err != nil:
+		return nil, fmt.Errorf("error querying asset group: %w", err)
 	}
 
 	fundResp, err := r.cfg.AssetWallet.FundBurn(

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -2063,6 +2063,8 @@ func (r *rpcServer) SendAsset(_ context.Context,
 func (r *rpcServer) BurnAsset(ctx context.Context,
 	in *taprpc.BurnAssetRequest) (*taprpc.BurnAssetResponse, error) {
 
+	rpcsLog.Debug("Executing asset burn")
+
 	var assetID asset.ID
 	switch {
 	case len(in.GetAssetId()) > 0:
@@ -2105,6 +2107,15 @@ func (r *rpcServer) BurnAsset(ctx context.Context,
 	case err != nil:
 		return nil, fmt.Errorf("error querying asset group: %w", err)
 	}
+
+	var serializedGroupKey []byte
+	if groupKey != nil {
+		serializedGroupKey = groupKey.SerializeCompressed()
+	}
+
+	rpcsLog.Infof("Burning asset (asset_id=%x, group_key=%x, "+
+		"burn_amount=%d)", assetID[:], serializedGroupKey,
+		in.AmountToBurn)
 
 	fundResp, err := r.cfg.AssetWallet.FundBurn(
 		ctx, &tapscript.FundingDescriptor{


### PR DESCRIPTION
This PR adds an itest which ensures that we can burn an asset from an asset group in the simplest case.

It makes the following changes to the `BurnAsset` RPC endpoint:
* Adds additional logging.
* Adds missing error handling when attempting to retrieve a group key.


This PR was created in an attempt to re-produce bug https://github.com/lightninglabs/taproot-assets/issues/704