### PR TITLE
vPSBT: add sighash support (flattened virtual transactions)

### DIFF
--- a/asset/asset.go
+++ b/asset/asset.go
@@ -451,6 +451,8 @@ const (
 	// output key, allowing the ability for an asset to indirectly commit to
 	// multiple spending conditions.
 	ScriptV0 ScriptVersion = 0
+
+	ScriptV1 ScriptVersion = 1
 )
 
 // AssetGroup holds information about an asset group, including the genesis

--- a/asset/mock.go
+++ b/asset/mock.go
@@ -140,7 +140,7 @@ func virtualGenesisTxOut(newAsset *Asset) (*wire.TxOut, error) {
 // MockGroupTxBuilder.
 func virtualGenesisTx(newAsset *Asset) (*wire.MsgTx, error) {
 	var (
-		txIn *wire.TxIn
+		txIn []*wire.TxIn
 		err  error
 	)
 
@@ -159,7 +159,10 @@ func virtualGenesisTx(newAsset *Asset) (*wire.MsgTx, error) {
 	// With our single input and output mapped, we're ready to construct our
 	// virtual transaction.
 	virtualTx := wire.NewMsgTx(2)
-	virtualTx.AddTxIn(txIn)
+
+	for _, txIn := range txIn {
+		virtualTx.AddTxIn(txIn)
+	}
 	virtualTx.AddTxOut(txOut)
 	return virtualTx, nil
 }

--- a/asset/tx.go
+++ b/asset/tx.go
@@ -59,16 +59,16 @@ func VirtualTxWithInput(virtualTx *wire.MsgTx, input *Asset,
 
 	txCopy := virtualTx.Copy()
 	txCopy.LockTime = uint32(input.LockTime)
-	txCopy.TxIn[zeroIndex].PreviousOutPoint.Index = idx
-	txCopy.TxIn[zeroIndex].Sequence = uint32(input.RelativeLockTime)
-	txCopy.TxIn[zeroIndex].Witness = witness
+	txCopy.TxIn[idx].PreviousOutPoint.Index = idx
+	txCopy.TxIn[idx].Sequence = uint32(input.RelativeLockTime)
+	txCopy.TxIn[idx].Witness = witness
 	return txCopy
 }
 
 // VirtualGenesisTxIn computes the single input of a Taproot Asset virtual
 // transaction that represents a grouped asset genesis. The input prevout's hash
 // is the root of a MS-SMT committing to only the genesis asset.
-func VirtualGenesisTxIn(newAsset *Asset) (*wire.TxIn, mssmt.Tree, error) {
+func VirtualGenesisTxIn(newAsset *Asset) ([]*wire.TxIn, mssmt.Tree, error) {
 	inputTree := mssmt.NewCompactedTree(mssmt.NewDefaultStore())
 
 	// TODO(bhandras): thread the context through.
@@ -100,7 +100,11 @@ func VirtualGenesisTxIn(newAsset *Asset) (*wire.TxIn, mssmt.Tree, error) {
 
 	prevOut := VirtualTxInPrevOut(treeRoot)
 
-	return wire.NewTxIn(prevOut, nil, nil), inputTree, nil
+	txIns := []*wire.TxIn{
+		wire.NewTxIn(prevOut, nil, nil),
+	}
+
+	return txIns, inputTree, nil
 }
 
 // GenesisPrevOutFetcher returns a Taproot Asset input's `PrevOutFetcher` to be

--- a/tapscript/mint.go
+++ b/tapscript/mint.go
@@ -31,7 +31,7 @@ func BuildGenesisTx(newAsset *asset.Asset) (*wire.MsgTx,
 
 	// Now, create the virtual transaction that represents this asset
 	// minting.
-	virtualTx, _, err := VirtualTx(newAsset, nil)
+	virtualTx, _, err := VirtualTx(newAsset, nil, []*asset.Asset{newAsset})
 	if err != nil {
 		return nil, nil, err
 	}

--- a/tapscript/send.go
+++ b/tapscript/send.go
@@ -648,9 +648,14 @@ func SignVirtualTransaction(vPkt *tappsbt.VPacket, signer Signer,
 		prevAssets[input.PrevID] = input.Asset()
 	}
 
+	assetOutputs := make([]*asset.Asset, len(outputs))
+	for idx := range outputs {
+		assetOutputs[idx] = outputs[idx].Asset
+	}
+
 	// Create a Taproot Asset virtual transaction representing the asset
 	// transfer.
-	virtualTx, _, err := VirtualTx(newAsset, prevAssets)
+	virtualTx, _, err := VirtualTx(newAsset, prevAssets, assetOutputs)
 	if err != nil {
 		return err
 	}
@@ -669,7 +674,7 @@ func SignVirtualTransaction(vPkt *tappsbt.VPacket, signer Signer,
 		// Sign the virtual transaction based on the input script
 		// information (key spend or script spend).
 		newWitness, err := CreateTaprootSignature(
-			input, inputSpecificVirtualTx, 0, signer,
+			input, inputSpecificVirtualTx, idx, signer,
 		)
 		if err != nil {
 			return fmt.Errorf("error creating taproot "+


### PR DESCRIPTION
## Description

This PR adds sighash support for vPSBTs

## Todo list
- [ ] Decide on the set of sighash flags to support for witnesses
- [ ] Add sighash logic for validation
- [ ] Add extra vPSBT tests that cover the supported sighashes
- [ ] Add itest for trustless swap



Closes #577 