### PR TITLE
vPSBT: add sighash support (no version bump)

### DIFF
--- a/itest/test_list_on_test.go
+++ b/itest/test_list_on_test.go
@@ -174,6 +174,14 @@ var testCases = []*testCase{
 		test: testPsbtMultiSend,
 	},
 	{
+		name: "psbt sighash none",
+		test: testPsbtSighashNone,
+	},
+	{
+		name: "psbt sighash none invalid",
+		test: testPsbtSighashNoneInvalid,
+	},
+	{
 		name: "multi input psbt single asset id",
 		test: testMultiInputPsbtSingleAssetID,
 	},

--- a/tapcfg/server.go
+++ b/tapcfg/server.go
@@ -298,14 +298,15 @@ func genServerConfig(cfg *Config, cfgLogger btclog.Logger,
 	virtualTxSigner := tap.NewLndRpcVirtualTxSigner(lndServices)
 	coinSelect := tapfreighter.NewCoinSelect(assetStore)
 	assetWallet := tapfreighter.NewAssetWallet(&tapfreighter.WalletConfig{
-		CoinSelector: coinSelect,
-		AssetProofs:  proofArchive,
-		AddrBook:     tapdbAddrBook,
-		KeyRing:      keyRing,
-		Signer:       virtualTxSigner,
-		TxValidator:  &tap.ValidatorV0{},
-		Wallet:       walletAnchor,
-		ChainParams:  &tapChainParams,
+		CoinSelector:     coinSelect,
+		AssetProofs:      proofArchive,
+		AddrBook:         tapdbAddrBook,
+		KeyRing:          keyRing,
+		Signer:           virtualTxSigner,
+		TxValidator:      &tap.ValidatorV0{},
+		WitnessValidator: &tap.WitnessValidatorV0{},
+		Wallet:           walletAnchor,
+		ChainParams:      &tapChainParams,
 	})
 
 	// Addresses can have different proof couriers configured, but both

--- a/tapfreighter/wallet.go
+++ b/tapfreighter/wallet.go
@@ -384,6 +384,10 @@ type WalletConfig struct {
 	// transaction we create.
 	TxValidator tapscript.TxValidator
 
+	// WitnessValidator allows us to validate the witnesses of vPSBTs
+	// we create.
+	WitnessValidator tapscript.WitnessValidator
+
 	// Wallet is used to fund+sign PSBTs for the transfer transaction.
 	Wallet WalletAnchor
 
@@ -1103,7 +1107,7 @@ func (f *AssetWallet) SignVirtualPacket(vPkt *tappsbt.VPacket,
 	// Asset leaves. The witness data for each input will be assigned for
 	// us.
 	err := tapscript.SignVirtualTransaction(
-		vPkt, f.cfg.Signer, f.cfg.TxValidator,
+		vPkt, f.cfg.Signer, f.cfg.WitnessValidator,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("unable to generate Taproot Asset "+
@@ -1505,7 +1509,7 @@ func (f *AssetWallet) SignOwnershipProof(
 		ownedAsset.Copy(), f.cfg.ChainParams,
 	)
 	err := tapscript.SignVirtualTransaction(
-		vPkt, f.cfg.Signer, f.cfg.TxValidator,
+		vPkt, f.cfg.Signer, f.cfg.WitnessValidator,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("unable to generate Taproot Asset "+

--- a/tapscript/interface.go
+++ b/tapscript/interface.go
@@ -17,6 +17,17 @@ type TxValidator interface {
 		prevAssets commitment.InputSet) error
 }
 
+// WitnessValidator is the interface used to validate the witnesses of an asset
+// transfer. This method may be used in partially constructed asset transfers
+// to only check signature validity.
+type WitnessValidator interface {
+	// ValidateWitnesses validates the generated witnesses of an asset
+	// transfer.
+	ValidateWitnesses(newAsset *asset.Asset,
+		splitAssets []*commitment.SplitAsset,
+		prevAssets commitment.InputSet) error
+}
+
 // Signer is the interface used to compute the witness for a Taproot Asset
 // virtual TX.
 type Signer interface {

--- a/tapscript/send_test.go
+++ b/tapscript/send_test.go
@@ -77,6 +77,7 @@ type spendData struct {
 	asset2GenesisTx               wire.MsgTx
 	asset2GenesisProof            proof.Proof
 	validator                     tapscript.TxValidator
+	witnessValidator              tapscript.WitnessValidator
 	signer                        *tapscript.MockSigner
 }
 
@@ -171,6 +172,9 @@ func initSpendScenario(t *testing.T) spendData {
 
 	// Validator instance needed to call the Taproot Asset VM.
 	state.validator = &tap.ValidatorV0{}
+
+	// VPsbtValidator helper method of the VM is needed for signing vPSBTs.
+	state.witnessValidator = &tap.WitnessValidatorV0{}
 
 	// Signer needed to generate a witness for the spend.
 	state.signer = tapscript.NewMockSigner(&state.spenderPrivKey)
@@ -887,7 +891,7 @@ var signVirtualTransactionTestCases = []testCase{{
 
 		pkt.Inputs[0].Asset().Genesis = state.genesis1collect
 		return tapscript.SignVirtualTransaction(
-			pkt, state.signer, state.validator,
+			pkt, state.signer, state.witnessValidator,
 		)
 	},
 	err: vm.Error{Kind: vm.ErrIDMismatch},
@@ -908,7 +912,7 @@ var signVirtualTransactionTestCases = []testCase{{
 		firstPrevID.OutPoint.Index = 1337
 
 		return tapscript.SignVirtualTransaction(
-			pkt, state.signer, state.validator,
+			pkt, state.signer, state.witnessValidator,
 		)
 	},
 	err: vm.ErrNoInputs,
@@ -928,7 +932,7 @@ var signVirtualTransactionTestCases = []testCase{{
 
 		unvalidatedAsset := pkt.Outputs[0].Asset.Copy()
 		err = tapscript.SignVirtualTransaction(
-			pkt, state.signer, state.validator,
+			pkt, state.signer, state.witnessValidator,
 		)
 		require.NoError(t, err)
 
@@ -953,7 +957,7 @@ var signVirtualTransactionTestCases = []testCase{{
 
 		unvalidatedAsset := pkt.Outputs[0].Asset.Copy()
 		err = tapscript.SignVirtualTransaction(
-			pkt, state.signer, state.validator,
+			pkt, state.signer, state.witnessValidator,
 		)
 		require.NoError(t, err)
 
@@ -977,7 +981,7 @@ var signVirtualTransactionTestCases = []testCase{{
 
 		unvalidatedAsset := pkt.Outputs[0].Asset.Copy()
 		err = tapscript.SignVirtualTransaction(
-			pkt, state.signer, state.validator,
+			pkt, state.signer, state.witnessValidator,
 		)
 		require.NoError(t, err)
 
@@ -1000,7 +1004,7 @@ var signVirtualTransactionTestCases = []testCase{{
 
 		unvalidatedAsset := pkt.Outputs[0].Asset.Copy()
 		err = tapscript.SignVirtualTransaction(
-			pkt, state.signer, state.validator,
+			pkt, state.signer, state.witnessValidator,
 		)
 		require.NoError(t, err)
 
@@ -1025,7 +1029,7 @@ var signVirtualTransactionTestCases = []testCase{{
 
 		unvalidatedAsset := pkt.Outputs[0].Asset.Copy()
 		err = tapscript.SignVirtualTransaction(
-			pkt, state.signer, state.validator,
+			pkt, state.signer, state.witnessValidator,
 		)
 		require.NoError(t, err)
 
@@ -1093,7 +1097,7 @@ var createOutputCommitmentsTestCases = []testCase{{
 		err := tapscript.PrepareOutputAssets(context.Background(), pkt)
 		require.NoError(t, err)
 		err = tapscript.SignVirtualTransaction(
-			pkt, state.signer, state.validator,
+			pkt, state.signer, state.witnessValidator,
 		)
 		require.NoError(t, err)
 
@@ -1127,7 +1131,7 @@ var createOutputCommitmentsTestCases = []testCase{{
 		err := tapscript.PrepareOutputAssets(context.Background(), pkt)
 		require.NoError(t, err)
 		err = tapscript.SignVirtualTransaction(
-			pkt, state.signer, state.validator,
+			pkt, state.signer, state.witnessValidator,
 		)
 		require.NoError(t, err)
 
@@ -1165,7 +1169,7 @@ var createOutputCommitmentsTestCases = []testCase{{
 		err := tapscript.PrepareOutputAssets(context.Background(), pkt)
 		require.NoError(t, err)
 		err = tapscript.SignVirtualTransaction(
-			pkt, state.signer, state.validator,
+			pkt, state.signer, state.witnessValidator,
 		)
 		require.NoError(t, err)
 
@@ -1193,7 +1197,7 @@ var createOutputCommitmentsTestCases = []testCase{{
 		err := tapscript.PrepareOutputAssets(context.Background(), pkt)
 		require.NoError(t, err)
 		err = tapscript.SignVirtualTransaction(
-			pkt, state.signer, state.validator,
+			pkt, state.signer, state.witnessValidator,
 		)
 		require.NoError(t, err)
 
@@ -1221,7 +1225,7 @@ var createOutputCommitmentsTestCases = []testCase{{
 		err := tapscript.PrepareOutputAssets(context.Background(), pkt)
 		require.NoError(t, err)
 		err = tapscript.SignVirtualTransaction(
-			pkt, state.signer, state.validator,
+			pkt, state.signer, state.witnessValidator,
 		)
 		require.NoError(t, err)
 
@@ -1250,7 +1254,7 @@ var createOutputCommitmentsTestCases = []testCase{{
 		err := tapscript.PrepareOutputAssets(context.Background(), pkt)
 		require.NoError(t, err)
 		err = tapscript.SignVirtualTransaction(
-			pkt, state.signer, state.validator,
+			pkt, state.signer, state.witnessValidator,
 		)
 		require.NoError(t, err)
 
@@ -1280,7 +1284,7 @@ var createOutputCommitmentsTestCases = []testCase{{
 		err := tapscript.PrepareOutputAssets(context.Background(), pkt)
 		require.NoError(t, err)
 		err = tapscript.SignVirtualTransaction(
-			pkt, state.signer, state.validator,
+			pkt, state.signer, state.witnessValidator,
 		)
 		require.NoError(t, err)
 
@@ -1327,7 +1331,7 @@ var updateTaprootOutputKeysTestCases = []testCase{{
 		err := tapscript.PrepareOutputAssets(context.Background(), pkt)
 		require.NoError(t, err)
 		err = tapscript.SignVirtualTransaction(
-			pkt, state.signer, state.validator,
+			pkt, state.signer, state.witnessValidator,
 		)
 		require.NoError(t, err)
 
@@ -1363,7 +1367,7 @@ var updateTaprootOutputKeysTestCases = []testCase{{
 		err := tapscript.PrepareOutputAssets(context.Background(), pkt)
 		require.NoError(t, err)
 		err = tapscript.SignVirtualTransaction(
-			pkt, state.signer, state.validator,
+			pkt, state.signer, state.witnessValidator,
 		)
 		require.NoError(t, err)
 
@@ -1399,7 +1403,7 @@ var updateTaprootOutputKeysTestCases = []testCase{{
 		err := tapscript.PrepareOutputAssets(context.Background(), pkt)
 		require.NoError(t, err)
 		err = tapscript.SignVirtualTransaction(
-			pkt, state.signer, state.validator,
+			pkt, state.signer, state.witnessValidator,
 		)
 		require.NoError(t, err)
 
@@ -1438,7 +1442,7 @@ var updateTaprootOutputKeysTestCases = []testCase{{
 		err := tapscript.PrepareOutputAssets(context.Background(), pkt)
 		require.NoError(t, err)
 		err = tapscript.SignVirtualTransaction(
-			pkt, state.signer, state.validator,
+			pkt, state.signer, state.witnessValidator,
 		)
 		require.NoError(t, err)
 
@@ -1477,7 +1481,7 @@ var updateTaprootOutputKeysTestCases = []testCase{{
 		err := tapscript.PrepareOutputAssets(context.Background(), pkt)
 		require.NoError(t, err)
 		err = tapscript.SignVirtualTransaction(
-			pkt, state.signer, state.validator,
+			pkt, state.signer, state.witnessValidator,
 		)
 		require.NoError(t, err)
 
@@ -1517,7 +1521,7 @@ var updateTaprootOutputKeysTestCases = []testCase{{
 		err := tapscript.PrepareOutputAssets(context.Background(), pkt)
 		require.NoError(t, err)
 		err = tapscript.SignVirtualTransaction(
-			pkt, state.signer, state.validator,
+			pkt, state.signer, state.witnessValidator,
 		)
 		require.NoError(t, err)
 
@@ -1558,7 +1562,7 @@ var updateTaprootOutputKeysTestCases = []testCase{{
 		err := tapscript.PrepareOutputAssets(context.Background(), pkt)
 		require.NoError(t, err)
 		err = tapscript.SignVirtualTransaction(
-			pkt, state.signer, state.validator,
+			pkt, state.signer, state.witnessValidator,
 		)
 		require.NoError(t, err)
 
@@ -1611,7 +1615,7 @@ func createSpend(t *testing.T, state *spendData, inputSet commitment.InputSet,
 	err := tapscript.PrepareOutputAssets(context.Background(), pkt)
 	require.NoError(t, err)
 	err = tapscript.SignVirtualTransaction(
-		pkt, state.signer, state.validator,
+		pkt, state.signer, state.witnessValidator,
 	)
 	require.NoError(t, err)
 

--- a/tx_validator.go
+++ b/tx_validator.go
@@ -31,3 +31,19 @@ func (v *ValidatorV0) Execute(newAsset *asset.Asset,
 // A compile time assertion to ensure ValidatorV0 meets the
 // tapscript.TxValidator interface.
 var _ tapscript.TxValidator = (*ValidatorV0)(nil)
+
+// WitnessValidatorV0 is an implementation of the tapscript.WitnessValidator
+// interface that supports Taproot Asset script version 0.
+type WitnessValidatorV0 struct{}
+
+// ValidateWitnesses validates the created witnesses of an asset transfer.
+func (v *WitnessValidatorV0) ValidateWitnesses(newAsset *asset.Asset,
+	splitAssets []*commitment.SplitAsset,
+	prevAssets commitment.InputSet) error {
+
+	return vm.ValidateWitnesses(newAsset, splitAssets, prevAssets)
+}
+
+// A compile time assertion to ensure WitnessValidatorV0 meets the
+// tapscript.WitnessValidator interface.
+var _ tapscript.WitnessValidator = (*WitnessValidatorV0)(nil)

--- a/vm/testdata/vm_validation_generated.json
+++ b/vm/testdata/vm_validation_generated.json
@@ -3,10 +3,10 @@
     {
       "asset": {
         "version": 0,
-        "genesis_first_prev_out": "41b7c09a3e6f241c576f9ac7070f0914c3f10e0f2125519bd23a4efeeaddb7a0:322737779",
-        "genesis_tag": "8a58677a0c56348f8921a266b11d0f334c62fe52ba53af19779cb2948b6570ff",
-        "genesis_meta_hash": "8a58677a0c56348f8921a266b11d0f334c62fe52ba53af19779cb2948b6570ff",
-        "genesis_output_index": 1004997808,
+        "genesis_first_prev_out": "baebca0827a6b8853ffa8aa44a03a497e13488f03f0777e80684a6bfdc90a231:2843150114",
+        "genesis_tag": "bcce3c7bd3d8df93fab7e125ddebafe65a31bd5d41e2d2ce9c2b17892f0fea19",
+        "genesis_meta_hash": "bcce3c7bd3d8df93fab7e125ddebafe65a31bd5d41e2d2ce9c2b17892f0fea19",
+        "genesis_output_index": 25252826,
         "genesis_type": 1,
         "amount": 1,
         "lock_time": 0,
@@ -19,16 +19,16 @@
               "script_key": "000000000000000000000000000000000000000000000000000000000000000000"
             },
             "tx_witness": [
-              "902b5695044cc9db3ef11237d9a37d762ef506b4c8645a8714a9c3ae94bbb7769aee6e81548e2ec0321301e4dc6e2836dae86785df923356001cd3a18856da24"
+              "297f4842b7ee83ee465e450e424b804b2fff79fb5f8a3fa70bf6f1b68da700530ab10528d9cd67845bded511d8c7e29f8fcd606934851998f0a753cfbb2e9d69"
             ],
             "split_commitment": null
           }
         ],
         "split_commitment_root": null,
         "script_version": 0,
-        "script_key": "02ce93c240cac6167b03bf1777220f40c674d6ada75fa351d1934735f20dbb32a2",
+        "script_key": "025a4b19bfbfe332c479951667fd805ba831cffda42297f07639c1ea35a8a08d03",
         "group_key": {
-          "group_key": "02123bdeb5b563a3e9d287bd46ef8b8c95c22c06763005fcbac5e022cebbf68139"
+          "group_key": "0388a3f149700749ea5fd807c2b8f114b24916c04b895ad157bdf236a7623c9f36"
         }
       },
       "split_set": [],
@@ -38,10 +38,10 @@
     {
       "asset": {
         "version": 1,
-        "genesis_first_prev_out": "e17c02d5b55397b4926431624c583b0a7f201283b654043a6680d58fe8ba8f22:2674673580",
-        "genesis_tag": "3dbf8e7dcafc9e138647a4b44ed4bce964ed47f74aa594468ced323cb76f0d3f",
-        "genesis_meta_hash": "3dbf8e7dcafc9e138647a4b44ed4bce964ed47f74aa594468ced323cb76f0d3f",
-        "genesis_output_index": 2400003416,
+        "genesis_first_prev_out": "ba77aec76fad5e0ce6e5cd00c4e533e9a3bb18c948b9e962e5dcfd887953e8e5:3701924107",
+        "genesis_tag": "76c1bdd19ab8e2925c6daee4de5ef9f9dcf08dfcbd02b80809398585928a0f7d",
+        "genesis_meta_hash": "76c1bdd19ab8e2925c6daee4de5ef9f9dcf08dfcbd02b80809398585928a0f7d",
+        "genesis_output_index": 3357625226,
         "genesis_type": 1,
         "amount": 1,
         "lock_time": 0,
@@ -59,7 +59,7 @@
         ],
         "split_commitment_root": null,
         "script_version": 0,
-        "script_key": "02d68d2ed7ad27ef0c76178587dda47a7fc347abd8e4ace770089542cac06fe783",
+        "script_key": "02f2545c83427fe2a0f7f6290673fd9d6921f504d70f29514a1f50ff972c94e1fc",
         "group_key": null
       },
       "split_set": [],
@@ -68,11 +68,11 @@
     },
     {
       "asset": {
-        "version": 0,
-        "genesis_first_prev_out": "f038c8cd8563130769fb0f4fb4ebb265b33b61e4f4f1f7fec87131d579c5dfc1:3537477305",
-        "genesis_tag": "54f9442483c7b98b938045da519843854b0ed3f7ba951a493f321f0966603022",
-        "genesis_meta_hash": "54f9442483c7b98b938045da519843854b0ed3f7ba951a493f321f0966603022",
-        "genesis_output_index": 315151549,
+        "version": 1,
+        "genesis_first_prev_out": "a644db2122649be16159cdf006e7309f035b88ab7f55666529f9370ff59da1d7:1571125468",
+        "genesis_tag": "da6745fba6a04c5c37c7ca35036f11732ce8bc27b48868611fc73c82a491bfab",
+        "genesis_meta_hash": "da6745fba6a04c5c37c7ca35036f11732ce8bc27b48868611fc73c82a491bfab",
+        "genesis_output_index": 2578299031,
         "genesis_type": 1,
         "amount": 1,
         "lock_time": 0,
@@ -85,16 +85,16 @@
               "script_key": "000000000000000000000000000000000000000000000000000000000000000000"
             },
             "tx_witness": [
-              "aec2543805dcbf6bd7341bfe4fb017895145569c1535c69db66d297beb41763b7d927fbca494efa112ee5e1f4a092da40717cfd9d451e5a97e372ef942c3d671"
+              "af724efa70f319d41bbd13cb9231c2f09a8ce91b1c34d90477809704fc8f55d2a738c4a7ae5739a5438a0c459ddb252795e7c719107715506e35c05840efbd95"
             ],
             "split_commitment": null
           }
         ],
         "split_commitment_root": null,
         "script_version": 0,
-        "script_key": "02c140c218e3b96329b576d1c6e332e52ff3f033f80c18d379900698c1e4a0229c",
+        "script_key": "029229d07ca63009fbfc3a729d620a86be733cd639b47c1c8c7219aaa8ec4a47bb",
         "group_key": {
-          "group_key": "0364e5f701e3916096e5fe27c17f75d163c7b185d6dac096140252ec2e34dcb11f"
+          "group_key": "021f5476124e9b230432d89b2a33a6d329a83f66f38f28565bd6fc1f34c34b9474"
         }
       },
       "split_set": [],
@@ -103,13 +103,13 @@
     },
     {
       "asset": {
-        "version": 1,
-        "genesis_first_prev_out": "3831661b336077ccd0ac46076870b5f13e5e6e09d0c910a9f569213bda0507db:281238800",
-        "genesis_tag": "c02cca4291aed169dce5039d6ab00e40f67aab29332de1448b35507c7c8a09c4",
-        "genesis_meta_hash": "c02cca4291aed169dce5039d6ab00e40f67aab29332de1448b35507c7c8a09c4",
-        "genesis_output_index": 104980405,
+        "version": 0,
+        "genesis_first_prev_out": "aae3a6cc0da3d50b2a0313380457d78a405c84d1213a38874a2a2340e1374513:671247821",
+        "genesis_tag": "1fae1ebdd7aa6269c2ec7f4057b33593bc84888c970fd528d4a99a1eab9d2420",
+        "genesis_meta_hash": "1fae1ebdd7aa6269c2ec7f4057b33593bc84888c970fd528d4a99a1eab9d2420",
+        "genesis_output_index": 2274794023,
         "genesis_type": 0,
-        "amount": 2477731492,
+        "amount": 792948165,
         "lock_time": 0,
         "relative_lock_time": 0,
         "prev_witnesses": [
@@ -120,16 +120,16 @@
               "script_key": "000000000000000000000000000000000000000000000000000000000000000000"
             },
             "tx_witness": [
-              "c3a7420a41c59e15399ab6d36051efe970c63f4882312819812a8cdcef0dc5dc02dcd1491e726a52140e82b41f59296c784591473118fa8bf6d430922384f108"
+              "39cefa1d850e6ad29d929ff787dd49801772b6418f79c46ca6b9962b8356709d7528624fd4dcc67a20b493094b7bc320965e77b0aa0a0a6acd213dff7c910d96"
             ],
             "split_commitment": null
           }
         ],
         "split_commitment_root": null,
         "script_version": 0,
-        "script_key": "023556fb74445e2225b7e28c165d05f0d391c5c90e2647430fde9b3a69c303d7fe",
+        "script_key": "02a827c87ee856e86335b351f9897b8febde668084e2bdfac1035c6d9fcaac0c60",
         "group_key": {
-          "group_key": "02f80bd327614129c30240232055dac87f8fe12504949826bded344104580b8d86"
+          "group_key": "02ab403713c469bbdb819102873db7ad3b5090b181936c63d984d4fb0549573471"
         }
       },
       "split_set": [],
@@ -139,12 +139,12 @@
     {
       "asset": {
         "version": 0,
-        "genesis_first_prev_out": "7c9a40b87a93c930a03c8ea2c4ea724de2450df4baa53a0341bcb9cd147baeeb:3237541110",
-        "genesis_tag": "820ac85de3f8e784870fd87a36cc0d163833df636613a9cc947437b6592835b9",
-        "genesis_meta_hash": "820ac85de3f8e784870fd87a36cc0d163833df636613a9cc947437b6592835b9",
-        "genesis_output_index": 628422945,
+        "genesis_first_prev_out": "0c12692922dc4085d3a349b0bcf930b4e027f21867fd10a4cb7ec70332fa3920:3842949771",
+        "genesis_tag": "ec049c9e7a5cf944232d10353f64434abae060f6506ad3fdb1f4415b0af9ce8c",
+        "genesis_meta_hash": "ec049c9e7a5cf944232d10353f64434abae060f6506ad3fdb1f4415b0af9ce8c",
+        "genesis_output_index": 145179341,
         "genesis_type": 0,
-        "amount": 3806648833,
+        "amount": 2179085690,
         "lock_time": 0,
         "relative_lock_time": 0,
         "prev_witnesses": [
@@ -157,16 +157,16 @@
             "tx_witness": [
               "666f6f626172",
               "76a914f6c97547d73156abb300ae059905c4acaadd09dd88",
-              "c1950014e1fc635521ed29fd4f6627fa40df04a0890e0b9321eb007d4c6b37a4203062ef42258bb7a102a21f5e18b3d631feb54656ee8c88f8e8542ebed978a3ac"
+              "c055d8aca488374ddf86e760443f13c861b8912daccb433278084b404740d3af58bd5d223aebd0c8cd46c7f624b0ae50714f73626d5d384829d5f6b6335074662f"
             ],
             "split_commitment": null
           }
         ],
         "split_commitment_root": null,
         "script_version": 0,
-        "script_key": "02802a64d3b7796b929eda7ab01bb6e19eb630e088a231e1883b607329d4bb3d65",
+        "script_key": "0231b29675bbd4714fa4e0dd991be872d03f0267cbf56410a652c60d669f0f1d94",
         "group_key": {
-          "group_key": "035b2b9776803786a2ace2453fc8e8f4e0654386102e7d3333954f5343e24e9379"
+          "group_key": "027c161e4da543ce35e48f4562567c24417eebcdc602ae71b76d5e474786e21172"
         }
       },
       "split_set": [],
@@ -175,11 +175,11 @@
     },
     {
       "asset": {
-        "version": 0,
-        "genesis_first_prev_out": "362efb8911ec482319682c1ddee5c5f78bc637e0e18f4099adb8979be16159cd:3676381796",
-        "genesis_tag": "a491bfabd7a19df50fdc78a55dbbc2fd37f9296566557fab885b039f30e706f0",
-        "genesis_meta_hash": "a491bfabd7a19df50fdc78a55dbbc2fd37f9296566557fab885b039f30e706f0",
-        "genesis_output_index": 4278841148,
+        "version": 1,
+        "genesis_first_prev_out": "59b47697c6f9348b362700334984a40b8d54dbbbc7e416e293d8761c5b171a80:797136880",
+        "genesis_tag": "dd54ae1688e49efb5efe65dcdad34bc860010e7c8c997cd5f9e320ca7d39d4ba",
+        "genesis_meta_hash": "dd54ae1688e49efb5efe65dcdad34bc860010e7c8c997cd5f9e320ca7d39d4ba",
+        "genesis_output_index": 3864730842,
         "genesis_type": 1,
         "amount": 1,
         "lock_time": 0,
@@ -192,18 +192,18 @@
               "script_key": "000000000000000000000000000000000000000000000000000000000000000000"
             },
             "tx_witness": [
-              "b3fd2717307c405198d4b8fff4f52a29abd5c2511982b9d2cd9d2441dfa2f3c0fe9d4e765e9f39e599e817b4a26db83c28f2273c61c0baefc8db570e7ac2b18f",
-              "200b748282f5153a5b9ce981b9c27ff6c07d03495645912549b3a5108c7c8dce23ac",
-              "c10b748282f5153a5b9ce981b9c27ff6c07d03495645912549b3a5108c7c8dce236c2e4bb01e316abaaee288d69c06cc608cedefd6e1a06813786c4ec51b6e1d38"
+              "6b11cdc6b9e61a2313b029fe8a47702c2c890dc390b5db81ec0b108169afb02a9c6412bbf22f6464a9ae202cff1bda0555291e758a85abdb7eeaf9fadee31653",
+              "20b106376af2a74b2a403cedd93463934416341ddefb27f7085bebc955c3fafde3ac",
+              "c1b106376af2a74b2a403cedd93463934416341ddefb27f7085bebc955c3fafde36c2e4bb01e316abaaee288d69c06cc608cedefd6e1a06813786c4ec51b6e1d38"
             ],
             "split_commitment": null
           }
         ],
         "split_commitment_root": null,
         "script_version": 0,
-        "script_key": "026c2ca7b75d9b6ce9e7662cf3b0a86db7d5e42d286687be837763824ae9ef8991",
+        "script_key": "020437d23794b6887f6e94e31a5fd9e1b1199f5ab00a190527f8a1107429e2d237",
         "group_key": {
-          "group_key": "0334cb3413f0aaede9333695a029eaa78cb0f4ff46924ad915930e24c4350f78da"
+          "group_key": "038d915d520265b56b6d3603979e3c0358e341eb0a9a1f3b20537a8fb2586b1e17"
         }
       },
       "split_set": [],
@@ -213,12 +213,12 @@
     {
       "asset": {
         "version": 0,
-        "genesis_first_prev_out": "20dccb278a577a01a6b56b2a1b7ff02a0e0ad64e9e805321becad4c60f949050:2863979956",
-        "genesis_tag": "56e2766a4109150eed424f0f743543cdea66e5baaa03edc918e8305bb19fc0c6",
-        "genesis_meta_hash": "56e2766a4109150eed424f0f743543cdea66e5baaa03edc918e8305bb19fc0c6",
-        "genesis_output_index": 2592649334,
+        "genesis_first_prev_out": "da3d9194ab5496eb965f147e1d41b0c3e7d37cdca33fd5665aca1e9f46739455:3136269216",
+        "genesis_tag": "87293d9271da736e4398c1e37fb75c4bf02786e1faf4b610cd1377fbb9ae1806",
+        "genesis_meta_hash": "87293d9271da736e4398c1e37fb75c4bf02786e1faf4b610cd1377fbb9ae1806",
+        "genesis_output_index": 797209575,
         "genesis_type": 0,
-        "amount": 1262400392,
+        "amount": 1769629366,
         "lock_time": 0,
         "relative_lock_time": 0,
         "prev_witnesses": [
@@ -229,16 +229,16 @@
               "script_key": "000000000000000000000000000000000000000000000000000000000000000000"
             },
             "tx_witness": [
-              "ae487990572699d56462d2cf03f97a40ff92786baf7492dddb8c1e1234724bc7c8aad19f68172c7379e3f20ee23eb0da39f8eeb513ef842e4ff4e10a1583b21d"
+              "b861b6a635ec13e78bfc15b4165539e3460eb72aef4bdd9e15260d466297bfdf748667091cfb52c8328cfad4b1d63e7c87805471b8482634cbf67089da29adc2"
             ],
             "split_commitment": null
           }
         ],
         "split_commitment_root": null,
         "script_version": 0,
-        "script_key": "02f3a0dc750414bb840a9ef9757b7b3b45eff0d09feb82d8ef0b349a3bf408399d",
+        "script_key": "024c3187b67474989a27ce48a924bdfe7a3bb241bb95875492a24f47d41bf16863",
         "group_key": {
-          "group_key": "039f0381e980ac8c361dd309e666070db96af19642e258466e3e3c2c7dea67cf47"
+          "group_key": "03853150c932ad71e8ccfde61d7827807fe4b3dbde7e4f0efb92e919d2218eea9c"
         }
       },
       "split_set": [],
@@ -247,13 +247,13 @@
     },
     {
       "asset": {
-        "version": 1,
-        "genesis_first_prev_out": "bec5135f427bc6a2c7fd67fe69880daec953efc18df029d6fc440f3c5d4e5f76:35454190",
-        "genesis_tag": "89ba98e6a543758d7093a494df5cc36d09c7a6472a41f29c380a987b1ecdcf84",
-        "genesis_meta_hash": "89ba98e6a543758d7093a494df5cc36d09c7a6472a41f29c380a987b1ecdcf84",
-        "genesis_output_index": 487351199,
+        "version": 0,
+        "genesis_first_prev_out": "28e90b51a21def81a59b069814efaa8d4a13421325584c55f059f52f276ebcbc:352116202",
+        "genesis_tag": "4bf5090d57df9db6f0d91dd8b11b804f331adb7efb087a5604e9e22b4d54db40",
+        "genesis_meta_hash": "4bf5090d57df9db6f0d91dd8b11b804f331adb7efb087a5604e9e22b4d54db40",
+        "genesis_output_index": 297291386,
         "genesis_type": 0,
-        "amount": 2562795839,
+        "amount": 2250032736,
         "lock_time": 0,
         "relative_lock_time": 0,
         "prev_witnesses": [
@@ -269,7 +269,7 @@
         ],
         "split_commitment_root": null,
         "script_version": 0,
-        "script_key": "02093b204eeaa197c1215e88874d8f6e9b264ed96205dfca11c84ec0d217c8fe24",
+        "script_key": "023262e9012850a60e347381d56d38eeb331689d231d45b318f23fa6e1d1222362",
         "group_key": null
       },
       "split_set": [],
@@ -279,10 +279,10 @@
     {
       "asset": {
         "version": 1,
-        "genesis_first_prev_out": "6ac84d624c11cf3a797c6e353e1c8184b38c6f716af5a68cb22076b4be0cc66f:1423273655",
-        "genesis_tag": "e488751afcd72aa176c0fcde9316f676fd527d9c42105b851639f09ea70533d2",
-        "genesis_meta_hash": "e488751afcd72aa176c0fcde9316f676fd527d9c42105b851639f09ea70533d2",
-        "genesis_output_index": 4286309944,
+        "genesis_first_prev_out": "fc713e95fc88a94ee3af4611afb431f6bd344ff44a0a6a47e927dfa628aa50d2:1707262020",
+        "genesis_tag": "3dd6081af95e16f248ab03da494112449ce7bdace6c988292f95699bb5e4d9c8",
+        "genesis_meta_hash": "3dd6081af95e16f248ab03da494112449ce7bdace6c988292f95699bb5e4d9c8",
+        "genesis_output_index": 597078880,
         "genesis_type": 1,
         "amount": 1,
         "lock_time": 0,
@@ -291,20 +291,20 @@
           {
             "prev_id": {
               "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
-              "asset_id": "4dfd9a16a535e36e62c913bca54437fa29fbfdce574929d7fafb1433eec5703c",
-              "script_key": "025632be1ae642f4cb61a9f0f3805ee83e2c644e7e5d3e0798f1083ca3fd98ce5b"
+              "asset_id": "73e32f8a8a0bfbf87890e7e21d25a5d730806ebfa1e63ddbefd830777215531f",
+              "script_key": "027dec6da263d548a7a7d9a99dbaee3f316fbdfc3294c9e88f45c3df286cc42ef9"
             },
             "tx_witness": [
-              "0fcfad437e03a1ebe514cbcf815235bc4c3c36ccd36a73142bc88daf0a02fdb6a446b5aeeebfa44ab37a2a00d32571c431e1f65b4d294c20142542b519df887b"
+              "63f01de0fd767ac1329f25e3b23d773ce25308ccfe4a18ff47c9ef41389c2e70d8c27e8b2f4e39b5d8623f7540564f42c3d22e4c056c84aac2845db874e7c9c6"
             ],
             "split_commitment": null
           }
         ],
         "split_commitment_root": null,
         "script_version": 0,
-        "script_key": "0213d8ea32b66ace3a63546793a5c7c103c235f562475d5b2dd3e48df1e3a4f29a",
+        "script_key": "02705a63080178c26efaacb971327cf072d840e4efe0f339eb89978dcabc86da73",
         "group_key": {
-          "group_key": "02039feb0f05bc666a1d2c0239c2d151b0b068f8cab88f34236f99d4e01a1ff32d"
+          "group_key": "026e34301650831e9fc4070f5ac48b4f8be4c38206beddd355dd45de75728cf8fb"
         }
       },
       "split_set": [],
@@ -312,15 +312,15 @@
         {
           "prev_id": {
             "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
-            "asset_id": "4dfd9a16a535e36e62c913bca54437fa29fbfdce574929d7fafb1433eec5703c",
-            "script_key": "025632be1ae642f4cb61a9f0f3805ee83e2c644e7e5d3e0798f1083ca3fd98ce5b"
+            "asset_id": "73e32f8a8a0bfbf87890e7e21d25a5d730806ebfa1e63ddbefd830777215531f",
+            "script_key": "027dec6da263d548a7a7d9a99dbaee3f316fbdfc3294c9e88f45c3df286cc42ef9"
           },
           "asset": {
             "version": 1,
-            "genesis_first_prev_out": "6ac84d624c11cf3a797c6e353e1c8184b38c6f716af5a68cb22076b4be0cc66f:1423273655",
-            "genesis_tag": "e488751afcd72aa176c0fcde9316f676fd527d9c42105b851639f09ea70533d2",
-            "genesis_meta_hash": "e488751afcd72aa176c0fcde9316f676fd527d9c42105b851639f09ea70533d2",
-            "genesis_output_index": 4286309944,
+            "genesis_first_prev_out": "fc713e95fc88a94ee3af4611afb431f6bd344ff44a0a6a47e927dfa628aa50d2:1707262020",
+            "genesis_tag": "3dd6081af95e16f248ab03da494112449ce7bdace6c988292f95699bb5e4d9c8",
+            "genesis_meta_hash": "3dd6081af95e16f248ab03da494112449ce7bdace6c988292f95699bb5e4d9c8",
+            "genesis_output_index": 597078880,
             "genesis_type": 1,
             "amount": 1,
             "lock_time": 0,
@@ -333,16 +333,16 @@
                   "script_key": "000000000000000000000000000000000000000000000000000000000000000000"
                 },
                 "tx_witness": [
-                  "04bc46d20e879537c52979ce2f507dd45d66ee8dd51c9fe9d030baf00f4ff186f485cb8c05b411107b52ac310d6ff8016b3051f5afe3721ab942224f41f281a3"
+                  "8d7cd107bc1bf17c07a21e8df207a08fb0d5e03a46e95d868c0f649f9f4fcc82c1feca270eae7b29a0c5c97567c9c7e6a9eb34732fe46c9eb77bc8d1c23875de"
                 ],
                 "split_commitment": null
               }
             ],
             "split_commitment_root": null,
             "script_version": 0,
-            "script_key": "025632be1ae642f4cb61a9f0f3805ee83e2c644e7e5d3e0798f1083ca3fd98ce5b",
+            "script_key": "027dec6da263d548a7a7d9a99dbaee3f316fbdfc3294c9e88f45c3df286cc42ef9",
             "group_key": {
-              "group_key": "02039feb0f05bc666a1d2c0239c2d151b0b068f8cab88f34236f99d4e01a1ff32d"
+              "group_key": "026e34301650831e9fc4070f5ac48b4f8be4c38206beddd355dd45de75728cf8fb"
             }
           }
         }
@@ -351,46 +351,46 @@
     },
     {
       "asset": {
-        "version": 0,
-        "genesis_first_prev_out": "0749f7c314b25f2556745b1cde4b526ba41a49be4b510b39635bb7430c66791f:1735791462",
-        "genesis_tag": "b06cfaf077881d733a5e643b7c46976647d1c1d3f8f6237c6218fa86fb47080b",
-        "genesis_meta_hash": "b06cfaf077881d733a5e643b7c46976647d1c1d3f8f6237c6218fa86fb47080b",
-        "genesis_output_index": 3044543265,
+        "version": 1,
+        "genesis_first_prev_out": "cdfce6c74e28c130d7cc0f4db5b769d41ffaa8be9186c638e3d5e57a31428445:1522789417",
+        "genesis_tag": "b6656203b522c60e97cc61914621c564243913ae643f1c9c9e0ad00a14f66eaa",
+        "genesis_meta_hash": "b6656203b522c60e97cc61914621c564243913ae643f1c9c9e0ad00a14f66eaa",
+        "genesis_output_index": 1470911854,
         "genesis_type": 0,
-        "amount": 1551123241,
+        "amount": 3570597366,
         "lock_time": 0,
         "relative_lock_time": 0,
         "prev_witnesses": [
           {
             "prev_id": {
               "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
-              "asset_id": "1e93642746ba867ab8c24fefa2b21289ee6c77c3767dfe2c825e0e73be94a4c4",
-              "script_key": "0253b9eeadefc631ac26162f7c4c17c4b9c1d8135e528880d2838d67123781ffc8"
+              "asset_id": "6a7c78f2887eb00a598269ffd7c4a9b081a4caa3de7890da3313f18a4964f2a2",
+              "script_key": "02bfdfe627d938cc719f6146cc352d3076ebb05f51823047747aac7956df140dcd"
             },
             "tx_witness": [
-              "143143712dd2860c1929e631d145ce5682ea515478fa4dd112f7c7e0c0f17342856a79ca0ec987184db081f827cf8457f851285fbfefaaafefe8044cb1cd5da4"
+              "a4dece837753db0c306508e426606449734ab1f8cba29c3574b800e7d41cf6c11452b0a0eaf9d39bfdfa3b2aa494c56f266c57d04c03652233609f605011109b"
             ],
             "split_commitment": null
           },
           {
             "prev_id": {
               "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
-              "asset_id": "6fe67e7dff9839c2f0de9123c5f49ccfe3445f1c75da10ee2cc0745c4a9f4f45",
-              "script_key": "020392234f8a24248363b5615ffec8b12b3c680f9365d09cf59da2c1898d5b9fd5"
+              "asset_id": "8c494c7dbe8005858792bea84bd19f2f1361b5b69b0a8367b5f575850a59fac3",
+              "script_key": "021f7a851338cf07138e9aa7d0273b83779ded048f1b6432bc24eb43c56c07c1d3"
             },
             "tx_witness": [
-              "a9c86db4dc8491b71cfb3373b52ac6db25eb22b302d0fa74089782b403574723aa71c1765b02de5406e8b2bb688265479e94e4cfdcf0fa8b1948ce59b4d4f560",
-              "20783a6704689312484fbc0640bad8e338baea5a9c0f91c923337a39074e91303dad56b2",
-              "c0783a6704689312484fbc0640bad8e338baea5a9c0f91c923337a39074e91303d"
+              "6ad706276421de961e1293c9bf20262da9b30cfa0b687025eef9dd33413edf2882172eba978dcb22120254dd47a5bb87da47284f37637833c60a7c5a8be6c12c",
+              "209d443f0010f24d6a65811d897fb7f23855f2e3dcb94a8db5e0f1c722aa7f0df7ad56b2",
+              "c19d443f0010f24d6a65811d897fb7f23855f2e3dcb94a8db5e0f1c722aa7f0df7"
             ],
             "split_commitment": null
           }
         ],
         "split_commitment_root": null,
         "script_version": 0,
-        "script_key": "021a2e95ea7441d8f59e8d97dbe0ba1801d55fc3e690850ed19a734baef430d411",
+        "script_key": "0216765a34a6f685ae3550461beb7df2a8155a746db37ee202510da1eb37af8c56",
         "group_key": {
-          "group_key": "03aa3eca6699c14818c0880a9f56cad1348e3cd106ded2899ca86610bdfc1275f8"
+          "group_key": "03dd57b51c3580a5639a540bcc7f7f3d3b854b4f468970759586d07bc175583629"
         }
       },
       "split_set": [],
@@ -398,17 +398,17 @@
         {
           "prev_id": {
             "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
-            "asset_id": "6fe67e7dff9839c2f0de9123c5f49ccfe3445f1c75da10ee2cc0745c4a9f4f45",
-            "script_key": "020392234f8a24248363b5615ffec8b12b3c680f9365d09cf59da2c1898d5b9fd5"
+            "asset_id": "8c494c7dbe8005858792bea84bd19f2f1361b5b69b0a8367b5f575850a59fac3",
+            "script_key": "021f7a851338cf07138e9aa7d0273b83779ded048f1b6432bc24eb43c56c07c1d3"
           },
           "asset": {
             "version": 0,
-            "genesis_first_prev_out": "e86ce977a6acd3cd7d229a95cc49c0f2bf17555fa478a246ced086ca0edd88eb:2669854653",
-            "genesis_tag": "85dd276ee1f43c8cd7e92a993eb15107d02f59ba75f8dd1442ee37786ddb902d",
-            "genesis_meta_hash": "85dd276ee1f43c8cd7e92a993eb15107d02f59ba75f8dd1442ee37786ddb902d",
-            "genesis_output_index": 3119091779,
+            "genesis_first_prev_out": "ebf5c816ced216110ae5271d4ca8fc60026e36eb007b2750145bf1b9d907d3fa:3017411140",
+            "genesis_tag": "3241bde178f692898b1ece2dbcb19a97e64c4710326528f24b099d0b674bd614",
+            "genesis_meta_hash": "3241bde178f692898b1ece2dbcb19a97e64c4710326528f24b099d0b674bd614",
+            "genesis_output_index": 2831251244,
             "genesis_type": 0,
-            "amount": 829650825,
+            "amount": 1578738511,
             "lock_time": 0,
             "relative_lock_time": 6,
             "prev_witnesses": [
@@ -419,33 +419,33 @@
                   "script_key": "000000000000000000000000000000000000000000000000000000000000000000"
                 },
                 "tx_witness": [
-                  "087410702d6caebf4773527bfc8ab552aeceb16dc650f1aa38c9ad3daf2ba6ae9e1f2118a252c71a3a358bdf48ea633ceb9b5007f0772097313bbc62d96e29c8"
+                  "c031c4db621541b4bf736ae9301dcf5f11d2d8825ad6f8bc33aec8fead089f7690f367ee297218e1a377b805004ce4868625ef792a71d636e373b273cd046558"
                 ],
                 "split_commitment": null
               }
             ],
             "split_commitment_root": null,
             "script_version": 0,
-            "script_key": "020392234f8a24248363b5615ffec8b12b3c680f9365d09cf59da2c1898d5b9fd5",
+            "script_key": "021f7a851338cf07138e9aa7d0273b83779ded048f1b6432bc24eb43c56c07c1d3",
             "group_key": {
-              "group_key": "02f2e316463d8568a8f21c950707a2b3daf1fb321a6036a241b91e74f3023d4732"
+              "group_key": "0209b18f9e6f542f350421c6f6dea5e9d7a8999af4fbbabf311df5862e56efdc68"
             }
           }
         },
         {
           "prev_id": {
             "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
-            "asset_id": "1e93642746ba867ab8c24fefa2b21289ee6c77c3767dfe2c825e0e73be94a4c4",
-            "script_key": "0253b9eeadefc631ac26162f7c4c17c4b9c1d8135e528880d2838d67123781ffc8"
+            "asset_id": "6a7c78f2887eb00a598269ffd7c4a9b081a4caa3de7890da3313f18a4964f2a2",
+            "script_key": "02bfdfe627d938cc719f6146cc352d3076ebb05f51823047747aac7956df140dcd"
           },
           "asset": {
-            "version": 0,
-            "genesis_first_prev_out": "0749f7c314b25f2556745b1cde4b526ba41a49be4b510b39635bb7430c66791f:1735791462",
-            "genesis_tag": "b06cfaf077881d733a5e643b7c46976647d1c1d3f8f6237c6218fa86fb47080b",
-            "genesis_meta_hash": "b06cfaf077881d733a5e643b7c46976647d1c1d3f8f6237c6218fa86fb47080b",
-            "genesis_output_index": 3044543265,
+            "version": 1,
+            "genesis_first_prev_out": "cdfce6c74e28c130d7cc0f4db5b769d41ffaa8be9186c638e3d5e57a31428445:1522789417",
+            "genesis_tag": "b6656203b522c60e97cc61914621c564243913ae643f1c9c9e0ad00a14f66eaa",
+            "genesis_meta_hash": "b6656203b522c60e97cc61914621c564243913ae643f1c9c9e0ad00a14f66eaa",
+            "genesis_output_index": 1470911854,
             "genesis_type": 0,
-            "amount": 721472416,
+            "amount": 1991858855,
             "lock_time": 0,
             "relative_lock_time": 0,
             "prev_witnesses": [
@@ -456,16 +456,16 @@
                   "script_key": "000000000000000000000000000000000000000000000000000000000000000000"
                 },
                 "tx_witness": [
-                  "3ae44504a350b686c5d0eebaa5119af9618cb6cec2f35a4290eaab04f2b5d68b40047712da4c72d82afecea251c1beca29dc3cdb714aacfb49b5118b9e81ce4c"
+                  "855e3602591644302b545df748cc0d4becb306135167ce713155dcc78de0260b323ed11a46797dda001212a0731f11a403a329dabd28ef04d9bed938f8eb6943"
                 ],
                 "split_commitment": null
               }
             ],
             "split_commitment_root": null,
             "script_version": 0,
-            "script_key": "0253b9eeadefc631ac26162f7c4c17c4b9c1d8135e528880d2838d67123781ffc8",
+            "script_key": "02bfdfe627d938cc719f6146cc352d3076ebb05f51823047747aac7956df140dcd",
             "group_key": {
-              "group_key": "03aa3eca6699c14818c0880a9f56cad1348e3cd106ded2899ca86610bdfc1275f8"
+              "group_key": "03dd57b51c3580a5639a540bcc7f7f3d3b854b4f468970759586d07bc175583629"
             }
           }
         }
@@ -475,10 +475,10 @@
     {
       "asset": {
         "version": 0,
-        "genesis_first_prev_out": "1b6e9ef52bfe55e280959e40fd3182a38aae50dc0977d1d2a8dee9dbd60b5dce:3933183076",
-        "genesis_tag": "00d0834ceb5c41553afd12576f3fbb9a8e05883ccc51c9a1269b6d8e9d27123d",
-        "genesis_meta_hash": "00d0834ceb5c41553afd12576f3fbb9a8e05883ccc51c9a1269b6d8e9d27123d",
-        "genesis_output_index": 3926918705,
+        "genesis_first_prev_out": "f8af8eef6b9fb4fea095995b00c9f3537cf16200e6df0b3404303753d7c2fabd:218715601",
+        "genesis_tag": "89fa9844f8061d462e28f174489e75140f84e842040141cc59ce38f9551850cf",
+        "genesis_meta_hash": "89fa9844f8061d462e28f174489e75140f84e842040141cc59ce38f9551850cf",
+        "genesis_output_index": 4076044011,
         "genesis_type": 0,
         "amount": 1,
         "lock_time": 0,
@@ -487,40 +487,40 @@
           {
             "prev_id": {
               "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
-              "asset_id": "f9ea747b1965f44561fb7dba932b2745e14fd3fd305d72b1557a15379bf2f7df",
-              "script_key": "02c9f327102d8c3dfb206b730fb4dada2a60d2ca2e368053ceeff6ac1042c11c68"
+              "asset_id": "f9e28e5f7ff4405bfc60ce07a46c7a3268b6ace4170198d542ce70ba57513b10",
+              "script_key": "029158bf8897374fb4b9dd568cd12d627e2c87448871d05528aae1caadb3adc8b0"
             },
             "tx_witness": [
-              "4db9a1a88010cf7134f01719848d6f041be889cf13fa32a514a929bd322eae6aad28a7da2a8fc0549cce3ea93b959261e36bf9a13f10dacff1159d694ba071c1"
+              "32c8a2ba16ca6a046a5986f6d8faeea4a0a2efdfc616b652607e89c61d9cfd46f9ce23dfd04a8b12ffa73ae6524370667c2bfda6638d8b2d66c01e64a3c5cdad"
             ],
             "split_commitment": null
           }
         ],
         "split_commitment_root": {
-          "hash": "2c54490ea036766b17b924a04c74b78975b0377d84d549877999b25e04feaeba",
+          "hash": "5b63954ebe705abba7d7fc0734cdfd384cf93d1c3257e72c586bf0bfa0c7b997",
           "sum": "3"
         },
         "script_version": 0,
-        "script_key": "02c9f327102d8c3dfb206b730fb4dada2a60d2ca2e368053ceeff6ac1042c11c68",
+        "script_key": "029158bf8897374fb4b9dd568cd12d627e2c87448871d05528aae1caadb3adc8b0",
         "group_key": {
-          "group_key": "0228a7bc5a7d093fcb96b84fe68d8c61f46132128d4d137bfdd446741f36dc8c8c"
+          "group_key": "03f7eb502c0d4ce09939db07d6c13a36721a32cf1e745934d55943337950f045d7"
         }
       },
       "split_set": [
         {
           "key": {
             "output_index": 0,
-            "asset_id": "f9ea747b1965f44561fb7dba932b2745e14fd3fd305d72b1557a15379bf2f7df",
-            "script_key": "02c9f327102d8c3dfb206b730fb4dada2a60d2ca2e368053ceeff6ac1042c11c68",
+            "asset_id": "f9e28e5f7ff4405bfc60ce07a46c7a3268b6ace4170198d542ce70ba57513b10",
+            "script_key": "029158bf8897374fb4b9dd568cd12d627e2c87448871d05528aae1caadb3adc8b0",
             "amount": 1
           },
           "value": {
             "asset": {
               "version": 0,
-              "genesis_first_prev_out": "1b6e9ef52bfe55e280959e40fd3182a38aae50dc0977d1d2a8dee9dbd60b5dce:3933183076",
-              "genesis_tag": "00d0834ceb5c41553afd12576f3fbb9a8e05883ccc51c9a1269b6d8e9d27123d",
-              "genesis_meta_hash": "00d0834ceb5c41553afd12576f3fbb9a8e05883ccc51c9a1269b6d8e9d27123d",
-              "genesis_output_index": 3926918705,
+              "genesis_first_prev_out": "f8af8eef6b9fb4fea095995b00c9f3537cf16200e6df0b3404303753d7c2fabd:218715601",
+              "genesis_tag": "89fa9844f8061d462e28f174489e75140f84e842040141cc59ce38f9551850cf",
+              "genesis_meta_hash": "89fa9844f8061d462e28f174489e75140f84e842040141cc59ce38f9551850cf",
+              "genesis_output_index": 4076044011,
               "genesis_type": 0,
               "amount": 1,
               "lock_time": 0,
@@ -534,13 +534,13 @@
                   },
                   "tx_witness": null,
                   "split_commitment": {
-                    "proof": "000258d5fd7b9fb17a9285364fb15914f72787faa9b0c5796fb05a3bd00f56662d9a0000000000000001dfe21f236837793a1213d34fa677f9b8e24f61943814b49fb13f7b6d8ed9f6a00000000000000001ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff77",
+                    "proof": "0001a983f58b48e497c0a9c223c6e862ed628e3443f5f3a061b2fc23e81d7ce0bb1f0000000000000002ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffbf",
                     "root_asset": {
                       "version": 0,
-                      "genesis_first_prev_out": "1b6e9ef52bfe55e280959e40fd3182a38aae50dc0977d1d2a8dee9dbd60b5dce:3933183076",
-                      "genesis_tag": "00d0834ceb5c41553afd12576f3fbb9a8e05883ccc51c9a1269b6d8e9d27123d",
-                      "genesis_meta_hash": "00d0834ceb5c41553afd12576f3fbb9a8e05883ccc51c9a1269b6d8e9d27123d",
-                      "genesis_output_index": 3926918705,
+                      "genesis_first_prev_out": "f8af8eef6b9fb4fea095995b00c9f3537cf16200e6df0b3404303753d7c2fabd:218715601",
+                      "genesis_tag": "89fa9844f8061d462e28f174489e75140f84e842040141cc59ce38f9551850cf",
+                      "genesis_meta_hash": "89fa9844f8061d462e28f174489e75140f84e842040141cc59ce38f9551850cf",
+                      "genesis_output_index": 4076044011,
                       "genesis_type": 0,
                       "amount": 1,
                       "lock_time": 0,
@@ -549,23 +549,23 @@
                         {
                           "prev_id": {
                             "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
-                            "asset_id": "f9ea747b1965f44561fb7dba932b2745e14fd3fd305d72b1557a15379bf2f7df",
-                            "script_key": "02c9f327102d8c3dfb206b730fb4dada2a60d2ca2e368053ceeff6ac1042c11c68"
+                            "asset_id": "f9e28e5f7ff4405bfc60ce07a46c7a3268b6ace4170198d542ce70ba57513b10",
+                            "script_key": "029158bf8897374fb4b9dd568cd12d627e2c87448871d05528aae1caadb3adc8b0"
                           },
                           "tx_witness": [
-                            "4db9a1a88010cf7134f01719848d6f041be889cf13fa32a514a929bd322eae6aad28a7da2a8fc0549cce3ea93b959261e36bf9a13f10dacff1159d694ba071c1"
+                            "32c8a2ba16ca6a046a5986f6d8faeea4a0a2efdfc616b652607e89c61d9cfd46f9ce23dfd04a8b12ffa73ae6524370667c2bfda6638d8b2d66c01e64a3c5cdad"
                           ],
                           "split_commitment": null
                         }
                       ],
                       "split_commitment_root": {
-                        "hash": "2c54490ea036766b17b924a04c74b78975b0377d84d549877999b25e04feaeba",
+                        "hash": "5b63954ebe705abba7d7fc0734cdfd384cf93d1c3257e72c586bf0bfa0c7b997",
                         "sum": "3"
                       },
                       "script_version": 0,
-                      "script_key": "02c9f327102d8c3dfb206b730fb4dada2a60d2ca2e368053ceeff6ac1042c11c68",
+                      "script_key": "029158bf8897374fb4b9dd568cd12d627e2c87448871d05528aae1caadb3adc8b0",
                       "group_key": {
-                        "group_key": "0228a7bc5a7d093fcb96b84fe68d8c61f46132128d4d137bfdd446741f36dc8c8c"
+                        "group_key": "03f7eb502c0d4ce09939db07d6c13a36721a32cf1e745934d55943337950f045d7"
                       }
                     }
                   }
@@ -573,9 +573,9 @@
               ],
               "split_commitment_root": null,
               "script_version": 0,
-              "script_key": "02c9f327102d8c3dfb206b730fb4dada2a60d2ca2e368053ceeff6ac1042c11c68",
+              "script_key": "029158bf8897374fb4b9dd568cd12d627e2c87448871d05528aae1caadb3adc8b0",
               "group_key": {
-                "group_key": "0228a7bc5a7d093fcb96b84fe68d8c61f46132128d4d137bfdd446741f36dc8c8c"
+                "group_key": "03f7eb502c0d4ce09939db07d6c13a36721a32cf1e745934d55943337950f045d7"
               }
             },
             "output_index": 0
@@ -584,17 +584,17 @@
         {
           "key": {
             "output_index": 1,
-            "asset_id": "f9ea747b1965f44561fb7dba932b2745e14fd3fd305d72b1557a15379bf2f7df",
-            "script_key": "03ee2eacf4d2294a8d61139959541a8c56beeed3ceb91850505102118c0fc0c7f9",
+            "asset_id": "f9e28e5f7ff4405bfc60ce07a46c7a3268b6ace4170198d542ce70ba57513b10",
+            "script_key": "02b6d75d6abcb1fc027d8ad0dcc7838c99d3c38bdc667dac6711ba601b52366d03",
             "amount": 1
           },
           "value": {
             "asset": {
               "version": 0,
-              "genesis_first_prev_out": "1b6e9ef52bfe55e280959e40fd3182a38aae50dc0977d1d2a8dee9dbd60b5dce:3933183076",
-              "genesis_tag": "00d0834ceb5c41553afd12576f3fbb9a8e05883ccc51c9a1269b6d8e9d27123d",
-              "genesis_meta_hash": "00d0834ceb5c41553afd12576f3fbb9a8e05883ccc51c9a1269b6d8e9d27123d",
-              "genesis_output_index": 3926918705,
+              "genesis_first_prev_out": "f8af8eef6b9fb4fea095995b00c9f3537cf16200e6df0b3404303753d7c2fabd:218715601",
+              "genesis_tag": "89fa9844f8061d462e28f174489e75140f84e842040141cc59ce38f9551850cf",
+              "genesis_meta_hash": "89fa9844f8061d462e28f174489e75140f84e842040141cc59ce38f9551850cf",
+              "genesis_output_index": 4076044011,
               "genesis_type": 0,
               "amount": 1,
               "lock_time": 0,
@@ -608,13 +608,13 @@
                   },
                   "tx_witness": null,
                   "split_commitment": {
-                    "proof": "0002c314d8bd80814cb9fadf1cfb92102bfbeda9c57922370e194562c5e28af658c30000000000000001dfe21f236837793a1213d34fa677f9b8e24f61943814b49fb13f7b6d8ed9f6a00000000000000001ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff77",
+                    "proof": "0002e0526aceb72f537796ed4a9ed2ec5b589dac087612943a2bdd81f3242557366e0000000000000001c6de550a8a85bf8a97eb08bb258ae23f9c5c069a42a8bdb5bec6c9b61c848b140000000000000001ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff9f",
                     "root_asset": {
                       "version": 0,
-                      "genesis_first_prev_out": "1b6e9ef52bfe55e280959e40fd3182a38aae50dc0977d1d2a8dee9dbd60b5dce:3933183076",
-                      "genesis_tag": "00d0834ceb5c41553afd12576f3fbb9a8e05883ccc51c9a1269b6d8e9d27123d",
-                      "genesis_meta_hash": "00d0834ceb5c41553afd12576f3fbb9a8e05883ccc51c9a1269b6d8e9d27123d",
-                      "genesis_output_index": 3926918705,
+                      "genesis_first_prev_out": "f8af8eef6b9fb4fea095995b00c9f3537cf16200e6df0b3404303753d7c2fabd:218715601",
+                      "genesis_tag": "89fa9844f8061d462e28f174489e75140f84e842040141cc59ce38f9551850cf",
+                      "genesis_meta_hash": "89fa9844f8061d462e28f174489e75140f84e842040141cc59ce38f9551850cf",
+                      "genesis_output_index": 4076044011,
                       "genesis_type": 0,
                       "amount": 1,
                       "lock_time": 0,
@@ -623,23 +623,23 @@
                         {
                           "prev_id": {
                             "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
-                            "asset_id": "f9ea747b1965f44561fb7dba932b2745e14fd3fd305d72b1557a15379bf2f7df",
-                            "script_key": "02c9f327102d8c3dfb206b730fb4dada2a60d2ca2e368053ceeff6ac1042c11c68"
+                            "asset_id": "f9e28e5f7ff4405bfc60ce07a46c7a3268b6ace4170198d542ce70ba57513b10",
+                            "script_key": "029158bf8897374fb4b9dd568cd12d627e2c87448871d05528aae1caadb3adc8b0"
                           },
                           "tx_witness": [
-                            "4db9a1a88010cf7134f01719848d6f041be889cf13fa32a514a929bd322eae6aad28a7da2a8fc0549cce3ea93b959261e36bf9a13f10dacff1159d694ba071c1"
+                            "32c8a2ba16ca6a046a5986f6d8faeea4a0a2efdfc616b652607e89c61d9cfd46f9ce23dfd04a8b12ffa73ae6524370667c2bfda6638d8b2d66c01e64a3c5cdad"
                           ],
                           "split_commitment": null
                         }
                       ],
                       "split_commitment_root": {
-                        "hash": "2c54490ea036766b17b924a04c74b78975b0377d84d549877999b25e04feaeba",
+                        "hash": "5b63954ebe705abba7d7fc0734cdfd384cf93d1c3257e72c586bf0bfa0c7b997",
                         "sum": "3"
                       },
                       "script_version": 0,
-                      "script_key": "02c9f327102d8c3dfb206b730fb4dada2a60d2ca2e368053ceeff6ac1042c11c68",
+                      "script_key": "029158bf8897374fb4b9dd568cd12d627e2c87448871d05528aae1caadb3adc8b0",
                       "group_key": {
-                        "group_key": "0228a7bc5a7d093fcb96b84fe68d8c61f46132128d4d137bfdd446741f36dc8c8c"
+                        "group_key": "03f7eb502c0d4ce09939db07d6c13a36721a32cf1e745934d55943337950f045d7"
                       }
                     }
                   }
@@ -647,9 +647,9 @@
               ],
               "split_commitment_root": null,
               "script_version": 0,
-              "script_key": "02ee2eacf4d2294a8d61139959541a8c56beeed3ceb91850505102118c0fc0c7f9",
+              "script_key": "02b6d75d6abcb1fc027d8ad0dcc7838c99d3c38bdc667dac6711ba601b52366d03",
               "group_key": {
-                "group_key": "0228a7bc5a7d093fcb96b84fe68d8c61f46132128d4d137bfdd446741f36dc8c8c"
+                "group_key": "03f7eb502c0d4ce09939db07d6c13a36721a32cf1e745934d55943337950f045d7"
               }
             },
             "output_index": 1
@@ -658,17 +658,17 @@
         {
           "key": {
             "output_index": 2,
-            "asset_id": "f9ea747b1965f44561fb7dba932b2745e14fd3fd305d72b1557a15379bf2f7df",
-            "script_key": "031214811deb0d38f199fae6ef9871a910779583610df29756f3108c1862e4a2d6",
+            "asset_id": "f9e28e5f7ff4405bfc60ce07a46c7a3268b6ace4170198d542ce70ba57513b10",
+            "script_key": "03f7c7f36d7a30f1d2dd548224f4e5c52c89f486d32169ce895fa31f6360527601",
             "amount": 1
           },
           "value": {
             "asset": {
               "version": 0,
-              "genesis_first_prev_out": "1b6e9ef52bfe55e280959e40fd3182a38aae50dc0977d1d2a8dee9dbd60b5dce:3933183076",
-              "genesis_tag": "00d0834ceb5c41553afd12576f3fbb9a8e05883ccc51c9a1269b6d8e9d27123d",
-              "genesis_meta_hash": "00d0834ceb5c41553afd12576f3fbb9a8e05883ccc51c9a1269b6d8e9d27123d",
-              "genesis_output_index": 3926918705,
+              "genesis_first_prev_out": "f8af8eef6b9fb4fea095995b00c9f3537cf16200e6df0b3404303753d7c2fabd:218715601",
+              "genesis_tag": "89fa9844f8061d462e28f174489e75140f84e842040141cc59ce38f9551850cf",
+              "genesis_meta_hash": "89fa9844f8061d462e28f174489e75140f84e842040141cc59ce38f9551850cf",
+              "genesis_output_index": 4076044011,
               "genesis_type": 0,
               "amount": 1,
               "lock_time": 0,
@@ -682,13 +682,13 @@
                   },
                   "tx_witness": null,
                   "split_commitment": {
-                    "proof": "0001f525c7272e7a15496009d644c3373e404889d6d361f84dd5d48f38e4967a96ed0000000000000002ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7f",
+                    "proof": "000236a65c2767e907db5f2c9d8b0a2ed97554f2bb9e43f967e5a3d72b3ad4cf1f980000000000000001c6de550a8a85bf8a97eb08bb258ae23f9c5c069a42a8bdb5bec6c9b61c848b140000000000000001ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff9f",
                     "root_asset": {
                       "version": 0,
-                      "genesis_first_prev_out": "1b6e9ef52bfe55e280959e40fd3182a38aae50dc0977d1d2a8dee9dbd60b5dce:3933183076",
-                      "genesis_tag": "00d0834ceb5c41553afd12576f3fbb9a8e05883ccc51c9a1269b6d8e9d27123d",
-                      "genesis_meta_hash": "00d0834ceb5c41553afd12576f3fbb9a8e05883ccc51c9a1269b6d8e9d27123d",
-                      "genesis_output_index": 3926918705,
+                      "genesis_first_prev_out": "f8af8eef6b9fb4fea095995b00c9f3537cf16200e6df0b3404303753d7c2fabd:218715601",
+                      "genesis_tag": "89fa9844f8061d462e28f174489e75140f84e842040141cc59ce38f9551850cf",
+                      "genesis_meta_hash": "89fa9844f8061d462e28f174489e75140f84e842040141cc59ce38f9551850cf",
+                      "genesis_output_index": 4076044011,
                       "genesis_type": 0,
                       "amount": 1,
                       "lock_time": 0,
@@ -697,23 +697,23 @@
                         {
                           "prev_id": {
                             "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
-                            "asset_id": "f9ea747b1965f44561fb7dba932b2745e14fd3fd305d72b1557a15379bf2f7df",
-                            "script_key": "02c9f327102d8c3dfb206b730fb4dada2a60d2ca2e368053ceeff6ac1042c11c68"
+                            "asset_id": "f9e28e5f7ff4405bfc60ce07a46c7a3268b6ace4170198d542ce70ba57513b10",
+                            "script_key": "029158bf8897374fb4b9dd568cd12d627e2c87448871d05528aae1caadb3adc8b0"
                           },
                           "tx_witness": [
-                            "4db9a1a88010cf7134f01719848d6f041be889cf13fa32a514a929bd322eae6aad28a7da2a8fc0549cce3ea93b959261e36bf9a13f10dacff1159d694ba071c1"
+                            "32c8a2ba16ca6a046a5986f6d8faeea4a0a2efdfc616b652607e89c61d9cfd46f9ce23dfd04a8b12ffa73ae6524370667c2bfda6638d8b2d66c01e64a3c5cdad"
                           ],
                           "split_commitment": null
                         }
                       ],
                       "split_commitment_root": {
-                        "hash": "2c54490ea036766b17b924a04c74b78975b0377d84d549877999b25e04feaeba",
+                        "hash": "5b63954ebe705abba7d7fc0734cdfd384cf93d1c3257e72c586bf0bfa0c7b997",
                         "sum": "3"
                       },
                       "script_version": 0,
-                      "script_key": "02c9f327102d8c3dfb206b730fb4dada2a60d2ca2e368053ceeff6ac1042c11c68",
+                      "script_key": "029158bf8897374fb4b9dd568cd12d627e2c87448871d05528aae1caadb3adc8b0",
                       "group_key": {
-                        "group_key": "0228a7bc5a7d093fcb96b84fe68d8c61f46132128d4d137bfdd446741f36dc8c8c"
+                        "group_key": "03f7eb502c0d4ce09939db07d6c13a36721a32cf1e745934d55943337950f045d7"
                       }
                     }
                   }
@@ -721,9 +721,9 @@
               ],
               "split_commitment_root": null,
               "script_version": 0,
-              "script_key": "021214811deb0d38f199fae6ef9871a910779583610df29756f3108c1862e4a2d6",
+              "script_key": "02f7c7f36d7a30f1d2dd548224f4e5c52c89f486d32169ce895fa31f6360527601",
               "group_key": {
-                "group_key": "0228a7bc5a7d093fcb96b84fe68d8c61f46132128d4d137bfdd446741f36dc8c8c"
+                "group_key": "03f7eb502c0d4ce09939db07d6c13a36721a32cf1e745934d55943337950f045d7"
               }
             },
             "output_index": 2
@@ -734,15 +734,15 @@
         {
           "prev_id": {
             "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
-            "asset_id": "f9ea747b1965f44561fb7dba932b2745e14fd3fd305d72b1557a15379bf2f7df",
-            "script_key": "02c9f327102d8c3dfb206b730fb4dada2a60d2ca2e368053ceeff6ac1042c11c68"
+            "asset_id": "f9e28e5f7ff4405bfc60ce07a46c7a3268b6ace4170198d542ce70ba57513b10",
+            "script_key": "029158bf8897374fb4b9dd568cd12d627e2c87448871d05528aae1caadb3adc8b0"
           },
           "asset": {
-            "version": 0,
-            "genesis_first_prev_out": "1b6e9ef52bfe55e280959e40fd3182a38aae50dc0977d1d2a8dee9dbd60b5dce:3933183076",
-            "genesis_tag": "00d0834ceb5c41553afd12576f3fbb9a8e05883ccc51c9a1269b6d8e9d27123d",
-            "genesis_meta_hash": "00d0834ceb5c41553afd12576f3fbb9a8e05883ccc51c9a1269b6d8e9d27123d",
-            "genesis_output_index": 3926918705,
+            "version": 1,
+            "genesis_first_prev_out": "f8af8eef6b9fb4fea095995b00c9f3537cf16200e6df0b3404303753d7c2fabd:218715601",
+            "genesis_tag": "89fa9844f8061d462e28f174489e75140f84e842040141cc59ce38f9551850cf",
+            "genesis_meta_hash": "89fa9844f8061d462e28f174489e75140f84e842040141cc59ce38f9551850cf",
+            "genesis_output_index": 4076044011,
             "genesis_type": 0,
             "amount": 3,
             "lock_time": 0,
@@ -755,16 +755,16 @@
                   "script_key": "000000000000000000000000000000000000000000000000000000000000000000"
                 },
                 "tx_witness": [
-                  "fd92e5283b52b53cd4dce0936e3345500545ef295f94bfe6d9e0dacfa31530c86156a18832a44ccdea1ce0b058475dcde697125031d79dea696595e05f535207"
+                  "21136cf9d1561577861e661af0ff595e163099eda18b25e26011b84e973009bf3b8ba6e79d22f31065b2065bc321facd4ec95e8ba39f0952a3fa7cc459dc83ca"
                 ],
                 "split_commitment": null
               }
             ],
             "split_commitment_root": null,
             "script_version": 0,
-            "script_key": "02c9f327102d8c3dfb206b730fb4dada2a60d2ca2e368053ceeff6ac1042c11c68",
+            "script_key": "029158bf8897374fb4b9dd568cd12d627e2c87448871d05528aae1caadb3adc8b0",
             "group_key": {
-              "group_key": "0228a7bc5a7d093fcb96b84fe68d8c61f46132128d4d137bfdd446741f36dc8c8c"
+              "group_key": "03f7eb502c0d4ce09939db07d6c13a36721a32cf1e745934d55943337950f045d7"
             }
           }
         }
@@ -774,10 +774,10 @@
     {
       "asset": {
         "version": 0,
-        "genesis_first_prev_out": "0a44b9d907d3fa14d64b670b9d094bf228653210474ce6979ab1bc2dce1e4132:4135117245",
-        "genesis_tag": "4184793cc9892308e296b334c85f7097edc16927c2451c4cd7e53f239aa4f4c8",
-        "genesis_meta_hash": "4184793cc9892308e296b334c85f7097edc16927c2451c4cd7e53f239aa4f4c8",
-        "genesis_output_index": 1343511537,
+        "genesis_first_prev_out": "7097a97441370317b1a5503c32add769755a2e5f7917900434d2e05cdd62b30a:2367084110",
+        "genesis_tag": "85610765e4c86414692bf4bde20ed899e97727b7ea1d95d7c621717c560f1d26",
+        "genesis_meta_hash": "85610765e4c86414692bf4bde20ed899e97727b7ea1d95d7c621717c560f1d26",
+        "genesis_output_index": 3759419319,
         "genesis_type": 0,
         "amount": 0,
         "lock_time": 0,
@@ -786,40 +786,40 @@
           {
             "prev_id": {
               "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
-              "asset_id": "3a82ca3ae29ffed3be997c5fec27f50afc5baf621078d4217e64266ae5388f84",
-              "script_key": "024d31c37d9b6241b83a419b71196bf0829ad7585aeccf846db8df9235c27883ef"
+              "asset_id": "2f42f28cd7f8b56ca89b479f14df418a8e2d8d1f2ae14889361123222b14ad55",
+              "script_key": "021b4022556d7b049eca07391faf05ecb0c122c00db47008424f8a9102d046e30d"
             },
             "tx_witness": [
-              "781a68d89a40610b18f41f85b38f30a7d8bbf239e7c2363ccc21c3994c2f8821e99a6d4df4f70ed263639518077668e97938de8eaccdd36d2996cc098bfa1c1a"
+              "26387fbcee0fe761375ab234d707aeca1ab45160b88f996d4f00ed55fedd261756f1981183d3a7ac948c7d6641aabfd7c6cad729eec8c0668caab4c732587fe2"
             ],
             "split_commitment": null
           }
         ],
         "split_commitment_root": {
-          "hash": "503be244b546135136ae00cc9ff829ce0e70b87f1fb1fc1ae5187e4e3876a6a8",
+          "hash": "f562b9e5fdacb6472df892afe2a7f3f6888d75fb7d5458abe14c9b5d968e4abd",
           "sum": "3"
         },
         "script_version": 0,
         "script_key": "027c79b9b26e463895eef5679d8558942c86c4ad2233adef01bc3e6d540b3653fe",
         "group_key": {
-          "group_key": "03b20ff63c8d1cf6e1b6ffafb3b33fdfd455cbd3d343553803525a2480663682ef"
+          "group_key": "02bacef4ec7c251a32d3e28c5f142a35490cbcb2362178bb90195d5388466df76c"
         }
       },
       "split_set": [
         {
           "key": {
             "output_index": 0,
-            "asset_id": "3a82ca3ae29ffed3be997c5fec27f50afc5baf621078d4217e64266ae5388f84",
+            "asset_id": "2f42f28cd7f8b56ca89b479f14df418a8e2d8d1f2ae14889361123222b14ad55",
             "script_key": "027c79b9b26e463895eef5679d8558942c86c4ad2233adef01bc3e6d540b3653fe",
             "amount": 0
           },
           "value": {
             "asset": {
               "version": 0,
-              "genesis_first_prev_out": "0a44b9d907d3fa14d64b670b9d094bf228653210474ce6979ab1bc2dce1e4132:4135117245",
-              "genesis_tag": "4184793cc9892308e296b334c85f7097edc16927c2451c4cd7e53f239aa4f4c8",
-              "genesis_meta_hash": "4184793cc9892308e296b334c85f7097edc16927c2451c4cd7e53f239aa4f4c8",
-              "genesis_output_index": 1343511537,
+              "genesis_first_prev_out": "7097a97441370317b1a5503c32add769755a2e5f7917900434d2e05cdd62b30a:2367084110",
+              "genesis_tag": "85610765e4c86414692bf4bde20ed899e97727b7ea1d95d7c621717c560f1d26",
+              "genesis_meta_hash": "85610765e4c86414692bf4bde20ed899e97727b7ea1d95d7c621717c560f1d26",
+              "genesis_output_index": 3759419319,
               "genesis_type": 0,
               "amount": 0,
               "lock_time": 0,
@@ -833,13 +833,13 @@
                   },
                   "tx_witness": null,
                   "split_commitment": {
-                    "proof": "0001cf77ff5059f99f662f601967bbedcee1ac1c57d29d787f2c242caa9875cc88e80000000000000003ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7f",
+                    "proof": "0001e3fc8fd9f13d5d01ac48b03e9bb8c07e5cefc609770725c8ff80dcd8cf83a48d0000000000000003fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd",
                     "root_asset": {
                       "version": 0,
-                      "genesis_first_prev_out": "0a44b9d907d3fa14d64b670b9d094bf228653210474ce6979ab1bc2dce1e4132:4135117245",
-                      "genesis_tag": "4184793cc9892308e296b334c85f7097edc16927c2451c4cd7e53f239aa4f4c8",
-                      "genesis_meta_hash": "4184793cc9892308e296b334c85f7097edc16927c2451c4cd7e53f239aa4f4c8",
-                      "genesis_output_index": 1343511537,
+                      "genesis_first_prev_out": "7097a97441370317b1a5503c32add769755a2e5f7917900434d2e05cdd62b30a:2367084110",
+                      "genesis_tag": "85610765e4c86414692bf4bde20ed899e97727b7ea1d95d7c621717c560f1d26",
+                      "genesis_meta_hash": "85610765e4c86414692bf4bde20ed899e97727b7ea1d95d7c621717c560f1d26",
+                      "genesis_output_index": 3759419319,
                       "genesis_type": 0,
                       "amount": 0,
                       "lock_time": 0,
@@ -848,23 +848,23 @@
                         {
                           "prev_id": {
                             "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
-                            "asset_id": "3a82ca3ae29ffed3be997c5fec27f50afc5baf621078d4217e64266ae5388f84",
-                            "script_key": "024d31c37d9b6241b83a419b71196bf0829ad7585aeccf846db8df9235c27883ef"
+                            "asset_id": "2f42f28cd7f8b56ca89b479f14df418a8e2d8d1f2ae14889361123222b14ad55",
+                            "script_key": "021b4022556d7b049eca07391faf05ecb0c122c00db47008424f8a9102d046e30d"
                           },
                           "tx_witness": [
-                            "781a68d89a40610b18f41f85b38f30a7d8bbf239e7c2363ccc21c3994c2f8821e99a6d4df4f70ed263639518077668e97938de8eaccdd36d2996cc098bfa1c1a"
+                            "26387fbcee0fe761375ab234d707aeca1ab45160b88f996d4f00ed55fedd261756f1981183d3a7ac948c7d6641aabfd7c6cad729eec8c0668caab4c732587fe2"
                           ],
                           "split_commitment": null
                         }
                       ],
                       "split_commitment_root": {
-                        "hash": "503be244b546135136ae00cc9ff829ce0e70b87f1fb1fc1ae5187e4e3876a6a8",
+                        "hash": "f562b9e5fdacb6472df892afe2a7f3f6888d75fb7d5458abe14c9b5d968e4abd",
                         "sum": "3"
                       },
                       "script_version": 0,
                       "script_key": "027c79b9b26e463895eef5679d8558942c86c4ad2233adef01bc3e6d540b3653fe",
                       "group_key": {
-                        "group_key": "03b20ff63c8d1cf6e1b6ffafb3b33fdfd455cbd3d343553803525a2480663682ef"
+                        "group_key": "02bacef4ec7c251a32d3e28c5f142a35490cbcb2362178bb90195d5388466df76c"
                       }
                     }
                   }
@@ -874,7 +874,7 @@
               "script_version": 0,
               "script_key": "027c79b9b26e463895eef5679d8558942c86c4ad2233adef01bc3e6d540b3653fe",
               "group_key": {
-                "group_key": "03b20ff63c8d1cf6e1b6ffafb3b33fdfd455cbd3d343553803525a2480663682ef"
+                "group_key": "02bacef4ec7c251a32d3e28c5f142a35490cbcb2362178bb90195d5388466df76c"
               }
             },
             "output_index": 0
@@ -883,17 +883,17 @@
         {
           "key": {
             "output_index": 1,
-            "asset_id": "3a82ca3ae29ffed3be997c5fec27f50afc5baf621078d4217e64266ae5388f84",
-            "script_key": "029d1322813bc7116745b66bb98bb7728d8048175d1bd0e8585445d432fc3b307d",
+            "asset_id": "2f42f28cd7f8b56ca89b479f14df418a8e2d8d1f2ae14889361123222b14ad55",
+            "script_key": "02d02167cae928655aa116aa71d349259ecdd2d569918c43e43a99270ec43cb38d",
             "amount": 3
           },
           "value": {
             "asset": {
               "version": 0,
-              "genesis_first_prev_out": "0a44b9d907d3fa14d64b670b9d094bf228653210474ce6979ab1bc2dce1e4132:4135117245",
-              "genesis_tag": "4184793cc9892308e296b334c85f7097edc16927c2451c4cd7e53f239aa4f4c8",
-              "genesis_meta_hash": "4184793cc9892308e296b334c85f7097edc16927c2451c4cd7e53f239aa4f4c8",
-              "genesis_output_index": 1343511537,
+              "genesis_first_prev_out": "7097a97441370317b1a5503c32add769755a2e5f7917900434d2e05cdd62b30a:2367084110",
+              "genesis_tag": "85610765e4c86414692bf4bde20ed899e97727b7ea1d95d7c621717c560f1d26",
+              "genesis_meta_hash": "85610765e4c86414692bf4bde20ed899e97727b7ea1d95d7c621717c560f1d26",
+              "genesis_output_index": 3759419319,
               "genesis_type": 0,
               "amount": 3,
               "lock_time": 0,
@@ -907,13 +907,13 @@
                   },
                   "tx_witness": null,
                   "split_commitment": {
-                    "proof": "0001978b056562d4aacef52cbce59bb73cbef6aececbdd054aaf254151fba4d85af00000000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7f",
+                    "proof": "0001286425b32661c866146b8246c1987fcb8821c4c3fb182c92862d59ab99d238820000000000000000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd",
                     "root_asset": {
                       "version": 0,
-                      "genesis_first_prev_out": "0a44b9d907d3fa14d64b670b9d094bf228653210474ce6979ab1bc2dce1e4132:4135117245",
-                      "genesis_tag": "4184793cc9892308e296b334c85f7097edc16927c2451c4cd7e53f239aa4f4c8",
-                      "genesis_meta_hash": "4184793cc9892308e296b334c85f7097edc16927c2451c4cd7e53f239aa4f4c8",
-                      "genesis_output_index": 1343511537,
+                      "genesis_first_prev_out": "7097a97441370317b1a5503c32add769755a2e5f7917900434d2e05cdd62b30a:2367084110",
+                      "genesis_tag": "85610765e4c86414692bf4bde20ed899e97727b7ea1d95d7c621717c560f1d26",
+                      "genesis_meta_hash": "85610765e4c86414692bf4bde20ed899e97727b7ea1d95d7c621717c560f1d26",
+                      "genesis_output_index": 3759419319,
                       "genesis_type": 0,
                       "amount": 0,
                       "lock_time": 0,
@@ -922,23 +922,23 @@
                         {
                           "prev_id": {
                             "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
-                            "asset_id": "3a82ca3ae29ffed3be997c5fec27f50afc5baf621078d4217e64266ae5388f84",
-                            "script_key": "024d31c37d9b6241b83a419b71196bf0829ad7585aeccf846db8df9235c27883ef"
+                            "asset_id": "2f42f28cd7f8b56ca89b479f14df418a8e2d8d1f2ae14889361123222b14ad55",
+                            "script_key": "021b4022556d7b049eca07391faf05ecb0c122c00db47008424f8a9102d046e30d"
                           },
                           "tx_witness": [
-                            "781a68d89a40610b18f41f85b38f30a7d8bbf239e7c2363ccc21c3994c2f8821e99a6d4df4f70ed263639518077668e97938de8eaccdd36d2996cc098bfa1c1a"
+                            "26387fbcee0fe761375ab234d707aeca1ab45160b88f996d4f00ed55fedd261756f1981183d3a7ac948c7d6641aabfd7c6cad729eec8c0668caab4c732587fe2"
                           ],
                           "split_commitment": null
                         }
                       ],
                       "split_commitment_root": {
-                        "hash": "503be244b546135136ae00cc9ff829ce0e70b87f1fb1fc1ae5187e4e3876a6a8",
+                        "hash": "f562b9e5fdacb6472df892afe2a7f3f6888d75fb7d5458abe14c9b5d968e4abd",
                         "sum": "3"
                       },
                       "script_version": 0,
                       "script_key": "027c79b9b26e463895eef5679d8558942c86c4ad2233adef01bc3e6d540b3653fe",
                       "group_key": {
-                        "group_key": "03b20ff63c8d1cf6e1b6ffafb3b33fdfd455cbd3d343553803525a2480663682ef"
+                        "group_key": "02bacef4ec7c251a32d3e28c5f142a35490cbcb2362178bb90195d5388466df76c"
                       }
                     }
                   }
@@ -946,9 +946,9 @@
               ],
               "split_commitment_root": null,
               "script_version": 0,
-              "script_key": "029d1322813bc7116745b66bb98bb7728d8048175d1bd0e8585445d432fc3b307d",
+              "script_key": "02d02167cae928655aa116aa71d349259ecdd2d569918c43e43a99270ec43cb38d",
               "group_key": {
-                "group_key": "03b20ff63c8d1cf6e1b6ffafb3b33fdfd455cbd3d343553803525a2480663682ef"
+                "group_key": "02bacef4ec7c251a32d3e28c5f142a35490cbcb2362178bb90195d5388466df76c"
               }
             },
             "output_index": 1
@@ -959,15 +959,15 @@
         {
           "prev_id": {
             "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
-            "asset_id": "3a82ca3ae29ffed3be997c5fec27f50afc5baf621078d4217e64266ae5388f84",
-            "script_key": "024d31c37d9b6241b83a419b71196bf0829ad7585aeccf846db8df9235c27883ef"
+            "asset_id": "2f42f28cd7f8b56ca89b479f14df418a8e2d8d1f2ae14889361123222b14ad55",
+            "script_key": "021b4022556d7b049eca07391faf05ecb0c122c00db47008424f8a9102d046e30d"
           },
           "asset": {
-            "version": 1,
-            "genesis_first_prev_out": "0a44b9d907d3fa14d64b670b9d094bf228653210474ce6979ab1bc2dce1e4132:4135117245",
-            "genesis_tag": "4184793cc9892308e296b334c85f7097edc16927c2451c4cd7e53f239aa4f4c8",
-            "genesis_meta_hash": "4184793cc9892308e296b334c85f7097edc16927c2451c4cd7e53f239aa4f4c8",
-            "genesis_output_index": 1343511537,
+            "version": 0,
+            "genesis_first_prev_out": "7097a97441370317b1a5503c32add769755a2e5f7917900434d2e05cdd62b30a:2367084110",
+            "genesis_tag": "85610765e4c86414692bf4bde20ed899e97727b7ea1d95d7c621717c560f1d26",
+            "genesis_meta_hash": "85610765e4c86414692bf4bde20ed899e97727b7ea1d95d7c621717c560f1d26",
+            "genesis_output_index": 3759419319,
             "genesis_type": 0,
             "amount": 3,
             "lock_time": 0,
@@ -980,16 +980,16 @@
                   "script_key": "000000000000000000000000000000000000000000000000000000000000000000"
                 },
                 "tx_witness": [
-                  "e0c80d974c8c0c1a1c1ada5df57327e4c30172e373313eb23d99133959bb776bef0108279bb9c8aed5069285d7684b0bce86ec0e0307490bd0058e913b05e09b"
+                  "9d5e4ce35cfee5a351615f0e083528c30b4448dbe24d6bc0f4ffeae217a40133e31e3f3672d3a43a74ab6cd9e20f5b0f4de1f0654e042bf89be6e4cbdf603fc3"
                 ],
                 "split_commitment": null
               }
             ],
             "split_commitment_root": null,
             "script_version": 0,
-            "script_key": "024d31c37d9b6241b83a419b71196bf0829ad7585aeccf846db8df9235c27883ef",
+            "script_key": "021b4022556d7b049eca07391faf05ecb0c122c00db47008424f8a9102d046e30d",
             "group_key": {
-              "group_key": "03b20ff63c8d1cf6e1b6ffafb3b33fdfd455cbd3d343553803525a2480663682ef"
+              "group_key": "02bacef4ec7c251a32d3e28c5f142a35490cbcb2362178bb90195d5388466df76c"
             }
           }
         }
@@ -999,10 +999,10 @@
     {
       "asset": {
         "version": 0,
-        "genesis_first_prev_out": "d9c33d26074dde56e5df58c69b45107896f2960964373dae4042453014a83a1a:2289424226",
-        "genesis_tag": "8625b583cd7be33913c30c419d047cf3baf40fd05219a1fcec717b87a65fa022",
-        "genesis_meta_hash": "8625b583cd7be33913c30c419d047cf3baf40fd05219a1fcec717b87a65fa022",
-        "genesis_output_index": 4375182,
+        "genesis_first_prev_out": "0882863527436b170d751c11837899f25a928f8a984cc4088b27c3b797cae424:3039434871",
+        "genesis_tag": "6035eab7e2da420f32ed5c94bc12a34dc68eb99257a7ea03b69d6c760b0681fa",
+        "genesis_meta_hash": "6035eab7e2da420f32ed5c94bc12a34dc68eb99257a7ea03b69d6c760b0681fa",
+        "genesis_output_index": 829625319,
         "genesis_type": 1,
         "amount": 0,
         "lock_time": 0,
@@ -1011,40 +1011,40 @@
           {
             "prev_id": {
               "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
-              "asset_id": "2d26f975a45265c3ee185e8fe5b2d08ac1c8660848ca98773537a54db2d922a9",
-              "script_key": "02b09cec8b91b99e3629a5ad06ead2c38f7885f55335daf8e7a5d24aa07360ad8b"
+              "asset_id": "3326a3da8e8409999562150950fe0273a67b26b68d3a7cdb4ba943833d299003",
+              "script_key": "02d5285df1075b56c1db54e9462da3de9e5142e7a3991820e8de32eb646cdc1599"
             },
             "tx_witness": [
-              "7e29a002623312e26fd994943529368f5eea006b1905b338e0982c19341725d008ca707fbbbd5b5b83805b4dd68a165077700324b7076c7f267eedf8f29fc08e"
+              "00e7ccda6ae0f1a1ae3c5d67948fe1aeb47b16404a1efb3bd86ffa738f770811c07c0da0bbd634d2cdda6c258e87749fbdd09780860fa9e20f53938bb077fe13"
             ],
             "split_commitment": null
           }
         ],
         "split_commitment_root": {
-          "hash": "833747850f7d2a676782b44b08ec0d6b7e2b38fef2f7bafb5a00d03a98e86336",
+          "hash": "b9e58b41296c252ba35225c63d268cc799eab4a8ebb66333cc3938d7d61fc1ae",
           "sum": "1"
         },
         "script_version": 0,
         "script_key": "027c79b9b26e463895eef5679d8558942c86c4ad2233adef01bc3e6d540b3653fe",
         "group_key": {
-          "group_key": "034b8a8acbd8b054004284e8d774a79e2e3d367779754374b11532e9479f97acaf"
+          "group_key": "02b524919cd4107a70d28eb416a8ed9a9d28fa01c420548a5a8495ee39ddbd713e"
         }
       },
       "split_set": [
         {
           "key": {
             "output_index": 0,
-            "asset_id": "2d26f975a45265c3ee185e8fe5b2d08ac1c8660848ca98773537a54db2d922a9",
+            "asset_id": "3326a3da8e8409999562150950fe0273a67b26b68d3a7cdb4ba943833d299003",
             "script_key": "027c79b9b26e463895eef5679d8558942c86c4ad2233adef01bc3e6d540b3653fe",
             "amount": 0
           },
           "value": {
             "asset": {
               "version": 0,
-              "genesis_first_prev_out": "d9c33d26074dde56e5df58c69b45107896f2960964373dae4042453014a83a1a:2289424226",
-              "genesis_tag": "8625b583cd7be33913c30c419d047cf3baf40fd05219a1fcec717b87a65fa022",
-              "genesis_meta_hash": "8625b583cd7be33913c30c419d047cf3baf40fd05219a1fcec717b87a65fa022",
-              "genesis_output_index": 4375182,
+              "genesis_first_prev_out": "0882863527436b170d751c11837899f25a928f8a984cc4088b27c3b797cae424:3039434871",
+              "genesis_tag": "6035eab7e2da420f32ed5c94bc12a34dc68eb99257a7ea03b69d6c760b0681fa",
+              "genesis_meta_hash": "6035eab7e2da420f32ed5c94bc12a34dc68eb99257a7ea03b69d6c760b0681fa",
+              "genesis_output_index": 829625319,
               "genesis_type": 1,
               "amount": 0,
               "lock_time": 0,
@@ -1058,13 +1058,13 @@
                   },
                   "tx_witness": null,
                   "split_commitment": {
-                    "proof": "00012df3a8a25b66c512037284e446ee8095e0c90c4376c426705ab13208366c80310000000000000001ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffdf",
+                    "proof": "00012de2236a290e3df6dd860fca6714667e261f0ee32c15917dab5fbc754460621d0000000000000001ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffbf",
                     "root_asset": {
                       "version": 0,
-                      "genesis_first_prev_out": "d9c33d26074dde56e5df58c69b45107896f2960964373dae4042453014a83a1a:2289424226",
-                      "genesis_tag": "8625b583cd7be33913c30c419d047cf3baf40fd05219a1fcec717b87a65fa022",
-                      "genesis_meta_hash": "8625b583cd7be33913c30c419d047cf3baf40fd05219a1fcec717b87a65fa022",
-                      "genesis_output_index": 4375182,
+                      "genesis_first_prev_out": "0882863527436b170d751c11837899f25a928f8a984cc4088b27c3b797cae424:3039434871",
+                      "genesis_tag": "6035eab7e2da420f32ed5c94bc12a34dc68eb99257a7ea03b69d6c760b0681fa",
+                      "genesis_meta_hash": "6035eab7e2da420f32ed5c94bc12a34dc68eb99257a7ea03b69d6c760b0681fa",
+                      "genesis_output_index": 829625319,
                       "genesis_type": 1,
                       "amount": 0,
                       "lock_time": 0,
@@ -1073,23 +1073,23 @@
                         {
                           "prev_id": {
                             "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
-                            "asset_id": "2d26f975a45265c3ee185e8fe5b2d08ac1c8660848ca98773537a54db2d922a9",
-                            "script_key": "02b09cec8b91b99e3629a5ad06ead2c38f7885f55335daf8e7a5d24aa07360ad8b"
+                            "asset_id": "3326a3da8e8409999562150950fe0273a67b26b68d3a7cdb4ba943833d299003",
+                            "script_key": "02d5285df1075b56c1db54e9462da3de9e5142e7a3991820e8de32eb646cdc1599"
                           },
                           "tx_witness": [
-                            "7e29a002623312e26fd994943529368f5eea006b1905b338e0982c19341725d008ca707fbbbd5b5b83805b4dd68a165077700324b7076c7f267eedf8f29fc08e"
+                            "00e7ccda6ae0f1a1ae3c5d67948fe1aeb47b16404a1efb3bd86ffa738f770811c07c0da0bbd634d2cdda6c258e87749fbdd09780860fa9e20f53938bb077fe13"
                           ],
                           "split_commitment": null
                         }
                       ],
                       "split_commitment_root": {
-                        "hash": "833747850f7d2a676782b44b08ec0d6b7e2b38fef2f7bafb5a00d03a98e86336",
+                        "hash": "b9e58b41296c252ba35225c63d268cc799eab4a8ebb66333cc3938d7d61fc1ae",
                         "sum": "1"
                       },
                       "script_version": 0,
                       "script_key": "027c79b9b26e463895eef5679d8558942c86c4ad2233adef01bc3e6d540b3653fe",
                       "group_key": {
-                        "group_key": "034b8a8acbd8b054004284e8d774a79e2e3d367779754374b11532e9479f97acaf"
+                        "group_key": "02b524919cd4107a70d28eb416a8ed9a9d28fa01c420548a5a8495ee39ddbd713e"
                       }
                     }
                   }
@@ -1099,7 +1099,7 @@
               "script_version": 0,
               "script_key": "027c79b9b26e463895eef5679d8558942c86c4ad2233adef01bc3e6d540b3653fe",
               "group_key": {
-                "group_key": "034b8a8acbd8b054004284e8d774a79e2e3d367779754374b11532e9479f97acaf"
+                "group_key": "02b524919cd4107a70d28eb416a8ed9a9d28fa01c420548a5a8495ee39ddbd713e"
               }
             },
             "output_index": 0
@@ -1108,17 +1108,17 @@
         {
           "key": {
             "output_index": 1,
-            "asset_id": "2d26f975a45265c3ee185e8fe5b2d08ac1c8660848ca98773537a54db2d922a9",
-            "script_key": "021ac5bf195bcb03129cb23c5a8f6886b7883d65db0004761ee6e815417a7abc9d",
+            "asset_id": "3326a3da8e8409999562150950fe0273a67b26b68d3a7cdb4ba943833d299003",
+            "script_key": "02ed980cf090a7648981236786b1a2996666fbbeff75d99f197d150a2d72b7a3dc",
             "amount": 1
           },
           "value": {
             "asset": {
               "version": 0,
-              "genesis_first_prev_out": "d9c33d26074dde56e5df58c69b45107896f2960964373dae4042453014a83a1a:2289424226",
-              "genesis_tag": "8625b583cd7be33913c30c419d047cf3baf40fd05219a1fcec717b87a65fa022",
-              "genesis_meta_hash": "8625b583cd7be33913c30c419d047cf3baf40fd05219a1fcec717b87a65fa022",
-              "genesis_output_index": 4375182,
+              "genesis_first_prev_out": "0882863527436b170d751c11837899f25a928f8a984cc4088b27c3b797cae424:3039434871",
+              "genesis_tag": "6035eab7e2da420f32ed5c94bc12a34dc68eb99257a7ea03b69d6c760b0681fa",
+              "genesis_meta_hash": "6035eab7e2da420f32ed5c94bc12a34dc68eb99257a7ea03b69d6c760b0681fa",
+              "genesis_output_index": 829625319,
               "genesis_type": 1,
               "amount": 1,
               "lock_time": 0,
@@ -1132,13 +1132,13 @@
                   },
                   "tx_witness": null,
                   "split_commitment": {
-                    "proof": "00012e1e6cd893c1ed465478fc6906523269fbae8a86d0dbcf1200786e1e80cc987b0000000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffdf",
+                    "proof": "00010491f773eda6b88c0096a2c5f7284d996f42d6460ef3780b857f6691209273730000000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffbf",
                     "root_asset": {
                       "version": 0,
-                      "genesis_first_prev_out": "d9c33d26074dde56e5df58c69b45107896f2960964373dae4042453014a83a1a:2289424226",
-                      "genesis_tag": "8625b583cd7be33913c30c419d047cf3baf40fd05219a1fcec717b87a65fa022",
-                      "genesis_meta_hash": "8625b583cd7be33913c30c419d047cf3baf40fd05219a1fcec717b87a65fa022",
-                      "genesis_output_index": 4375182,
+                      "genesis_first_prev_out": "0882863527436b170d751c11837899f25a928f8a984cc4088b27c3b797cae424:3039434871",
+                      "genesis_tag": "6035eab7e2da420f32ed5c94bc12a34dc68eb99257a7ea03b69d6c760b0681fa",
+                      "genesis_meta_hash": "6035eab7e2da420f32ed5c94bc12a34dc68eb99257a7ea03b69d6c760b0681fa",
+                      "genesis_output_index": 829625319,
                       "genesis_type": 1,
                       "amount": 0,
                       "lock_time": 0,
@@ -1147,23 +1147,23 @@
                         {
                           "prev_id": {
                             "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
-                            "asset_id": "2d26f975a45265c3ee185e8fe5b2d08ac1c8660848ca98773537a54db2d922a9",
-                            "script_key": "02b09cec8b91b99e3629a5ad06ead2c38f7885f55335daf8e7a5d24aa07360ad8b"
+                            "asset_id": "3326a3da8e8409999562150950fe0273a67b26b68d3a7cdb4ba943833d299003",
+                            "script_key": "02d5285df1075b56c1db54e9462da3de9e5142e7a3991820e8de32eb646cdc1599"
                           },
                           "tx_witness": [
-                            "7e29a002623312e26fd994943529368f5eea006b1905b338e0982c19341725d008ca707fbbbd5b5b83805b4dd68a165077700324b7076c7f267eedf8f29fc08e"
+                            "00e7ccda6ae0f1a1ae3c5d67948fe1aeb47b16404a1efb3bd86ffa738f770811c07c0da0bbd634d2cdda6c258e87749fbdd09780860fa9e20f53938bb077fe13"
                           ],
                           "split_commitment": null
                         }
                       ],
                       "split_commitment_root": {
-                        "hash": "833747850f7d2a676782b44b08ec0d6b7e2b38fef2f7bafb5a00d03a98e86336",
+                        "hash": "b9e58b41296c252ba35225c63d268cc799eab4a8ebb66333cc3938d7d61fc1ae",
                         "sum": "1"
                       },
                       "script_version": 0,
                       "script_key": "027c79b9b26e463895eef5679d8558942c86c4ad2233adef01bc3e6d540b3653fe",
                       "group_key": {
-                        "group_key": "034b8a8acbd8b054004284e8d774a79e2e3d367779754374b11532e9479f97acaf"
+                        "group_key": "02b524919cd4107a70d28eb416a8ed9a9d28fa01c420548a5a8495ee39ddbd713e"
                       }
                     }
                   }
@@ -1171,9 +1171,9 @@
               ],
               "split_commitment_root": null,
               "script_version": 0,
-              "script_key": "021ac5bf195bcb03129cb23c5a8f6886b7883d65db0004761ee6e815417a7abc9d",
+              "script_key": "02ed980cf090a7648981236786b1a2996666fbbeff75d99f197d150a2d72b7a3dc",
               "group_key": {
-                "group_key": "034b8a8acbd8b054004284e8d774a79e2e3d367779754374b11532e9479f97acaf"
+                "group_key": "02b524919cd4107a70d28eb416a8ed9a9d28fa01c420548a5a8495ee39ddbd713e"
               }
             },
             "output_index": 1
@@ -1184,15 +1184,15 @@
         {
           "prev_id": {
             "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
-            "asset_id": "2d26f975a45265c3ee185e8fe5b2d08ac1c8660848ca98773537a54db2d922a9",
-            "script_key": "02b09cec8b91b99e3629a5ad06ead2c38f7885f55335daf8e7a5d24aa07360ad8b"
+            "asset_id": "3326a3da8e8409999562150950fe0273a67b26b68d3a7cdb4ba943833d299003",
+            "script_key": "02d5285df1075b56c1db54e9462da3de9e5142e7a3991820e8de32eb646cdc1599"
           },
           "asset": {
             "version": 1,
-            "genesis_first_prev_out": "d9c33d26074dde56e5df58c69b45107896f2960964373dae4042453014a83a1a:2289424226",
-            "genesis_tag": "8625b583cd7be33913c30c419d047cf3baf40fd05219a1fcec717b87a65fa022",
-            "genesis_meta_hash": "8625b583cd7be33913c30c419d047cf3baf40fd05219a1fcec717b87a65fa022",
-            "genesis_output_index": 4375182,
+            "genesis_first_prev_out": "0882863527436b170d751c11837899f25a928f8a984cc4088b27c3b797cae424:3039434871",
+            "genesis_tag": "6035eab7e2da420f32ed5c94bc12a34dc68eb99257a7ea03b69d6c760b0681fa",
+            "genesis_meta_hash": "6035eab7e2da420f32ed5c94bc12a34dc68eb99257a7ea03b69d6c760b0681fa",
+            "genesis_output_index": 829625319,
             "genesis_type": 1,
             "amount": 1,
             "lock_time": 0,
@@ -1205,16 +1205,16 @@
                   "script_key": "000000000000000000000000000000000000000000000000000000000000000000"
                 },
                 "tx_witness": [
-                  "23e3df3d723a11728c2c8198c429e68898992009d611204af8da3898af71640aab667ac29d4c2c308b268412b7856de7cfd257809df8775d393a0589b0da5aee"
+                  "41a6d36d4fe2efd66a1cc332c28a44eee3f41d97c4cd430432e310c02fb362c9b86a50da8c6b6e2ea6f1d4eb75208595ec8796fa3216e5ce8b099062876684c4"
                 ],
                 "split_commitment": null
               }
             ],
             "split_commitment_root": null,
             "script_version": 0,
-            "script_key": "02b09cec8b91b99e3629a5ad06ead2c38f7885f55335daf8e7a5d24aa07360ad8b",
+            "script_key": "02d5285df1075b56c1db54e9462da3de9e5142e7a3991820e8de32eb646cdc1599",
             "group_key": {
-              "group_key": "034b8a8acbd8b054004284e8d774a79e2e3d367779754374b11532e9479f97acaf"
+              "group_key": "02b524919cd4107a70d28eb416a8ed9a9d28fa01c420548a5a8495ee39ddbd713e"
             }
           }
         }
@@ -2141,6 +2141,544 @@
         }
       ],
       "comment": "script tree spend state transition valid sig sighash single"
+    },
+    {
+      "asset": {
+        "version": 0,
+        "genesis_first_prev_out": "2301767cb5cf04f59bb789c820f5c353cf52ca320796a7106796b83f19047619:584406196",
+        "genesis_tag": "8d8724b0cf3fae17a3f79be1072fb63c35d6042c4160f38ee9e2a9f3fb4ffb00",
+        "genesis_meta_hash": "8d8724b0cf3fae17a3f79be1072fb63c35d6042c4160f38ee9e2a9f3fb4ffb00",
+        "genesis_output_index": 3805718990,
+        "genesis_type": 0,
+        "amount": 1,
+        "lock_time": 0,
+        "relative_lock_time": 0,
+        "prev_witnesses": [
+          {
+            "prev_id": {
+              "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
+              "asset_id": "bfd35eeb607775ed158942bd03ed2a8411ab2b2b1f7d8b17fc58cd74bab7dec6",
+              "script_key": "02483021d30533dc23daaa5da3273a7c59d3fbbfcb689ad11b674bb76653723ff0"
+            },
+            "tx_witness": [
+              "31b24797df5f7b8712eb8d870df41e83d86c93ab0c96ff18cfb05fca785b860e635d8e297890b1d2a55c701818f6af99f786547a01980ba14553349556a673ac03",
+              "2016d30bad506c4b871aba4c1306473b287c084a13661eb09ef3d47b99a19d4524ac",
+              "c116d30bad506c4b871aba4c1306473b287c084a13661eb09ef3d47b99a19d45246c2e4bb01e316abaaee288d69c06cc608cedefd6e1a06813786c4ec51b6e1d38"
+            ],
+            "split_commitment": null
+          }
+        ],
+        "split_commitment_root": {
+          "hash": "5783bfda6743c69ce6c2393e4e1f711696f10ba01577d3f909a596e8cb25f463",
+          "sum": "3"
+        },
+        "script_version": 0,
+        "script_key": "02483021d30533dc23daaa5da3273a7c59d3fbbfcb689ad11b674bb76653723ff0",
+        "group_key": {
+          "group_key": "0369fef33531afc3772097ce7d5eae7d48a7db05ff5ccca8adc492c9f00a9a18f5"
+        }
+      },
+      "split_set": [
+        {
+          "key": {
+            "output_index": 0,
+            "asset_id": "bfd35eeb607775ed158942bd03ed2a8411ab2b2b1f7d8b17fc58cd74bab7dec6",
+            "script_key": "02483021d30533dc23daaa5da3273a7c59d3fbbfcb689ad11b674bb76653723ff0",
+            "amount": 1
+          },
+          "value": {
+            "asset": {
+              "version": 0,
+              "genesis_first_prev_out": "2301767cb5cf04f59bb789c820f5c353cf52ca320796a7106796b83f19047619:584406196",
+              "genesis_tag": "8d8724b0cf3fae17a3f79be1072fb63c35d6042c4160f38ee9e2a9f3fb4ffb00",
+              "genesis_meta_hash": "8d8724b0cf3fae17a3f79be1072fb63c35d6042c4160f38ee9e2a9f3fb4ffb00",
+              "genesis_output_index": 3805718990,
+              "genesis_type": 0,
+              "amount": 1,
+              "lock_time": 0,
+              "relative_lock_time": 0,
+              "prev_witnesses": [
+                {
+                  "prev_id": {
+                    "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
+                    "asset_id": "0000000000000000000000000000000000000000000000000000000000000000",
+                    "script_key": "000000000000000000000000000000000000000000000000000000000000000000"
+                  },
+                  "tx_witness": null,
+                  "split_commitment": {
+                    "proof": "00027ea4013e578c05a837e1d94531b44c0d0ef58721a4073c2056fb7fd78e32f19a00000000000000019e9ee9e01a56fd6bdfac20cbccfd18b58a319c2157f92b9511a3aef51219b2ee0000000000000001ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff3f",
+                    "root_asset": {
+                      "version": 0,
+                      "genesis_first_prev_out": "2301767cb5cf04f59bb789c820f5c353cf52ca320796a7106796b83f19047619:584406196",
+                      "genesis_tag": "8d8724b0cf3fae17a3f79be1072fb63c35d6042c4160f38ee9e2a9f3fb4ffb00",
+                      "genesis_meta_hash": "8d8724b0cf3fae17a3f79be1072fb63c35d6042c4160f38ee9e2a9f3fb4ffb00",
+                      "genesis_output_index": 3805718990,
+                      "genesis_type": 0,
+                      "amount": 1,
+                      "lock_time": 0,
+                      "relative_lock_time": 0,
+                      "prev_witnesses": [
+                        {
+                          "prev_id": {
+                            "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
+                            "asset_id": "bfd35eeb607775ed158942bd03ed2a8411ab2b2b1f7d8b17fc58cd74bab7dec6",
+                            "script_key": "02483021d30533dc23daaa5da3273a7c59d3fbbfcb689ad11b674bb76653723ff0"
+                          },
+                          "tx_witness": [
+                            "31b24797df5f7b8712eb8d870df41e83d86c93ab0c96ff18cfb05fca785b860e635d8e297890b1d2a55c701818f6af99f786547a01980ba14553349556a673ac03",
+                            "2016d30bad506c4b871aba4c1306473b287c084a13661eb09ef3d47b99a19d4524ac",
+                            "c116d30bad506c4b871aba4c1306473b287c084a13661eb09ef3d47b99a19d45246c2e4bb01e316abaaee288d69c06cc608cedefd6e1a06813786c4ec51b6e1d38"
+                          ],
+                          "split_commitment": null
+                        }
+                      ],
+                      "split_commitment_root": {
+                        "hash": "5783bfda6743c69ce6c2393e4e1f711696f10ba01577d3f909a596e8cb25f463",
+                        "sum": "3"
+                      },
+                      "script_version": 0,
+                      "script_key": "02483021d30533dc23daaa5da3273a7c59d3fbbfcb689ad11b674bb76653723ff0",
+                      "group_key": {
+                        "group_key": "0369fef33531afc3772097ce7d5eae7d48a7db05ff5ccca8adc492c9f00a9a18f5"
+                      }
+                    }
+                  }
+                }
+              ],
+              "split_commitment_root": null,
+              "script_version": 0,
+              "script_key": "02483021d30533dc23daaa5da3273a7c59d3fbbfcb689ad11b674bb76653723ff0",
+              "group_key": {
+                "group_key": "0369fef33531afc3772097ce7d5eae7d48a7db05ff5ccca8adc492c9f00a9a18f5"
+              }
+            },
+            "output_index": 0
+          }
+        },
+        {
+          "key": {
+            "output_index": 1,
+            "asset_id": "bfd35eeb607775ed158942bd03ed2a8411ab2b2b1f7d8b17fc58cd74bab7dec6",
+            "script_key": "034175f1f609feba5dbeb3c37ad30bcec6686450cfc0d1ec51a2d99671f718195c",
+            "amount": 1
+          },
+          "value": {
+            "asset": {
+              "version": 0,
+              "genesis_first_prev_out": "2301767cb5cf04f59bb789c820f5c353cf52ca320796a7106796b83f19047619:584406196",
+              "genesis_tag": "8d8724b0cf3fae17a3f79be1072fb63c35d6042c4160f38ee9e2a9f3fb4ffb00",
+              "genesis_meta_hash": "8d8724b0cf3fae17a3f79be1072fb63c35d6042c4160f38ee9e2a9f3fb4ffb00",
+              "genesis_output_index": 3805718990,
+              "genesis_type": 0,
+              "amount": 1,
+              "lock_time": 0,
+              "relative_lock_time": 0,
+              "prev_witnesses": [
+                {
+                  "prev_id": {
+                    "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
+                    "asset_id": "0000000000000000000000000000000000000000000000000000000000000000",
+                    "script_key": "000000000000000000000000000000000000000000000000000000000000000000"
+                  },
+                  "tx_witness": null,
+                  "split_commitment": {
+                    "proof": "0002b1e430398e6f7879ddf8be82e454bb5fdf48f73d9ef3ce16ae37665be8e41deb00000000000000019e9ee9e01a56fd6bdfac20cbccfd18b58a319c2157f92b9511a3aef51219b2ee0000000000000001ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff3f",
+                    "root_asset": {
+                      "version": 0,
+                      "genesis_first_prev_out": "2301767cb5cf04f59bb789c820f5c353cf52ca320796a7106796b83f19047619:584406196",
+                      "genesis_tag": "8d8724b0cf3fae17a3f79be1072fb63c35d6042c4160f38ee9e2a9f3fb4ffb00",
+                      "genesis_meta_hash": "8d8724b0cf3fae17a3f79be1072fb63c35d6042c4160f38ee9e2a9f3fb4ffb00",
+                      "genesis_output_index": 3805718990,
+                      "genesis_type": 0,
+                      "amount": 1,
+                      "lock_time": 0,
+                      "relative_lock_time": 0,
+                      "prev_witnesses": [
+                        {
+                          "prev_id": {
+                            "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
+                            "asset_id": "bfd35eeb607775ed158942bd03ed2a8411ab2b2b1f7d8b17fc58cd74bab7dec6",
+                            "script_key": "02483021d30533dc23daaa5da3273a7c59d3fbbfcb689ad11b674bb76653723ff0"
+                          },
+                          "tx_witness": [
+                            "31b24797df5f7b8712eb8d870df41e83d86c93ab0c96ff18cfb05fca785b860e635d8e297890b1d2a55c701818f6af99f786547a01980ba14553349556a673ac03",
+                            "2016d30bad506c4b871aba4c1306473b287c084a13661eb09ef3d47b99a19d4524ac",
+                            "c116d30bad506c4b871aba4c1306473b287c084a13661eb09ef3d47b99a19d45246c2e4bb01e316abaaee288d69c06cc608cedefd6e1a06813786c4ec51b6e1d38"
+                          ],
+                          "split_commitment": null
+                        }
+                      ],
+                      "split_commitment_root": {
+                        "hash": "5783bfda6743c69ce6c2393e4e1f711696f10ba01577d3f909a596e8cb25f463",
+                        "sum": "3"
+                      },
+                      "script_version": 0,
+                      "script_key": "02483021d30533dc23daaa5da3273a7c59d3fbbfcb689ad11b674bb76653723ff0",
+                      "group_key": {
+                        "group_key": "0369fef33531afc3772097ce7d5eae7d48a7db05ff5ccca8adc492c9f00a9a18f5"
+                      }
+                    }
+                  }
+                }
+              ],
+              "split_commitment_root": null,
+              "script_version": 0,
+              "script_key": "024175f1f609feba5dbeb3c37ad30bcec6686450cfc0d1ec51a2d99671f718195c",
+              "group_key": {
+                "group_key": "0369fef33531afc3772097ce7d5eae7d48a7db05ff5ccca8adc492c9f00a9a18f5"
+              }
+            },
+            "output_index": 1
+          }
+        },
+        {
+          "key": {
+            "output_index": 2,
+            "asset_id": "bfd35eeb607775ed158942bd03ed2a8411ab2b2b1f7d8b17fc58cd74bab7dec6",
+            "script_key": "0300bef0bafe1c3bb66324cdb47b3f3f81f9a194858db90d75f6c8b06bfe4b5330",
+            "amount": 1
+          },
+          "value": {
+            "asset": {
+              "version": 0,
+              "genesis_first_prev_out": "2301767cb5cf04f59bb789c820f5c353cf52ca320796a7106796b83f19047619:584406196",
+              "genesis_tag": "8d8724b0cf3fae17a3f79be1072fb63c35d6042c4160f38ee9e2a9f3fb4ffb00",
+              "genesis_meta_hash": "8d8724b0cf3fae17a3f79be1072fb63c35d6042c4160f38ee9e2a9f3fb4ffb00",
+              "genesis_output_index": 3805718990,
+              "genesis_type": 0,
+              "amount": 1,
+              "lock_time": 0,
+              "relative_lock_time": 0,
+              "prev_witnesses": [
+                {
+                  "prev_id": {
+                    "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
+                    "asset_id": "0000000000000000000000000000000000000000000000000000000000000000",
+                    "script_key": "000000000000000000000000000000000000000000000000000000000000000000"
+                  },
+                  "tx_witness": null,
+                  "split_commitment": {
+                    "proof": "00010a8b1e8c767739811ff1d180eba32e94551f0fda7638d748d0a5e70fd2d35f8a0000000000000002ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7f",
+                    "root_asset": {
+                      "version": 0,
+                      "genesis_first_prev_out": "2301767cb5cf04f59bb789c820f5c353cf52ca320796a7106796b83f19047619:584406196",
+                      "genesis_tag": "8d8724b0cf3fae17a3f79be1072fb63c35d6042c4160f38ee9e2a9f3fb4ffb00",
+                      "genesis_meta_hash": "8d8724b0cf3fae17a3f79be1072fb63c35d6042c4160f38ee9e2a9f3fb4ffb00",
+                      "genesis_output_index": 3805718990,
+                      "genesis_type": 0,
+                      "amount": 1,
+                      "lock_time": 0,
+                      "relative_lock_time": 0,
+                      "prev_witnesses": [
+                        {
+                          "prev_id": {
+                            "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
+                            "asset_id": "bfd35eeb607775ed158942bd03ed2a8411ab2b2b1f7d8b17fc58cd74bab7dec6",
+                            "script_key": "02483021d30533dc23daaa5da3273a7c59d3fbbfcb689ad11b674bb76653723ff0"
+                          },
+                          "tx_witness": [
+                            "31b24797df5f7b8712eb8d870df41e83d86c93ab0c96ff18cfb05fca785b860e635d8e297890b1d2a55c701818f6af99f786547a01980ba14553349556a673ac03",
+                            "2016d30bad506c4b871aba4c1306473b287c084a13661eb09ef3d47b99a19d4524ac",
+                            "c116d30bad506c4b871aba4c1306473b287c084a13661eb09ef3d47b99a19d45246c2e4bb01e316abaaee288d69c06cc608cedefd6e1a06813786c4ec51b6e1d38"
+                          ],
+                          "split_commitment": null
+                        }
+                      ],
+                      "split_commitment_root": {
+                        "hash": "5783bfda6743c69ce6c2393e4e1f711696f10ba01577d3f909a596e8cb25f463",
+                        "sum": "3"
+                      },
+                      "script_version": 0,
+                      "script_key": "02483021d30533dc23daaa5da3273a7c59d3fbbfcb689ad11b674bb76653723ff0",
+                      "group_key": {
+                        "group_key": "0369fef33531afc3772097ce7d5eae7d48a7db05ff5ccca8adc492c9f00a9a18f5"
+                      }
+                    }
+                  }
+                }
+              ],
+              "split_commitment_root": null,
+              "script_version": 0,
+              "script_key": "0200bef0bafe1c3bb66324cdb47b3f3f81f9a194858db90d75f6c8b06bfe4b5330",
+              "group_key": {
+                "group_key": "0369fef33531afc3772097ce7d5eae7d48a7db05ff5ccca8adc492c9f00a9a18f5"
+              }
+            },
+            "output_index": 2
+          }
+        }
+      ],
+      "input_set": [
+        {
+          "prev_id": {
+            "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
+            "asset_id": "bfd35eeb607775ed158942bd03ed2a8411ab2b2b1f7d8b17fc58cd74bab7dec6",
+            "script_key": "02483021d30533dc23daaa5da3273a7c59d3fbbfcb689ad11b674bb76653723ff0"
+          },
+          "asset": {
+            "version": 0,
+            "genesis_first_prev_out": "2301767cb5cf04f59bb789c820f5c353cf52ca320796a7106796b83f19047619:584406196",
+            "genesis_tag": "8d8724b0cf3fae17a3f79be1072fb63c35d6042c4160f38ee9e2a9f3fb4ffb00",
+            "genesis_meta_hash": "8d8724b0cf3fae17a3f79be1072fb63c35d6042c4160f38ee9e2a9f3fb4ffb00",
+            "genesis_output_index": 3805718990,
+            "genesis_type": 0,
+            "amount": 3,
+            "lock_time": 0,
+            "relative_lock_time": 0,
+            "prev_witnesses": [
+              {
+                "prev_id": {
+                  "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
+                  "asset_id": "0000000000000000000000000000000000000000000000000000000000000000",
+                  "script_key": "000000000000000000000000000000000000000000000000000000000000000000"
+                },
+                "tx_witness": [
+                  "84d9d75a73949800b80fd2a1c4313c27d7c4f9d8f9b5a00a7f32a4b217615a76edf6101980d2c6d423a3db16fcb0f9c3e7d8243d24680ee9992a44f386015add"
+                ],
+                "split_commitment": null
+              }
+            ],
+            "split_commitment_root": null,
+            "script_version": 0,
+            "script_key": "02483021d30533dc23daaa5da3273a7c59d3fbbfcb689ad11b674bb76653723ff0",
+            "group_key": {
+              "group_key": "0369fef33531afc3772097ce7d5eae7d48a7db05ff5ccca8adc492c9f00a9a18f5"
+            }
+          }
+        }
+      ],
+      "comment": "script tree spend state transition valid sig sighash single"
+    },
+    {
+      "asset": {
+        "version": 0,
+        "genesis_first_prev_out": "64ce6551cb894b4e8e20f31127a39040f4b6f47f6f70ff3be70cb0c09a3e6f24:4047389111",
+        "genesis_tag": "a0b773963c130ad797ddeafe4e3ad29b5125210f0ef1c314090f07c79a6f571c",
+        "genesis_meta_hash": "a0b773963c130ad797ddeafe4e3ad29b5125210f0ef1c314090f07c79a6f571c",
+        "genesis_output_index": 681360684,
+        "genesis_type": 0,
+        "amount": 2,
+        "lock_time": 0,
+        "relative_lock_time": 0,
+        "prev_witnesses": [
+          {
+            "prev_id": {
+              "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
+              "asset_id": "00438d168166b885663d9400a605ea631ef847f6576b37a9719df354b11ff95e",
+              "script_key": "025f86c895912d8816ea0c2dd9a6b0a27749ba51d2f2cb73ef169106ce5cfc05e3"
+            },
+            "tx_witness": [
+              "2fe224cc01c57289ea75eb3c406619474590b1ddea5217ab23ca005dc16e4bc68136777e55cf7e0bb65ba3474ae9dfc828dc588ee8a62fd898415cbd3677f94f02",
+              "203f72444470c4dc7860744d55a3a12f1f964061f45246454848e9d48d83140cf1ac",
+              "c13f72444470c4dc7860744d55a3a12f1f964061f45246454848e9d48d83140cf16c2e4bb01e316abaaee288d69c06cc608cedefd6e1a06813786c4ec51b6e1d38"
+            ],
+            "split_commitment": null
+          }
+        ],
+        "split_commitment_root": {
+          "hash": "8b00bd598a658947f1b7120986bee0be77a82a343e36582189ec092290673676",
+          "sum": "3"
+        },
+        "script_version": 0,
+        "script_key": "025f86c895912d8816ea0c2dd9a6b0a27749ba51d2f2cb73ef169106ce5cfc05e3",
+        "group_key": {
+          "group_key": "03aa1cfc8a3bdab14d0e273c3890c58ebaca32ac0866566234756ed136fe041430"
+        }
+      },
+      "split_set": [
+        {
+          "key": {
+            "output_index": 0,
+            "asset_id": "00438d168166b885663d9400a605ea631ef847f6576b37a9719df354b11ff95e",
+            "script_key": "025f86c895912d8816ea0c2dd9a6b0a27749ba51d2f2cb73ef169106ce5cfc05e3",
+            "amount": 2
+          },
+          "value": {
+            "asset": {
+              "version": 0,
+              "genesis_first_prev_out": "64ce6551cb894b4e8e20f31127a39040f4b6f47f6f70ff3be70cb0c09a3e6f24:4047389111",
+              "genesis_tag": "a0b773963c130ad797ddeafe4e3ad29b5125210f0ef1c314090f07c79a6f571c",
+              "genesis_meta_hash": "a0b773963c130ad797ddeafe4e3ad29b5125210f0ef1c314090f07c79a6f571c",
+              "genesis_output_index": 681360684,
+              "genesis_type": 0,
+              "amount": 2,
+              "lock_time": 0,
+              "relative_lock_time": 0,
+              "prev_witnesses": [
+                {
+                  "prev_id": {
+                    "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
+                    "asset_id": "0000000000000000000000000000000000000000000000000000000000000000",
+                    "script_key": "000000000000000000000000000000000000000000000000000000000000000000"
+                  },
+                  "tx_witness": null,
+                  "split_commitment": {
+                    "proof": "00014f1288245a16c4e9668c66f0e2cc0c4f7195e4a4dbb34ba0302925c0e33960850000000000000001ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7f",
+                    "root_asset": {
+                      "version": 0,
+                      "genesis_first_prev_out": "64ce6551cb894b4e8e20f31127a39040f4b6f47f6f70ff3be70cb0c09a3e6f24:4047389111",
+                      "genesis_tag": "a0b773963c130ad797ddeafe4e3ad29b5125210f0ef1c314090f07c79a6f571c",
+                      "genesis_meta_hash": "a0b773963c130ad797ddeafe4e3ad29b5125210f0ef1c314090f07c79a6f571c",
+                      "genesis_output_index": 681360684,
+                      "genesis_type": 0,
+                      "amount": 2,
+                      "lock_time": 0,
+                      "relative_lock_time": 0,
+                      "prev_witnesses": [
+                        {
+                          "prev_id": {
+                            "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
+                            "asset_id": "00438d168166b885663d9400a605ea631ef847f6576b37a9719df354b11ff95e",
+                            "script_key": "025f86c895912d8816ea0c2dd9a6b0a27749ba51d2f2cb73ef169106ce5cfc05e3"
+                          },
+                          "tx_witness": [
+                            "2fe224cc01c57289ea75eb3c406619474590b1ddea5217ab23ca005dc16e4bc68136777e55cf7e0bb65ba3474ae9dfc828dc588ee8a62fd898415cbd3677f94f02",
+                            "203f72444470c4dc7860744d55a3a12f1f964061f45246454848e9d48d83140cf1ac",
+                            "c13f72444470c4dc7860744d55a3a12f1f964061f45246454848e9d48d83140cf16c2e4bb01e316abaaee288d69c06cc608cedefd6e1a06813786c4ec51b6e1d38"
+                          ],
+                          "split_commitment": null
+                        }
+                      ],
+                      "split_commitment_root": {
+                        "hash": "8b00bd598a658947f1b7120986bee0be77a82a343e36582189ec092290673676",
+                        "sum": "3"
+                      },
+                      "script_version": 0,
+                      "script_key": "025f86c895912d8816ea0c2dd9a6b0a27749ba51d2f2cb73ef169106ce5cfc05e3",
+                      "group_key": {
+                        "group_key": "03aa1cfc8a3bdab14d0e273c3890c58ebaca32ac0866566234756ed136fe041430"
+                      }
+                    }
+                  }
+                }
+              ],
+              "split_commitment_root": null,
+              "script_version": 0,
+              "script_key": "025f86c895912d8816ea0c2dd9a6b0a27749ba51d2f2cb73ef169106ce5cfc05e3",
+              "group_key": {
+                "group_key": "03aa1cfc8a3bdab14d0e273c3890c58ebaca32ac0866566234756ed136fe041430"
+              }
+            },
+            "output_index": 0
+          }
+        },
+        {
+          "key": {
+            "output_index": 1,
+            "asset_id": "00438d168166b885663d9400a605ea631ef847f6576b37a9719df354b11ff95e",
+            "script_key": "03e11956b952922bf5d540810e88ec962c1108957be1ac018d06404db2b654ed38",
+            "amount": 1
+          },
+          "value": {
+            "asset": {
+              "version": 0,
+              "genesis_first_prev_out": "64ce6551cb894b4e8e20f31127a39040f4b6f47f6f70ff3be70cb0c09a3e6f24:4047389111",
+              "genesis_tag": "a0b773963c130ad797ddeafe4e3ad29b5125210f0ef1c314090f07c79a6f571c",
+              "genesis_meta_hash": "a0b773963c130ad797ddeafe4e3ad29b5125210f0ef1c314090f07c79a6f571c",
+              "genesis_output_index": 681360684,
+              "genesis_type": 0,
+              "amount": 1,
+              "lock_time": 0,
+              "relative_lock_time": 0,
+              "prev_witnesses": [
+                {
+                  "prev_id": {
+                    "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
+                    "asset_id": "0000000000000000000000000000000000000000000000000000000000000000",
+                    "script_key": "000000000000000000000000000000000000000000000000000000000000000000"
+                  },
+                  "tx_witness": null,
+                  "split_commitment": {
+                    "proof": "000171b9bc25aca8a3f460a39b1638eac161fa96ecb2fe66a9be1b24ce13ee4578cc0000000000000002ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7f",
+                    "root_asset": {
+                      "version": 0,
+                      "genesis_first_prev_out": "64ce6551cb894b4e8e20f31127a39040f4b6f47f6f70ff3be70cb0c09a3e6f24:4047389111",
+                      "genesis_tag": "a0b773963c130ad797ddeafe4e3ad29b5125210f0ef1c314090f07c79a6f571c",
+                      "genesis_meta_hash": "a0b773963c130ad797ddeafe4e3ad29b5125210f0ef1c314090f07c79a6f571c",
+                      "genesis_output_index": 681360684,
+                      "genesis_type": 0,
+                      "amount": 2,
+                      "lock_time": 0,
+                      "relative_lock_time": 0,
+                      "prev_witnesses": [
+                        {
+                          "prev_id": {
+                            "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
+                            "asset_id": "00438d168166b885663d9400a605ea631ef847f6576b37a9719df354b11ff95e",
+                            "script_key": "025f86c895912d8816ea0c2dd9a6b0a27749ba51d2f2cb73ef169106ce5cfc05e3"
+                          },
+                          "tx_witness": [
+                            "2fe224cc01c57289ea75eb3c406619474590b1ddea5217ab23ca005dc16e4bc68136777e55cf7e0bb65ba3474ae9dfc828dc588ee8a62fd898415cbd3677f94f02",
+                            "203f72444470c4dc7860744d55a3a12f1f964061f45246454848e9d48d83140cf1ac",
+                            "c13f72444470c4dc7860744d55a3a12f1f964061f45246454848e9d48d83140cf16c2e4bb01e316abaaee288d69c06cc608cedefd6e1a06813786c4ec51b6e1d38"
+                          ],
+                          "split_commitment": null
+                        }
+                      ],
+                      "split_commitment_root": {
+                        "hash": "8b00bd598a658947f1b7120986bee0be77a82a343e36582189ec092290673676",
+                        "sum": "3"
+                      },
+                      "script_version": 0,
+                      "script_key": "025f86c895912d8816ea0c2dd9a6b0a27749ba51d2f2cb73ef169106ce5cfc05e3",
+                      "group_key": {
+                        "group_key": "03aa1cfc8a3bdab14d0e273c3890c58ebaca32ac0866566234756ed136fe041430"
+                      }
+                    }
+                  }
+                }
+              ],
+              "split_commitment_root": null,
+              "script_version": 0,
+              "script_key": "02e11956b952922bf5d540810e88ec962c1108957be1ac018d06404db2b654ed38",
+              "group_key": {
+                "group_key": "03aa1cfc8a3bdab14d0e273c3890c58ebaca32ac0866566234756ed136fe041430"
+              }
+            },
+            "output_index": 1
+          }
+        }
+      ],
+      "input_set": [
+        {
+          "prev_id": {
+            "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
+            "asset_id": "00438d168166b885663d9400a605ea631ef847f6576b37a9719df354b11ff95e",
+            "script_key": "025f86c895912d8816ea0c2dd9a6b0a27749ba51d2f2cb73ef169106ce5cfc05e3"
+          },
+          "asset": {
+            "version": 0,
+            "genesis_first_prev_out": "64ce6551cb894b4e8e20f31127a39040f4b6f47f6f70ff3be70cb0c09a3e6f24:4047389111",
+            "genesis_tag": "a0b773963c130ad797ddeafe4e3ad29b5125210f0ef1c314090f07c79a6f571c",
+            "genesis_meta_hash": "a0b773963c130ad797ddeafe4e3ad29b5125210f0ef1c314090f07c79a6f571c",
+            "genesis_output_index": 681360684,
+            "genesis_type": 0,
+            "amount": 3,
+            "lock_time": 0,
+            "relative_lock_time": 0,
+            "prev_witnesses": [
+              {
+                "prev_id": {
+                  "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
+                  "asset_id": "0000000000000000000000000000000000000000000000000000000000000000",
+                  "script_key": "000000000000000000000000000000000000000000000000000000000000000000"
+                },
+                "tx_witness": [
+                  "13ae02fe8213054e0f3ee3949efd551b2710d0531e3d2d4b4d92bd599b0315579ac591ead548804ff45c0eddc020c39efce9d69492ce41be6156302d48a32d11"
+                ],
+                "split_commitment": null
+              }
+            ],
+            "split_commitment_root": null,
+            "script_version": 0,
+            "script_key": "025f86c895912d8816ea0c2dd9a6b0a27749ba51d2f2cb73ef169106ce5cfc05e3",
+            "group_key": {
+              "group_key": "03aa1cfc8a3bdab14d0e273c3890c58ebaca32ac0866566234756ed136fe041430"
+            }
+          }
+        }
+      ],
+      "comment": "script tree spend state transition valid sig sighash none"
     }
   ],
   "error_test_cases": null

--- a/vm/testdata/vm_validation_generated_error_cases.json
+++ b/vm/testdata/vm_validation_generated_error_cases.json
@@ -3,11 +3,11 @@
   "error_test_cases": [
     {
       "asset": {
-        "version": 1,
-        "genesis_first_prev_out": "ab031f765a41e67230b027b7e0fc24541c3b6bd9c19e7792417fc3a82947a67e:1240912481",
-        "genesis_tag": "82caa9568e5b6fe9d8a9ddd9eb09277b92cef9046efa18500944cbe800a0b152",
-        "genesis_meta_hash": "82caa9568e5b6fe9d8a9ddd9eb09277b92cef9046efa18500944cbe800a0b152",
-        "genesis_output_index": 1154067264,
+        "version": 0,
+        "genesis_first_prev_out": "2e3298237e62a7eb16922dd0f175c897a14c5136fd600756ff806531e0661912:1409503501",
+        "genesis_tag": "e5ee6a0fbb3e9346cef81f0ae9515ef30fa47a364e75aea9e111d596e685a591",
+        "genesis_meta_hash": "e5ee6a0fbb3e9346cef81f0ae9515ef30fa47a364e75aea9e111d596e685a591",
+        "genesis_output_index": 3526088515,
         "genesis_type": 1,
         "amount": 1,
         "lock_time": 0,
@@ -20,16 +20,16 @@
               "script_key": "000000000000000000000000000000000000000000000000000000000000000000"
             },
             "tx_witness": [
-              "b3623de5e4cd170675607dcae34a492b954b760a6704887a97925df7fba3fac7f4d7ce5312fec37714f9ec3dd5e53a43838cfd8c323185961f0f126bf577f0d9"
+              "4f2085d12c5a0422ec95e308670c320b19f150a921c2fe63d8cc1b015fbaf62a9694a490110cb684144b539b6a60cfee2b2cacae989c3b0cc2029afe17eb9b8d"
             ],
             "split_commitment": null
           }
         ],
         "split_commitment_root": null,
         "script_version": 0,
-        "script_key": "023f72ea6b7de11b1f7e4410533fbed6c51f68e0de6dd4a0b29ca1ab188f9d68d8",
+        "script_key": "02cd690a177ecd13e2693f6996517aefd447d0ee92eda31d0481999ddf6cda0d13",
         "group_key": {
-          "group_key": "02a38c0e898a695c68b893f425b73857b936fa6d1e133d8b2ef160f4e3b1c9a62a"
+          "group_key": "036e51c9311a039c139c74292015496c22399bb81318ed9ad902666836579d624e"
         }
       },
       "split_set": [],
@@ -41,11 +41,11 @@
             "script_key": "000000000000000000000000000000000000000000000000000000000000000000"
           },
           "asset": {
-            "version": 1,
-            "genesis_first_prev_out": "ab031f765a41e67230b027b7e0fc24541c3b6bd9c19e7792417fc3a82947a67e:1240912481",
-            "genesis_tag": "82caa9568e5b6fe9d8a9ddd9eb09277b92cef9046efa18500944cbe800a0b152",
-            "genesis_meta_hash": "82caa9568e5b6fe9d8a9ddd9eb09277b92cef9046efa18500944cbe800a0b152",
-            "genesis_output_index": 1154067264,
+            "version": 0,
+            "genesis_first_prev_out": "2e3298237e62a7eb16922dd0f175c897a14c5136fd600756ff806531e0661912:1409503501",
+            "genesis_tag": "e5ee6a0fbb3e9346cef81f0ae9515ef30fa47a364e75aea9e111d596e685a591",
+            "genesis_meta_hash": "e5ee6a0fbb3e9346cef81f0ae9515ef30fa47a364e75aea9e111d596e685a591",
+            "genesis_output_index": 3526088515,
             "genesis_type": 1,
             "amount": 1,
             "lock_time": 0,
@@ -58,16 +58,16 @@
                   "script_key": "000000000000000000000000000000000000000000000000000000000000000000"
                 },
                 "tx_witness": [
-                  "b3623de5e4cd170675607dcae34a492b954b760a6704887a97925df7fba3fac7f4d7ce5312fec37714f9ec3dd5e53a43838cfd8c323185961f0f126bf577f0d9"
+                  "4f2085d12c5a0422ec95e308670c320b19f150a921c2fe63d8cc1b015fbaf62a9694a490110cb684144b539b6a60cfee2b2cacae989c3b0cc2029afe17eb9b8d"
                 ],
                 "split_commitment": null
               }
             ],
             "split_commitment_root": null,
             "script_version": 0,
-            "script_key": "023f72ea6b7de11b1f7e4410533fbed6c51f68e0de6dd4a0b29ca1ab188f9d68d8",
+            "script_key": "02cd690a177ecd13e2693f6996517aefd447d0ee92eda31d0481999ddf6cda0d13",
             "group_key": {
-              "group_key": "02a38c0e898a695c68b893f425b73857b936fa6d1e133d8b2ef160f4e3b1c9a62a"
+              "group_key": "036e51c9311a039c139c74292015496c22399bb81318ed9ad902666836579d624e"
             }
           }
         }
@@ -77,11 +77,11 @@
     },
     {
       "asset": {
-        "version": 1,
-        "genesis_first_prev_out": "0facd9f5511802781b6a22b648e604214064018153da939bb8b580c8ba3ffa8a:665237637",
-        "genesis_tag": "2f0fea1931a290220777a93143dfdcbfa68406e877073ff08834e197a4034aa4",
-        "genesis_meta_hash": "2f0fea1931a290220777a93143dfdcbfa68406e877073ff08834e197a4034aa4",
-        "genesis_output_index": 1921998668,
+        "version": 0,
+        "genesis_first_prev_out": "3a570dd2d99eb979c5dfc122306066091f323f491a95baf7d30e4b858bb9c783:3661987987",
+        "genesis_tag": "fb5766ab431a032b72b9a7e937ed648d0801f29055d3090d2463718254f94424",
+        "genesis_meta_hash": "fb5766ab431a032b72b9a7e937ed648d0801f29055d3090d2463718254f94424",
+        "genesis_output_index": 3362861525,
         "genesis_type": 1,
         "amount": 1,
         "lock_time": 0,
@@ -99,7 +99,7 @@
         ],
         "split_commitment_root": null,
         "script_version": 0,
-        "script_key": "0297198e8cd006ea177c6f4085f6418d63d16fed776a1db4fea72659698f593a00",
+        "script_key": "02f4c8aa78528db8e77557391bc762b9e1408aaeaebc96f5b6bdc1e9378a24b35e",
         "group_key": null
       },
       "split_set": [],
@@ -111,11 +111,11 @@
             "script_key": "000000000000000000000000000000000000000000000000000000000000000000"
           },
           "asset": {
-            "version": 1,
-            "genesis_first_prev_out": "0facd9f5511802781b6a22b648e604214064018153da939bb8b580c8ba3ffa8a:665237637",
-            "genesis_tag": "2f0fea1931a290220777a93143dfdcbfa68406e877073ff08834e197a4034aa4",
-            "genesis_meta_hash": "2f0fea1931a290220777a93143dfdcbfa68406e877073ff08834e197a4034aa4",
-            "genesis_output_index": 1921998668,
+            "version": 0,
+            "genesis_first_prev_out": "3a570dd2d99eb979c5dfc122306066091f323f491a95baf7d30e4b858bb9c783:3661987987",
+            "genesis_tag": "fb5766ab431a032b72b9a7e937ed648d0801f29055d3090d2463718254f94424",
+            "genesis_meta_hash": "fb5766ab431a032b72b9a7e937ed648d0801f29055d3090d2463718254f94424",
+            "genesis_output_index": 3362861525,
             "genesis_type": 1,
             "amount": 1,
             "lock_time": 0,
@@ -133,7 +133,7 @@
             ],
             "split_commitment_root": null,
             "script_version": 0,
-            "script_key": "0297198e8cd006ea177c6f4085f6418d63d16fed776a1db4fea72659698f593a00",
+            "script_key": "02f4c8aa78528db8e77557391bc762b9e1408aaeaebc96f5b6bdc1e9378a24b35e",
             "group_key": null
           }
         }
@@ -143,11 +143,11 @@
     },
     {
       "asset": {
-        "version": 0,
-        "genesis_first_prev_out": "91860a80d0564cf20a65daea4753b428d723bc6fc8214b8a189b251dba77aecd:1577903845",
-        "genesis_tag": "928a0f7de50be1a6dc1d5768e8537988fddce562e9b948c918bba3e933e5c400",
-        "genesis_meta_hash": "928a0f7de50be1a6dc1d5768e8537988fddce562e9b948c918bba3e933e5c400",
-        "genesis_output_index": 3293953285,
+        "version": 1,
+        "genesis_first_prev_out": "da0504620310c35d1007dbc4098a7c7c50358b44e12d3329ab7af6400eb0ae91:3856427473",
+        "genesis_tag": "23e196c9dfff7fbaff4ffe94f4589733e563e19d3045aad3e226488ac02cca42",
+        "genesis_meta_hash": "23e196c9dfff7fbaff4ffe94f4589733e563e19d3045aad3e226488ac02cca42",
+        "genesis_output_index": 164677904,
         "genesis_type": 1,
         "amount": 1,
         "lock_time": 0,
@@ -160,14 +160,14 @@
               "script_key": "000000000000000000000000000000000000000000000000000000000000000000"
             },
             "tx_witness": [
-              "f01f4c59cdfeded75530bf58d6df7dee16f7b6ee7410d639284ea07bc5fd3edd5fb0cae40d19d03763209eb9d61042bb73c2178fa0631e7a467a6df46dd53134"
+              "db883e03a6b99caf3725787fa4fe7332f1b36c0b9790df654be8016e4fc3c703dc61a45afb528363ead8476c6a4a58583b48e280d6202f5085feccec837d6d1e"
             ],
             "split_commitment": null
           }
         ],
         "split_commitment_root": null,
         "script_version": 0,
-        "script_key": "0299caff80c752766f57a3460b863ba93d725d5f660b9925d01be90b66be7af064",
+        "script_key": "0291a6454f77765cc3672452157500b60da542d7696707aa25f31752d80f27bcd7",
         "group_key": null
       },
       "split_set": [],
@@ -177,11 +177,11 @@
     },
     {
       "asset": {
-        "version": 0,
-        "genesis_first_prev_out": "26ee4381075b1ccd2ab86ead7e74d4b80f63d487b8e5d22bd74362a7eb16922d:848831358",
-        "genesis_tag": "e685a591121966e031650d510354aa845580ff560760fd36514ca197c875f1d0",
-        "genesis_meta_hash": "e685a591121966e031650d510354aa845580ff560760fd36514ca197c875f1d0",
-        "genesis_output_index": 2635277229,
+        "version": 1,
+        "genesis_first_prev_out": "147baeebbe0de7c0f8f4f6b9352859b6377494cca9136663df3338160dcc367a:2229795043",
+        "genesis_tag": "2fa319f245a8657ec122eaf4ad5425c249ee160e17b95541c2aee5df820ac85d",
+        "genesis_meta_hash": "2fa319f245a8657ec122eaf4ad5425c249ee160e17b95541c2aee5df820ac85d",
+        "genesis_output_index": 2772042561,
         "genesis_type": 1,
         "amount": 1,
         "lock_time": 0,
@@ -199,9 +199,9 @@
         ],
         "split_commitment_root": null,
         "script_version": 0,
-        "script_key": "02b6d7c5c57cc52f95b8bdf8a828e145765c45cbf52f3a5c6ecec55aaf2a8aa81c",
+        "script_key": "02a18aa081b1afbac4eaaa39d9510fd08dda4452976838d1680cbec694f04b80d9",
         "group_key": {
-          "group_key": "03c90ef7636738c0c0e013915b4f909bbfb969ad091c453cd36d9535c37db5e63d"
+          "group_key": "028964f791a55434f0318efc033e81c2264793145730e46b6961a0d7dd861b151a"
         }
       },
       "split_set": [],
@@ -211,11 +211,11 @@
     },
     {
       "asset": {
-        "version": 1,
-        "genesis_first_prev_out": "734bc3eb01055eb17d0ca62520ac90364f9a87969a2779d81547f02daa2a0313:228840715",
-        "genesis_tag": "ab9d2420134537cd6d02282e0981e140232a4a87383a21d1845c408ad7570438",
-        "genesis_meta_hash": "ab9d2420134537cd6d02282e0981e140232a4a87383a21d1845c408ad7570438",
-        "genesis_output_index": 2459797971,
+        "version": 0,
+        "genesis_first_prev_out": "4f42ed0e1509416a76e25692f934738febb48eaa7db08bda568afd768e687e95:939413394",
+        "genesis_tag": "133eb52094f2dd5c08731f52315d828846e37df68fd10658b480f2ac84233633",
+        "genesis_meta_hash": "133eb52094f2dd5c08731f52315d828846e37df68fd10658b480f2ac84233633",
+        "genesis_output_index": 1127576591,
         "genesis_type": 1,
         "amount": 1,
         "lock_time": 0,
@@ -230,16 +230,16 @@
             "tx_witness": [
               "6e6f742d666f6f626172",
               "76a914f6c97547d73156abb300ae059905c4acaadd09dd88",
-              "c032db0b53c6e0e993ab7d423f04b1074fe6e04e68761dc5dde60d23aaf2c135cccb3078e9ee8912f58408af2c7cdf2131f91db66c9e7f23a97ef5dbbf4bfba964"
+              "c1b911fc3adc62dc8d1d3ee3aee2055fde508955619eea3b11b7176430882c98a6deb40b0181be5ff2c36bd10cf114c89e57427bf99b1c66d6219c3c1a79bf3e84"
             ],
             "split_commitment": null
           }
         ],
         "split_commitment_root": null,
         "script_version": 0,
-        "script_key": "0275bb6e4567091e032229419605d25a1fd18061d49cb61276ac0c8e7e82937024",
+        "script_key": "021e5d208f9595bb2534fd2e6c01de546192239bffd854b6dfa6ab047241d3327f",
         "group_key": {
-          "group_key": "0206b3f2b65bc666534c0771d63774c68f775aa8deecd4303f7be47e1a04863b02"
+          "group_key": "033a1ea868d92ccb807d7d1f57118ee5cc46d45a00ff3dcc70308e6ebc5a54352d"
         }
       },
       "split_set": [],
@@ -250,12 +250,12 @@
     {
       "asset": {
         "version": 0,
-        "genesis_first_prev_out": "d95dc39c34adec84198128e4d4457b9829aa21a708a742cd07200fe80c126949:1082512291",
-        "genesis_tag": "0af9ce8c208bc20ee526741539fa3203c77ecba410fd6718f227e0b430f9bcb0",
-        "genesis_meta_hash": "0af9ce8c208bc20ee526741539fa3203c77ecba410fd6718f227e0b430f9bcb0",
-        "genesis_output_index": 3995861003,
+        "genesis_first_prev_out": "a493708d7543a5e698ba897c46956067382511b464c014486da6db8b1542eaf5:1997138983",
+        "genesis_tag": "41770c01746de44f3db6e3402e7873db7635516e87b33e4b412ba3df68544920",
+        "genesis_meta_hash": "41770c01746de44f3db6e3402e7873db7635516e87b33e4b412ba3df68544920",
+        "genesis_output_index": 1202112265,
         "genesis_type": 0,
-        "amount": 1722300808,
+        "amount": 3377721282,
         "lock_time": 0,
         "relative_lock_time": 0,
         "prev_witnesses": [
@@ -267,17 +267,17 @@
             },
             "tx_witness": [
               "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
-              "20a6b5b7c3381832e2776b1cc7f788744c70795f467bd51edda49087aa0f33e22aac",
-              "c0a6b5b7c3381832e2776b1cc7f788744c70795f467bd51edda49087aa0f33e22a6c2e4bb01e316abaaee288d69c06cc608cedefd6e1a06813786c4ec51b6e1d38"
+              "2096e802fb89f4ca9abd07a677ac5949538f0e50fb8afcaea3a0e611456a6c4d2dac",
+              "c196e802fb89f4ca9abd07a677ac5949538f0e50fb8afcaea3a0e611456a6c4d2d6c2e4bb01e316abaaee288d69c06cc608cedefd6e1a06813786c4ec51b6e1d38"
             ],
             "split_commitment": null
           }
         ],
         "split_commitment_root": null,
         "script_version": 0,
-        "script_key": "02e0e01afa5a409f675f08e7aa73833044c594053a30a08762cf91e4305e11ae3a",
+        "script_key": "0224ee18b631b9de04a82d787624e842271fc415e768788d66793ea47d4e767481",
         "group_key": {
-          "group_key": "021e0fcecf38e736ffada96501778094994a51725ced993d293c96dba1ad6e0048"
+          "group_key": "03d2a7eb2681d1bd3f91606876d81fe5f034d612724e37c1438c1b0b64ac9dedfb"
         }
       },
       "split_set": [],
@@ -288,10 +288,10 @@
     {
       "asset": {
         "version": 0,
-        "genesis_first_prev_out": "00efcc20aeaed4e9a843a70d56c818d73dc58438baf202fd5dff976108fa3463:3046907851",
-        "genesis_tag": "0027368b34f9c69776b4591532da1c5be68ef4eebe8cb8fa7dc5483fb70c2c89",
-        "genesis_meta_hash": "0027368b34f9c69776b4591532da1c5be68ef4eebe8cb8fa7dc5483fb70c2c89",
-        "genesis_output_index": 4074289298,
+        "genesis_first_prev_out": "f3277cba5317843f63f3a3979121a6d9270425c03436a4a948d0f30a66ffd26a:3183688595",
+        "genesis_tag": "1a478d6bd55dd2c04dad86d2053d5d25b014e3d8b64322cdcb5004faa46cfa2d",
+        "genesis_meta_hash": "1a478d6bd55dd2c04dad86d2053d5d25b014e3d8b64322cdcb5004faa46cfa2d",
+        "genesis_output_index": 3703683436,
         "genesis_type": 0,
         "amount": 0,
         "lock_time": 0,
@@ -300,40 +300,40 @@
           {
             "prev_id": {
               "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
-              "asset_id": "65dc05008bbaa854f18d6cea36ddedfb18f143d0fb8b25f74ae31e65a9bcc470",
-              "script_key": "02b789da43491e3d6fabfcbe3db6c49532222d83a3669c1c4d8d06c701ec311ffa"
+              "asset_id": "6d73cedd040693dbf90dc471da34d8945b21d3e072457bd554142022495c2e33",
+              "script_key": "02159e360085cd1ab3fdea55725526b12876d1f15fabd8dcf7560c3419fd7970f2"
             },
             "tx_witness": [
-              "cc74e5d3268739912e18c95f381c5e1212cce15c2d6c138c19148bbdbc4d9b7d4851fc949a00331443d4ec60d87c1178e357e562df52052d2e26fd143f80f395"
+              "65dce054ce71875fc29d69e2689b1f3387e51235a90baa29a840a4269c6b175458365edf78bce46c1905815aab8846c9cb7e2dc2dd59b60245f18bbe069581a6"
             ],
             "split_commitment": null
           }
         ],
         "split_commitment_root": {
-          "hash": "fdcdc935eee44830f9f4d5801f6b8394d51bc303be26a7bef631020b8fe44c6e",
+          "hash": "003615bf4095ecefa14d4184740ee87a6cf2c997afcc4fd29c5c20f7962c7f0c",
           "sum": "1"
         },
         "script_version": 0,
         "script_key": "027c79b9b26e463895eef5679d8558942c86c4ad2233adef01bc3e6d540b3653fe",
         "group_key": {
-          "group_key": "03ff40f114db4581500be6204f6a6d50b6e080c38d200485de200e5f5c909bb27b"
+          "group_key": "0364e94238755a9a6a3a73eff5b56922fc0b2fe267267d407e05cbc45708479088"
         }
       },
       "split_set": [
         {
           "key": {
             "output_index": 0,
-            "asset_id": "65dc05008bbaa854f18d6cea36ddedfb18f143d0fb8b25f74ae31e65a9bcc470",
+            "asset_id": "6d73cedd040693dbf90dc471da34d8945b21d3e072457bd554142022495c2e33",
             "script_key": "027c79b9b26e463895eef5679d8558942c86c4ad2233adef01bc3e6d540b3653fe",
             "amount": 0
           },
           "value": {
             "asset": {
               "version": 0,
-              "genesis_first_prev_out": "00efcc20aeaed4e9a843a70d56c818d73dc58438baf202fd5dff976108fa3463:3046907851",
-              "genesis_tag": "0027368b34f9c69776b4591532da1c5be68ef4eebe8cb8fa7dc5483fb70c2c89",
-              "genesis_meta_hash": "0027368b34f9c69776b4591532da1c5be68ef4eebe8cb8fa7dc5483fb70c2c89",
-              "genesis_output_index": 4074289298,
+              "genesis_first_prev_out": "f3277cba5317843f63f3a3979121a6d9270425c03436a4a948d0f30a66ffd26a:3183688595",
+              "genesis_tag": "1a478d6bd55dd2c04dad86d2053d5d25b014e3d8b64322cdcb5004faa46cfa2d",
+              "genesis_meta_hash": "1a478d6bd55dd2c04dad86d2053d5d25b014e3d8b64322cdcb5004faa46cfa2d",
+              "genesis_output_index": 3703683436,
               "genesis_type": 1,
               "amount": 0,
               "lock_time": 0,
@@ -347,13 +347,13 @@
                   },
                   "tx_witness": null,
                   "split_commitment": {
-                    "proof": "000190b993263d314a2af7f7a0ecaf1ee92edafdce632a623ace1c3508dcaac853ab0000000000000001ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffbf",
+                    "proof": "00016dd4bf667f397e2827690c23675f61c081a909df84188503e774a91e4d2ac27b0000000000000001ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffdf",
                     "root_asset": {
                       "version": 0,
-                      "genesis_first_prev_out": "00efcc20aeaed4e9a843a70d56c818d73dc58438baf202fd5dff976108fa3463:3046907851",
-                      "genesis_tag": "0027368b34f9c69776b4591532da1c5be68ef4eebe8cb8fa7dc5483fb70c2c89",
-                      "genesis_meta_hash": "0027368b34f9c69776b4591532da1c5be68ef4eebe8cb8fa7dc5483fb70c2c89",
-                      "genesis_output_index": 4074289298,
+                      "genesis_first_prev_out": "f3277cba5317843f63f3a3979121a6d9270425c03436a4a948d0f30a66ffd26a:3183688595",
+                      "genesis_tag": "1a478d6bd55dd2c04dad86d2053d5d25b014e3d8b64322cdcb5004faa46cfa2d",
+                      "genesis_meta_hash": "1a478d6bd55dd2c04dad86d2053d5d25b014e3d8b64322cdcb5004faa46cfa2d",
+                      "genesis_output_index": 3703683436,
                       "genesis_type": 1,
                       "amount": 0,
                       "lock_time": 0,
@@ -362,23 +362,23 @@
                         {
                           "prev_id": {
                             "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
-                            "asset_id": "65dc05008bbaa854f18d6cea36ddedfb18f143d0fb8b25f74ae31e65a9bcc470",
-                            "script_key": "02b789da43491e3d6fabfcbe3db6c49532222d83a3669c1c4d8d06c701ec311ffa"
+                            "asset_id": "6d73cedd040693dbf90dc471da34d8945b21d3e072457bd554142022495c2e33",
+                            "script_key": "02159e360085cd1ab3fdea55725526b12876d1f15fabd8dcf7560c3419fd7970f2"
                           },
                           "tx_witness": [
-                            "cc74e5d3268739912e18c95f381c5e1212cce15c2d6c138c19148bbdbc4d9b7d4851fc949a00331443d4ec60d87c1178e357e562df52052d2e26fd143f80f395"
+                            "65dce054ce71875fc29d69e2689b1f3387e51235a90baa29a840a4269c6b175458365edf78bce46c1905815aab8846c9cb7e2dc2dd59b60245f18bbe069581a6"
                           ],
                           "split_commitment": null
                         }
                       ],
                       "split_commitment_root": {
-                        "hash": "fdcdc935eee44830f9f4d5801f6b8394d51bc303be26a7bef631020b8fe44c6e",
+                        "hash": "003615bf4095ecefa14d4184740ee87a6cf2c997afcc4fd29c5c20f7962c7f0c",
                         "sum": "1"
                       },
                       "script_version": 0,
                       "script_key": "027c79b9b26e463895eef5679d8558942c86c4ad2233adef01bc3e6d540b3653fe",
                       "group_key": {
-                        "group_key": "03ff40f114db4581500be6204f6a6d50b6e080c38d200485de200e5f5c909bb27b"
+                        "group_key": "0364e94238755a9a6a3a73eff5b56922fc0b2fe267267d407e05cbc45708479088"
                       }
                     }
                   }
@@ -388,7 +388,7 @@
               "script_version": 0,
               "script_key": "027c79b9b26e463895eef5679d8558942c86c4ad2233adef01bc3e6d540b3653fe",
               "group_key": {
-                "group_key": "03ff40f114db4581500be6204f6a6d50b6e080c38d200485de200e5f5c909bb27b"
+                "group_key": "0364e94238755a9a6a3a73eff5b56922fc0b2fe267267d407e05cbc45708479088"
               }
             },
             "output_index": 0
@@ -397,17 +397,17 @@
         {
           "key": {
             "output_index": 1,
-            "asset_id": "65dc05008bbaa854f18d6cea36ddedfb18f143d0fb8b25f74ae31e65a9bcc470",
-            "script_key": "03a69f64cf78ae6d24425d198efd5287df9ca01184ae8fef0ea9a0aca96ed11b71",
+            "asset_id": "6d73cedd040693dbf90dc471da34d8945b21d3e072457bd554142022495c2e33",
+            "script_key": "03f99ac47475c14a0a488a27ec137755e2388f094bc3c40a39b09b27f8ef13eb19",
             "amount": 1
           },
           "value": {
             "asset": {
               "version": 0,
-              "genesis_first_prev_out": "00efcc20aeaed4e9a843a70d56c818d73dc58438baf202fd5dff976108fa3463:3046907851",
-              "genesis_tag": "0027368b34f9c69776b4591532da1c5be68ef4eebe8cb8fa7dc5483fb70c2c89",
-              "genesis_meta_hash": "0027368b34f9c69776b4591532da1c5be68ef4eebe8cb8fa7dc5483fb70c2c89",
-              "genesis_output_index": 4074289298,
+              "genesis_first_prev_out": "f3277cba5317843f63f3a3979121a6d9270425c03436a4a948d0f30a66ffd26a:3183688595",
+              "genesis_tag": "1a478d6bd55dd2c04dad86d2053d5d25b014e3d8b64322cdcb5004faa46cfa2d",
+              "genesis_meta_hash": "1a478d6bd55dd2c04dad86d2053d5d25b014e3d8b64322cdcb5004faa46cfa2d",
+              "genesis_output_index": 3703683436,
               "genesis_type": 1,
               "amount": 1,
               "lock_time": 0,
@@ -421,13 +421,13 @@
                   },
                   "tx_witness": null,
                   "split_commitment": {
-                    "proof": "0001bff80a3a37c3db0f8b9296ab6e4ff7624b5254089ca5bc64395713f7c0e3eeb50000000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffbf",
+                    "proof": "0001f5a4ee360237ea2753d695c2fa2261ca3b37fa3ef2e10d62a717e6183a7baf660000000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffdf",
                     "root_asset": {
                       "version": 0,
-                      "genesis_first_prev_out": "00efcc20aeaed4e9a843a70d56c818d73dc58438baf202fd5dff976108fa3463:3046907851",
-                      "genesis_tag": "0027368b34f9c69776b4591532da1c5be68ef4eebe8cb8fa7dc5483fb70c2c89",
-                      "genesis_meta_hash": "0027368b34f9c69776b4591532da1c5be68ef4eebe8cb8fa7dc5483fb70c2c89",
-                      "genesis_output_index": 4074289298,
+                      "genesis_first_prev_out": "f3277cba5317843f63f3a3979121a6d9270425c03436a4a948d0f30a66ffd26a:3183688595",
+                      "genesis_tag": "1a478d6bd55dd2c04dad86d2053d5d25b014e3d8b64322cdcb5004faa46cfa2d",
+                      "genesis_meta_hash": "1a478d6bd55dd2c04dad86d2053d5d25b014e3d8b64322cdcb5004faa46cfa2d",
+                      "genesis_output_index": 3703683436,
                       "genesis_type": 1,
                       "amount": 0,
                       "lock_time": 0,
@@ -436,23 +436,23 @@
                         {
                           "prev_id": {
                             "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
-                            "asset_id": "65dc05008bbaa854f18d6cea36ddedfb18f143d0fb8b25f74ae31e65a9bcc470",
-                            "script_key": "02b789da43491e3d6fabfcbe3db6c49532222d83a3669c1c4d8d06c701ec311ffa"
+                            "asset_id": "6d73cedd040693dbf90dc471da34d8945b21d3e072457bd554142022495c2e33",
+                            "script_key": "02159e360085cd1ab3fdea55725526b12876d1f15fabd8dcf7560c3419fd7970f2"
                           },
                           "tx_witness": [
-                            "cc74e5d3268739912e18c95f381c5e1212cce15c2d6c138c19148bbdbc4d9b7d4851fc949a00331443d4ec60d87c1178e357e562df52052d2e26fd143f80f395"
+                            "65dce054ce71875fc29d69e2689b1f3387e51235a90baa29a840a4269c6b175458365edf78bce46c1905815aab8846c9cb7e2dc2dd59b60245f18bbe069581a6"
                           ],
                           "split_commitment": null
                         }
                       ],
                       "split_commitment_root": {
-                        "hash": "fdcdc935eee44830f9f4d5801f6b8394d51bc303be26a7bef631020b8fe44c6e",
+                        "hash": "003615bf4095ecefa14d4184740ee87a6cf2c997afcc4fd29c5c20f7962c7f0c",
                         "sum": "1"
                       },
                       "script_version": 0,
                       "script_key": "027c79b9b26e463895eef5679d8558942c86c4ad2233adef01bc3e6d540b3653fe",
                       "group_key": {
-                        "group_key": "03ff40f114db4581500be6204f6a6d50b6e080c38d200485de200e5f5c909bb27b"
+                        "group_key": "0364e94238755a9a6a3a73eff5b56922fc0b2fe267267d407e05cbc45708479088"
                       }
                     }
                   }
@@ -460,9 +460,9 @@
               ],
               "split_commitment_root": null,
               "script_version": 0,
-              "script_key": "02a69f64cf78ae6d24425d198efd5287df9ca01184ae8fef0ea9a0aca96ed11b71",
+              "script_key": "02f99ac47475c14a0a488a27ec137755e2388f094bc3c40a39b09b27f8ef13eb19",
               "group_key": {
-                "group_key": "03ff40f114db4581500be6204f6a6d50b6e080c38d200485de200e5f5c909bb27b"
+                "group_key": "0364e94238755a9a6a3a73eff5b56922fc0b2fe267267d407e05cbc45708479088"
               }
             },
             "output_index": 1
@@ -473,15 +473,15 @@
         {
           "prev_id": {
             "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
-            "asset_id": "65dc05008bbaa854f18d6cea36ddedfb18f143d0fb8b25f74ae31e65a9bcc470",
-            "script_key": "02b789da43491e3d6fabfcbe3db6c49532222d83a3669c1c4d8d06c701ec311ffa"
+            "asset_id": "6d73cedd040693dbf90dc471da34d8945b21d3e072457bd554142022495c2e33",
+            "script_key": "02159e360085cd1ab3fdea55725526b12876d1f15fabd8dcf7560c3419fd7970f2"
           },
           "asset": {
             "version": 1,
-            "genesis_first_prev_out": "00efcc20aeaed4e9a843a70d56c818d73dc58438baf202fd5dff976108fa3463:3046907851",
-            "genesis_tag": "0027368b34f9c69776b4591532da1c5be68ef4eebe8cb8fa7dc5483fb70c2c89",
-            "genesis_meta_hash": "0027368b34f9c69776b4591532da1c5be68ef4eebe8cb8fa7dc5483fb70c2c89",
-            "genesis_output_index": 4074289298,
+            "genesis_first_prev_out": "f3277cba5317843f63f3a3979121a6d9270425c03436a4a948d0f30a66ffd26a:3183688595",
+            "genesis_tag": "1a478d6bd55dd2c04dad86d2053d5d25b014e3d8b64322cdcb5004faa46cfa2d",
+            "genesis_meta_hash": "1a478d6bd55dd2c04dad86d2053d5d25b014e3d8b64322cdcb5004faa46cfa2d",
+            "genesis_output_index": 3703683436,
             "genesis_type": 1,
             "amount": 1,
             "lock_time": 0,
@@ -494,16 +494,16 @@
                   "script_key": "000000000000000000000000000000000000000000000000000000000000000000"
                 },
                 "tx_witness": [
-                  "8913077c70671b56cd9ff36634dcd7c43e2f9ebecd26d3dd511956269dec654f8566d53c14c853bde83d87493bc92dd9deeca0a104016dc8ab21a64f3bef2a96"
+                  "a6c86ef904af32b91a37812b86f176ba900b84bb50c538cd235f86c9a5e516b5d7f911b9ff9fb6f4b7f23a59e30eb2f7e8f20e315099aebeecbe4cd36d6dafc6"
                 ],
                 "split_commitment": null
               }
             ],
             "split_commitment_root": null,
             "script_version": 0,
-            "script_key": "02b789da43491e3d6fabfcbe3db6c49532222d83a3669c1c4d8d06c701ec311ffa",
+            "script_key": "02159e360085cd1ab3fdea55725526b12876d1f15fabd8dcf7560c3419fd7970f2",
             "group_key": {
-              "group_key": "03ff40f114db4581500be6204f6a6d50b6e080c38d200485de200e5f5c909bb27b"
+              "group_key": "0364e94238755a9a6a3a73eff5b56922fc0b2fe267267d407e05cbc45708479088"
             }
           }
         }
@@ -513,13 +513,13 @@
     },
     {
       "asset": {
-        "version": 0,
-        "genesis_first_prev_out": "9712d515167bb82cda37d1240702aa747622dcc1b96c1a6b7b389f61f363f3a3:1394050111",
-        "genesis_tag": "a46cfa2d6ad2ff933bc3bd9a5a74660af3d048a9a43634c0250427d9a6219197",
-        "genesis_meta_hash": "a46cfa2d6ad2ff933bc3bd9a5a74660af3d048a9a43634c0250427d9a6219197",
-        "genesis_output_index": 1187578493,
+        "version": 1,
+        "genesis_first_prev_out": "a73531b9a0b1a83d5b6b03749c03413b061aff08820530f823fad17f075a807b:3836023333",
+        "genesis_tag": "d1e700164e518b243f424c46f9ea63db1c2c34b512c403c128ee19030a622651",
+        "genesis_meta_hash": "d1e700164e518b243f424c46f9ea63db1c2c34b512c403c128ee19030a622651",
+        "genesis_output_index": 2687317264,
         "genesis_type": 0,
-        "amount": 2336318498,
+        "amount": 825064770,
         "lock_time": 0,
         "relative_lock_time": 0,
         "prev_witnesses": [
@@ -530,16 +530,16 @@
               "script_key": "000000000000000000000000000000000000000000000000000000000000000000"
             },
             "tx_witness": [
-              "85f5c4a413d0123d7b9a6619a5dc96a461759f73a6acd9e985d7b8fcd1bd42fc88bca26b69bbfed123d8b621d85ade0b535ebbecbaeea80bc21381bffcdca0a7"
+              "19343af3bb8259c3cc85dd68941d32d22c353a03cdad324d44f795c94f9beeac6d6f86ccece7b57b34101bf6ef118f279b0a0d1b4d216f73eef6ab7ce62ea12d"
             ],
             "split_commitment": null
           }
         ],
         "split_commitment_root": null,
         "script_version": 0,
-        "script_key": "024b58e965a923ecdfca9320be069843e3f793e34e48666033543fe6f443c949c5",
+        "script_key": "022e34b005c066a8d1087fe5893f380aeb02cd60977d2b22b912fea9447da83c65",
         "group_key": {
-          "group_key": "033f55b8f882f0199ebae6ae7df04f884f5687e0c0f8ce6ace2d4baf06d38f9588"
+          "group_key": "037f6719a20af278c1fe087843b0bc469ed9b0fd41d9746c4f235289435b7c4657"
         }
       },
       "split_set": [
@@ -578,12 +578,12 @@
     {
       "asset": {
         "version": 1,
-        "genesis_first_prev_out": "00730a3ed0ededf211058365f39b8660aa5f2a4d2f8473e7f9503a50da3d9114:2532021855",
-        "genesis_tag": "b9ae180655a0abefbad700c09473469f1eca5a66d53fa3dc7cd3e7c3b0411d7e",
-        "genesis_meta_hash": "b9ae180655a0abefbad700c09473469f1eca5a66d53fa3dc7cd3e7c3b0411d7e",
-        "genesis_output_index": 1583323810,
+        "genesis_first_prev_out": "fcc076a12ad7fc1a7588e4e9d7979b4d2ed2d660b55d00f91cf2eae3eab52e8b:1571731326",
+        "genesis_tag": "fdc11f045c025c8d561adb0e7dfd4748fd4b20f84e53322471a410cdb3fd88e4",
+        "genesis_meta_hash": "fdc11f045c025c8d561adb0e7dfd4748fd4b20f84e53322471a410cdb3fd88e4",
+        "genesis_output_index": 2625458941,
         "genesis_type": 0,
-        "amount": 920604559,
+        "amount": 3012325234,
         "lock_time": 0,
         "relative_lock_time": 0,
         "prev_witnesses": [
@@ -599,7 +599,7 @@
         ],
         "split_commitment_root": null,
         "script_version": 0,
-        "script_key": "023f0ca0f5e26b54092971551865c44a8c40747095c9cfdbae4a1d108404d197b9",
+        "script_key": "027d3d618eedd917ee7ced6c1eb27af034799f1b4c438772084437fec8aeafcff6",
         "group_key": null
       },
       "split_set": [
@@ -638,12 +638,12 @@
     {
       "asset": {
         "version": 1,
-        "genesis_first_prev_out": "478fad38aa7e89b5f21d3ce9aed68ac35f19f0a6791c11b84e7a1def81a59b06:3909833122",
-        "genesis_tag": "4d54db40bcbc6e272ff5eaddfc1471459e59f0554c58251342134a8daaef1498",
-        "genesis_meta_hash": "4d54db40bcbc6e272ff5eaddfc1471459e59f0554c58251342134a8daaef1498",
-        "genesis_output_index": 1051386848,
+        "genesis_first_prev_out": "3a0ef514a306ae66d3a04cef522a5d2d46b03a3cd18919b27de85d4eeb7d6b00:3793681405",
+        "genesis_tag": "48794546a2474f04294d7a616215e5dd6c40a65bb6edb508c3680b14c176c327",
+        "genesis_meta_hash": "48794546a2474f04294d7a616215e5dd6c40a65bb6edb508c3680b14c176c327",
+        "genesis_output_index": 926974335,
         "genesis_type": 0,
-        "amount": 326552050,
+        "amount": 3704995758,
         "lock_time": 0,
         "relative_lock_time": 0,
         "prev_witnesses": [
@@ -654,14 +654,14 @@
               "script_key": "000000000000000000000000000000000000000000000000000000000000000000"
             },
             "tx_witness": [
-              "46390b80fab7a309106be916a4f2698494e166f66b786798e62ba06102efb6dc3ec245539ad18aae9750e424535c9034077e0966896f3026ef61ac7c902b7e4f"
+              "bc5384a5bdd18d75cc1a0eaff6e6cdd7b125be9d8801e6f016b97bf48af130cbf5790a751d1c9559e184a6bccb5d46a6822b8923214fb4776df6f4381a52fa11"
             ],
             "split_commitment": null
           }
         ],
         "split_commitment_root": null,
         "script_version": 0,
-        "script_key": "02b1b3dd6ffc80c1bac8649fe8cb2f09879d198724cd8d9598fd11017c3f918008",
+        "script_key": "02a128234035fb67ea1bd68a5e73b22d64800b38cdbc4c908804eebdd581cbfcb0",
         "group_key": null
       },
       "split_set": [],
@@ -672,12 +672,12 @@
     {
       "asset": {
         "version": 0,
-        "genesis_first_prev_out": "48d41ce747221f59ab8439abb31b6529231f9da00312c3f6a02d35103d5b6b03:3114316200",
-        "genesis_tag": "0a6226517b805a072512a5e4cd274b7fd1fa23f830058208ff1a063b41039c74",
-        "genesis_meta_hash": "0a6226517b805a072512a5e4cd274b7fd1fa23f830058208ff1a063b41039c74",
-        "genesis_output_index": 2711742261,
+        "genesis_first_prev_out": "2d97d042bb7a587d976edf598dd3a5962b00cb9f048fe6b5780b21f7c314b25f:3468101449",
+        "genesis_tag": "1f7966137667bd6661660c43b75b63390b514bbe491aa46b524bde1c5b745625",
+        "genesis_meta_hash": "1f7966137667bd6661660c43b75b63390b514bbe491aa46b524bde1c5b745625",
+        "genesis_output_index": 2341076031,
         "genesis_type": 0,
-        "amount": 3946693335,
+        "amount": 3997308126,
         "lock_time": 0,
         "relative_lock_time": 0,
         "prev_witnesses": [
@@ -693,9 +693,9 @@
         ],
         "split_commitment_root": null,
         "script_version": 0,
-        "script_key": "02fd7072b080d92a06742a4db375d24b1a9a36da1b8c8358722e28286cf770a79d",
+        "script_key": "02a17dda3655e9cd5bbad8b680d4a50c1b26ccb9f83f1ad3c1244d1efe958e3350",
         "group_key": {
-          "group_key": "0348284ecc7dcb11428f4533fad884afc8d58e77eb875842a78eb0d515e9ee031f"
+          "group_key": "03ffd572a2f2b2c4cd9f6300c1f582428aed8130c6778f4f5558a684947018c181"
         }
       },
       "split_set": [],
@@ -706,10 +706,10 @@
     {
       "asset": {
         "version": 0,
-        "genesis_first_prev_out": "d13753d7c2fabdcf501855f938ce59cc41010442e8840f14759e4874f198fa89:486996036",
-        "genesis_tag": "9f3a6988dba204ce1b09214475ae0ea864b8439bc9ea10db4d2b08c7fcf2e8bd",
-        "genesis_meta_hash": "9f3a6988dba204ce1b09214475ae0ea864b8439bc9ea10db4d2b08c7fcf2e8bd",
-        "genesis_output_index": 187958320,
+        "genesis_first_prev_out": "9efaaf78679934c9d1b4f643281835c934de4a54866d4dd4f34aadfa1e45c94e:2745842370",
+        "genesis_tag": "de4d07263dc3d9158ec242008226d1c6aea7f0846e12ce2d316e80da52234326",
+        "genesis_meta_hash": "de4d07263dc3d9158ec242008226d1c6aea7f0846e12ce2d316e80da52234326",
+        "genesis_output_index": 3756483305,
         "genesis_type": 0,
         "amount": 0,
         "lock_time": 0,
@@ -718,40 +718,40 @@
           {
             "prev_id": {
               "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
-              "asset_id": "a75a143757f3bf700683230f00baf67ff8ef221656db10907f4d42a842825fb2",
-              "script_key": "02a48c43845f8e31242280549622f7ab1a934d029250ef5287c86aaa1b1b487e5a"
+              "asset_id": "f08fd2e310db69092c2b553b63bab6a6d7199841bf1e3796a579e797f5e57c2e",
+              "script_key": "029bcaef545e88e622c44f26f18f3f4953f2203e62096acc9d44b608f060c01ed4"
             },
             "tx_witness": [
-              "f87e384a1fa86265276bcdc61edc3a36c7a64e28a3cf79c5ccd68b51b25131879df5a52ad9c3928a9b34b585f81128c45dc568459b00b1226b52f81b9e3bb839"
+              "5d74ddb6ece036fa995b24138e1d182394d99991012ccaca3cc55c04aa0d77158d25dfa04459937b98b7d0ed2419bf9807720770a854f7b44d83d35286b7b8f4"
             ],
             "split_commitment": null
           }
         ],
         "split_commitment_root": {
-          "hash": "b67dccb1f622775af3bccfc477bb4cbb5f45e104694b05f0a0e473a8abd81511",
+          "hash": "6c0c3a424ef3c43e8e8ebd0dea831b9b55f6a8a5c63afd7bbeeafb094bcb6ced",
           "sum": "3"
         },
         "script_version": 0,
-        "script_key": "02a48c43845f8e31242280549622f7ab1a934d029250ef5287c86aaa1b1b487e5a",
+        "script_key": "029bcaef545e88e622c44f26f18f3f4953f2203e62096acc9d44b608f060c01ed4",
         "group_key": {
-          "group_key": "0336cc68a7a9c68ddd00b75c10349606283a3ee49bd00f4ae832f4864ad0b75f13"
+          "group_key": "02368f0deab65c01494ec50151dd37ee21b490436bd432a8298224ae8b1d419a7e"
         }
       },
       "split_set": [
         {
           "key": {
             "output_index": 0,
-            "asset_id": "a75a143757f3bf700683230f00baf67ff8ef221656db10907f4d42a842825fb2",
+            "asset_id": "f08fd2e310db69092c2b553b63bab6a6d7199841bf1e3796a579e797f5e57c2e",
             "script_key": "027c79b9b26e463895eef5679d8558942c86c4ad2233adef01bc3e6d540b3653fe",
             "amount": 0
           },
           "value": {
             "asset": {
               "version": 0,
-              "genesis_first_prev_out": "d13753d7c2fabdcf501855f938ce59cc41010442e8840f14759e4874f198fa89:486996036",
-              "genesis_tag": "9f3a6988dba204ce1b09214475ae0ea864b8439bc9ea10db4d2b08c7fcf2e8bd",
-              "genesis_meta_hash": "9f3a6988dba204ce1b09214475ae0ea864b8439bc9ea10db4d2b08c7fcf2e8bd",
-              "genesis_output_index": 187958320,
+              "genesis_first_prev_out": "9efaaf78679934c9d1b4f643281835c934de4a54866d4dd4f34aadfa1e45c94e:2745842370",
+              "genesis_tag": "de4d07263dc3d9158ec242008226d1c6aea7f0846e12ce2d316e80da52234326",
+              "genesis_meta_hash": "de4d07263dc3d9158ec242008226d1c6aea7f0846e12ce2d316e80da52234326",
+              "genesis_output_index": 3756483305,
               "genesis_type": 0,
               "amount": 0,
               "lock_time": 0,
@@ -765,13 +765,13 @@
                   },
                   "tx_witness": null,
                   "split_commitment": {
-                    "proof": "00015ad9ab1a82ab7c3ed42857ff4c006bba447909d4b2385b1c47a446d16ec9448a0000000000000003ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7f",
+                    "proof": "000166315aca3b32f20f67f229a07cc94cba3195cd1fcd27f05f1b7c97caf75c43da0000000000000003ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7f",
                     "root_asset": {
                       "version": 0,
-                      "genesis_first_prev_out": "d13753d7c2fabdcf501855f938ce59cc41010442e8840f14759e4874f198fa89:486996036",
-                      "genesis_tag": "9f3a6988dba204ce1b09214475ae0ea864b8439bc9ea10db4d2b08c7fcf2e8bd",
-                      "genesis_meta_hash": "9f3a6988dba204ce1b09214475ae0ea864b8439bc9ea10db4d2b08c7fcf2e8bd",
-                      "genesis_output_index": 187958320,
+                      "genesis_first_prev_out": "9efaaf78679934c9d1b4f643281835c934de4a54866d4dd4f34aadfa1e45c94e:2745842370",
+                      "genesis_tag": "de4d07263dc3d9158ec242008226d1c6aea7f0846e12ce2d316e80da52234326",
+                      "genesis_meta_hash": "de4d07263dc3d9158ec242008226d1c6aea7f0846e12ce2d316e80da52234326",
+                      "genesis_output_index": 3756483305,
                       "genesis_type": 0,
                       "amount": 0,
                       "lock_time": 0,
@@ -780,23 +780,23 @@
                         {
                           "prev_id": {
                             "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
-                            "asset_id": "a75a143757f3bf700683230f00baf67ff8ef221656db10907f4d42a842825fb2",
-                            "script_key": "02a48c43845f8e31242280549622f7ab1a934d029250ef5287c86aaa1b1b487e5a"
+                            "asset_id": "f08fd2e310db69092c2b553b63bab6a6d7199841bf1e3796a579e797f5e57c2e",
+                            "script_key": "029bcaef545e88e622c44f26f18f3f4953f2203e62096acc9d44b608f060c01ed4"
                           },
                           "tx_witness": [
-                            "f87e384a1fa86265276bcdc61edc3a36c7a64e28a3cf79c5ccd68b51b25131879df5a52ad9c3928a9b34b585f81128c45dc568459b00b1226b52f81b9e3bb839"
+                            "5d74ddb6ece036fa995b24138e1d182394d99991012ccaca3cc55c04aa0d77158d25dfa04459937b98b7d0ed2419bf9807720770a854f7b44d83d35286b7b8f4"
                           ],
                           "split_commitment": null
                         }
                       ],
                       "split_commitment_root": {
-                        "hash": "b67dccb1f622775af3bccfc477bb4cbb5f45e104694b05f0a0e473a8abd81511",
+                        "hash": "6c0c3a424ef3c43e8e8ebd0dea831b9b55f6a8a5c63afd7bbeeafb094bcb6ced",
                         "sum": "3"
                       },
                       "script_version": 0,
                       "script_key": "027c79b9b26e463895eef5679d8558942c86c4ad2233adef01bc3e6d540b3653fe",
                       "group_key": {
-                        "group_key": "0336cc68a7a9c68ddd00b75c10349606283a3ee49bd00f4ae832f4864ad0b75f13"
+                        "group_key": "02368f0deab65c01494ec50151dd37ee21b490436bd432a8298224ae8b1d419a7e"
                       }
                     }
                   }
@@ -806,7 +806,7 @@
               "script_version": 0,
               "script_key": "027c79b9b26e463895eef5679d8558942c86c4ad2233adef01bc3e6d540b3653fe",
               "group_key": {
-                "group_key": "0336cc68a7a9c68ddd00b75c10349606283a3ee49bd00f4ae832f4864ad0b75f13"
+                "group_key": "02368f0deab65c01494ec50151dd37ee21b490436bd432a8298224ae8b1d419a7e"
               }
             },
             "output_index": 0
@@ -815,17 +815,17 @@
         {
           "key": {
             "output_index": 1,
-            "asset_id": "a75a143757f3bf700683230f00baf67ff8ef221656db10907f4d42a842825fb2",
-            "script_key": "031840b583689a8f9760d67acf43439dfb6114059f49bc01aa5deb96c7df6f8ce6",
+            "asset_id": "f08fd2e310db69092c2b553b63bab6a6d7199841bf1e3796a579e797f5e57c2e",
+            "script_key": "038701ecc37a65472f3dbb4d11f3df9f09c5006a7f158e261b64e9b3743a6cbae4",
             "amount": 3
           },
           "value": {
             "asset": {
               "version": 0,
-              "genesis_first_prev_out": "d13753d7c2fabdcf501855f938ce59cc41010442e8840f14759e4874f198fa89:486996036",
-              "genesis_tag": "9f3a6988dba204ce1b09214475ae0ea864b8439bc9ea10db4d2b08c7fcf2e8bd",
-              "genesis_meta_hash": "9f3a6988dba204ce1b09214475ae0ea864b8439bc9ea10db4d2b08c7fcf2e8bd",
-              "genesis_output_index": 187958320,
+              "genesis_first_prev_out": "9efaaf78679934c9d1b4f643281835c934de4a54866d4dd4f34aadfa1e45c94e:2745842370",
+              "genesis_tag": "de4d07263dc3d9158ec242008226d1c6aea7f0846e12ce2d316e80da52234326",
+              "genesis_meta_hash": "de4d07263dc3d9158ec242008226d1c6aea7f0846e12ce2d316e80da52234326",
+              "genesis_output_index": 3756483305,
               "genesis_type": 0,
               "amount": 3,
               "lock_time": 0,
@@ -839,13 +839,13 @@
                   },
                   "tx_witness": null,
                   "split_commitment": {
-                    "proof": "000135ec88b1b7e5b48e8ac3d9c37b1c8dc4b100b3c1c1bfdc5f4b32b867c7cefa280000000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7f",
+                    "proof": "000174717874fe878ae135eeb4b79668fd4a830e016512ecd010c102445d129bdeff0000000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7f",
                     "root_asset": {
                       "version": 0,
-                      "genesis_first_prev_out": "d13753d7c2fabdcf501855f938ce59cc41010442e8840f14759e4874f198fa89:486996036",
-                      "genesis_tag": "9f3a6988dba204ce1b09214475ae0ea864b8439bc9ea10db4d2b08c7fcf2e8bd",
-                      "genesis_meta_hash": "9f3a6988dba204ce1b09214475ae0ea864b8439bc9ea10db4d2b08c7fcf2e8bd",
-                      "genesis_output_index": 187958320,
+                      "genesis_first_prev_out": "9efaaf78679934c9d1b4f643281835c934de4a54866d4dd4f34aadfa1e45c94e:2745842370",
+                      "genesis_tag": "de4d07263dc3d9158ec242008226d1c6aea7f0846e12ce2d316e80da52234326",
+                      "genesis_meta_hash": "de4d07263dc3d9158ec242008226d1c6aea7f0846e12ce2d316e80da52234326",
+                      "genesis_output_index": 3756483305,
                       "genesis_type": 0,
                       "amount": 0,
                       "lock_time": 0,
@@ -854,23 +854,23 @@
                         {
                           "prev_id": {
                             "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
-                            "asset_id": "a75a143757f3bf700683230f00baf67ff8ef221656db10907f4d42a842825fb2",
-                            "script_key": "02a48c43845f8e31242280549622f7ab1a934d029250ef5287c86aaa1b1b487e5a"
+                            "asset_id": "f08fd2e310db69092c2b553b63bab6a6d7199841bf1e3796a579e797f5e57c2e",
+                            "script_key": "029bcaef545e88e622c44f26f18f3f4953f2203e62096acc9d44b608f060c01ed4"
                           },
                           "tx_witness": [
-                            "f87e384a1fa86265276bcdc61edc3a36c7a64e28a3cf79c5ccd68b51b25131879df5a52ad9c3928a9b34b585f81128c45dc568459b00b1226b52f81b9e3bb839"
+                            "5d74ddb6ece036fa995b24138e1d182394d99991012ccaca3cc55c04aa0d77158d25dfa04459937b98b7d0ed2419bf9807720770a854f7b44d83d35286b7b8f4"
                           ],
                           "split_commitment": null
                         }
                       ],
                       "split_commitment_root": {
-                        "hash": "b67dccb1f622775af3bccfc477bb4cbb5f45e104694b05f0a0e473a8abd81511",
+                        "hash": "6c0c3a424ef3c43e8e8ebd0dea831b9b55f6a8a5c63afd7bbeeafb094bcb6ced",
                         "sum": "3"
                       },
                       "script_version": 0,
                       "script_key": "027c79b9b26e463895eef5679d8558942c86c4ad2233adef01bc3e6d540b3653fe",
                       "group_key": {
-                        "group_key": "0336cc68a7a9c68ddd00b75c10349606283a3ee49bd00f4ae832f4864ad0b75f13"
+                        "group_key": "02368f0deab65c01494ec50151dd37ee21b490436bd432a8298224ae8b1d419a7e"
                       }
                     }
                   }
@@ -878,9 +878,9 @@
               ],
               "split_commitment_root": null,
               "script_version": 0,
-              "script_key": "021840b583689a8f9760d67acf43439dfb6114059f49bc01aa5deb96c7df6f8ce6",
+              "script_key": "028701ecc37a65472f3dbb4d11f3df9f09c5006a7f158e261b64e9b3743a6cbae4",
               "group_key": {
-                "group_key": "0336cc68a7a9c68ddd00b75c10349606283a3ee49bd00f4ae832f4864ad0b75f13"
+                "group_key": "02368f0deab65c01494ec50151dd37ee21b490436bd432a8298224ae8b1d419a7e"
               }
             },
             "output_index": 1
@@ -891,15 +891,15 @@
         {
           "prev_id": {
             "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
-            "asset_id": "a75a143757f3bf700683230f00baf67ff8ef221656db10907f4d42a842825fb2",
-            "script_key": "02a48c43845f8e31242280549622f7ab1a934d029250ef5287c86aaa1b1b487e5a"
+            "asset_id": "f08fd2e310db69092c2b553b63bab6a6d7199841bf1e3796a579e797f5e57c2e",
+            "script_key": "029bcaef545e88e622c44f26f18f3f4953f2203e62096acc9d44b608f060c01ed4"
           },
           "asset": {
-            "version": 0,
-            "genesis_first_prev_out": "d13753d7c2fabdcf501855f938ce59cc41010442e8840f14759e4874f198fa89:486996036",
-            "genesis_tag": "9f3a6988dba204ce1b09214475ae0ea864b8439bc9ea10db4d2b08c7fcf2e8bd",
-            "genesis_meta_hash": "9f3a6988dba204ce1b09214475ae0ea864b8439bc9ea10db4d2b08c7fcf2e8bd",
-            "genesis_output_index": 187958320,
+            "version": 1,
+            "genesis_first_prev_out": "9efaaf78679934c9d1b4f643281835c934de4a54866d4dd4f34aadfa1e45c94e:2745842370",
+            "genesis_tag": "de4d07263dc3d9158ec242008226d1c6aea7f0846e12ce2d316e80da52234326",
+            "genesis_meta_hash": "de4d07263dc3d9158ec242008226d1c6aea7f0846e12ce2d316e80da52234326",
+            "genesis_output_index": 3756483305,
             "genesis_type": 0,
             "amount": 3,
             "lock_time": 0,
@@ -912,16 +912,16 @@
                   "script_key": "000000000000000000000000000000000000000000000000000000000000000000"
                 },
                 "tx_witness": [
-                  "50a9621fdfc773c1269b08df9549873d6d97eb35ae03365117c4cb3c45db75e60ef47299e6a27c12dd3bb1c5bdc0f8e8b24ad1422b1e25c5d3b1ccd0d11028af"
+                  "36dd2fb8218ec741f1e2c6554632846a3b048b9e79cd1a3a7d50e54552790d6d1d218bbb772e0cf7e61430fd1f8e3fb46a97952b94ba03fe5ff0cee81bb50011"
                 ],
                 "split_commitment": null
               }
             ],
             "split_commitment_root": null,
             "script_version": 0,
-            "script_key": "02a48c43845f8e31242280549622f7ab1a934d029250ef5287c86aaa1b1b487e5a",
+            "script_key": "029bcaef545e88e622c44f26f18f3f4953f2203e62096acc9d44b608f060c01ed4",
             "group_key": {
-              "group_key": "0336cc68a7a9c68ddd00b75c10349606283a3ee49bd00f4ae832f4864ad0b75f13"
+              "group_key": "02368f0deab65c01494ec50151dd37ee21b490436bd432a8298224ae8b1d419a7e"
             }
           }
         }
@@ -932,10 +932,10 @@
     {
       "asset": {
         "version": 0,
-        "genesis_first_prev_out": "64c8e465076185c22f20dca2f10984a308b9b036beb6dfce30dfaa5400c6b353:3740505622",
-        "genesis_tag": "4c4c29910f8feb7557bfffcfe7428b4703144bd6d7fe5b3f5de748918553df54",
-        "genesis_meta_hash": "4c4c29910f8feb7557bfffcfe7428b4703144bd6d7fe5b3f5de748918553df54",
-        "genesis_output_index": 4096485652,
+        "genesis_first_prev_out": "2a4b735937f40d3b628bd494710cb199c0d99e9f0dc0dc5791df9bc89a84c511:768933090",
+        "genesis_tag": "7d83a18eb3b8a1612aad5d3ea7e8e35f325c9168ac490f22cb713ddb61fbd960",
+        "genesis_meta_hash": "7d83a18eb3b8a1612aad5d3ea7e8e35f325c9168ac490f22cb713ddb61fbd960",
+        "genesis_output_index": 3879045727,
         "genesis_type": 0,
         "amount": 0,
         "lock_time": 0,
@@ -944,40 +944,40 @@
           {
             "prev_id": {
               "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
-              "asset_id": "c87bcb90aae3205ca0e0fd20cb3f3d0450025222da658fe113efff8b9906a8b9",
-              "script_key": "022d4601708757cbd031f01cfb1b60b0f7ad69af74008a114b8eb7b85c6c635519"
+              "asset_id": "c9f6aaa07782bf78109ed338790a1c0d33c795cb02d2b33ba9cedca009da20af",
+              "script_key": "02ba55174cc22bf6519f812b78377d80fc1d76a7757602283fcc70b7c7073db9fa"
             },
             "tx_witness": [
-              "8868771c0d429167353b6f011dbc77e99ff3fe4784587d6858094e4298f01da94c036126a25d69b823ac6703cd1b379c0be199aa03a959cd1b22825375a93cb7"
+              "baf7fed39a26feacc0affd44431af18395f922fd9813342085491e868e6cd385a95a0ea15399d3f79c581c5aa842624b5e374941764cbbb0de56dc1098c75f97"
             ],
             "split_commitment": null
           }
         ],
         "split_commitment_root": {
-          "hash": "0118471d2b2da22a10aa791fc62b49544a58780c3b32fab39a6101c95628675d",
+          "hash": "21f4be2312df0912e9b9cd70e246397d0ca398d3e9770483686819b6bb180285",
           "sum": "3"
         },
         "script_version": 0,
         "script_key": "027c79b9b26e463895eef5679d8558942c86c4ad2233adef01bc3e6d540b3653fe",
         "group_key": {
-          "group_key": "02d56d44bc06f13a242233f961d5ff13fc288e7a8ba47413ddfbe35e98ca2247fe"
+          "group_key": "03cd09e95438dea827303eff471bafb819561b627f313104145aaf3a2f9849e813"
         }
       },
       "split_set": [
         {
           "key": {
             "output_index": 0,
-            "asset_id": "c87bcb90aae3205ca0e0fd20cb3f3d0450025222da658fe113efff8b9906a8b9",
+            "asset_id": "c9f6aaa07782bf78109ed338790a1c0d33c795cb02d2b33ba9cedca009da20af",
             "script_key": "027c79b9b26e463895eef5679d8558942c86c4ad2233adef01bc3e6d540b3653fe",
             "amount": 0
           },
           "value": {
             "asset": {
               "version": 0,
-              "genesis_first_prev_out": "64c8e465076185c22f20dca2f10984a308b9b036beb6dfce30dfaa5400c6b353:3740505622",
-              "genesis_tag": "4c4c29910f8feb7557bfffcfe7428b4703144bd6d7fe5b3f5de748918553df54",
-              "genesis_meta_hash": "4c4c29910f8feb7557bfffcfe7428b4703144bd6d7fe5b3f5de748918553df54",
-              "genesis_output_index": 4096485652,
+              "genesis_first_prev_out": "2a4b735937f40d3b628bd494710cb199c0d99e9f0dc0dc5791df9bc89a84c511:768933090",
+              "genesis_tag": "7d83a18eb3b8a1612aad5d3ea7e8e35f325c9168ac490f22cb713ddb61fbd960",
+              "genesis_meta_hash": "7d83a18eb3b8a1612aad5d3ea7e8e35f325c9168ac490f22cb713ddb61fbd960",
+              "genesis_output_index": 3879045727,
               "genesis_type": 0,
               "amount": 0,
               "lock_time": 0,
@@ -991,13 +991,13 @@
                   },
                   "tx_witness": null,
                   "split_commitment": {
-                    "proof": "00019c46d307730f49d6c01ec9c64d4d01ea1756ae85198f881d7b4f99e738962e040000000000000003ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffdf",
+                    "proof": "0001131e7db1c8d6d3905cde7010bb6e4c2c2a946356e9a44a01e86d131b2ae7751b0000000000000003ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffbf",
                     "root_asset": {
                       "version": 0,
-                      "genesis_first_prev_out": "64c8e465076185c22f20dca2f10984a308b9b036beb6dfce30dfaa5400c6b353:3740505622",
-                      "genesis_tag": "4c4c29910f8feb7557bfffcfe7428b4703144bd6d7fe5b3f5de748918553df54",
-                      "genesis_meta_hash": "4c4c29910f8feb7557bfffcfe7428b4703144bd6d7fe5b3f5de748918553df54",
-                      "genesis_output_index": 4096485652,
+                      "genesis_first_prev_out": "2a4b735937f40d3b628bd494710cb199c0d99e9f0dc0dc5791df9bc89a84c511:768933090",
+                      "genesis_tag": "7d83a18eb3b8a1612aad5d3ea7e8e35f325c9168ac490f22cb713ddb61fbd960",
+                      "genesis_meta_hash": "7d83a18eb3b8a1612aad5d3ea7e8e35f325c9168ac490f22cb713ddb61fbd960",
+                      "genesis_output_index": 3879045727,
                       "genesis_type": 0,
                       "amount": 0,
                       "lock_time": 0,
@@ -1006,23 +1006,23 @@
                         {
                           "prev_id": {
                             "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
-                            "asset_id": "c87bcb90aae3205ca0e0fd20cb3f3d0450025222da658fe113efff8b9906a8b9",
-                            "script_key": "022d4601708757cbd031f01cfb1b60b0f7ad69af74008a114b8eb7b85c6c635519"
+                            "asset_id": "c9f6aaa07782bf78109ed338790a1c0d33c795cb02d2b33ba9cedca009da20af",
+                            "script_key": "02ba55174cc22bf6519f812b78377d80fc1d76a7757602283fcc70b7c7073db9fa"
                           },
                           "tx_witness": [
-                            "8868771c0d429167353b6f011dbc77e99ff3fe4784587d6858094e4298f01da94c036126a25d69b823ac6703cd1b379c0be199aa03a959cd1b22825375a93cb7"
+                            "baf7fed39a26feacc0affd44431af18395f922fd9813342085491e868e6cd385a95a0ea15399d3f79c581c5aa842624b5e374941764cbbb0de56dc1098c75f97"
                           ],
                           "split_commitment": null
                         }
                       ],
                       "split_commitment_root": {
-                        "hash": "0118471d2b2da22a10aa791fc62b49544a58780c3b32fab39a6101c95628675d",
+                        "hash": "21f4be2312df0912e9b9cd70e246397d0ca398d3e9770483686819b6bb180285",
                         "sum": "3"
                       },
                       "script_version": 0,
                       "script_key": "027c79b9b26e463895eef5679d8558942c86c4ad2233adef01bc3e6d540b3653fe",
                       "group_key": {
-                        "group_key": "02d56d44bc06f13a242233f961d5ff13fc288e7a8ba47413ddfbe35e98ca2247fe"
+                        "group_key": "03cd09e95438dea827303eff471bafb819561b627f313104145aaf3a2f9849e813"
                       }
                     }
                   }
@@ -1030,9 +1030,9 @@
               ],
               "split_commitment_root": null,
               "script_version": 0,
-              "script_key": "022d4601708757cbd031f01cfb1b60b0f7ad69af74008a114b8eb7b85c6c635519",
+              "script_key": "02ba55174cc22bf6519f812b78377d80fc1d76a7757602283fcc70b7c7073db9fa",
               "group_key": {
-                "group_key": "02d56d44bc06f13a242233f961d5ff13fc288e7a8ba47413ddfbe35e98ca2247fe"
+                "group_key": "03cd09e95438dea827303eff471bafb819561b627f313104145aaf3a2f9849e813"
               }
             },
             "output_index": 0
@@ -1041,17 +1041,17 @@
         {
           "key": {
             "output_index": 1,
-            "asset_id": "c87bcb90aae3205ca0e0fd20cb3f3d0450025222da658fe113efff8b9906a8b9",
-            "script_key": "03d604259f07a97b1af5331f385ad03b00b941a30820c1a3e971d18b0235a28d38",
+            "asset_id": "c9f6aaa07782bf78109ed338790a1c0d33c795cb02d2b33ba9cedca009da20af",
+            "script_key": "025e24a0e42abce128d2706689d292176001c0a97d07a31ba6110b2ddd0c5fd132",
             "amount": 3
           },
           "value": {
             "asset": {
               "version": 0,
-              "genesis_first_prev_out": "64c8e465076185c22f20dca2f10984a308b9b036beb6dfce30dfaa5400c6b353:3740505622",
-              "genesis_tag": "4c4c29910f8feb7557bfffcfe7428b4703144bd6d7fe5b3f5de748918553df54",
-              "genesis_meta_hash": "4c4c29910f8feb7557bfffcfe7428b4703144bd6d7fe5b3f5de748918553df54",
-              "genesis_output_index": 4096485652,
+              "genesis_first_prev_out": "2a4b735937f40d3b628bd494710cb199c0d99e9f0dc0dc5791df9bc89a84c511:768933090",
+              "genesis_tag": "7d83a18eb3b8a1612aad5d3ea7e8e35f325c9168ac490f22cb713ddb61fbd960",
+              "genesis_meta_hash": "7d83a18eb3b8a1612aad5d3ea7e8e35f325c9168ac490f22cb713ddb61fbd960",
+              "genesis_output_index": 3879045727,
               "genesis_type": 0,
               "amount": 3,
               "lock_time": 0,
@@ -1065,13 +1065,13 @@
                   },
                   "tx_witness": null,
                   "split_commitment": {
-                    "proof": "0001540962c7bad73841db79dac8b2e6f63f0c7ec58a5bc63b90dd11c29af2cbbce50000000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffdf",
+                    "proof": "0001caf37247eca3d31958e7cece1cc341202ac100316be5e49f2b8399e11460e5f60000000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffbf",
                     "root_asset": {
                       "version": 0,
-                      "genesis_first_prev_out": "64c8e465076185c22f20dca2f10984a308b9b036beb6dfce30dfaa5400c6b353:3740505622",
-                      "genesis_tag": "4c4c29910f8feb7557bfffcfe7428b4703144bd6d7fe5b3f5de748918553df54",
-                      "genesis_meta_hash": "4c4c29910f8feb7557bfffcfe7428b4703144bd6d7fe5b3f5de748918553df54",
-                      "genesis_output_index": 4096485652,
+                      "genesis_first_prev_out": "2a4b735937f40d3b628bd494710cb199c0d99e9f0dc0dc5791df9bc89a84c511:768933090",
+                      "genesis_tag": "7d83a18eb3b8a1612aad5d3ea7e8e35f325c9168ac490f22cb713ddb61fbd960",
+                      "genesis_meta_hash": "7d83a18eb3b8a1612aad5d3ea7e8e35f325c9168ac490f22cb713ddb61fbd960",
+                      "genesis_output_index": 3879045727,
                       "genesis_type": 0,
                       "amount": 0,
                       "lock_time": 0,
@@ -1080,23 +1080,23 @@
                         {
                           "prev_id": {
                             "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
-                            "asset_id": "c87bcb90aae3205ca0e0fd20cb3f3d0450025222da658fe113efff8b9906a8b9",
-                            "script_key": "022d4601708757cbd031f01cfb1b60b0f7ad69af74008a114b8eb7b85c6c635519"
+                            "asset_id": "c9f6aaa07782bf78109ed338790a1c0d33c795cb02d2b33ba9cedca009da20af",
+                            "script_key": "02ba55174cc22bf6519f812b78377d80fc1d76a7757602283fcc70b7c7073db9fa"
                           },
                           "tx_witness": [
-                            "8868771c0d429167353b6f011dbc77e99ff3fe4784587d6858094e4298f01da94c036126a25d69b823ac6703cd1b379c0be199aa03a959cd1b22825375a93cb7"
+                            "baf7fed39a26feacc0affd44431af18395f922fd9813342085491e868e6cd385a95a0ea15399d3f79c581c5aa842624b5e374941764cbbb0de56dc1098c75f97"
                           ],
                           "split_commitment": null
                         }
                       ],
                       "split_commitment_root": {
-                        "hash": "0118471d2b2da22a10aa791fc62b49544a58780c3b32fab39a6101c95628675d",
+                        "hash": "21f4be2312df0912e9b9cd70e246397d0ca398d3e9770483686819b6bb180285",
                         "sum": "3"
                       },
                       "script_version": 0,
                       "script_key": "027c79b9b26e463895eef5679d8558942c86c4ad2233adef01bc3e6d540b3653fe",
                       "group_key": {
-                        "group_key": "02d56d44bc06f13a242233f961d5ff13fc288e7a8ba47413ddfbe35e98ca2247fe"
+                        "group_key": "03cd09e95438dea827303eff471bafb819561b627f313104145aaf3a2f9849e813"
                       }
                     }
                   }
@@ -1104,9 +1104,9 @@
               ],
               "split_commitment_root": null,
               "script_version": 0,
-              "script_key": "02d604259f07a97b1af5331f385ad03b00b941a30820c1a3e971d18b0235a28d38",
+              "script_key": "025e24a0e42abce128d2706689d292176001c0a97d07a31ba6110b2ddd0c5fd132",
               "group_key": {
-                "group_key": "02d56d44bc06f13a242233f961d5ff13fc288e7a8ba47413ddfbe35e98ca2247fe"
+                "group_key": "03cd09e95438dea827303eff471bafb819561b627f313104145aaf3a2f9849e813"
               }
             },
             "output_index": 1
@@ -1117,15 +1117,15 @@
         {
           "prev_id": {
             "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
-            "asset_id": "c87bcb90aae3205ca0e0fd20cb3f3d0450025222da658fe113efff8b9906a8b9",
-            "script_key": "022d4601708757cbd031f01cfb1b60b0f7ad69af74008a114b8eb7b85c6c635519"
+            "asset_id": "c9f6aaa07782bf78109ed338790a1c0d33c795cb02d2b33ba9cedca009da20af",
+            "script_key": "02ba55174cc22bf6519f812b78377d80fc1d76a7757602283fcc70b7c7073db9fa"
           },
           "asset": {
             "version": 0,
-            "genesis_first_prev_out": "64c8e465076185c22f20dca2f10984a308b9b036beb6dfce30dfaa5400c6b353:3740505622",
-            "genesis_tag": "4c4c29910f8feb7557bfffcfe7428b4703144bd6d7fe5b3f5de748918553df54",
-            "genesis_meta_hash": "4c4c29910f8feb7557bfffcfe7428b4703144bd6d7fe5b3f5de748918553df54",
-            "genesis_output_index": 4096485652,
+            "genesis_first_prev_out": "2a4b735937f40d3b628bd494710cb199c0d99e9f0dc0dc5791df9bc89a84c511:768933090",
+            "genesis_tag": "7d83a18eb3b8a1612aad5d3ea7e8e35f325c9168ac490f22cb713ddb61fbd960",
+            "genesis_meta_hash": "7d83a18eb3b8a1612aad5d3ea7e8e35f325c9168ac490f22cb713ddb61fbd960",
+            "genesis_output_index": 3879045727,
             "genesis_type": 0,
             "amount": 3,
             "lock_time": 0,
@@ -1138,16 +1138,16 @@
                   "script_key": "000000000000000000000000000000000000000000000000000000000000000000"
                 },
                 "tx_witness": [
-                  "e985c6f7e546bc0158122753e19e7fc3846c23cb22d7c2e117338661c9722e6965c1949aa6db5a0654acf4153551610d1618cee283ae4404da0c1098904ed16e"
+                  "584dc3bb442dfcb560593ea0ca04fbc0836a16cb7c53b15edf1c53fe072ca8225cc02e7ba07cbc6189f53cb2bb419e2ab2808547ee565683de11decf8729d3f6"
                 ],
                 "split_commitment": null
               }
             ],
             "split_commitment_root": null,
             "script_version": 0,
-            "script_key": "022d4601708757cbd031f01cfb1b60b0f7ad69af74008a114b8eb7b85c6c635519",
+            "script_key": "02ba55174cc22bf6519f812b78377d80fc1d76a7757602283fcc70b7c7073db9fa",
             "group_key": {
-              "group_key": "02d56d44bc06f13a242233f961d5ff13fc288e7a8ba47413ddfbe35e98ca2247fe"
+              "group_key": "03cd09e95438dea827303eff471bafb819561b627f313104145aaf3a2f9849e813"
             }
           }
         }
@@ -1466,10 +1466,10 @@
     {
       "asset": {
         "version": 0,
-        "genesis_first_prev_out": "2301767cb5cf04f59bb789c820f5c353cf52ca320796a7106796b83f19047619:584406196",
-        "genesis_tag": "8d8724b0cf3fae17a3f79be1072fb63c35d6042c4160f38ee9e2a9f3fb4ffb00",
-        "genesis_meta_hash": "8d8724b0cf3fae17a3f79be1072fb63c35d6042c4160f38ee9e2a9f3fb4ffb00",
-        "genesis_output_index": 3805718990,
+        "genesis_first_prev_out": "dda9d8e96f5b8e56a9ca82a42dd96e5aefbff5b2d5a1134b5ac059483870e475:2181640856",
+        "genesis_tag": "6fb77970466a5626fe33408cf9e88e2c797408a32d29416baf206a329cfffd4a",
+        "genesis_meta_hash": "6fb77970466a5626fe33408cf9e88e2c797408a32d29416baf206a329cfffd4a",
+        "genesis_output_index": 83480210,
         "genesis_type": 0,
         "amount": 1,
         "lock_time": 0,
@@ -1478,42 +1478,42 @@
           {
             "prev_id": {
               "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
-              "asset_id": "bfd35eeb607775ed158942bd03ed2a8411ab2b2b1f7d8b17fc58cd74bab7dec6",
-              "script_key": "02483021d30533dc23daaa5da3273a7c59d3fbbfcb689ad11b674bb76653723ff0"
+              "asset_id": "8f2a967db5f72072c371eb33eb2a2903481a88cd215af353a3341a9d29ea1ae0",
+              "script_key": "02d3f0558daa6e7ce8bbca992d1f454efeb78749f5f7be1df685bba36c4410bf35"
             },
             "tx_witness": [
               "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
-              "2016d30bad506c4b871aba4c1306473b287c084a13661eb09ef3d47b99a19d4524ac",
-              "c116d30bad506c4b871aba4c1306473b287c084a13661eb09ef3d47b99a19d45246c2e4bb01e316abaaee288d69c06cc608cedefd6e1a06813786c4ec51b6e1d38"
+              "208e1400d70ad3c68f853eb5f83a3a91b3115009d964a1277c6f9aec2e2f4a54c5ac",
+              "c08e1400d70ad3c68f853eb5f83a3a91b3115009d964a1277c6f9aec2e2f4a54c56c2e4bb01e316abaaee288d69c06cc608cedefd6e1a06813786c4ec51b6e1d38"
             ],
             "split_commitment": null
           }
         ],
         "split_commitment_root": {
-          "hash": "5783bfda6743c69ce6c2393e4e1f711696f10ba01577d3f909a596e8cb25f463",
+          "hash": "be69c2252a779194feda0db3eef1997d9c2e20a811cdf425c8b236376440c78e",
           "sum": "3"
         },
         "script_version": 0,
-        "script_key": "02483021d30533dc23daaa5da3273a7c59d3fbbfcb689ad11b674bb76653723ff0",
+        "script_key": "02d3f0558daa6e7ce8bbca992d1f454efeb78749f5f7be1df685bba36c4410bf35",
         "group_key": {
-          "group_key": "0369fef33531afc3772097ce7d5eae7d48a7db05ff5ccca8adc492c9f00a9a18f5"
+          "group_key": "02dd0416f0678b31576c90b7e3625d8abcbd55e2fcefec6c02025eb527d989524b"
         }
       },
       "split_set": [
         {
           "key": {
             "output_index": 0,
-            "asset_id": "bfd35eeb607775ed158942bd03ed2a8411ab2b2b1f7d8b17fc58cd74bab7dec6",
-            "script_key": "02483021d30533dc23daaa5da3273a7c59d3fbbfcb689ad11b674bb76653723ff0",
+            "asset_id": "8f2a967db5f72072c371eb33eb2a2903481a88cd215af353a3341a9d29ea1ae0",
+            "script_key": "02d3f0558daa6e7ce8bbca992d1f454efeb78749f5f7be1df685bba36c4410bf35",
             "amount": 1
           },
           "value": {
             "asset": {
               "version": 0,
-              "genesis_first_prev_out": "2301767cb5cf04f59bb789c820f5c353cf52ca320796a7106796b83f19047619:584406196",
-              "genesis_tag": "8d8724b0cf3fae17a3f79be1072fb63c35d6042c4160f38ee9e2a9f3fb4ffb00",
-              "genesis_meta_hash": "8d8724b0cf3fae17a3f79be1072fb63c35d6042c4160f38ee9e2a9f3fb4ffb00",
-              "genesis_output_index": 3805718990,
+              "genesis_first_prev_out": "dda9d8e96f5b8e56a9ca82a42dd96e5aefbff5b2d5a1134b5ac059483870e475:2181640856",
+              "genesis_tag": "6fb77970466a5626fe33408cf9e88e2c797408a32d29416baf206a329cfffd4a",
+              "genesis_meta_hash": "6fb77970466a5626fe33408cf9e88e2c797408a32d29416baf206a329cfffd4a",
+              "genesis_output_index": 83480210,
               "genesis_type": 0,
               "amount": 1,
               "lock_time": 0,
@@ -1527,13 +1527,13 @@
                   },
                   "tx_witness": null,
                   "split_commitment": {
-                    "proof": "00027ea4013e578c05a837e1d94531b44c0d0ef58721a4073c2056fb7fd78e32f19a00000000000000019e9ee9e01a56fd6bdfac20cbccfd18b58a319c2157f92b9511a3aef51219b2ee0000000000000001ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff3f",
+                    "proof": "0002a7f90996f8bb52a54dce36de86761e4556d8d08c963cec31bcfa62756db9b09800000000000000011d2de1fd638cf661081fe281bfc5f84ee6a46c00949dcc4b61f4c1e9b77c5c060000000000000001ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff3f",
                     "root_asset": {
                       "version": 0,
-                      "genesis_first_prev_out": "2301767cb5cf04f59bb789c820f5c353cf52ca320796a7106796b83f19047619:584406196",
-                      "genesis_tag": "8d8724b0cf3fae17a3f79be1072fb63c35d6042c4160f38ee9e2a9f3fb4ffb00",
-                      "genesis_meta_hash": "8d8724b0cf3fae17a3f79be1072fb63c35d6042c4160f38ee9e2a9f3fb4ffb00",
-                      "genesis_output_index": 3805718990,
+                      "genesis_first_prev_out": "dda9d8e96f5b8e56a9ca82a42dd96e5aefbff5b2d5a1134b5ac059483870e475:2181640856",
+                      "genesis_tag": "6fb77970466a5626fe33408cf9e88e2c797408a32d29416baf206a329cfffd4a",
+                      "genesis_meta_hash": "6fb77970466a5626fe33408cf9e88e2c797408a32d29416baf206a329cfffd4a",
+                      "genesis_output_index": 83480210,
                       "genesis_type": 0,
                       "amount": 1,
                       "lock_time": 0,
@@ -1542,25 +1542,25 @@
                         {
                           "prev_id": {
                             "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
-                            "asset_id": "bfd35eeb607775ed158942bd03ed2a8411ab2b2b1f7d8b17fc58cd74bab7dec6",
-                            "script_key": "02483021d30533dc23daaa5da3273a7c59d3fbbfcb689ad11b674bb76653723ff0"
+                            "asset_id": "8f2a967db5f72072c371eb33eb2a2903481a88cd215af353a3341a9d29ea1ae0",
+                            "script_key": "02d3f0558daa6e7ce8bbca992d1f454efeb78749f5f7be1df685bba36c4410bf35"
                           },
                           "tx_witness": [
                             "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
-                            "2016d30bad506c4b871aba4c1306473b287c084a13661eb09ef3d47b99a19d4524ac",
-                            "c116d30bad506c4b871aba4c1306473b287c084a13661eb09ef3d47b99a19d45246c2e4bb01e316abaaee288d69c06cc608cedefd6e1a06813786c4ec51b6e1d38"
+                            "208e1400d70ad3c68f853eb5f83a3a91b3115009d964a1277c6f9aec2e2f4a54c5ac",
+                            "c08e1400d70ad3c68f853eb5f83a3a91b3115009d964a1277c6f9aec2e2f4a54c56c2e4bb01e316abaaee288d69c06cc608cedefd6e1a06813786c4ec51b6e1d38"
                           ],
                           "split_commitment": null
                         }
                       ],
                       "split_commitment_root": {
-                        "hash": "5783bfda6743c69ce6c2393e4e1f711696f10ba01577d3f909a596e8cb25f463",
+                        "hash": "be69c2252a779194feda0db3eef1997d9c2e20a811cdf425c8b236376440c78e",
                         "sum": "3"
                       },
                       "script_version": 0,
-                      "script_key": "02483021d30533dc23daaa5da3273a7c59d3fbbfcb689ad11b674bb76653723ff0",
+                      "script_key": "02d3f0558daa6e7ce8bbca992d1f454efeb78749f5f7be1df685bba36c4410bf35",
                       "group_key": {
-                        "group_key": "0369fef33531afc3772097ce7d5eae7d48a7db05ff5ccca8adc492c9f00a9a18f5"
+                        "group_key": "02dd0416f0678b31576c90b7e3625d8abcbd55e2fcefec6c02025eb527d989524b"
                       }
                     }
                   }
@@ -1568,9 +1568,9 @@
               ],
               "split_commitment_root": null,
               "script_version": 0,
-              "script_key": "02483021d30533dc23daaa5da3273a7c59d3fbbfcb689ad11b674bb76653723ff0",
+              "script_key": "02d3f0558daa6e7ce8bbca992d1f454efeb78749f5f7be1df685bba36c4410bf35",
               "group_key": {
-                "group_key": "0369fef33531afc3772097ce7d5eae7d48a7db05ff5ccca8adc492c9f00a9a18f5"
+                "group_key": "02dd0416f0678b31576c90b7e3625d8abcbd55e2fcefec6c02025eb527d989524b"
               }
             },
             "output_index": 0
@@ -1579,17 +1579,17 @@
         {
           "key": {
             "output_index": 1,
-            "asset_id": "bfd35eeb607775ed158942bd03ed2a8411ab2b2b1f7d8b17fc58cd74bab7dec6",
-            "script_key": "034175f1f609feba5dbeb3c37ad30bcec6686450cfc0d1ec51a2d99671f718195c",
+            "asset_id": "8f2a967db5f72072c371eb33eb2a2903481a88cd215af353a3341a9d29ea1ae0",
+            "script_key": "034189106139c4de320215d2068616749064cc1774eaeacd1e8b5aed1790d834e5",
             "amount": 1
           },
           "value": {
             "asset": {
               "version": 0,
-              "genesis_first_prev_out": "2301767cb5cf04f59bb789c820f5c353cf52ca320796a7106796b83f19047619:584406196",
-              "genesis_tag": "8d8724b0cf3fae17a3f79be1072fb63c35d6042c4160f38ee9e2a9f3fb4ffb00",
-              "genesis_meta_hash": "8d8724b0cf3fae17a3f79be1072fb63c35d6042c4160f38ee9e2a9f3fb4ffb00",
-              "genesis_output_index": 3805718990,
+              "genesis_first_prev_out": "dda9d8e96f5b8e56a9ca82a42dd96e5aefbff5b2d5a1134b5ac059483870e475:2181640856",
+              "genesis_tag": "6fb77970466a5626fe33408cf9e88e2c797408a32d29416baf206a329cfffd4a",
+              "genesis_meta_hash": "6fb77970466a5626fe33408cf9e88e2c797408a32d29416baf206a329cfffd4a",
+              "genesis_output_index": 83480210,
               "genesis_type": 0,
               "amount": 1,
               "lock_time": 0,
@@ -1603,13 +1603,13 @@
                   },
                   "tx_witness": null,
                   "split_commitment": {
-                    "proof": "0002b1e430398e6f7879ddf8be82e454bb5fdf48f73d9ef3ce16ae37665be8e41deb00000000000000019e9ee9e01a56fd6bdfac20cbccfd18b58a319c2157f92b9511a3aef51219b2ee0000000000000001ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff3f",
+                    "proof": "00015cb0a4cbfd5b4cd05885b2aa3c98f417af87beef358fac770099e094bf321e690000000000000002ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7f",
                     "root_asset": {
                       "version": 0,
-                      "genesis_first_prev_out": "2301767cb5cf04f59bb789c820f5c353cf52ca320796a7106796b83f19047619:584406196",
-                      "genesis_tag": "8d8724b0cf3fae17a3f79be1072fb63c35d6042c4160f38ee9e2a9f3fb4ffb00",
-                      "genesis_meta_hash": "8d8724b0cf3fae17a3f79be1072fb63c35d6042c4160f38ee9e2a9f3fb4ffb00",
-                      "genesis_output_index": 3805718990,
+                      "genesis_first_prev_out": "dda9d8e96f5b8e56a9ca82a42dd96e5aefbff5b2d5a1134b5ac059483870e475:2181640856",
+                      "genesis_tag": "6fb77970466a5626fe33408cf9e88e2c797408a32d29416baf206a329cfffd4a",
+                      "genesis_meta_hash": "6fb77970466a5626fe33408cf9e88e2c797408a32d29416baf206a329cfffd4a",
+                      "genesis_output_index": 83480210,
                       "genesis_type": 0,
                       "amount": 1,
                       "lock_time": 0,
@@ -1618,25 +1618,25 @@
                         {
                           "prev_id": {
                             "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
-                            "asset_id": "bfd35eeb607775ed158942bd03ed2a8411ab2b2b1f7d8b17fc58cd74bab7dec6",
-                            "script_key": "02483021d30533dc23daaa5da3273a7c59d3fbbfcb689ad11b674bb76653723ff0"
+                            "asset_id": "8f2a967db5f72072c371eb33eb2a2903481a88cd215af353a3341a9d29ea1ae0",
+                            "script_key": "02d3f0558daa6e7ce8bbca992d1f454efeb78749f5f7be1df685bba36c4410bf35"
                           },
                           "tx_witness": [
                             "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
-                            "2016d30bad506c4b871aba4c1306473b287c084a13661eb09ef3d47b99a19d4524ac",
-                            "c116d30bad506c4b871aba4c1306473b287c084a13661eb09ef3d47b99a19d45246c2e4bb01e316abaaee288d69c06cc608cedefd6e1a06813786c4ec51b6e1d38"
+                            "208e1400d70ad3c68f853eb5f83a3a91b3115009d964a1277c6f9aec2e2f4a54c5ac",
+                            "c08e1400d70ad3c68f853eb5f83a3a91b3115009d964a1277c6f9aec2e2f4a54c56c2e4bb01e316abaaee288d69c06cc608cedefd6e1a06813786c4ec51b6e1d38"
                           ],
                           "split_commitment": null
                         }
                       ],
                       "split_commitment_root": {
-                        "hash": "5783bfda6743c69ce6c2393e4e1f711696f10ba01577d3f909a596e8cb25f463",
+                        "hash": "be69c2252a779194feda0db3eef1997d9c2e20a811cdf425c8b236376440c78e",
                         "sum": "3"
                       },
                       "script_version": 0,
-                      "script_key": "02483021d30533dc23daaa5da3273a7c59d3fbbfcb689ad11b674bb76653723ff0",
+                      "script_key": "02d3f0558daa6e7ce8bbca992d1f454efeb78749f5f7be1df685bba36c4410bf35",
                       "group_key": {
-                        "group_key": "0369fef33531afc3772097ce7d5eae7d48a7db05ff5ccca8adc492c9f00a9a18f5"
+                        "group_key": "02dd0416f0678b31576c90b7e3625d8abcbd55e2fcefec6c02025eb527d989524b"
                       }
                     }
                   }
@@ -1644,9 +1644,9 @@
               ],
               "split_commitment_root": null,
               "script_version": 0,
-              "script_key": "024175f1f609feba5dbeb3c37ad30bcec6686450cfc0d1ec51a2d99671f718195c",
+              "script_key": "024189106139c4de320215d2068616749064cc1774eaeacd1e8b5aed1790d834e5",
               "group_key": {
-                "group_key": "0369fef33531afc3772097ce7d5eae7d48a7db05ff5ccca8adc492c9f00a9a18f5"
+                "group_key": "02dd0416f0678b31576c90b7e3625d8abcbd55e2fcefec6c02025eb527d989524b"
               }
             },
             "output_index": 1
@@ -1655,17 +1655,17 @@
         {
           "key": {
             "output_index": 2,
-            "asset_id": "bfd35eeb607775ed158942bd03ed2a8411ab2b2b1f7d8b17fc58cd74bab7dec6",
-            "script_key": "0300bef0bafe1c3bb66324cdb47b3f3f81f9a194858db90d75f6c8b06bfe4b5330",
+            "asset_id": "8f2a967db5f72072c371eb33eb2a2903481a88cd215af353a3341a9d29ea1ae0",
+            "script_key": "03fd8fc358d739cdaeae92f022e40669a4b80604d29d585cd881b2d675f46940a5",
             "amount": 1
           },
           "value": {
             "asset": {
               "version": 0,
-              "genesis_first_prev_out": "2301767cb5cf04f59bb789c820f5c353cf52ca320796a7106796b83f19047619:584406196",
-              "genesis_tag": "8d8724b0cf3fae17a3f79be1072fb63c35d6042c4160f38ee9e2a9f3fb4ffb00",
-              "genesis_meta_hash": "8d8724b0cf3fae17a3f79be1072fb63c35d6042c4160f38ee9e2a9f3fb4ffb00",
-              "genesis_output_index": 3805718990,
+              "genesis_first_prev_out": "dda9d8e96f5b8e56a9ca82a42dd96e5aefbff5b2d5a1134b5ac059483870e475:2181640856",
+              "genesis_tag": "6fb77970466a5626fe33408cf9e88e2c797408a32d29416baf206a329cfffd4a",
+              "genesis_meta_hash": "6fb77970466a5626fe33408cf9e88e2c797408a32d29416baf206a329cfffd4a",
+              "genesis_output_index": 83480210,
               "genesis_type": 0,
               "amount": 1,
               "lock_time": 0,
@@ -1679,13 +1679,13 @@
                   },
                   "tx_witness": null,
                   "split_commitment": {
-                    "proof": "00010a8b1e8c767739811ff1d180eba32e94551f0fda7638d748d0a5e70fd2d35f8a0000000000000002ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7f",
+                    "proof": "0002e5a538506e896429b7d0fa369b15f7a95555ea3df869247471d5eb013a0fdf6000000000000000011d2de1fd638cf661081fe281bfc5f84ee6a46c00949dcc4b61f4c1e9b77c5c060000000000000001ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff3f",
                     "root_asset": {
                       "version": 0,
-                      "genesis_first_prev_out": "2301767cb5cf04f59bb789c820f5c353cf52ca320796a7106796b83f19047619:584406196",
-                      "genesis_tag": "8d8724b0cf3fae17a3f79be1072fb63c35d6042c4160f38ee9e2a9f3fb4ffb00",
-                      "genesis_meta_hash": "8d8724b0cf3fae17a3f79be1072fb63c35d6042c4160f38ee9e2a9f3fb4ffb00",
-                      "genesis_output_index": 3805718990,
+                      "genesis_first_prev_out": "dda9d8e96f5b8e56a9ca82a42dd96e5aefbff5b2d5a1134b5ac059483870e475:2181640856",
+                      "genesis_tag": "6fb77970466a5626fe33408cf9e88e2c797408a32d29416baf206a329cfffd4a",
+                      "genesis_meta_hash": "6fb77970466a5626fe33408cf9e88e2c797408a32d29416baf206a329cfffd4a",
+                      "genesis_output_index": 83480210,
                       "genesis_type": 0,
                       "amount": 1,
                       "lock_time": 0,
@@ -1694,25 +1694,25 @@
                         {
                           "prev_id": {
                             "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
-                            "asset_id": "bfd35eeb607775ed158942bd03ed2a8411ab2b2b1f7d8b17fc58cd74bab7dec6",
-                            "script_key": "02483021d30533dc23daaa5da3273a7c59d3fbbfcb689ad11b674bb76653723ff0"
+                            "asset_id": "8f2a967db5f72072c371eb33eb2a2903481a88cd215af353a3341a9d29ea1ae0",
+                            "script_key": "02d3f0558daa6e7ce8bbca992d1f454efeb78749f5f7be1df685bba36c4410bf35"
                           },
                           "tx_witness": [
                             "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
-                            "2016d30bad506c4b871aba4c1306473b287c084a13661eb09ef3d47b99a19d4524ac",
-                            "c116d30bad506c4b871aba4c1306473b287c084a13661eb09ef3d47b99a19d45246c2e4bb01e316abaaee288d69c06cc608cedefd6e1a06813786c4ec51b6e1d38"
+                            "208e1400d70ad3c68f853eb5f83a3a91b3115009d964a1277c6f9aec2e2f4a54c5ac",
+                            "c08e1400d70ad3c68f853eb5f83a3a91b3115009d964a1277c6f9aec2e2f4a54c56c2e4bb01e316abaaee288d69c06cc608cedefd6e1a06813786c4ec51b6e1d38"
                           ],
                           "split_commitment": null
                         }
                       ],
                       "split_commitment_root": {
-                        "hash": "5783bfda6743c69ce6c2393e4e1f711696f10ba01577d3f909a596e8cb25f463",
+                        "hash": "be69c2252a779194feda0db3eef1997d9c2e20a811cdf425c8b236376440c78e",
                         "sum": "3"
                       },
                       "script_version": 0,
-                      "script_key": "02483021d30533dc23daaa5da3273a7c59d3fbbfcb689ad11b674bb76653723ff0",
+                      "script_key": "02d3f0558daa6e7ce8bbca992d1f454efeb78749f5f7be1df685bba36c4410bf35",
                       "group_key": {
-                        "group_key": "0369fef33531afc3772097ce7d5eae7d48a7db05ff5ccca8adc492c9f00a9a18f5"
+                        "group_key": "02dd0416f0678b31576c90b7e3625d8abcbd55e2fcefec6c02025eb527d989524b"
                       }
                     }
                   }
@@ -1720,9 +1720,9 @@
               ],
               "split_commitment_root": null,
               "script_version": 0,
-              "script_key": "0200bef0bafe1c3bb66324cdb47b3f3f81f9a194858db90d75f6c8b06bfe4b5330",
+              "script_key": "02fd8fc358d739cdaeae92f022e40669a4b80604d29d585cd881b2d675f46940a5",
               "group_key": {
-                "group_key": "0369fef33531afc3772097ce7d5eae7d48a7db05ff5ccca8adc492c9f00a9a18f5"
+                "group_key": "02dd0416f0678b31576c90b7e3625d8abcbd55e2fcefec6c02025eb527d989524b"
               }
             },
             "output_index": 2
@@ -1733,15 +1733,15 @@
         {
           "prev_id": {
             "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
-            "asset_id": "bfd35eeb607775ed158942bd03ed2a8411ab2b2b1f7d8b17fc58cd74bab7dec6",
-            "script_key": "02483021d30533dc23daaa5da3273a7c59d3fbbfcb689ad11b674bb76653723ff0"
+            "asset_id": "8f2a967db5f72072c371eb33eb2a2903481a88cd215af353a3341a9d29ea1ae0",
+            "script_key": "02d3f0558daa6e7ce8bbca992d1f454efeb78749f5f7be1df685bba36c4410bf35"
           },
           "asset": {
             "version": 0,
-            "genesis_first_prev_out": "2301767cb5cf04f59bb789c820f5c353cf52ca320796a7106796b83f19047619:584406196",
-            "genesis_tag": "8d8724b0cf3fae17a3f79be1072fb63c35d6042c4160f38ee9e2a9f3fb4ffb00",
-            "genesis_meta_hash": "8d8724b0cf3fae17a3f79be1072fb63c35d6042c4160f38ee9e2a9f3fb4ffb00",
-            "genesis_output_index": 3805718990,
+            "genesis_first_prev_out": "dda9d8e96f5b8e56a9ca82a42dd96e5aefbff5b2d5a1134b5ac059483870e475:2181640856",
+            "genesis_tag": "6fb77970466a5626fe33408cf9e88e2c797408a32d29416baf206a329cfffd4a",
+            "genesis_meta_hash": "6fb77970466a5626fe33408cf9e88e2c797408a32d29416baf206a329cfffd4a",
+            "genesis_output_index": 83480210,
             "genesis_type": 0,
             "amount": 3,
             "lock_time": 0,
@@ -1754,16 +1754,16 @@
                   "script_key": "000000000000000000000000000000000000000000000000000000000000000000"
                 },
                 "tx_witness": [
-                  "84d9d75a73949800b80fd2a1c4313c27d7c4f9d8f9b5a00a7f32a4b217615a76edf6101980d2c6d423a3db16fcb0f9c3e7d8243d24680ee9992a44f386015add"
+                  "0eaf5a53f341f2adb60b563682ffe1f4efc4216f7b21d6b7557b67c92abd58b582c496539cda487b1a58e0f90d802eeb3a3dee8163c606c9b4118699525d322b"
                 ],
                 "split_commitment": null
               }
             ],
             "split_commitment_root": null,
             "script_version": 0,
-            "script_key": "02483021d30533dc23daaa5da3273a7c59d3fbbfcb689ad11b674bb76653723ff0",
+            "script_key": "02d3f0558daa6e7ce8bbca992d1f454efeb78749f5f7be1df685bba36c4410bf35",
             "group_key": {
-              "group_key": "0369fef33531afc3772097ce7d5eae7d48a7db05ff5ccca8adc492c9f00a9a18f5"
+              "group_key": "02dd0416f0678b31576c90b7e3625d8abcbd55e2fcefec6c02025eb527d989524b"
             }
           }
         }


### PR DESCRIPTION
# Description 
This PR replaces https://github.com/lightninglabs/taproot-assets/pull/759 , as it introduces simple sighash functionality (`SIGHASH_ALL` and `SIGHASH_NONE`) for vPSBTs without changing the way we create the virtual transactions that are being signed. This allows us to be backwards compatible and does not require a new script version. 