### PR TITLE
proof courier: general cleanup and refactor, re-try after restart

### DIFF
--- a/itest/send_test.go
+++ b/itest/send_test.go
@@ -21,6 +21,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var (
+	transferTypeSend = taprpc.ProofTransferType_PROOF_TRANSFER_TYPE_SEND
+)
+
 // testBasicSendUnidirectional tests that we can properly send assets back and
 // forth between nodes.
 func testBasicSendUnidirectional(t *harnessTest) {
@@ -619,7 +623,7 @@ func testReattemptFailedSendHashmailCourier(t *harnessTest) {
 			switch eventTyped := event.Event.(type) {
 			case *taprpc.SendAssetEvent_ProofTransferBackoffWaitEvent:
 				ev := eventTyped.ProofTransferBackoffWaitEvent
-				if ev.TransferType != taprpc.ProofTransferType_PROOF_TRANSFER_TYPE_SEND {
+				if ev.TransferType != transferTypeSend {
 					return false
 				}
 
@@ -726,7 +730,7 @@ func testReattemptFailedSendUniCourier(t *harnessTest) {
 			switch eventTyped := event.Event.(type) {
 			case *taprpc.SendAssetEvent_ProofTransferBackoffWaitEvent:
 				ev := eventTyped.ProofTransferBackoffWaitEvent
-				if ev.TransferType != taprpc.ProofTransferType_PROOF_TRANSFER_TYPE_SEND {
+				if ev.TransferType != transferTypeSend {
 					return false
 				}
 
@@ -1000,7 +1004,7 @@ func testOfflineReceiverEventuallyReceives(t *harnessTest) {
 				// node. We therefore expect to receive
 				// deliver transfer type backoff wait events
 				// for sending transfers.
-				if ev.TransferType != taprpc.ProofTransferType_PROOF_TRANSFER_TYPE_SEND {
+				if ev.TransferType != transferTypeSend {
 					return false
 				}
 

--- a/itest/tapd_harness.go
+++ b/itest/tapd_harness.go
@@ -76,7 +76,7 @@ const (
 	// defaultProofTransferReceiverAckTimeout is the default itest specific
 	// timeout we'll use for waiting for a receiver to acknowledge a proof
 	// transfer.
-	defaultProofTransferReceiverAckTimeout = 15 * time.Second
+	defaultProofTransferReceiverAckTimeout = 5 * time.Second
 )
 
 // tapdHarness is a test harness that holds everything that is needed to

--- a/proof/courier.go
+++ b/proof/courier.go
@@ -185,13 +185,6 @@ func (h *UniverseRpcCourierAddr) Url() *url.URL {
 func (h *UniverseRpcCourierAddr) NewCourier(_ context.Context,
 	cfg *CourierCfg, recipient Recipient) (Courier, error) {
 
-	// Skip the initial delivery delay for the universe RPC courier.
-	// This courier skips the initial delay because it uses the backoff
-	// procedure for each proof within a proof file separately.
-	// Consequently, if we attempt to perform two consecutive send events
-	// which share the same proof lineage (matching ancestral proofs), the
-	// second send event will be delayed by the initial delay.
-	cfg.BackoffCfg.SkipInitDelay = true
 	backoffHandle := NewBackoffHandler(cfg.BackoffCfg, cfg.TransferLog)
 
 	// Ensure that the courier address is a universe RPC address.
@@ -557,10 +550,10 @@ func (e *BackoffExecError) Error() string {
 
 // BackoffCfg configures the behaviour of the proof delivery backoff procedure.
 type BackoffCfg struct {
-	// SkipInitDelay is a flag that indicates whether we should skip
-	// the initial delay before attempting to deliver the proof to the
-	// receiver.
-	SkipInitDelay bool
+	// SkipInitDelay is a flag that indicates whether we should skip the
+	// initial delay before attempting to deliver the proof to the receiver
+	// or receiving from the sender.
+	SkipInitDelay bool `long:"skipinitdelay" description:"Skip the initial delay before attempting to deliver the proof to the receiver or receiving from the sender."`
 
 	// BackoffResetWait is the amount of time we'll wait before
 	// resetting the backoff counter to its initial state.
@@ -1048,6 +1041,13 @@ func (h *HashMailCourier) SetSubscribers(
 // A compile-time assertion to ensure the HashMailCourier meets the
 // proof.Courier interface.
 var _ Courier = (*HashMailCourier)(nil)
+
+// UniverseRpcCourierCfg is the config for the universe RPC proof courier.
+type UniverseRpcCourierCfg struct {
+	// BackoffCfg configures the behaviour of the proof delivery
+	// functionality.
+	BackoffCfg *BackoffCfg
+}
 
 // UniverseRpcCourier is a universe RPC proof courier service handle. It
 // implements the Courier interface.

--- a/proof/mock.go
+++ b/proof/mock.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/hex"
 	"io"
+	"sync"
 	"testing"
 	"time"
 
@@ -13,6 +14,7 @@ import (
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/taproot-assets/asset"
 	"github.com/lightninglabs/taproot-assets/commitment"
+	"github.com/lightninglabs/taproot-assets/fn"
 	"github.com/lightninglabs/taproot-assets/internal/test"
 	"github.com/stretchr/testify/require"
 )
@@ -73,6 +75,80 @@ func MockGroupAnchorVerifier(gen *asset.Genesis,
 
 	return nil
 }
+
+// MockProofCourier is a mock proof courier which stores the last proof it
+// received.
+type MockProofCourier struct {
+	sync.Mutex
+
+	currentProofs map[asset.SerializedKey]*AnnotatedProof
+
+	subscribers map[uint64]*fn.EventReceiver[fn.Event]
+}
+
+// NewMockProofCourier returns a new mock proof courier.
+func NewMockProofCourier() *MockProofCourier {
+	return &MockProofCourier{
+		currentProofs: make(map[asset.SerializedKey]*AnnotatedProof),
+	}
+}
+
+// Start starts the proof courier service.
+func (m *MockProofCourier) Start(chan error) error {
+	return nil
+}
+
+// Stop stops the proof courier service.
+func (m *MockProofCourier) Stop() error {
+	return nil
+}
+
+// DeliverProof attempts to delivery a proof to the receiver, using the
+// information in the Addr type.
+func (m *MockProofCourier) DeliverProof(_ context.Context,
+	proof *AnnotatedProof) error {
+
+	m.Lock()
+	defer m.Unlock()
+
+	m.currentProofs[asset.ToSerialized(&proof.ScriptKey)] = proof
+
+	return nil
+}
+
+// ReceiveProof attempts to obtain a proof as identified by the passed
+// locator from the source encapsulated within the specified address.
+func (m *MockProofCourier) ReceiveProof(_ context.Context,
+	loc Locator) (*AnnotatedProof, error) {
+
+	m.Lock()
+	defer m.Unlock()
+
+	proof, ok := m.currentProofs[asset.ToSerialized(&loc.ScriptKey)]
+	if !ok {
+		return nil, ErrProofNotFound
+	}
+
+	return proof, nil
+}
+
+// SetSubscribers sets the set of subscribers that will be notified
+// of proof courier related events.
+func (m *MockProofCourier) SetSubscribers(
+	subscribers map[uint64]*fn.EventReceiver[fn.Event]) {
+
+	m.Lock()
+	defer m.Unlock()
+
+	m.subscribers = subscribers
+}
+
+// Close stops the courier instance.
+func (m *MockProofCourier) Close() error {
+	return nil
+}
+
+var _ Courier = (*MockProofCourier)(nil)
 
 type ValidTestCase struct {
 	Proof    *TestProof `json:"proof"`

--- a/proof/mock.go
+++ b/proof/mock.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/hex"
 	"io"
+	"net/url"
 	"sync"
 	"testing"
 	"time"
@@ -74,6 +75,20 @@ func MockGroupAnchorVerifier(gen *asset.Genesis,
 	groupKey *asset.GroupKey) error {
 
 	return nil
+}
+
+// MockProofCourierDispatcher is a mock proof courier dispatcher which returns
+// the same courier for all requests.
+type MockProofCourierDispatcher struct {
+	Courier Courier
+}
+
+// NewCourier instantiates a new courier service handle given a service
+// URL address.
+func (m *MockProofCourierDispatcher) NewCourier(*url.URL, Recipient) (Courier,
+	error) {
+
+	return m.Courier, nil
 }
 
 // MockProofCourier is a mock proof courier which stores the last proof it

--- a/tapcfg/config.go
+++ b/tapcfg/config.go
@@ -303,8 +303,9 @@ type Config struct {
 	ReOrgSafeDepth int32 `long:"reorgsafedepth" description:"The number of confirmations we'll wait for before considering a transaction safely buried in the chain."`
 
 	// The following options are used to configure the proof courier.
-	DefaultProofCourierAddr string                    `long:"proofcourieraddr" description:"Default proof courier service address."`
-	HashMailCourier         *proof.HashMailCourierCfg `group:"proofcourier" namespace:"hashmailcourier"`
+	DefaultProofCourierAddr string                       `long:"proofcourieraddr" description:"Default proof courier service address."`
+	HashMailCourier         *proof.HashMailCourierCfg    `group:"hashmailcourier" namespace:"hashmailcourier"`
+	UniverseRpcCourier      *proof.UniverseRpcCourierCfg `group:"universerpccourier" namespace:"universerpccourier"`
 
 	CustodianProofRetrievalDelay time.Duration `long:"custodianproofretrievaldelay" description:"The number of seconds the custodian waits after identifying an asset transfer on-chain and before retrieving the corresponding proof."`
 
@@ -385,6 +386,15 @@ func DefaultConfig() Config {
 		HashMailCourier: &proof.HashMailCourierCfg{
 			ReceiverAckTimeout: defaultProofTransferReceiverAckTimeout,
 			BackoffCfg: &proof.BackoffCfg{
+				BackoffResetWait: defaultProofTransferBackoffResetWait,
+				NumTries:         defaultProofTransferNumTries,
+				InitialBackoff:   defaultProofTransferInitialBackoff,
+				MaxBackoff:       defaultProofTransferMaxBackoff,
+			},
+		},
+		UniverseRpcCourier: &proof.UniverseRpcCourierCfg{
+			BackoffCfg: &proof.BackoffCfg{
+				SkipInitDelay:    true,
 				BackoffResetWait: defaultProofTransferBackoffResetWait,
 				NumTries:         defaultProofTransferNumTries,
 				InitialBackoff:   defaultProofTransferInitialBackoff,

--- a/tapcfg/server.go
+++ b/tapcfg/server.go
@@ -322,9 +322,9 @@ func genServerConfig(cfg *Config, cfgLogger btclog.Logger,
 	// types of couriers that currently exist will receive this config upon
 	// initialization.
 	proofCourierCfg := &proof.CourierCfg{
-		ReceiverAckTimeout: cfg.HashMailCourier.ReceiverAckTimeout,
-		BackoffCfg:         cfg.HashMailCourier.BackoffCfg,
-		TransferLog:        assetStore,
+		HashMailCfg:    cfg.HashMailCourier,
+		UniverseRpcCfg: cfg.UniverseRpcCourier,
+		TransferLog:    assetStore,
 	}
 
 	return &tap.Config{

--- a/tapcfg/server.go
+++ b/tapcfg/server.go
@@ -231,18 +231,6 @@ func genServerConfig(cfg *Config, cfgLogger btclog.Logger,
 		}
 	}
 
-	// TODO(ffranr): This logic is leftover for integration tests which
-	//  do not yet enable a proof courier. Remove once all integration tests
-	//  support a proof courier.
-	var proofCourierCfg *proof.CourierCfg
-	if cfg.HashMailCourier != nil {
-		proofCourierCfg = &proof.CourierCfg{
-			ReceiverAckTimeout: cfg.HashMailCourier.ReceiverAckTimeout,
-			BackoffCfg:         cfg.HashMailCourier.BackoffCfg,
-			TransferLog:        assetStore,
-		}
-	}
-
 	reOrgWatcher := tapgarden.NewReOrgWatcher(&tapgarden.ReOrgWatcherConfig{
 		ChainBridge: chainBridge,
 		GroupVerifier: tapgarden.GenGroupVerifier(
@@ -329,6 +317,15 @@ func genServerConfig(cfg *Config, cfgLogger btclog.Logger,
 		Wallet:       walletAnchor,
 		ChainParams:  &tapChainParams,
 	})
+
+	// Addresses can have different proof couriers configured, but both
+	// types of couriers that currently exist will receive this config upon
+	// initialization.
+	proofCourierCfg := &proof.CourierCfg{
+		ReceiverAckTimeout: cfg.HashMailCourier.ReceiverAckTimeout,
+		BackoffCfg:         cfg.HashMailCourier.BackoffCfg,
+		TransferLog:        assetStore,
+	}
 
 	return &tap.Config{
 		DebugLevel:   cfg.DebugLevel,

--- a/tapfreighter/parcel.go
+++ b/tapfreighter/parcel.go
@@ -183,7 +183,7 @@ func (p *AddressParcel) Validate() error {
 		tapAddr := p.destAddrs[idx]
 
 		// Validate proof courier addresses.
-		_, err := proof.ParseCourierAddrUrl(tapAddr.ProofCourierAddr)
+		err := proof.ValidateCourierAddress(&tapAddr.ProofCourierAddr)
 		if err != nil {
 			return fmt.Errorf("invalid proof courier address: %w",
 				err)

--- a/tapgarden/custodian.go
+++ b/tapgarden/custodian.go
@@ -400,13 +400,6 @@ func (c *Custodian) inspectWalletTx(walletTx *lndclient.Transaction) error {
 			continue
 		}
 
-		// TODO(ffranr): This proof courier disabled check should be
-		//  removed. It was implemented because some integration test do
-		//  not setup and use a proof courier.
-		if c.cfg.ProofCourierCfg == nil {
-			continue
-		}
-
 		// Now that we've seen this output on chain, we'll launch a
 		// goroutine to use the ProofCourier to import the proof into
 		// our local DB.

--- a/tapgarden/custodian.go
+++ b/tapgarden/custodian.go
@@ -498,15 +498,6 @@ func (c *Custodian) receiveProof(addr *address.Tap, op wire.OutPoint) {
 		log.Errorf("Unable to import proofs: %v", err)
 		return
 	}
-
-	// At this point the "receive" process is complete. We will now notify
-	// all status event subscribers.
-	receiveCompleteEvent := NewAssetRecvCompleteEvent(*addr, op)
-	err = c.publishSubscriberStatusEvent(receiveCompleteEvent)
-	if err != nil {
-		log.Errorf("Unable publish status event: %v", err)
-		return
-	}
 }
 
 // mapToTapAddr attempts to match a transaction output to a Taproot Asset
@@ -707,13 +698,23 @@ func (c *Custodian) mapProofToEvent(p proof.Blob) error {
 func (c *Custodian) setReceiveCompleted(event *address.Event,
 	lastProof *proof.Proof, proofFile *proof.File) error {
 
+	// At this point the "receive" process is complete. We will now notify
+	// all status event subscribers.
+	receiveCompleteEvent := NewAssetRecvCompleteEvent(
+		*event.Addr.Tap, event.Outpoint,
+	)
+	err := c.publishSubscriberStatusEvent(receiveCompleteEvent)
+	if err != nil {
+		log.Errorf("Unable publish status event: %v", err)
+	}
+
 	// The proof is created after a single confirmation. To make sure we
 	// notice if the anchor transaction is re-organized out of the chain, we
 	// give all the not-yet-sufficiently-buried proofs in the received proof
 	// file to the re-org watcher and replace the updated proof in the local
 	// proof archive if a re-org happens. The sender will do the same, so no
 	// re-send of the proof is necessary.
-	err := c.cfg.ProofWatcher.MaybeWatch(
+	err = c.cfg.ProofWatcher.MaybeWatch(
 		proofFile, c.cfg.ProofWatcher.DefaultUpdateCallback(),
 	)
 	if err != nil {


### PR DESCRIPTION
Fixes https://github.com/lightninglabs/taproot-assets/issues/597.

This PR removes a bunch of TODOs around the way proof couriers are instantiated and receive their configuration.
After the refactor we then fix a bug where we didn't attempt to fetch a proof using a proof courier again after restarting the daemon.
