### PR TITLE
tools: exclude non-project files from go version consistency lint check

### DIFF
--- a/tools/check-go-version-dockerfile.sh
+++ b/tools/check-go-version-dockerfile.sh
@@ -25,8 +25,12 @@ fi
 
 target_go_version="$1"
 
+# Create array to store multiple directories to be excluded from the .Dockerfile search
+exclusionDirectories=("./vendor")
+# Append all directories with not -path to create `find` parameters to exclude directories.
+findExclusionArgs=( "${exclusionDirectories[@]/#/"-not -path" }" )
 # Search for Dockerfiles in the current directory and its subdirectories
-dockerfiles=$(find . -type f -name "*.Dockerfile" -o -name "Dockerfile")
+dockerfiles=$(find . -type f $findExclusionArgs -name "*.Dockerfile" -o -name "Dockerfile" )
 
 # Check each Dockerfile
 for file in $dockerfiles; do


### PR DESCRIPTION
Replaces #775 
@ffranr noticed lint check (Go versions consistency check) was examining the local vendor directory. 
This directory contains irrelevant project dependency files, which shouldn't be linted. 
PR adds exclusion filters to remove directories from being linted.
