### PR TITLE
itest: extend multi-input PSBT spend test to include partial value spend

### DIFF
--- a/itest/assertions.go
+++ b/itest/assertions.go
@@ -751,6 +751,7 @@ func AssertAssetOutboundTransferWithOutputs(t *testing.T,
 	outpoints := make(map[string]struct{})
 	scripts := make(map[string]struct{})
 	for _, o := range outputs {
+		// Ensure that each transfer output script key is unique.
 		_, ok := scripts[string(o.ScriptKey)]
 		require.False(t, ok)
 


### PR DESCRIPTION
This commit extends the existing multi-input PSBT spend test to also include a partial value spend.