### PR TITLE
multi: add linters for switch exhaustiveness, if-else chains, and err handling

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -23,8 +23,15 @@ linters-settings:
     excludes:
       - G402 # Look for bad TLS connection settings.
       - G306 # Poor file permissions used when writing to a new file.
+  exhaustive:
+    default-signifies-exhaustive: true
+  gocritic:
+      enabled-checks:
+        - singleCaseSwitch
+        - ifElseChain
+        - assignOp
+        - unlambda
   staticcheck:
-    go: "1.19"
     checks: ["-SA1019"]
 
 linters:
@@ -34,6 +41,11 @@ linters:
     - tagliatelle
     - whitespace
     - gosec
+    - unused
+    - gocritic
+    - unconvert
+    - nilerr
+    - exhaustive
 
 issues:
   exclude-rules:

--- a/asset/asset.go
+++ b/asset/asset.go
@@ -778,11 +778,7 @@ func (g *GroupKey) IsEqual(otherGroupKey *GroupKey) bool {
 		return false
 	}
 
-	return slices.EqualFunc(
-		g.Witness, otherGroupKey.Witness, func(a, b []byte) bool {
-			return bytes.Equal(a, b)
-		},
-	)
+	return slices.EqualFunc(g.Witness, otherGroupKey.Witness, bytes.Equal)
 }
 
 // IsEqualGroup returns true if this group key describes the same asset group

--- a/asset/mock.go
+++ b/asset/mock.go
@@ -270,6 +270,8 @@ func SignOutputRaw(priv *btcec.PrivateKey, tx *wire.MsgTx,
 			signDesc.Output.Value, signDesc.Output.PkScript,
 			leaf, signDesc.HashType, privKey,
 		)
+	default:
+		// A witness V0 sign method should never appear here.
 	}
 	if err != nil {
 		return nil, err

--- a/cmd/tapcli/addrs.go
+++ b/cmd/tapcli/addrs.go
@@ -64,8 +64,7 @@ var newAddrCommand = cli.Command{
 }
 
 func newAddr(ctx *cli.Context) error {
-	switch {
-	case ctx.String(assetIDName) == "":
+	if ctx.String(assetIDName) == "" {
 		return cli.ShowSubcommandHelp(ctx)
 	}
 

--- a/cmd/tapcli/addrs.go
+++ b/cmd/tapcli/addrs.go
@@ -162,7 +162,7 @@ func queryAddr(ctx *cli.Context) error {
 
 	addrs, err := client.QueryAddrs(ctxc, &taprpc.QueryAddrRequest{
 		CreatedAfter:  start,
-		CreatedBefore: int64(end),
+		CreatedBefore: end,
 		Limit:         int32(ctx.Int64(limitName)),
 		Offset:        int32(ctx.Int64(offsetName)),
 	})

--- a/cmd/tapcli/proofs.go
+++ b/cmd/tapcli/proofs.go
@@ -59,8 +59,7 @@ var verifyProofCommand = cli.Command{
 }
 
 func verifyProof(ctx *cli.Context) error {
-	switch {
-	case ctx.String(proofPathName) == "":
+	if ctx.String(proofPathName) == "" {
 		return cli.ShowSubcommandHelp(ctx)
 	}
 
@@ -126,8 +125,7 @@ func decodeProof(ctx *cli.Context) error {
 	client, cleanUp := getClient(ctx)
 	defer cleanUp()
 
-	switch {
-	case !ctx.IsSet(proofPathName):
+	if !ctx.IsSet(proofPathName) {
 		_ = cli.ShowCommandHelp(ctx, "decode")
 		return nil
 	}
@@ -176,8 +174,7 @@ var verifyOwnershipCommand = cli.Command{
 }
 
 func verifyOwnershipProof(ctx *cli.Context) error {
-	switch {
-	case ctx.String(proofPathName) == "":
+	if ctx.String(proofPathName) == "" {
 		return cli.ShowSubcommandHelp(ctx)
 	}
 

--- a/cmd/tapcli/universe.go
+++ b/cmd/tapcli/universe.go
@@ -516,8 +516,7 @@ var universeProofInsertInsert = cli.Command{
 }
 
 func universeProofInsert(ctx *cli.Context) error {
-	switch {
-	case ctx.String(proofPathName) == "":
+	if ctx.String(proofPathName) == "" {
 		return cli.ShowSubcommandHelp(ctx)
 	}
 
@@ -617,8 +616,7 @@ var universeSyncCommand = cli.Command{
 }
 
 func universeSync(ctx *cli.Context) error {
-	switch {
-	case ctx.String(universeHostName) == "":
+	if ctx.String(universeHostName) == "" {
 		return cli.ShowSubcommandHelp(ctx)
 	}
 
@@ -721,8 +719,7 @@ var universeFederationAddCommand = cli.Command{
 }
 
 func universeFederationAdd(ctx *cli.Context) error {
-	switch {
-	case ctx.String(universeHostName) == "":
+	if ctx.String(universeHostName) == "" {
 		return cli.ShowSubcommandHelp(ctx)
 	}
 
@@ -771,9 +768,9 @@ var universeFederationDelCommand = cli.Command{
 }
 
 func universeFederationDel(ctx *cli.Context) error {
-	switch {
-	case ctx.String(universeHostName) == "" &&
-		ctx.Int(universeServerID) == 0:
+	if ctx.String(universeHostName) == "" &&
+		ctx.Int(universeServerID) == 0 {
+
 		return cli.ShowSubcommandHelp(ctx)
 	}
 

--- a/commitment/commitment_test.go
+++ b/commitment/commitment_test.go
@@ -450,15 +450,16 @@ func TestMintAndDeriveTapCommitment(t *testing.T) {
 
 			var tapCommitment *TapCommitment
 
-			if includesAsset && includesAssetGroup {
+			switch {
+			case includesAsset && includesAssetGroup:
 				tapCommitment, err = proof.DeriveByAssetInclusion(
 					asset,
 				)
-			} else if includesAssetGroup {
+			case !includesAsset && includesAssetGroup:
 				tapCommitment, err = proof.DeriveByAssetExclusion(
 					asset.AssetCommitmentKey(),
 				)
-			} else {
+			case !includesAsset && !includesAssetGroup:
 				tapCommitment, err = proof.DeriveByAssetCommitmentExclusion(
 					asset.TapCommitmentKey(),
 				)

--- a/commitment/taproot.go
+++ b/commitment/taproot.go
@@ -233,7 +233,7 @@ func (t *TapscriptPreimage) IsEmpty() bool {
 
 // Type returns the preimage type.
 func (t *TapscriptPreimage) Type() TapscriptPreimageType {
-	return TapscriptPreimageType(t.siblingType)
+	return t.siblingType
 }
 
 // TapHash returns the tap hash of this preimage according to its type.

--- a/itest/mint_batch_stress_test.go
+++ b/itest/mint_batch_stress_test.go
@@ -202,7 +202,7 @@ func mintBatchStressTest(
 	// outpoints matching the chain anchor of the group anchor.
 	mintOutpoint := collectibleAnchor.ChainAnchor.AnchorOutpoint
 
-	leafKeys, err := fetchAllLeafKeys(t, alice, &collectUniID)
+	leafKeys, err := fetchAllLeafKeys(alice, &collectUniID)
 	require.NoError(t, err)
 
 	require.Len(t, leafKeys, batchSize)

--- a/itest/mint_batch_stress_test.go
+++ b/itest/mint_batch_stress_test.go
@@ -121,7 +121,7 @@ func mintBatchStressTest(
 
 	// Update the asset name and metadata to match an index.
 	incrementMintAsset := func(asset *mintrpc.MintAsset, ind int) {
-		asset.Name = asset.Name + strconv.Itoa(ind)
+		asset.Name += strconv.Itoa(ind)
 		binary.PutUvarint(metadataPrefix, uint64(ind))
 		copy(asset.AssetMeta.Data[0:metaPrefixSize], metadataPrefix)
 	}

--- a/itest/psbt_test.go
+++ b/itest/psbt_test.go
@@ -602,7 +602,7 @@ func runPsbtInteractiveSplitSendTest(ctxt context.Context, t *harnessTest,
 		// Swap the sender and receiver nodes starting at the second
 		// iteration.
 		if i > 0 {
-			sendAmt = sendAmt / 2
+			sendAmt /= 2
 			changeAmt = sendAmt
 			sender, receiver = receiver, sender
 			senderSum, receiverSum = receiverSum, senderSum

--- a/itest/universe_pagination_test.go
+++ b/itest/universe_pagination_test.go
@@ -180,7 +180,7 @@ func mintBatchAssetsTest(
 		// all outpoints matching the chain anchor of the group anchor.
 		mintOutpoint := collectibleAnchor.ChainAnchor.AnchorOutpoint
 
-		leafKeys, err := fetchAllLeafKeys(t, alice, &collectUniID)
+		leafKeys, err := fetchAllLeafKeys(alice, &collectUniID)
 		require.NoError(t, err)
 
 		require.Len(t, leafKeys, len(mintBatch))
@@ -218,8 +218,8 @@ func mintBatchAssetsTest(
 }
 
 // fetchAllLeafKeys fetches all leaf keys for a given universe ID.
-func fetchAllLeafKeys(t *testing.T, alice TapdClient,
-	id *unirpc.ID) ([]*unirpc.AssetKey, error) {
+func fetchAllLeafKeys(alice TapdClient, id *unirpc.ID) ([]*unirpc.AssetKey,
+	error) {
 
 	keys := make([]*unirpc.AssetKey, 0)
 	offset := int32(0)

--- a/itest/universe_pagination_test.go
+++ b/itest/universe_pagination_test.go
@@ -88,7 +88,7 @@ func mintBatchAssetsTest(
 
 	// Update the asset name and metadata to match an index.
 	incrementMintAsset := func(asset *mintrpc.MintAsset, ind int) {
-		asset.Name = asset.Name + strconv.Itoa(ind)
+		asset.Name += strconv.Itoa(ind)
 		binary.PutUvarint(metadataPrefix, uint64(ind))
 		copy(asset.AssetMeta.Data[0:metaPrefixSize], metadataPrefix)
 	}

--- a/mssmt/tree_test.go
+++ b/mssmt/tree_test.go
@@ -68,8 +68,8 @@ func genTestStores(t *testing.T) map[string]makeTestTreeStoreFunc {
 }
 
 func printStoreStats(t *testing.T, store mssmt.TreeStore) {
-	switch s := store.(type) {
-	case *mssmt.DefaultStore:
+	s, ok := store.(*mssmt.DefaultStore)
+	if ok {
 		t.Logf("%s: %s", t.Name(), s.Stats())
 	}
 }

--- a/proof/courier.go
+++ b/proof/courier.go
@@ -1163,9 +1163,6 @@ func (c *UniverseRpcCourier) ReceiveProof(ctx context.Context,
 			// Retrieve proof from courier.
 			resp, err := c.client.QueryProof(ctx, &universeKey)
 			if err != nil {
-				return err
-			}
-			if err != nil {
 				return fmt.Errorf("error retrieving proof "+
 					"from universe courier service: %w",
 					err)

--- a/proof/tx.go
+++ b/proof/tx.go
@@ -89,7 +89,7 @@ func NewTxMerkleProof(txs []*wire.MsgTx, txIdx int) (*TxMerkleProof, error) {
 
 		// Update the currentIdx to reflect the next level in the tree.
 		// We divide by 2 since we always hash in pairs.
-		currentIdx = currentIdx / 2
+		currentIdx /= 2
 
 		// We've arrived at the root so our proof is complete.
 		if len(hashes) == 1 {

--- a/proof/tx.go
+++ b/proof/tx.go
@@ -62,12 +62,13 @@ func NewTxMerkleProof(txs []*wire.MsgTx, txIdx int) (*TxMerkleProof, error) {
 			// If we are the left child, a right sibling may not
 			// exist.
 			hash := hashes[currentIdx+1]
-			if hash != nil {
+			switch {
+			case hash != nil:
 				sibling = *hash
-			} else if hashes[currentIdx] == nil {
-				return nil, errors.New("invalid merkle tree")
-			} else {
+			case hashes[currentIdx] != nil:
 				sibling = *hashes[currentIdx]
+			default:
+				return nil, errors.New("invalid merkle tree")
 			}
 		} else {
 			// If we are the right child, there'll always be a left

--- a/rfq/manager.go
+++ b/rfq/manager.go
@@ -296,8 +296,8 @@ func (m *Manager) handleIncomingMessage(incomingMsg rfqmsg.IncomingMsg) error {
 // messages that will be sent to a peer.
 func (m *Manager) handleOutgoingMessage(outgoingMsg rfqmsg.OutgoingMsg) error {
 	// Perform type specific handling of the outgoing message.
-	switch msg := outgoingMsg.(type) {
-	case *rfqmsg.Accept:
+	msg, ok := outgoingMsg.(*rfqmsg.Accept)
+	if ok {
 		// Before sending an accept message to a peer, inform the HTLC
 		// order handler that we've accepted the quote request.
 		m.orderHandler.RegisterChannelRemit(*msg)

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -817,7 +817,7 @@ func (r *rpcServer) listBalancesByAsset(ctx context.Context,
 
 		resp.AssetBalances[assetIDStr] = &taprpc.AssetBalance{
 			AssetGenesis: &taprpc.GenesisInfo{
-				Version:      int32(balance.Version),
+				Version:      balance.Version,
 				GenesisPoint: balance.GenesisPoint.String(),
 				AssetType:    taprpc.AssetType(balance.Type),
 				Name:         balance.Tag,

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -720,8 +720,7 @@ func (r *rpcServer) checkBalanceOverflow(ctx context.Context,
 func (r *rpcServer) ListAssets(ctx context.Context,
 	req *taprpc.ListAssetRequest) (*taprpc.ListAssetResponse, error) {
 
-	switch {
-	case req.IncludeSpent && req.IncludeLeased:
+	if req.IncludeSpent && req.IncludeLeased {
 		return nil, fmt.Errorf("cannot specify both include_spent " +
 			"and include_leased")
 	}

--- a/tapdb/addrs.go
+++ b/tapdb/addrs.go
@@ -288,7 +288,7 @@ func (t *TapAddressBook) InsertAddrs(ctx context.Context,
 					&addr.TaprootOutputKey,
 				),
 				Amount:           int64(addr.Amount),
-				AssetType:        int16(assetGen.AssetType),
+				AssetType:        assetGen.AssetType,
 				CreationTime:     addr.CreationTime.UTC(),
 				ProofCourierAddr: proofCourierAddrBytes,
 			})

--- a/tapdb/asset_minting.go
+++ b/tapdb/asset_minting.go
@@ -620,10 +620,8 @@ func fetchAssetSprouts(ctx context.Context, q PendingAssetStore,
 						Index: extractSqlInt32[uint32](
 							sprout.GroupKeyIndex,
 						),
-						Family: keychain.KeyFamily(
-							extractSqlInt32[keychain.KeyFamily](
-								sprout.GroupKeyFamily,
-							),
+						Family: extractSqlInt32[keychain.KeyFamily](
+							sprout.GroupKeyFamily,
 						),
 					},
 				},

--- a/tapdb/assets_store.go
+++ b/tapdb/assets_store.go
@@ -1153,7 +1153,8 @@ func (a *AssetStore) FetchAssetProofs(ctx context.Context,
 		// TODO(roasbeef): can modify the query to use IN somewhere
 		// instead? then would take input params and insert into
 		// virtual rows to use
-		for _, locator := range targetAssets {
+		for ind := range targetAssets {
+			locator := targetAssets[ind]
 			args, err := locatorToProofQuery(locator)
 			if err != nil {
 				return err

--- a/tapdb/migrations.go
+++ b/tapdb/migrations.go
@@ -59,6 +59,7 @@ func (m *migrationLogger) Printf(format string, v ...interface{}) {
 		m.log.Errorf(format, v...)
 	case btclog.LevelCritical:
 		m.log.Criticalf(format, v...)
+	case btclog.LevelOff:
 	}
 }
 

--- a/tapdb/multiverse.go
+++ b/tapdb/multiverse.go
@@ -225,8 +225,8 @@ func newRootPageQuery(q universe.RootNodesQuery) rootPageQuery {
 		withAmountsById: q.WithAmountsById,
 		leafQuery: leafQuery{
 			sortDirection: q.SortDirection,
-			offset:        int32(q.Offset),
-			limit:         int32(q.Limit),
+			offset:        q.Offset,
+			limit:         q.Limit,
 		},
 	}
 }
@@ -401,8 +401,8 @@ type leafQuery struct {
 func newLeafQuery(q universe.UniverseLeafKeysQuery) leafQuery {
 	return leafQuery{
 		sortDirection: q.SortDirection,
-		offset:        int32(q.Offset),
-		limit:         int32(q.Limit),
+		offset:        q.Offset,
+		limit:         q.Limit,
 	}
 }
 
@@ -725,13 +725,13 @@ func (b *MultiverseStore) RootNodes(ctx context.Context,
 
 	params := sqlc.UniverseRootsParams{
 		SortDirection: sqlInt16(q.SortDirection),
-		NumOffset:     int32(q.Offset),
+		NumOffset:     q.Offset,
 		NumLimit: func() int32 {
 			if q.Limit == 0 {
 				return universe.MaxPageSize
 			}
 
-			return int32(q.Limit)
+			return q.Limit
 		}(),
 	}
 

--- a/tapdb/sqlutils.go
+++ b/tapdb/sqlutils.go
@@ -101,7 +101,7 @@ func extractSqlInt32[T constraints.Integer](num sql.NullInt32) T {
 // NOTE: This function is intended to be used along with the wire.WriteOutPoint
 // function. Once the ReadOutPoint function is exported, then it can be used in
 // place of this.
-func readOutPoint(r io.Reader, pver uint32, version int32, op *wire.OutPoint) error {
+func readOutPoint(r io.Reader, _ uint32, _ uint32, op *wire.OutPoint) error {
 	_, err := io.ReadFull(r, op.Hash[:])
 	if err != nil {
 		return err

--- a/tapdb/universe_federation.go
+++ b/tapdb/universe_federation.go
@@ -279,7 +279,7 @@ func (u *UniverseFederationDB) RemoveServers(ctx context.Context,
 			// host string instead. This avoids bugs where a user
 			// doesn't set the ID value, and we try to delete the
 			// very first server.
-			uniID := int64(a.ID)
+			uniID := a.ID
 			if a.HostStr() != "" {
 				uniID = -1
 			}

--- a/tapfreighter/chain_porter.go
+++ b/tapfreighter/chain_porter.go
@@ -657,10 +657,6 @@ func (p *ChainPorter) transferReceiverProof(pkg *sendPackage) error {
 
 		// Deliver proof to proof courier service.
 		err = courier.DeliverProof(ctx, receiverProof)
-		if err != nil {
-			return fmt.Errorf("failed to deliver proof via "+
-				"courier service: %w", err)
-		}
 
 		// If the proof courier returned a backoff error, then
 		// we'll just return nil here so that we can retry
@@ -670,7 +666,8 @@ func (p *ChainPorter) transferReceiverProof(pkg *sendPackage) error {
 			return nil
 		}
 		if err != nil {
-			return fmt.Errorf("error delivering proof: %w", err)
+			return fmt.Errorf("failed to deliver proof via "+
+				"courier service: %w", err)
 		}
 
 		return nil

--- a/tapfreighter/wallet.go
+++ b/tapfreighter/wallet.go
@@ -333,7 +333,7 @@ func (s *CoinSelect) selectForAmount(minTotalAmount uint64,
 
 			// Keep track of the total amount of assets we've seen
 			// so far.
-			amountSum += uint64(anchoredCommitment.Asset.Amount)
+			amountSum += anchoredCommitment.Asset.Amount
 			if amountSum >= minTotalAmount {
 				// At this point a target min amount was
 				// specified and has been reached.

--- a/tapgarden/mock.go
+++ b/tapgarden/mock.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
-	"github.com/lightninglabs/taproot-assets/tapsend"
 	"math/rand"
 	"testing"
 	"time"
@@ -23,6 +22,7 @@ import (
 	"github.com/lightninglabs/taproot-assets/asset"
 	"github.com/lightninglabs/taproot-assets/internal/test"
 	"github.com/lightninglabs/taproot-assets/proof"
+	"github.com/lightninglabs/taproot-assets/tapsend"
 	"github.com/lightningnetwork/lnd/chainntnfs"
 	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/lightningnetwork/lnd/lnwallet"
@@ -520,7 +520,7 @@ func (m *MockKeyRing) DeriveNextKey(ctx context.Context,
 
 	priv, err := btcec.NewPrivateKey()
 	if err != nil {
-		return keychain.KeyDescriptor{}, nil
+		return keychain.KeyDescriptor{}, err
 	}
 
 	loc := keychain.KeyLocator{

--- a/tools/check-go-version-dockerfile.sh
+++ b/tools/check-go-version-dockerfile.sh
@@ -38,7 +38,7 @@ target_go_version="$1"
 while IFS= read -r -d '' file; do
     target_files+=("$file")
 done < <(find . \
-    -path ./vendor -prune -o \
+    -path ".**/vendor" -prune -o \
     -type f \
     \( -name "*.Dockerfile" -o -name "Dockerfile" \) \
     -print0 \

--- a/tools/check-go-version-yaml.sh
+++ b/tools/check-go-version-yaml.sh
@@ -49,7 +49,7 @@ target_go_version="$1"
 while IFS= read -r -d '' file; do
     target_files+=("$file")
 done < <(find . \
-    -path ./vendor -prune -o \
+    -path ".**/vendor" -prune -o \
     -type f \
     \( -name "*.yaml" -o -name "*.yml" \) \
     -print0 \

--- a/universe/auto_syncer.go
+++ b/universe/auto_syncer.go
@@ -141,9 +141,7 @@ func (f *FederationEnvoy) Start() error {
 		// Before we start the main goroutine, we'll add the set of
 		// static Universe servers.
 		addrs := f.cfg.StaticFederationMembers
-		serverAddrs := fn.Map(addrs, func(a string) ServerAddr {
-			return NewServerAddrFromStr(a)
-		})
+		serverAddrs := fn.Map(addrs, NewServerAddrFromStr)
 
 		serverAddrs = fn.Filter(serverAddrs, func(a ServerAddr) bool {
 			// Before we add the server as a federation member, we

--- a/universe/auto_syncer.go
+++ b/universe/auto_syncer.go
@@ -848,6 +848,7 @@ func (f *FederationEnvoy) SyncAssetInfo(ctx context.Context,
 		if err != nil {
 			log.Debugf("asset lookup for %v failed with remote"+
 				"server: %v", assetID.String(), addr.HostStr())
+			//lint:ignore nilerr failure is expected and logged
 			return nil
 		}
 

--- a/universe_rpc_diff.go
+++ b/universe_rpc_diff.go
@@ -82,8 +82,8 @@ func (r *RpcUniverseDiff) RootNodes(ctx context.Context,
 	universeRoots, err := r.conn.AssetRoots(
 		ctx, &unirpc.AssetRootRequest{
 			WithAmountsById: q.WithAmountsById,
-			Offset:          int32(q.Offset),
-			Limit:           int32(q.Limit),
+			Offset:          q.Offset,
+			Limit:           q.Limit,
 			Direction:       unirpc.SortDirection(q.SortDirection),
 		},
 	)
@@ -133,8 +133,8 @@ func (r *RpcUniverseDiff) UniverseLeafKeys(ctx context.Context,
 		ctx, &unirpc.AssetLeafKeysRequest{
 			Id:        uniID,
 			Direction: unirpc.SortDirection(q.SortDirection),
-			Offset:    int32(q.Offset),
-			Limit:     int32(q.Limit),
+			Offset:    q.Offset,
+			Limit:     q.Limit,
 		},
 	)
 	if err != nil {


### PR DESCRIPTION
Inspired by #812. These are some lints that felt useful for keeping style consistent, as well as how we use `switch`.

I've added fixes for a few small issues, and lint runtime (both cold and hot module cache) on my machine increased from 13.5 to ~16 seconds.

I'm not sure which linters could be used to replicate the gopls analyzers I'm using locally, but those fixes were less important IMO.