### PR TITLE
make: Enhance/fix go version linting

### DIFF
--- a/tools/check-go-version-dockerfile.sh
+++ b/tools/check-go-version-dockerfile.sh
@@ -17,6 +17,9 @@ check_go_version() {
     fi
 }
 
+# Export function to be accessible by subshells e.g. `find -exec`
+export -f check_go_version
+
 # Check if the target Go version argument is provided
 if [ $# -eq 0 ]; then
     echo "Usage: $0 <target_go_version>"
@@ -25,12 +28,11 @@ fi
 
 target_go_version="$1"
 
-# Search for Dockerfiles in the current directory and its subdirectories
-dockerfiles=$(find . -type f -name "*.Dockerfile" -o -name "Dockerfile")
-
-# Check each Dockerfile
-for file in $dockerfiles; do
-    check_go_version "$file" "$target_go_version"
-done
+# Run check_go_version on Dockerfiles files present in non pruned directory
+find . \
+    -path ./vendor -prune -o \
+    -type f \
+    \( -name "*.Dockerfile" -o -name "Dockerfile" \) \
+    -exec bash -c 'check_go_version $1 '"$target_go_version" bash {} \;
 
 echo "All Dockerfiles pass the Go version check for Go version $target_go_version."

--- a/tools/check-go-version-dockerfile.sh
+++ b/tools/check-go-version-dockerfile.sh
@@ -30,10 +30,19 @@ fi
 target_go_version="$1"
 
 # Run check_go_version on Dockerfiles files present in non pruned directory
-find . \
+# Display version-check results with tee
+version_check_results=$( find . \
     -path ./vendor -prune -o \
     -type f \
     \( -name "*.Dockerfile" -o -name "Dockerfile" \) \
-    -exec bash -c 'check_go_version $1 '"$target_go_version" bash {} \;
+    -exec bash -c 'check_go_version $1 '"$target_go_version" bash {} \; | tee /dev/tty )
 
-echo "All Dockerfiles pass the Go version check for Go version $target_go_version."
+# Produce exit status
+if [ -z "$version_check_results" ] || [[ "$version_check_results" =~ "FAIL:" ]]; then
+    # 'FAIL:'' contained in output, an error as occurred, exit with error
+    exit 1
+else
+    # no errors occurred, succeed
+    echo "PASS: All Dockerfiles files conform to Go version $target_go_version."
+    exit 0
+fi

--- a/tools/check-go-version-dockerfile.sh
+++ b/tools/check-go-version-dockerfile.sh
@@ -7,8 +7,8 @@ check_go_version() {
     local dockerfile="$1"
     local required_go_version="$2"
 
-    # Use grep to find lines with 'FROM golang:'
-    local go_lines=$(grep -i '^FROM golang:' "$dockerfile")
+    # Extract the Go version used in $dockerfile
+    local extracted_go_version=$(grep -i '^FROM golang:' "$dockerfile" | tr -d "_-:' [:alpha:]")
 
     # Check if all lines have the required Go version
     if echo "$go_lines" | grep -q -v "$required_go_version"; then

--- a/tools/check-go-version-dockerfile.sh
+++ b/tools/check-go-version-dockerfile.sh
@@ -10,12 +10,11 @@ check_go_version() {
     # Extract the Go version used in $dockerfile
     local extracted_go_version=$(grep -i '^FROM golang:' "$dockerfile" | tr -d "_-:' [:alpha:]")
 
-    # Check if all lines have the required Go version
-    if echo "$go_lines" | grep -q -v "$required_go_version"; then
-        echo "Error: $dockerfile does not use Go version $required_go_version exclusively."
-        exit 1
+    # Check if Dockerfile only contains stipulated Go version
+    if [ "$extracted_go_version" != "$required_go_version" ]; then
+        echo "FAIL: $dockerfile specifies Go version '$extracted_go_version' violating conformance. '$required_go_version' is required."
     else
-        echo "$dockerfile is using Go version $required_go_version."
+        echo "$dockerfile specifies Go version $required_go_version."
     fi
 }
 

--- a/tools/check-go-version-dockerfile.sh
+++ b/tools/check-go-version-dockerfile.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
+# This script will check Go-version conformance in relevant docker files. Else, exit with error
+# A Makefile linter-target runs this script
 
-# Function to check if the Dockerfile contains only the specified Go version
+# Function to check if a Dockerfile contains only the stipulated Go version
 check_go_version() {
     local dockerfile="$1"
     local required_go_version="$2"

--- a/tools/check-go-version-yaml.sh
+++ b/tools/check-go-version-yaml.sh
@@ -22,8 +22,7 @@ check_go_version() {
 
         # Check if the extracted Go version matches the required version
         if [ "$extracted_go_version" != "$required_go_version" ]; then
-            echo "Error: $yamlfile specifies Go version '$extracted_go_version', but not version '$required_go_version'."
-            exit 1
+            echo "FAIL: $yamlfile specifies Go version '$extracted_go_version' violating conformance. '$required_go_version' is required."
         else
             echo "$yamlfile specifies Go version $required_go_version."
         fi

--- a/tools/check-go-version-yaml.sh
+++ b/tools/check-go-version-yaml.sh
@@ -18,7 +18,7 @@ check_go_version() {
         # GO_VERSION: 1.21.0
         # GO_VERSION:1.21.0
         #   GO_VERSION:1.21.0
-        local extracted_go_version=$(echo "$go_lines" | sed -n 's/^[[:space:]]*GO_VERSION:[[:space:]]*\(['\''"]\?\)\?\([0-9]\+\.[0-9]\+\.[0-9]\+\)\(['\''"]\?\)\?/\2/p')
+        local extracted_go_version=$(<<<"$go_lines" tr -d "[:alpha:] ':_\"")
 
         # Check if the extracted Go version matches the required version
         if [ "$extracted_go_version" != "$required_go_version" ]; then

--- a/tools/check-go-version-yaml.sh
+++ b/tools/check-go-version-yaml.sh
@@ -28,6 +28,9 @@ check_go_version() {
     fi
 }
 
+# Export function to be accessible by subshells e.g. `find -exec`
+export -f check_go_version
+
 # Check if the target Go version argument is provided
 if [ $# -eq 0 ]; then
     echo "Usage: $0 <target_go_version>"
@@ -36,12 +39,11 @@ fi
 
 target_go_version="$1"
 
-# Search for YAML files in the current directory and its subdirectories
-yaml_files=$(find . -type f -name "*.yaml" -o -name "*.yml")
-
-# Check each YAML file
-for file in $yaml_files; do
-    check_go_version "$file" "$target_go_version"
-done
+# Run check_go_version on YAML files present in non pruned directory
+find . \
+    -path ./vendor -prune -o \
+    -type f \
+    \( -name "*.yaml" -o -name "*.yml" \) \
+    -exec bash -c 'check_go_version $1 '"$target_go_version" bash {} \;
 
 echo "All YAML files pass the Go version check for Go version $target_go_version."

--- a/tools/check-go-version-yaml.sh
+++ b/tools/check-go-version-yaml.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
+# This script will check Go-version conformance in relevant docker files. Else, exit with error
+# A Makefile linter-target runs this script
 
-# Function to check if the YAML file contains the specified Go version after 'GO_VERSION:'
+# Function to check if a YAML file contains the stipulated Go version after 'GO_VERSION:'
 check_go_version() {
     local yamlfile="$1"
     local required_go_version="$2"

--- a/tools/check-go-version-yaml.sh
+++ b/tools/check-go-version-yaml.sh
@@ -42,10 +42,19 @@ fi
 target_go_version="$1"
 
 # Run check_go_version on YAML files present in non pruned directory
-find . \
+# Display version-check results with tee
+version_check_results=$( find . \
     -path ./vendor -prune -o \
     -type f \
     \( -name "*.yaml" -o -name "*.yml" \) \
-    -exec bash -c 'check_go_version $1 '"$target_go_version" bash {} \;
+    -exec bash -c 'check_go_version $1 '"$target_go_version" bash {} \; | tee /dev/tty )
 
-echo "All YAML files pass the Go version check for Go version $target_go_version."
+# Produce exit status
+if [ -z "$version_check_results" ] || [[ "$version_check_results" =~ "FAIL:" ]]; then
+    # 'FAIL:'' contained in output, an error as occurred, exit with error
+    exit 1
+else
+    # no errors occurred, succeed
+    echo "PASS: All YAML files conform to Go version $target_go_version."
+    exit 0
+fi


### PR DESCRIPTION
A portability bug in BSD vs GNU sed is remediated in this PR as well as tightening up when Go version validation fails.

- make: simplify calling Go version consistency checks
- make: add comments to describe purpose of the linter-supporting scripts
- make: replace non-portable use of sed with tr
- make: replace error condition's predicate Instead of returning an error if any go version exists other than the stipulated version, require the extracted Go version to be the stipulated version
- make: error reporting logic - Add error reporting logic   Error if false-negative version validation exist: e.g. find command   fails to induce check_go_version - Add validation-failure reporting - Capture output of check_go_version for validation processing
- make: Modify phrasing of error report to communicate violated version and stipulated version Remove exit status to be replaced with FAIL error-message presence

## Tests
Tests to validate true positive and true negative
```sh
echo "Validate help print"
./tools/check-go-version-dockerfile.sh
./tools/check-go-version-yaml.sh
echo "Validate pass condition"
./tools/check-go-version-dockerfile.sh 1.21.4
./tools/check-go-version-yaml.sh 1.21.4
echo "Validate failure condition"
./tools/check-go-version-dockerfile.sh 96
./tools/check-go-version-yaml.sh 96
```
