### PR TITLE
itest: use configurable timeout for load test

### DIFF
--- a/itest/assertions.go
+++ b/itest/assertions.go
@@ -688,8 +688,19 @@ func AssertAddrEvent(t *testing.T, client taprpc.TaprootAssetsClient,
 	addr *taprpc.Addr, numEvents int,
 	expectedStatus taprpc.AddrEventStatus) {
 
+	AssertAddrEventCustomTimeout(
+		t, client, addr, numEvents, expectedStatus, defaultWaitTimeout,
+	)
+}
+
+// AssertAddrEventCustomTimeout makes sure the given address was detected by
+// the given daemon within the given timeout.
+func AssertAddrEventCustomTimeout(t *testing.T,
+	client taprpc.TaprootAssetsClient, addr *taprpc.Addr, numEvents int,
+	expectedStatus taprpc.AddrEventStatus, timeout time.Duration) {
+
 	ctxb := context.Background()
-	ctxt, cancel := context.WithTimeout(ctxb, defaultWaitTimeout)
+	ctxt, cancel := context.WithTimeout(ctxb, timeout)
 	defer cancel()
 
 	err := wait.NoError(func() error {
@@ -717,7 +728,7 @@ func AssertAddrEvent(t *testing.T, client taprpc.TaprootAssetsClient,
 		t.Logf("Got address event %s", eventJSON)
 
 		return nil
-	}, defaultWaitTimeout)
+	}, timeout)
 	require.NoError(t, err)
 }
 


### PR DESCRIPTION
As investigated by @calvinrzachman, here's a small fix to make the load test more reliable.

Because things can take a bit longer the more addresses and events there are, the initial proof retrieval attempt of the universe proof courier can fail, causing it to go into a 30 second backoff. Because we used a hard coded timeout of 30 seconds for the transfer to complete, this sometimes failed the load test.
By making sure we use the same, configurable, timeout where relevant, we make the send process more reliable.

In addition, the following lines should be added to the load test nodes to shorten the duration of the backoff:

```
universerpccourier.initialbackoff=2s
universerpccourier.maxbackoff=30s
```