### PR TITLE
itest: trustless swap based on vPSBT/PSBT sighash flags

### DIFF
--- a/itest/test_list_on_test.go
+++ b/itest/test_list_on_test.go
@@ -190,6 +190,10 @@ var testCases = []*testCase{
 		test: testPsbtSighashNoneInvalid,
 	},
 	{
+		name: "psbt trustless swap",
+		test: testPsbtTrustlessSwap,
+	},
+	{
 		name: "psbt external commit",
 		test: testPsbtExternalCommit,
 	},


### PR DESCRIPTION
## Description

Based on #787 , #779 

Closes #577 

This PR introduces a basic itest that follows the flow of a trustless swap that is possible by correctly manipulating the sighash flags on the asset and bitcoin levels. We create an asymmetry between the vPSBT that describes the asset transfer and the PSBT that anchors it in a bitcoin transaction. The vPSBT only commits to the inputs, allowing anyone to define their own output, while the PSBT commits to the output (which asks for more bitcoin than what is provided in the anchor input) and allows someone to bring their own input to fulfill the transaction.

This way, the only way to "claim" the loose assets on the vPSBT layer is by bringing your own bitcoin on the PSBT layer, which would effectively be the pay-out for the asset holder who created this swap offer.

## Todos

- [x] Add swap redemption part
~~- [ ] Add malicious actor test coverage~~