### PR TITLE
Add means to specify sqlite db file path for tapd test harness and db unit tests

### DIFF
--- a/itest/tapd_harness.go
+++ b/itest/tapd_harness.go
@@ -104,6 +104,10 @@ type harnessOpts struct {
 	// fedSyncTickerInterval is the interval at which the federation envoy
 	// sync ticker will fire.
 	fedSyncTickerInterval *time.Duration
+
+	// sqliteDatabaseFilePath is the path to the SQLite database file to
+	// use.
+	sqliteDatabaseFilePath *string
 }
 
 type harnessOption func(*harnessOpts)
@@ -186,6 +190,11 @@ func newTapdHarness(t *testing.T, ht *harnessTest, cfg tapdConfig,
 	// be queryable by other tapd nodes. This applies to federation syncing
 	// as well as RPC insert and query.
 	tapCfg.Universe.PublicAccess = true
+
+	// Set the SQLite database file path if it was specified.
+	if opts.sqliteDatabaseFilePath != nil {
+		tapCfg.Sqlite.DatabaseFileName = *opts.sqliteDatabaseFilePath
+	}
 
 	// Pass through the address asset syncer disable flag. If the option
 	// was not set, this will be false, which is the default.

--- a/itest/test_harness.go
+++ b/itest/test_harness.go
@@ -373,6 +373,10 @@ type tapdHarnessParams struct {
 	// noDefaultUniverseSync indicates whether the default universe server
 	// should be added as a federation server or not.
 	noDefaultUniverseSync bool
+
+	// sqliteDatabaseFilePath is the path to the SQLite database file to
+	// use.
+	sqliteDatabaseFilePath *string
 }
 
 type Option func(*tapdHarnessParams)
@@ -407,12 +411,14 @@ func setupTapdHarness(t *testing.T, ht *harnessTest,
 		ho.custodianProofRetrievalDelay = params.custodianProofRetrievalDelay
 		ho.addrAssetSyncerDisable = params.addrAssetSyncerDisable
 		ho.fedSyncTickerInterval = params.fedSyncTickerInterval
+		ho.sqliteDatabaseFilePath = params.sqliteDatabaseFilePath
 	}
 
-	tapdHarness, err := newTapdHarness(t, ht, tapdConfig{
+	tapdCfg := tapdConfig{
 		NetParams: harnessNetParams,
 		LndNode:   node,
-	}, harnessOpts)
+	}
+	tapdHarness, err := newTapdHarness(t, ht, tapdCfg, harnessOpts)
 	require.NoError(t, err)
 
 	// Start the tapd harness now.

--- a/tapdb/sqlite.go
+++ b/tapdb/sqlite.go
@@ -170,13 +170,21 @@ func (s *SqliteStore) ExecuteMigrations(target MigrationTarget) error {
 func NewTestSqliteDB(t *testing.T) *SqliteStore {
 	t.Helper()
 
-	dbFileName := filepath.Join(t.TempDir(), "tmp.db")
-	t.Logf("Creating new SQLite DB for testing: %s", dbFileName)
-
 	// TODO(roasbeef): if we pass :memory: for the file name, then we get
 	// an in mem version to speed up tests
+	dbPath := filepath.Join(t.TempDir(), "tmp.db")
+	t.Logf("Creating new SQLite DB handle for testing: %s", dbPath)
+
+	return NewTestSqliteDbHandleFromPath(t, dbPath)
+}
+
+// NewTestSqliteDbHandleFromPath is a helper function that creates a SQLite
+// database handle given a database file path.
+func NewTestSqliteDbHandleFromPath(t *testing.T, dbPath string) *SqliteStore {
+	t.Helper()
+
 	sqlDB, err := NewSqliteStore(&SqliteConfig{
-		DatabaseFileName: dbFileName,
+		DatabaseFileName: dbPath,
 		SkipMigrations:   false,
 	})
 	require.NoError(t, err)

--- a/tapdb/sqlutils_test.go
+++ b/tapdb/sqlutils_test.go
@@ -221,11 +221,8 @@ func (d *DbHandler) AddRandomServerAddrs(t *testing.T,
 	return addrs
 }
 
-// NewDbHandle creates a new store and query handle to the test database.
-func NewDbHandle(t *testing.T) *DbHandler {
-	// Create a new test database.
-	db := NewTestDB(t)
-
+// newDbHandleFromDb creates a new database store handle given a database store.
+func newDbHandleFromDb(db *BaseDB) *DbHandler {
 	testClock := clock.NewTestClock(time.Now())
 
 	// Gain a handle to the pending (minting) universe federation store.
@@ -267,4 +264,18 @@ func NewDbHandle(t *testing.T) *DbHandler {
 		AssetStore:              activeAssetsStore,
 		DirectQuery:             db,
 	}
+}
+
+// NewDbHandleFromPath creates a new database store handle given a database file
+// path.
+func NewDbHandleFromPath(t *testing.T, dbPath string) *DbHandler {
+	db := NewTestDbHandleFromPath(t, dbPath)
+	return newDbHandleFromDb(db.BaseDB)
+}
+
+// NewDbHandle creates a new database store handle.
+func NewDbHandle(t *testing.T) *DbHandler {
+	// Create a new test database with the default database file path.
+	db := NewTestDB(t)
+	return newDbHandleFromDb(db.BaseDB)
 }

--- a/tapdb/test_postgres.go
+++ b/tapdb/test_postgres.go
@@ -11,6 +11,12 @@ func NewTestDB(t *testing.T) *PostgresStore {
 	return NewTestPostgresDB(t)
 }
 
+// NewTestDbHandleFromPath is a helper function that creates a new handle to an
+// existing SQLite database for testing.
+func NewTestDbHandleFromPath(t *testing.T, dbPath string) *PostgresStore {
+	return NewTestPostgresDB(t)
+}
+
 // NewTestDBWithVersion is a helper function that creates a Postgres database
 // for testing and migrates it to the given version.
 func NewTestDBWithVersion(t *testing.T, version uint) *PostgresStore {

--- a/tapdb/test_sqlite.go
+++ b/tapdb/test_sqlite.go
@@ -11,6 +11,12 @@ func NewTestDB(t *testing.T) *SqliteStore {
 	return NewTestSqliteDB(t)
 }
 
+// NewTestDbHandleFromPath is a helper function that creates a new handle to an
+// existing SQLite database for testing.
+func NewTestDbHandleFromPath(t *testing.T, dbPath string) *SqliteStore {
+	return NewTestSqliteDbHandleFromPath(t, dbPath)
+}
+
 // NewTestDBWithVersion is a helper function that creates an SQLite database for
 // testing and migrates it to the given version.
 func NewTestDBWithVersion(t *testing.T, version uint) *SqliteStore {


### PR DESCRIPTION
This PR will allow us to specify a particular tapd sqlite database file when creating an itest tapd harness or when unit testing our database store functionality. This should help us in debugging tapd. 

This PR was created as part of the work towards solving https://github.com/lightninglabs/taproot-assets/issues/704