### PR TITLE
Multi-input PSBT spend for homogeneous input asset ID

### DIFF
--- a/itest/test_list_on_test.go
+++ b/itest/test_list_on_test.go
@@ -168,6 +168,10 @@ var testCases = []*testCase{
 		test: testPsbtMultiSend,
 	},
 	{
+		name: "multi input psbt single asset id",
+		test: testMultiInputPsbtSingleAssetID,
+	},
+	{
 		name: "universe REST API",
 		test: testUniverseREST,
 	},


### PR DESCRIPTION
This PR solves https://github.com/lightninglabs/taproot-assets/issues/297 for the case were each input asset ID is the same.

This PR modifies our asset send procedure such that we can spend a multi-input full value PSBT where each input has the same asset ID. The PR adds an itest to test the new changes.

There are more things we should test:
* more than 2 inputs
* sending the received PSBT spend onwards once more.

But lets keep this PR small if we can and open another (if that makes sense).