### PR TITLE
itest: universe server harness uses a dedicated LND node

### DIFF
--- a/itest/test_harness.go
+++ b/itest/test_harness.go
@@ -290,11 +290,13 @@ func nextAvailablePort() int {
 // setupHarnesses creates new server and client harnesses that are connected
 // to each other through an in-memory gRPC connection.
 func setupHarnesses(t *testing.T, ht *harnessTest,
-	lndHarness *lntest.HarnessTest,
+	lndHarness *lntest.HarnessTest, uniServerLndHarness *node.HarnessNode,
 	proofCourierType proof.CourierType) (*tapdHarness,
 	*universeServerHarness, proof.CourierHarness) {
 
-	universeServer := newUniverseServerHarness(t, ht, lndHarness.Bob)
+	// Create a new universe server harness and start it.
+	t.Log("Starting universe server harness")
+	universeServer := newUniverseServerHarness(t, ht, uniServerLndHarness)
 
 	t.Logf("Starting universe server harness, listening on %v",
 		universeServer.ListenAddr)

--- a/itest/universe_server_harness.go
+++ b/itest/universe_server_harness.go
@@ -14,6 +14,10 @@ type universeServerHarness struct {
 
 	// ListenAddr is the address that the service is listening on.
 	ListenAddr string
+
+	// lndHarness is the instance of the lnd harness that the service is
+	// using.
+	LndHarness *node.HarnessNode
 }
 
 func newUniverseServerHarness(t *testing.T, ht *harnessTest,
@@ -28,6 +32,7 @@ func newUniverseServerHarness(t *testing.T, ht *harnessTest,
 	return &universeServerHarness{
 		service:    service,
 		ListenAddr: service.rpcHost(),
+		LndHarness: lndHarness,
 	}
 }
 


### PR DESCRIPTION
In this commit we ensure that the universe server harness uses a new dedicated LND node. The universe harness previously used the Bob standby LND node. This change allows us to use an in-test tapd node with LND node Bob without conflicting with the universe server tapd node.

This change will be important when passing messages between tapd nodes (e.g. RFQ system) via LND nodes.

This work is necessary to complete: https://github.com/lightninglabs/taproot-assets/issues/766