### PR TITLE
tapgarden: add FundBatch and SealBatch requests

### DIFF
--- a/asset/asset_test.go
+++ b/asset/asset_test.go
@@ -800,7 +800,10 @@ func TestAssetGroupKey(t *testing.T) {
 	// need to provide a copy to arrive at the same result.
 	protoAsset := NewAssetNoErr(t, g, 1, 0, 0, fakeScriptKey, nil)
 	groupReq := NewGroupKeyRequestNoErr(t, fakeKeyDesc, g, protoAsset, nil)
-	keyGroup, err := DeriveGroupKey(genSigner, &genBuilder, *groupReq)
+	genTx, err := groupReq.BuildGroupVirtualTx(&genBuilder)
+	require.NoError(t, err)
+
+	keyGroup, err := DeriveGroupKey(genSigner, *genTx, *groupReq, nil)
 	require.NoError(t, err)
 
 	require.Equal(
@@ -816,9 +819,10 @@ func TestAssetGroupKey(t *testing.T) {
 	groupReq = NewGroupKeyRequestNoErr(
 		t, test.PubToKeyDesc(privKey.PubKey()), g, protoAsset, tapTweak,
 	)
-	keyGroup, err = DeriveCustomGroupKey(
-		genSigner, &genBuilder, *groupReq, nil, nil,
-	)
+	genTx, err = groupReq.BuildGroupVirtualTx(&genBuilder)
+	require.NoError(t, err)
+
+	keyGroup, err = DeriveGroupKey(genSigner, *genTx, *groupReq, nil)
 	require.NoError(t, err)
 
 	require.Equal(
@@ -873,34 +877,44 @@ func TestDeriveGroupKey(t *testing.T) {
 	}
 
 	// A prototype asset is required for building the genesis virtual TX.
-	_, err := DeriveGroupKey(genSigner, &genBuilder, groupReq)
+	_, err := groupReq.BuildGroupVirtualTx(&genBuilder)
 	require.ErrorContains(t, err, "grouped asset cannot be nil")
 
 	// The prototype asset must have a genesis witness.
 	groupReq.NewAsset = nonGenProtoAsset
-	_, err = DeriveGroupKey(genSigner, &genBuilder, groupReq)
+	_, err = groupReq.BuildGroupVirtualTx(&genBuilder)
 	require.ErrorContains(t, err, "asset is not a genesis asset")
 
 	// The prototype asset must not have a group key set.
 	groupReq.NewAsset = groupedProtoAsset
-	_, err = DeriveGroupKey(genSigner, &genBuilder, groupReq)
+	_, err = groupReq.BuildGroupVirtualTx(&genBuilder)
 	require.ErrorContains(t, err, "asset already has group key")
 
 	// The anchor genesis used for signing must have the same asset type
 	// as the prototype asset being signed.
 	groupReq.AnchorGen = collectGen
 	groupReq.NewAsset = protoAsset
-	_, err = DeriveGroupKey(genSigner, &genBuilder, groupReq)
+	_, err = groupReq.BuildGroupVirtualTx(&genBuilder)
 	require.ErrorContains(t, err, "asset group type mismatch")
 
 	// The group key request must include an internal key.
 	groupReq.AnchorGen = baseGen
 	groupReq.RawKey.PubKey = nil
-	_, err = DeriveGroupKey(genSigner, &genBuilder, groupReq)
+	_, err = groupReq.BuildGroupVirtualTx(&genBuilder)
 	require.ErrorContains(t, err, "missing group internal key")
 
+	// The tapscript root in the group key request must be exactly 32 bytes
+	// if present.
 	groupReq.RawKey = groupKeyDesc
-	groupKey, err := DeriveGroupKey(genSigner, &genBuilder, groupReq)
+	groupReq.TapscriptRoot = test.RandBytes(33)
+	_, err = groupReq.BuildGroupVirtualTx(&genBuilder)
+	require.ErrorContains(t, err, "tapscript root must be 32 bytes")
+
+	groupReq.TapscriptRoot = test.RandBytes(32)
+	genTx, err := groupReq.BuildGroupVirtualTx(&genBuilder)
+	require.NoError(t, err)
+
+	groupKey, err := DeriveGroupKey(genSigner, *genTx, groupReq, nil)
 	require.NoError(t, err)
 	require.NotNil(t, groupKey)
 }

--- a/commitment/commitment_test.go
+++ b/commitment/commitment_test.go
@@ -104,9 +104,14 @@ func TestNewAssetCommitment(t *testing.T) {
 		t, test.PubToKeyDesc(group1Pub), genesis1, genesis2ProtoAsset,
 		nil,
 	)
+	group1ReissuedGenTx, err := group1ReissuedGroupReq.BuildGroupVirtualTx(
+		&genTxBuilder,
+	)
+	require.NoError(t, err)
+
 	group1ReissuedGroupKey, err := asset.DeriveGroupKey(
-		asset.NewMockGenesisSigner(group1Priv), &genTxBuilder,
-		*group1ReissuedGroupReq,
+		asset.NewMockGenesisSigner(group1Priv), *group1ReissuedGenTx,
+		*group1ReissuedGroupReq, nil,
 	)
 	require.NoError(t, err)
 	group1Reissued = asset.NewAssetNoErr(
@@ -958,9 +963,14 @@ func TestUpdateAssetCommitment(t *testing.T) {
 	group1ReissuedGroupReq := asset.NewGroupKeyRequestNoErr(
 		t, test.PubToKeyDesc(group1Pub), genesis1, group1Reissued, nil,
 	)
+	group1ReissuedGenTx, err := group1ReissuedGroupReq.BuildGroupVirtualTx(
+		&genTxBuilder,
+	)
+	require.NoError(t, err)
+
 	group1ReissuedGroupKey, err := asset.DeriveGroupKey(
-		asset.NewMockGenesisSigner(group1Priv), &genTxBuilder,
-		*group1ReissuedGroupReq,
+		asset.NewMockGenesisSigner(group1Priv), *group1ReissuedGenTx,
+		*group1ReissuedGroupReq, nil,
 	)
 	require.NoError(t, err)
 	group1Reissued = asset.NewAssetNoErr(

--- a/fn/iter.go
+++ b/fn/iter.go
@@ -28,9 +28,9 @@ func ForEach[T any](items []T, f func(T)) {
 // ForEachMapItem is a generic implementation of a for-each (map with side
 // effects). This can be used to ensure that any normal for-loop don't run into
 // bugs due to loop variable scoping.
-func ForEachMapItem[T any, K comparable](items map[K]T, f func(T)) {
+func ForEachMapItem[T any, K comparable](items map[K]T, f func(K, T)) {
 	for i := range items {
-		f(items[i])
+		f(i, items[i])
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,6 @@ require (
 	github.com/lightningnetwork/lnd v0.17.0-beta.rc6.0.20240301195848-f61761277f14
 	github.com/lightningnetwork/lnd/cert v1.2.2
 	github.com/lightningnetwork/lnd/clock v1.1.1
-	github.com/lightningnetwork/lnd/ticker v1.1.1
 	github.com/lightningnetwork/lnd/tlv v1.2.3
 	github.com/lightningnetwork/lnd/tor v1.1.2
 	github.com/ory/dockertest/v3 v3.10.0
@@ -124,6 +123,7 @@ require (
 	github.com/lightningnetwork/lnd/healthcheck v1.2.3 // indirect
 	github.com/lightningnetwork/lnd/kvdb v1.4.5 // indirect
 	github.com/lightningnetwork/lnd/queue v1.1.1 // indirect
+	github.com/lightningnetwork/lnd/ticker v1.1.1 // indirect
 	github.com/ltcsuite/ltcd v0.0.0-20190101042124-f37f8bf35796 // indirect
 	github.com/mattn/go-isatty v0.0.17 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect

--- a/internal/test/helpers.go
+++ b/internal/test/helpers.go
@@ -91,6 +91,19 @@ func RandPrivKey(_ testing.TB) *btcec.PrivateKey {
 	return priv
 }
 
+func RandKeyDesc(t testing.TB) (keychain.KeyDescriptor, *btcec.PrivateKey) {
+	priv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	return keychain.KeyDescriptor{
+		PubKey: priv.PubKey(),
+		KeyLocator: keychain.KeyLocator{
+			Index:  RandInt[uint32](),
+			Family: keychain.KeyFamily(RandInt[uint32]()),
+		},
+	}, priv
+}
+
 func SchnorrPubKey(t testing.TB, privKey *btcec.PrivateKey) *btcec.PublicKey {
 	return SchnorrKey(t, privKey.PubKey())
 }

--- a/tapcfg/config.go
+++ b/tapcfg/config.go
@@ -64,11 +64,6 @@ const (
 
 	defaultConfigFileName = "tapd.conf"
 
-	// defaultBatchMintingInterval is the default interval used to
-	// determine when a set of pending assets should be flushed into a new
-	// batch.
-	defaultBatchMintingInterval = time.Minute * 10
-
 	// fallbackHashMailAddr is the fallback address we'll use to deliver
 	// proofs for asynchronous sends.
 	fallbackHashMailAddr = "mailbox.terminal.lightning.today:443"
@@ -298,8 +293,6 @@ type Config struct {
 	CPUProfile string `long:"cpuprofile" description:"Write CPU profile to the specified file"`
 	Profile    string `long:"profile" description:"Enable HTTP profiling on either a port or host:port"`
 
-	BatchMintingInterval time.Duration `long:"batch-minting-interval" description:"A duration (1m, 2h, etc) that governs how frequently pending assets are gather into a batch to be minted."`
-
 	ReOrgSafeDepth int32 `long:"reorgsafedepth" description:"The number of confirmations we'll wait for before considering a transaction safely buried in the chain."`
 
 	// The following options are used to configure the proof courier.
@@ -380,7 +373,6 @@ func DefaultConfig() Config {
 		},
 		LogWriter:               build.NewRotatingLogWriter(),
 		Prometheus:              monitoring.DefaultPrometheusConfig(),
-		BatchMintingInterval:    defaultBatchMintingInterval,
 		ReOrgSafeDepth:          defaultReOrgSafeDepth,
 		DefaultProofCourierAddr: defaultProofCourierAddr,
 		HashMailCourier: &proof.HashMailCourierCfg{

--- a/tapcfg/server.go
+++ b/tapcfg/server.go
@@ -23,7 +23,6 @@ import (
 	"github.com/lightningnetwork/lnd"
 	"github.com/lightningnetwork/lnd/clock"
 	"github.com/lightningnetwork/lnd/signal"
-	"github.com/lightningnetwork/lnd/ticker"
 )
 
 // databaseBackend is an interface that contains all methods our different
@@ -362,7 +361,6 @@ func genServerConfig(cfg *Config, cfgLogger btclog.Logger,
 				ProofWatcher:          reOrgWatcher,
 				UniversePushBatchSize: defaultUniverseSyncBatchSize,
 			},
-			BatchTicker:  ticker.NewForce(cfg.BatchMintingInterval),
 			ProofUpdates: proofArchive,
 			ErrChan:      mainErrChan,
 		}),

--- a/tapdb/asset_minting.go
+++ b/tapdb/asset_minting.go
@@ -1200,6 +1200,98 @@ func (a *AssetMintingStore) CommitBatchTx(ctx context.Context,
 	})
 }
 
+// AddSeedlingGroups stores the asset groups for seedlings associated with a
+// batch.
+func (a *AssetMintingStore) AddSeedlingGroups(ctx context.Context,
+	genesisOutpoint wire.OutPoint, assetGroups []*asset.AssetGroup) error {
+
+	var writeTxOpts AssetStoreTxOptions
+	return a.db.ExecTx(ctx, &writeTxOpts, func(q PendingAssetStore) error {
+		// fetch the outpoint ID inserted during funding
+		genesisPointID, err := upsertGenesisPoint(
+			ctx, q, genesisOutpoint,
+		)
+		if err != nil {
+			return fmt.Errorf("%w: %w", ErrUpsertGenesisPoint, err)
+		}
+
+		// insert genesis and group key
+		for idx := range assetGroups {
+			genAssetID, err := upsertGenesis(
+				ctx, q, genesisPointID,
+				*assetGroups[idx].Genesis,
+			)
+			if err != nil {
+				return fmt.Errorf("unable to upsert grouped "+
+					"seedling genesis: %w", err)
+			}
+
+			_, err = upsertGroupKey(
+				ctx, assetGroups[idx].GroupKey, q,
+				genesisPointID, genAssetID,
+			)
+			if err != nil {
+				return fmt.Errorf("unable to upsert group for "+
+					"grouped seedling: %w", err)
+			}
+		}
+
+		return nil
+	})
+}
+
+// FetchSeedlingGroups is used to fetch the asset groups for seedlings
+// associated with a funded batch.
+func (a *AssetMintingStore) FetchSeedlingGroups(ctx context.Context,
+	genesisPoint wire.OutPoint, anchorOutputIndex uint32,
+	seedlings []*tapgarden.Seedling) ([]*asset.AssetGroup, error) {
+
+	seedlingGroups := make([]*asset.AssetGroup, 0, len(seedlings))
+	seedlingGens := make([]*asset.Genesis, 0, len(seedlings))
+
+	// Compute meta hashes and geneses before reading from the DB.
+	fn.ForEach(seedlings, func(seedling *tapgarden.Seedling) {
+		gen := &asset.Genesis{
+			FirstPrevOut: genesisPoint,
+			Tag:          seedling.AssetName,
+			OutputIndex:  anchorOutputIndex,
+			Type:         seedling.AssetType,
+		}
+
+		if seedling.Meta != nil {
+			gen.MetaHash = seedling.Meta.MetaHash()
+		}
+
+		seedlingGens = append(seedlingGens, gen)
+	})
+
+	// Read geneses and asset groups.
+	readOpts := NewAssetStoreReadTx()
+	dbErr := a.db.ExecTx(ctx, &readOpts, func(q PendingAssetStore) error {
+		for i := range seedlingGens {
+			genID, err := fetchGenesisID(ctx, q, *seedlingGens[i])
+			if err != nil {
+				return err
+			}
+
+			groupKey, err := fetchGroupByGenesis(ctx, q, genID)
+			if err != nil {
+				return err
+			}
+
+			seedlingGroups = append(seedlingGroups, groupKey)
+		}
+
+		return nil
+	})
+
+	if dbErr != nil {
+		return nil, dbErr
+	}
+
+	return seedlingGroups, nil
+}
+
 // AddSproutsToBatch updates a batch with the passed batch transaction and also
 // binds the genesis transaction (which will create the set of assets in the
 // batch) to the batch itself.

--- a/tapdb/asset_minting_test.go
+++ b/tapdb/asset_minting_test.go
@@ -128,9 +128,10 @@ func storeGroupGenesis(t *testing.T, ctx context.Context, initGen asset.Genesis,
 	groupReq := asset.NewGroupKeyRequestNoErr(
 		t, privDesc, initGen, genProtoAsset, nil,
 	)
-	groupKey, err := asset.DeriveGroupKey(
-		genSigner, &genTxBuilder, *groupReq,
-	)
+	genTx, err := groupReq.BuildGroupVirtualTx(&genTxBuilder)
+	require.NoError(t, err)
+
+	groupKey, err := asset.DeriveGroupKey(genSigner, *genTx, *groupReq, nil)
 	require.NoError(t, err)
 
 	initialAsset := asset.RandAssetWithValues(
@@ -557,10 +558,16 @@ func seedlingsToAssetRoot(t *testing.T, genesisPoint wire.OutPoint,
 				*groupInfo.Genesis, protoAsset,
 				groupInfo.GroupKey.TapscriptRoot,
 			)
+			genTx, err := groupReq.BuildGroupVirtualTx(
+				&genTxBuilder,
+			)
+			require.NoError(t, err)
+
 			groupKey, err = asset.DeriveGroupKey(
 				asset.NewMockGenesisSigner(groupPriv),
-				&genTxBuilder, *groupReq,
+				*genTx, *groupReq, nil,
 			)
+			require.NoError(t, err)
 		}
 
 		if seedling.EnableEmission {
@@ -570,9 +577,15 @@ func seedlingsToAssetRoot(t *testing.T, genesisPoint wire.OutPoint,
 				t, groupKeyRaw, assetGen, protoAsset,
 				seedling.GroupTapscriptRoot,
 			)
-			groupKey, err = asset.DeriveGroupKey(
-				genSigner, &genTxBuilder, *groupReq,
+			genTx, err := groupReq.BuildGroupVirtualTx(
+				&genTxBuilder,
 			)
+			require.NoError(t, err)
+
+			groupKey, err = asset.DeriveGroupKey(
+				genSigner, *genTx, *groupReq, nil,
+			)
+			require.NoError(t, err)
 			newGroupPrivs[seedling.AssetName] = newGroupPriv
 			newGroupInfo[seedling.AssetName] = &asset.AssetGroup{
 				Genesis:  &assetGen,

--- a/tapdb/assets_store_test.go
+++ b/tapdb/assets_store_test.go
@@ -166,8 +166,11 @@ func randAsset(t *testing.T, genOpts ...assetGenOpt) *asset.Asset {
 	groupReq := asset.NewGroupKeyRequestNoErr(
 		t, groupKeyDesc, initialGen, protoAsset, nil,
 	)
+	genTx, err := groupReq.BuildGroupVirtualTx(&genTxBuilder)
+	require.NoError(t, err)
+
 	assetGroupKey, err = asset.DeriveGroupKey(
-		genSigner, &genTxBuilder, *groupReq,
+		genSigner, *genTx, *groupReq, nil,
 	)
 
 	require.NoError(t, err)

--- a/tapdb/sqlc/migrations/000017_seedling_script_group_keys.down.sql
+++ b/tapdb/sqlc/migrations/000017_seedling_script_group_keys.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE asset_seedlings DROP COLUMN script_key_id;
+ALTER TABLE asset_seedlings DROP COLUMN group_internal_key_id;
+ALTER TABLE asset_seedlings DROP COLUMN group_tapscript_root;

--- a/tapdb/sqlc/migrations/000017_seedling_script_group_keys.up.sql
+++ b/tapdb/sqlc/migrations/000017_seedling_script_group_keys.up.sql
@@ -1,0 +1,12 @@
+-- According to SQLite docs, a column added via ALTER TABLE cannot be both
+-- a REFERENCE and NOT NULL, so we'll have to enforce non-nilness outside of the DB.
+ALTER TABLE asset_seedlings ADD COLUMN script_key_id BIGINT REFERENCES script_keys(script_key_id);
+
+-- For a group anchor, we derive the internal key for the future group key early,
+-- to allow use of custom group witnesses.
+ALTER TABLE asset_seedlings ADD COLUMN group_internal_key_id BIGINT REFERENCES internal_keys(key_id);
+
+-- For a group key, the internal key can also be tweaked to commit to a
+-- tapscript tree. Once we finalize the batch, this tweak will also be stored
+-- as part of the asset group itself.
+ALTER TABLE asset_seedlings ADD COLUMN group_tapscript_root BLOB;

--- a/tapdb/sqlc/models.go
+++ b/tapdb/sqlc/models.go
@@ -87,16 +87,19 @@ type AssetProof struct {
 }
 
 type AssetSeedling struct {
-	SeedlingID      int64
-	AssetName       string
-	AssetVersion    int16
-	AssetType       int16
-	AssetSupply     int64
-	AssetMetaID     int64
-	EmissionEnabled bool
-	BatchID         int64
-	GroupGenesisID  sql.NullInt64
-	GroupAnchorID   sql.NullInt64
+	SeedlingID         int64
+	AssetName          string
+	AssetVersion       int16
+	AssetType          int16
+	AssetSupply        int64
+	AssetMetaID        int64
+	EmissionEnabled    bool
+	BatchID            int64
+	GroupGenesisID     sql.NullInt64
+	GroupAnchorID      sql.NullInt64
+	ScriptKeyID        sql.NullInt64
+	GroupInternalKeyID sql.NullInt64
+	GroupTapscriptRoot []byte
 }
 
 type AssetTransfer struct {

--- a/tapgarden/batch.go
+++ b/tapgarden/batch.go
@@ -219,3 +219,7 @@ func (m *MintingBatch) TapSibling() []byte {
 func (m *MintingBatch) UpdateTapSibling(sibling *chainhash.Hash) {
 	m.tapSibling = sibling
 }
+
+func (m *MintingBatch) IsFunded() bool {
+	return m.GenesisPacket != nil
+}

--- a/tapgarden/batch.go
+++ b/tapgarden/batch.go
@@ -50,9 +50,6 @@ type MintingBatch struct {
 	// GenesisPacket is the funded genesis packet that may or may not be
 	// fully signed. When broadcast, this will create all assets stored
 	// within this batch.
-	//
-	// NOTE: This field is only set if the state is beyond
-	// BatchStateCommitted.
 	GenesisPacket *tapsend.FundedPsbt
 
 	// RootAssetCommitment is the root Taproot Asset commitment for all the

--- a/tapgarden/batch.go
+++ b/tapgarden/batch.go
@@ -122,19 +122,6 @@ func (m *MintingBatch) Copy() *MintingBatch {
 	return batchCopy
 }
 
-// TODO(roasbeef): add batch validate method re unique names?
-
-// AddSeedling adds a new seedling to the batch.
-func (m *MintingBatch) addSeedling(s *Seedling) error {
-	if _, ok := m.Seedlings[s.AssetName]; ok {
-		return fmt.Errorf("asset with name %v already in batch",
-			s.AssetName)
-	}
-
-	m.Seedlings[s.AssetName] = s
-	return nil
-}
-
 // validateGroupAnchor checks if the group anchor for a seedling is valid.
 // A valid anchor must already be part of the batch and have emission enabled.
 func (m *MintingBatch) validateGroupAnchor(s *Seedling) error {

--- a/tapgarden/caretaker.go
+++ b/tapgarden/caretaker.go
@@ -412,64 +412,6 @@ func (b *BatchCaretaker) assetCultivator() {
 	}
 }
 
-// fundGenesisPsbt generates a PSBT packet we'll use to create an asset.  In
-// order to be able to create an asset, we need an initial genesis outpoint. To
-// obtain this we'll ask the wallet to fund a PSBT template for GenesisAmtSats
-// (all outputs need to hold some BTC to not be dust), and with a dummy script.
-// We need to use a dummy script as we can't know the actual script key since
-// that's dependent on the genesis outpoint.
-func (b *BatchCaretaker) fundGenesisPsbt(
-	ctx context.Context) (*tapsend.FundedPsbt, error) {
-
-	log.Infof("BatchCaretaker(%x): attempting to fund GenesisPacket",
-		b.batchKey[:])
-
-	txTemplate := wire.NewMsgTx(2)
-	txTemplate.AddTxOut(tapsend.CreateDummyOutput())
-	genesisPkt, err := psbt.NewFromUnsignedTx(txTemplate)
-	if err != nil {
-		return nil, fmt.Errorf("unable to make psbt packet: %w", err)
-	}
-
-	log.Infof("BatchCaretaker(%x): creating skeleton PSBT", b.batchKey[:])
-	log.Tracef("PSBT: %v", spew.Sdump(genesisPkt))
-
-	var feeRate chainfee.SatPerKWeight
-	switch {
-	// If a fee rate was manually assigned for this batch, use that instead
-	// of a fee rate estimate.
-	case b.cfg.BatchFeeRate != nil:
-		feeRate = *b.cfg.BatchFeeRate
-		log.Infof("BatchCaretaker(%x): using manual fee rate: %s, %d "+
-			"sat/vB", b.batchKey[:], feeRate.String(),
-			feeRate.FeePerKVByte()/1000)
-
-	default:
-		feeRate, err = b.cfg.ChainBridge.EstimateFee(
-			ctx, GenesisConfTarget,
-		)
-		if err != nil {
-			return nil, fmt.Errorf("unable to estimate fee: %w",
-				err)
-		}
-
-		log.Infof("BatchCaretaker(%x): estimated fee rate: %s",
-			b.batchKey[:], feeRate.FeePerKVByte().String())
-	}
-
-	fundedGenesisPkt, err := b.cfg.Wallet.FundPsbt(
-		ctx, genesisPkt, 1, feeRate,
-	)
-	if err != nil {
-		return nil, fmt.Errorf("unable to fund psbt: %w", err)
-	}
-
-	log.Infof("BatchCaretaker(%x): funded GenesisPacket", b.batchKey[:])
-	log.Tracef("GenesisPacket: %v", spew.Sdump(fundedGenesisPkt))
-
-	return fundedGenesisPkt, nil
-}
-
 // extractGenesisOutpoint extracts the genesis point (the first output from the
 // genesis transaction).
 func extractGenesisOutpoint(tx *wire.MsgTx) wire.OutPoint {
@@ -675,29 +617,37 @@ func (b *BatchCaretaker) stateStep(currentState BatchState) (BatchState, error) 
 	// batch, so we'll use the batch key as the internal key for the
 	// genesis transaction that'll create the batch.
 	case BatchStateFrozen:
-		// First, we'll fund a PSBT packet with enough coins allocated
-		// as inputs to be able to create our genesis output for the
-		// asset and also pay for fees.
-		//
 		// TODO(roasbeef): need to invalidate asset creation if on
 		// restart leases are gone
 		ctx, cancel := b.WithCtxQuitNoTimeout()
 		defer cancel()
-		genesisTxPkt, err := b.fundGenesisPsbt(ctx)
+
+		// Make a copy of the batch PSBT, which we'll modify and then
+		// update the batch with.
+		var psbtBuf bytes.Buffer
+		err := b.cfg.Batch.GenesisPacket.Pkt.Serialize(&psbtBuf)
 		if err != nil {
-			return 0, err
+			return 0, fmt.Errorf("unable to serialize genesis "+
+				"PSBT: %w", err)
 		}
 
-		genesisPoint := extractGenesisOutpoint(
-			genesisTxPkt.Pkt.UnsignedTx,
-		)
+		genesisTxPkt, err := psbt.NewFromRawBytes(&psbtBuf, false)
+		if err != nil {
+			return 0, fmt.Errorf("unable to deserialize genesis "+
+				"PSBT: %w", err)
+		}
+		changeOutputIndex := b.cfg.Batch.GenesisPacket.ChangeOutputIndex
 
 		// If the change output is first, then our commitment is second,
 		// and vice versa.
+		// TODO(jhb): return the anchor index instead of change? or both
+		// so this works for N outputs
 		b.anchorOutputIndex = 0
-		if genesisTxPkt.ChangeOutputIndex == 0 {
+		if changeOutputIndex == 0 {
 			b.anchorOutputIndex = 1
 		}
+
+		genesisPoint := extractGenesisOutpoint(genesisTxPkt.UnsignedTx)
 
 		// First, we'll turn all the seedlings into actual taproot assets.
 		tapCommitment, err := b.seedlingsToAssetSprouts(
@@ -737,23 +687,28 @@ func (b *BatchCaretaker) stateStep(currentState BatchState) (BatchState, error) 
 				"script: %w", err)
 		}
 
-		genesisTxPkt.Pkt.UnsignedTx.TxOut[b.anchorOutputIndex].PkScript = genesisScript
+		genesisTxPkt.UnsignedTx.
+			TxOut[b.anchorOutputIndex].PkScript = genesisScript
 
 		log.Infof("BatchCaretaker(%x): committing sprouts to disk",
 			b.batchKey[:])
 
+		fundedGenesisPsbt := tapsend.FundedPsbt{
+			Pkt:               genesisTxPkt,
+			ChangeOutputIndex: changeOutputIndex,
+		}
 		// With all our commitments created, we'll commit them to disk,
 		// replacing the existing seedlings we had created for each of
 		// these assets.
 		err = b.cfg.Log.AddSproutsToBatch(
 			ctx, b.cfg.Batch.BatchKey.PubKey,
-			genesisTxPkt, b.cfg.Batch.RootAssetCommitment,
+			&fundedGenesisPsbt, b.cfg.Batch.RootAssetCommitment,
 		)
 		if err != nil {
 			return 0, fmt.Errorf("unable to commit batch: %w", err)
 		}
 
-		b.cfg.Batch.GenesisPacket = genesisTxPkt
+		b.cfg.Batch.GenesisPacket.Pkt = genesisTxPkt
 
 		// Now that we know the script key for all the assets, we'll
 		// populate the asset metas map as we need that to create the

--- a/tapgarden/caretaker.go
+++ b/tapgarden/caretaker.go
@@ -509,8 +509,15 @@ func (b *BatchCaretaker) seedlingsToAssetSprouts(ctx context.Context,
 					"asset group membership: %w", err)
 			}
 
+			genTx, err := groupReq.BuildGenesisTx(
+				b.cfg.GenTxBuilder,
+			)
+			if err != nil {
+				return nil, err
+			}
+
 			sproutGroupKey, err = asset.DeriveGroupKey(
-				b.cfg.GenSigner, b.cfg.GenTxBuilder, *groupReq,
+				b.cfg.GenSigner, *genTx, *groupReq,
 			)
 			if err != nil {
 				return nil, fmt.Errorf("unable to tweak group "+
@@ -537,8 +544,15 @@ func (b *BatchCaretaker) seedlingsToAssetSprouts(ctx context.Context,
 					"asset group creation: %w", err)
 			}
 
+			genTx, err := groupReq.BuildGenesisTx(
+				b.cfg.GenTxBuilder,
+			)
+			if err != nil {
+				return nil, err
+			}
+
 			sproutGroupKey, err = asset.DeriveGroupKey(
-				b.cfg.GenSigner, b.cfg.GenTxBuilder, *groupReq,
+				b.cfg.GenSigner, *genTx, *groupReq,
 			)
 			if err != nil {
 				return nil, fmt.Errorf("unable to tweak group "+

--- a/tapgarden/caretaker.go
+++ b/tapgarden/caretaker.go
@@ -454,20 +454,12 @@ func (b *BatchCaretaker) seedlingsToAssetSprouts(ctx context.Context,
 			assetGen.MetaHash = seedling.Meta.MetaHash()
 		}
 
-		scriptKey, err := b.cfg.KeyRing.DeriveNextKey(
-			ctx, asset.TaprootAssetsKeyFamily,
-		)
-		if err != nil {
-			return nil, fmt.Errorf("unable to obtain script "+
-				"key: %w", err)
-		}
-		tweakedScriptKey := asset.NewScriptKeyBip86(scriptKey)
-
 		var (
 			amount         uint64
 			groupInfo      *asset.AssetGroup
 			protoAsset     *asset.Asset
 			sproutGroupKey *asset.GroupKey
+			err            error
 		)
 
 		// Determine the amount for the actual asset.
@@ -497,7 +489,8 @@ func (b *BatchCaretaker) seedlingsToAssetSprouts(ctx context.Context,
 		// partially filled asset as part of the signing process.
 		if groupInfo != nil || seedling.EnableEmission {
 			protoAsset, err = asset.New(
-				assetGen, amount, 0, 0, tweakedScriptKey, nil,
+				assetGen, amount, 0, 0, seedling.ScriptKey,
+				nil,
 				asset.WithAssetVersion(seedling.AssetVersion),
 			)
 			if err != nil {
@@ -530,16 +523,14 @@ func (b *BatchCaretaker) seedlingsToAssetSprouts(ctx context.Context,
 		// then use that to derive the key group signature
 		// along with the tweaked key group.
 		if seedling.EnableEmission {
-			rawGroupKey, err := b.cfg.KeyRing.DeriveNextKey(
-				ctx, asset.TaprootAssetsKeyFamily,
-			)
-			if err != nil {
-				return nil, fmt.Errorf("unable to derive "+
-					"group key: %w", err)
+			if seedling.GroupInternalKey == nil {
+				return nil, fmt.Errorf("unable to derive " +
+					"group key")
 			}
 
 			groupReq, err := asset.NewGroupKeyRequest(
-				rawGroupKey, assetGen, protoAsset, nil,
+				*seedling.GroupInternalKey, assetGen,
+				protoAsset, nil,
 			)
 			if err != nil {
 				return nil, fmt.Errorf("unable to request "+
@@ -563,7 +554,7 @@ func (b *BatchCaretaker) seedlingsToAssetSprouts(ctx context.Context,
 		// With the necessary keys components assembled, we'll create
 		// the actual asset now.
 		newAsset, err := asset.New(
-			assetGen, amount, 0, 0, tweakedScriptKey,
+			assetGen, amount, 0, 0, seedling.ScriptKey,
 			sproutGroupKey,
 			asset.WithAssetVersion(seedling.AssetVersion),
 		)

--- a/tapgarden/caretaker.go
+++ b/tapgarden/caretaker.go
@@ -1595,10 +1595,10 @@ func GenRawGroupAnchorVerifier(ctx context.Context) func(*asset.Genesis,
 		assetGroupKey := asset.ToSerialized(&groupKey.GroupPubKey)
 		groupAnchor, err := groupAnchors.Get(assetGroupKey)
 		if err != nil {
-			// TODO(jhb): add tapscript root support
 			singleTweak := gen.ID()
 			tweakedGroupKey, err := asset.GroupPubKey(
-				groupKey.RawKey.PubKey, singleTweak[:], nil,
+				groupKey.RawKey.PubKey, singleTweak[:],
+				groupKey.TapscriptRoot,
 			)
 			if err != nil {
 				return err

--- a/tapgarden/caretaker.go
+++ b/tapgarden/caretaker.go
@@ -431,15 +431,71 @@ func (b *BatchCaretaker) seedlingsToAssetSprouts(ctx context.Context,
 
 	newAssets := make([]*asset.Asset, 0, len(b.cfg.Batch.Seedlings))
 
-	// Seedlings that anchor a group may be referenced by other seedlings,
-	// and therefore need to be mapped to sprouts first so that we derive
-	// the initial tweaked group key early.
-	orderedSeedlings := SortSeedlings(maps.Values(b.cfg.Batch.Seedlings))
-	newGroups := make(map[string]*asset.AssetGroup, len(orderedSeedlings))
+	// separate grouped assets from ungrouped
+	groupedSeedlings, ungroupedSeedlings := filterSeedlingsWithGroup(
+		b.cfg.Batch.Seedlings,
+	)
+	groupedSeedlingCount := len(groupedSeedlings)
 
-	for _, seedlingName := range orderedSeedlings {
-		seedling := b.cfg.Batch.Seedlings[seedlingName]
+	// load seedling asset groups and check for correct group count
+	seedlingGroups, err := b.cfg.Log.FetchSeedlingGroups(
+		ctx, genesisPoint, assetOutputIndex,
+		maps.Values(groupedSeedlings),
+	)
+	if err != nil {
+		return nil, err
+	}
+	seedlingGroupCount := len(seedlingGroups)
 
+	if groupedSeedlingCount != seedlingGroupCount {
+		return nil, fmt.Errorf("wrong number of grouped assets and "+
+			"asset groups: %d, %d", groupedSeedlingCount,
+			seedlingGroupCount)
+	}
+
+	for i := range seedlingGroups {
+		// check that asset group has a witness, and that the group
+		// has a matching seedling
+		seedlingGroup := seedlingGroups[i]
+		if len(seedlingGroup.GroupKey.Witness) == 0 {
+			return nil, fmt.Errorf("not all seedling groups have " +
+				"witnesses")
+		}
+
+		seedling, ok := groupedSeedlings[seedlingGroup.Tag]
+		if !ok {
+			groupTweakedKey := seedlingGroup.GroupKey.GroupPubKey.
+				SerializeCompressed()
+			return nil, fmt.Errorf("no seedling with tag matching "+
+				"group: %v, %x", seedlingGroup.Tag,
+				groupTweakedKey)
+		}
+
+		// build assets for grouped seedlings
+		var amount uint64
+		switch seedling.AssetType {
+		case asset.Normal:
+			amount = seedling.Amount
+		case asset.Collectible:
+			amount = 1
+		}
+
+		newAsset, err := asset.New(
+			*seedlingGroup.Genesis, amount, 0, 0,
+			seedling.ScriptKey, seedlingGroup.GroupKey,
+			asset.WithAssetVersion(seedling.AssetVersion),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("unable to create new asset: %w",
+				err)
+		}
+
+		newAssets = append(newAssets, newAsset)
+	}
+
+	// build assets for ungrouped seedlings
+	for seedlingName := range ungroupedSeedlings {
+		seedling := ungroupedSeedlings[seedlingName]
 		assetGen := asset.Genesis{
 			FirstPrevOut: genesisPoint,
 			Tag:          seedling.AssetName,
@@ -454,15 +510,8 @@ func (b *BatchCaretaker) seedlingsToAssetSprouts(ctx context.Context,
 			assetGen.MetaHash = seedling.Meta.MetaHash()
 		}
 
-		var (
-			amount         uint64
-			groupInfo      *asset.AssetGroup
-			protoAsset     *asset.Asset
-			sproutGroupKey *asset.GroupKey
-			err            error
-		)
-
 		// Determine the amount for the actual asset.
+		var amount uint64
 		switch seedling.AssetType {
 		case asset.Normal:
 			amount = seedling.Amount
@@ -470,120 +519,15 @@ func (b *BatchCaretaker) seedlingsToAssetSprouts(ctx context.Context,
 			amount = 1
 		}
 
-		// If the seedling has a group key specified,
-		// that group key was validated earlier. We need to
-		// sign the new genesis with that group key.
-		if seedling.HasGroupKey() {
-			groupInfo = seedling.GroupInfo
-		}
-
-		// If the seedling has a group anchor specified, that anchor
-		// was validated earlier and the corresponding group has already
-		// been created. We need to look up the group key and sign
-		// the asset genesis with that key.
-		if seedling.GroupAnchor != nil {
-			groupInfo = newGroups[*seedling.GroupAnchor]
-		}
-
-		// If a group witness needs to be produced, then we will need a
-		// partially filled asset as part of the signing process.
-		if groupInfo != nil || seedling.EnableEmission {
-			protoAsset, err = asset.New(
-				assetGen, amount, 0, 0, seedling.ScriptKey,
-				nil,
-				asset.WithAssetVersion(seedling.AssetVersion),
-			)
-			if err != nil {
-				return nil, fmt.Errorf("unable to create "+
-					"asset for group key signing: %w", err)
-			}
-		}
-
-		if groupInfo != nil {
-			groupReq, err := asset.NewGroupKeyRequest(
-				groupInfo.GroupKey.RawKey, *groupInfo.Genesis,
-				protoAsset, nil,
-			)
-			if err != nil {
-				return nil, fmt.Errorf("unable to request "+
-					"asset group membership: %w", err)
-			}
-
-			genTx, err := groupReq.BuildGenesisTx(
-				b.cfg.GenTxBuilder,
-			)
-			if err != nil {
-				return nil, err
-			}
-
-			sproutGroupKey, err = asset.DeriveGroupKey(
-				b.cfg.GenSigner, *genTx, *groupReq,
-			)
-			if err != nil {
-				return nil, fmt.Errorf("unable to tweak group "+
-					"key: %w", err)
-			}
-		}
-
-		// If emission is enabled without a group key specified,
-		// then we'll need to generate another public key,
-		// then use that to derive the key group signature
-		// along with the tweaked key group.
-		if seedling.EnableEmission {
-			if seedling.GroupInternalKey == nil {
-				return nil, fmt.Errorf("unable to derive " +
-					"group key")
-			}
-
-			groupReq, err := asset.NewGroupKeyRequest(
-				*seedling.GroupInternalKey, assetGen,
-				protoAsset, nil,
-			)
-			if err != nil {
-				return nil, fmt.Errorf("unable to request "+
-					"asset group creation: %w", err)
-			}
-
-			genTx, err := groupReq.BuildGenesisTx(
-				b.cfg.GenTxBuilder,
-			)
-			if err != nil {
-				return nil, err
-			}
-
-			sproutGroupKey, err = asset.DeriveGroupKey(
-				b.cfg.GenSigner, *genTx, *groupReq,
-			)
-			if err != nil {
-				return nil, fmt.Errorf("unable to tweak group "+
-					"key: %w", err)
-			}
-
-			newGroups[seedlingName] = &asset.AssetGroup{
-				Genesis:  &assetGen,
-				GroupKey: sproutGroupKey,
-			}
-		}
-
 		// With the necessary keys components assembled, we'll create
 		// the actual asset now.
 		newAsset, err := asset.New(
-			assetGen, amount, 0, 0, seedling.ScriptKey,
-			sproutGroupKey,
+			assetGen, amount, 0, 0, seedling.ScriptKey, nil,
 			asset.WithAssetVersion(seedling.AssetVersion),
 		)
 		if err != nil {
 			return nil, fmt.Errorf("unable to create new asset: %w",
 				err)
-		}
-
-		// Verify the group witness if present.
-		if sproutGroupKey != nil {
-			err := b.cfg.TxValidator.Execute(newAsset, nil, nil)
-			if err != nil {
-				return nil, fmt.Errorf("unable to verify "+
-					"asset group witness: %w", err)
-			}
 		}
 
 		newAssets = append(newAssets, newAsset)

--- a/tapgarden/interface.go
+++ b/tapgarden/interface.go
@@ -209,6 +209,17 @@ type MintingStore interface {
 	FetchMintingBatch(ctx context.Context,
 		batchKey *btcec.PublicKey) (*MintingBatch, error)
 
+	// AddSeedlingGroups stores the asset groups for seedlings associated
+	// with a batch.
+	AddSeedlingGroups(ctx context.Context, genesisOutpoint wire.OutPoint,
+		assetGroups []*asset.AssetGroup) error
+
+	// FetchSeedlingGroups is used to fetch the asset groups for seedlings
+	// associated with a funded batch.
+	FetchSeedlingGroups(ctx context.Context, genesisOutpoint wire.OutPoint,
+		anchorOutputIndex uint32,
+		seedlings []*Seedling) ([]*asset.AssetGroup, error)
+
 	// AddSproutsToBatch adds a new set of sprouts to the batch, along with
 	// a GenesisPacket, that once signed and broadcast with create the
 	// set of assets on chain.

--- a/tapgarden/interface.go
+++ b/tapgarden/interface.go
@@ -257,6 +257,11 @@ type MintingStore interface {
 	// be committed to disk.
 	CommitBatchTapSibling(ctx context.Context, batchKey *btcec.PublicKey,
 		rootHash *chainhash.Hash) error
+
+	// CommitBatchTx adds a funded transaction to the batch, which also sets
+	// the genesis point for the batch.
+	CommitBatchTx(ctx context.Context, batchKey *btcec.PublicKey,
+		genesisTx *tapsend.FundedPsbt) error
 }
 
 // ChainBridge is our bridge to the target chain. It's used to get confirmation

--- a/tapgarden/interface.go
+++ b/tapgarden/interface.go
@@ -40,6 +40,14 @@ type Planter interface {
 	// returned.
 	CancelSeedling() error
 
+	// FundBatch attempts to provide a genesis point for the current batch,
+	// or create a new funded batch.
+	FundBatch(params FundParams) (*MintingBatch, error)
+
+	// SealBatch attempts to seal the current batch, by providing or
+	// deriving all witnesses necessary to create the final genesis TX.
+	SealBatch(params SealParams) (*MintingBatch, error)
+
 	// FinalizeBatch signals that the asset minter should finalize
 	// the current batch, if one exists.
 	FinalizeBatch(params FinalizeParams) (*MintingBatch, error)

--- a/tapgarden/mock.go
+++ b/tapgarden/mock.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
-	"math/rand"
 	"testing"
 	"time"
 
@@ -37,15 +36,17 @@ func RandSeedlings(t testing.TB, numSeedlings int) map[string]*Seedling {
 	for i := 0; i < numSeedlings; i++ {
 		metaBlob := test.RandBytes(32)
 		assetName := hex.EncodeToString(test.RandBytes(32))
+		scriptKey, _ := test.RandKeyDesc(t)
 		seedlings[assetName] = &Seedling{
 			// For now, we only test the v0 and v1 versions.
-			AssetVersion: asset.Version(rand.Int31n(2)),
-			AssetType:    asset.Type(rand.Int31n(2)),
+			AssetVersion: asset.Version(test.RandIntn(2)),
+			AssetType:    asset.Type(test.RandIntn(2)),
 			AssetName:    assetName,
 			Meta: &proof.MetaReveal{
 				Data: metaBlob,
 			},
-			Amount:         uint64(rand.Int31()),
+			Amount:         uint64(test.RandInt[uint32]()),
+			ScriptKey:      asset.NewScriptKeyBip86(scriptKey),
 			EnableEmission: test.RandBool(),
 		}
 	}
@@ -57,16 +58,11 @@ func RandSeedlings(t testing.TB, numSeedlings int) map[string]*Seedling {
 // seedlings populated for testing.
 func RandSeedlingMintingBatch(t testing.TB, numSeedlings int) *MintingBatch {
 	genesisTx := NewGenesisTx(t, chainfee.FeePerKwFloor)
+	BatchKey, _ := test.RandKeyDesc(t)
 	return &MintingBatch{
-		BatchKey: keychain.KeyDescriptor{
-			PubKey: test.RandPubKey(t),
-			KeyLocator: keychain.KeyLocator{
-				Index:  uint32(rand.Int31()),
-				Family: keychain.KeyFamily(rand.Int31()),
-			},
-		},
+		BatchKey:     BatchKey,
 		Seedlings:    RandSeedlings(t, numSeedlings),
-		HeightHint:   rand.Uint32(),
+		HeightHint:   test.RandInt[uint32](),
 		CreationTime: time.Now(),
 		GenesisPacket: &tapsend.FundedPsbt{
 			Pkt:               &genesisTx,
@@ -119,7 +115,7 @@ func FundGenesisTx(packet *psbt.Packet, feeRate chainfee.SatPerKWeight) {
 	// simulate the wallet funding the transaction.
 	packet.UnsignedTx.AddTxIn(&wire.TxIn{
 		PreviousOutPoint: wire.OutPoint{
-			Index: rand.Uint32(),
+			Index: test.RandInt[uint32](),
 		},
 	})
 

--- a/tapgarden/planter.go
+++ b/tapgarden/planter.go
@@ -19,7 +19,6 @@ import (
 	"github.com/lightninglabs/taproot-assets/tapsend"
 	"github.com/lightninglabs/taproot-assets/universe"
 	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
-	"github.com/lightningnetwork/lnd/ticker"
 	"golang.org/x/exp/maps"
 )
 
@@ -78,10 +77,6 @@ type GardenKit struct {
 // PlanterConfig is the main config for the ChainPlanter.
 type PlanterConfig struct {
 	GardenKit
-
-	// BatchTicker is used to notify the planter than it should assemble
-	// all asset requests into a new batch.
-	BatchTicker *ticker.Force
 
 	// ProofUpdates is the storage backend for updated proofs.
 	ProofUpdates proof.Archiver
@@ -638,31 +633,6 @@ func (c *ChainPlanter) gardener() {
 
 	for {
 		select {
-		case <-c.cfg.BatchTicker.Ticks():
-			// There is no pending batch, so we can just abort.
-			if c.pendingBatch == nil {
-				log.Debugf("No batches pending...doing nothing")
-				continue
-			}
-
-			defaultFeeRate := fn.None[chainfee.SatPerKWeight]()
-			emptyTapSibling := fn.None[asset.TapscriptTreeNodes]()
-
-			defaultFinalizeParams := FinalizeParams{
-				FeeRate:        defaultFeeRate,
-				SiblingTapTree: emptyTapSibling,
-			}
-			_, err := c.finalizeBatch(defaultFinalizeParams)
-			if err != nil {
-				c.cfg.ErrChan <- fmt.Errorf("unable to freeze "+
-					"minting batch: %w", err)
-				continue
-			}
-
-			// Now that we have a caretaker launched for this
-			// batch, we'll set the pending batch to nil
-			c.pendingBatch = nil
-
 		// A request for new asset issuance just arrived, add this to
 		// the pending batch and acknowledge the receipt back to the
 		// caller.

--- a/tapgarden/planter.go
+++ b/tapgarden/planter.go
@@ -879,7 +879,13 @@ func (c *ChainPlanter) gardener() {
 				req.Resolve(batches)
 
 			case reqTypeFundBatch:
-				log.Infof("Funding batch")
+				if c.pendingBatch != nil &&
+					c.pendingBatch.IsFunded() {
+
+					req.Error(fmt.Errorf("batch already " +
+						"funded"))
+					break
+				}
 
 				fundReqParams, err :=
 					typedParam[FundParams](req)
@@ -897,6 +903,8 @@ func (c *ChainPlanter) gardener() {
 						"minting batch: %w", err))
 					break
 				}
+
+				req.Resolve(c.pendingBatch)
 
 			// TODO(jhb): follow-up PR: Implement SealBatch command
 			case reqTypeSealBatch:
@@ -1190,6 +1198,15 @@ func (c *ChainPlanter) finalizeBatch(params FinalizeParams) (*BatchCaretaker,
 		err     error
 	)
 
+	// Before modifying the pending batch, check if the batch was already
+	// funded. If so, reject any provided parameters, as they would conflict
+	// with those previously used for batch funding.
+	haveParams := params.FeeRate.IsSome() || params.SiblingTapTree.IsSome()
+	if haveParams && c.pendingBatch.IsFunded() {
+		return nil, fmt.Errorf("cannot provide finalize parameters " +
+			"if batch already funded")
+	}
+
 	// Process the finalize parameters.
 	feeRate = params.FeeRate.UnwrapToPtr()
 
@@ -1427,7 +1444,7 @@ func (c *ChainPlanter) prepAssetSeedling(ctx context.Context,
 		req.ScriptKey = asset.NewScriptKeyBip86(scriptKey)
 	}
 
-	// Now that we know the field are valid, we'll check to see if a batch
+	// Now that we know the seedling is valid, we'll check to see if a batch
 	// already exists.
 	switch {
 	// No batch, so we'll create a new one with only this seedling as part

--- a/tapgarden/planter.go
+++ b/tapgarden/planter.go
@@ -1212,23 +1212,24 @@ func (c *ChainPlanter) finalizeBatch(params FinalizeParams) (*BatchCaretaker,
 	}
 
 	// If the batch already has a funded TX, we can skip funding the batch.
-	if c.pendingBatch.GenesisPacket == nil {
-		fundParams := FundParams(params)
-
+	if !c.pendingBatch.IsFunded() {
 		// Fund the batch before starting the caretaker. If funding
 		// fails, we can't start a caretaker for the batch, so we'll
 		// clear the pending batch. The batch will exist on disk for
 		// the user to recreate it if necessary.
-		err = c.fundBatch(ctx, fundParams)
+		// TODO(jhb): Don't clear pending batch here
+		err = c.fundBatch(ctx, FundParams(params))
 		if err != nil {
 			c.pendingBatch = nil
 			return nil, err
 		}
 	}
 
-	// TODO(jhb): move batch sibling handling entirely to fundBatch, remove
-	// logic around sibling storage
-	// TODO(jhb): check for batch sealing
+	// TODO(jhb): follow-up PR: detect batches that were already sealed
+	err = c.sealBatch(ctx, SealParams{})
+	if err != nil {
+		return nil, err
+	}
 
 	// Now that the batch has been frozen on disk, we can update the batch
 	// state to frozen before launching a new caretaker state machine for

--- a/tapgarden/planter.go
+++ b/tapgarden/planter.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcutil/psbt"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/davecgh/go-spew/spew"
@@ -15,6 +16,7 @@ import (
 	"github.com/lightninglabs/taproot-assets/fn"
 	"github.com/lightninglabs/taproot-assets/proof"
 	"github.com/lightninglabs/taproot-assets/tapscript"
+	"github.com/lightninglabs/taproot-assets/tapsend"
 	"github.com/lightninglabs/taproot-assets/universe"
 	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
 	"github.com/lightningnetwork/lnd/ticker"
@@ -438,6 +440,66 @@ func (c *ChainPlanter) newBatch() (*MintingBatch, error) {
 	return newBatch, nil
 }
 
+// fundGenesisPsbt generates a PSBT packet we'll use to create an asset.  In
+// order to be able to create an asset, we need an initial genesis outpoint. To
+// obtain this we'll ask the wallet to fund a PSBT template for GenesisAmtSats
+// (all outputs need to hold some BTC to not be dust), and with a dummy script.
+// We need to use a dummy script as we can't know the actual script key since
+// that's dependent on the genesis outpoint.
+func (c *ChainPlanter) fundGenesisPsbt(ctx context.Context,
+	batchKey asset.SerializedKey,
+	manualFeeRate *chainfee.SatPerKWeight) (*tapsend.FundedPsbt, error) {
+
+	log.Infof("Attempting to fund batch: %x", batchKey)
+
+	// Construct a 1-output TX as a template for our genesis TX, which the
+	// backing wallet will fund.
+	txTemplate := wire.NewMsgTx(2)
+	txTemplate.AddTxOut(tapsend.CreateDummyOutput())
+	genesisPkt, err := psbt.NewFromUnsignedTx(txTemplate)
+	if err != nil {
+		return nil, fmt.Errorf("unable to make psbt packet: %w", err)
+	}
+
+	log.Infof("creating skeleton PSBT for batch: %x", batchKey)
+	log.Tracef("PSBT: %v", spew.Sdump(genesisPkt))
+
+	var feeRate chainfee.SatPerKWeight
+	switch {
+	// If a fee rate was manually assigned for this batch, use that instead
+	// of a fee rate estimate.
+	case manualFeeRate != nil:
+		feeRate = *manualFeeRate
+		log.Infof("using manual fee rate for batch: %x, %s, %d sat/vB",
+			batchKey[:], feeRate.String(),
+			feeRate.FeePerKVByte()/1000)
+
+	default:
+		feeRate, err = c.cfg.ChainBridge.EstimateFee(
+			ctx, GenesisConfTarget,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("unable to estimate fee: %w",
+				err)
+		}
+
+		log.Infof("estimated fee rate for batch: %x, %s",
+			batchKey[:], feeRate.FeePerKVByte().String())
+	}
+
+	fundedGenesisPkt, err := c.cfg.Wallet.FundPsbt(
+		ctx, genesisPkt, 1, feeRate,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("unable to fund psbt: %w", err)
+	}
+
+	log.Infof("Funded GenesisPacket for batch: %x", batchKey)
+	log.Tracef("GenesisPacket: %v", spew.Sdump(fundedGenesisPkt))
+
+	return fundedGenesisPkt, nil
+}
+
 // freezeMintingBatch freezes a target minting batch which means that no new
 // assets can be added to the batch.
 func freezeMintingBatch(ctx context.Context, batchStore MintingStore,
@@ -792,55 +854,158 @@ func (c *ChainPlanter) gardener() {
 	}
 }
 
-// finalizeBatch creates a new caretaker for the batch and starts it.
-func (c *ChainPlanter) finalizeBatch(params FinalizeParams) (*BatchCaretaker,
-	error) {
-
+// fundBatch attempts to fund a minting batch and create a funded genesis PSBT.
+// This PSBT is a template that the caretaker will modify when finalizing the
+// batch. If a feerate or tapscript sibling are provided, those will be used
+// when funding the batch. If no pending batch exists, a batch will be created
+// with the funded genesis PSBT. After funding, the pending batch will be
+// saved to disk and updated in memory.
+func (c *ChainPlanter) fundBatch(ctx context.Context, params FundParams) error {
 	var (
 		feeRate  *chainfee.SatPerKWeight
 		rootHash *chainhash.Hash
 		err      error
 	)
 
-	ctx, cancel := c.WithCtxQuit()
-	defer cancel()
 	// If a tapscript tree was specified for this batch, we'll store it on
 	// disk. The caretaker we start for this batch will use it when deriving
 	// the final Taproot output key.
-	params.FeeRate.WhenSome(func(fr chainfee.SatPerKWeight) {
-		feeRate = &fr
-	})
+	feeRate = params.FeeRate.UnwrapToPtr()
 	params.SiblingTapTree.WhenSome(func(tn asset.TapscriptTreeNodes) {
-		rootHash, err = c.cfg.TreeStore.
-			StoreTapscriptTree(ctx, tn)
+		rootHash, err = c.cfg.TreeStore.StoreTapscriptTree(ctx, tn)
 	})
 
 	if err != nil {
-		return nil, fmt.Errorf("unable to store tapscript "+
-			"tree for minting batch: %w", err)
+		return fmt.Errorf("unable to store tapscript tree for minting "+
+			"batch: %w", err)
 	}
 
-	if rootHash != nil {
-		ctx, cancel = c.WithCtxQuit()
-		defer cancel()
-		err = c.cfg.Log.CommitBatchTapSibling(
-			ctx, c.pendingBatch.BatchKey.PubKey, rootHash,
+	// Update the batch by adding the sibling root hash and genesis TX.
+	updateBatch := func(batch *MintingBatch) error {
+		// Add the batch sibling root hash if present.
+		if rootHash != nil {
+			batch.tapSibling = rootHash
+		}
+
+		// Fund the batch with the specified fee rate.
+		batchKey := asset.ToSerialized(batch.BatchKey.PubKey)
+		batchTX, err := c.fundGenesisPsbt(ctx, batchKey, feeRate)
+		if err != nil {
+			return fmt.Errorf("unable to fund minting PSBT for "+
+				"batch: %x %w", batchKey[:], err)
+		}
+
+		batch.GenesisPacket = batchTX
+
+		return nil
+	}
+
+	switch {
+	// If we don't have a batch, we'll create an empty batch before funding
+	// and writing to disk.
+	case c.pendingBatch == nil:
+		newBatch, err := c.newBatch()
+		if err != nil {
+			return fmt.Errorf("unable to create new batch: %w", err)
+		}
+
+		err = updateBatch(newBatch)
+		if err != nil {
+			return err
+		}
+
+		// Now that we're done populating parts of the batch, write it
+		// to disk.
+		err = c.cfg.Log.CommitMintingBatch(ctx, newBatch)
+		if err != nil {
+			return err
+		}
+
+		c.pendingBatch = newBatch
+
+	// If we already have a batch, we need to attach the optional sibling
+	// root hash and fund the batch.
+	case c.pendingBatch != nil:
+		err = updateBatch(c.pendingBatch)
+		if err != nil {
+			return err
+		}
+
+		// Write the associated sibling root hash and TX to disk.
+		if c.pendingBatch.tapSibling != nil {
+			err = c.cfg.Log.CommitBatchTapSibling(
+				ctx, c.pendingBatch.BatchKey.PubKey, rootHash,
+			)
+			if err != nil {
+				return fmt.Errorf("unable to commit tapscript "+
+					"sibling for minting batch %w", err)
+			}
+		}
+
+		err = c.cfg.Log.CommitBatchTx(
+			ctx, c.pendingBatch.BatchKey.PubKey,
+			c.pendingBatch.GenesisPacket,
 		)
 		if err != nil {
-			return nil, fmt.Errorf("unable to commit tapscript "+
-				"sibling for minting batch %w", err)
+			return err
 		}
 	}
 
-	c.pendingBatch.tapSibling = rootHash
+	return nil
+}
 
+func (c *ChainPlanter) sealBatch(params SealParams) error {
+	return nil
+}
+
+// finalizeBatch creates a new caretaker for the batch and starts it.
+func (c *ChainPlanter) finalizeBatch(params FinalizeParams) (*BatchCaretaker,
+	error) {
+
+	var (
+		feeRate *chainfee.SatPerKWeight
+		err     error
+	)
+
+	// Process the finalize parameters.
+	feeRate = params.FeeRate.UnwrapToPtr()
+
+	ctx, cancel := c.WithCtxQuit()
+	defer cancel()
+
+	params.SiblingTapTree.WhenSome(func(tn asset.TapscriptTreeNodes) {
+		_, err = c.cfg.TreeStore.StoreTapscriptTree(ctx, tn)
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("unable to store tapscript tree for "+
+			"minting batch: %w", err)
+	}
 	// At this point, we have a non-empty batch, so we'll first finalize it
 	// on disk. This means no further seedlings can be added to this batch.
 	err = freezeMintingBatch(ctx, c.cfg.Log, c.pendingBatch)
 	if err != nil {
-		return nil, fmt.Errorf("unable to freeze minting batch: %w",
-			err)
+		return nil, err
 	}
+
+	// If the batch already has a funded TX, we can skip funding the batch.
+	if c.pendingBatch.GenesisPacket == nil {
+		fundParams := FundParams(params)
+
+		// Fund the batch before starting the caretaker. If funding
+		// fails, we can't start a caretaker for the batch, so we'll
+		// clear the pending batch. The batch will exist on disk for
+		// the user to recreate it if necessary.
+		err = c.fundBatch(ctx, fundParams)
+		if err != nil {
+			c.pendingBatch = nil
+			return nil, err
+		}
+	}
+
+	// TODO(jhb): move batch sibling handling entirely to fundBatch, remove
+	// logic around sibling storage
+	// TODO(jhb): check for batch sealing
 
 	// Now that the batch has been frozen on disk, we can update the batch
 	// state to frozen before launching a new caretaker state machine for

--- a/tapgarden/planter_test.go
+++ b/tapgarden/planter_test.go
@@ -35,16 +35,13 @@ import (
 	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/lightningnetwork/lnd/lntest/wait"
 	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
-	"github.com/lightningnetwork/lnd/ticker"
 	"github.com/stretchr/testify/require"
 )
 
 // Default to a large interval so the planter never actually ticks and only
 // rely on our manual ticks.
 var (
-	defaultInterval   = time.Hour * 24
 	defaultTimeout    = time.Second * 5
-	minterInterval    = time.Millisecond * 250
 	noCaretakerStates = fn.NewSet(
 		tapgarden.BatchStatePending,
 		tapgarden.BatchStateSeedlingCancelled,
@@ -84,8 +81,6 @@ type mintingTestHarness struct {
 
 	txValidator tapscript.TxValidator
 
-	ticker *ticker.Force
-
 	planter *tapgarden.ChainPlanter
 
 	batchKey *keychain.KeyDescriptor
@@ -101,8 +96,8 @@ type mintingTestHarness struct {
 
 // newMintingTestHarness creates a new test harness from an active minting
 // store and an existing testing context.
-func newMintingTestHarness(t *testing.T, store tapgarden.MintingStore,
-	interval time.Duration) *mintingTestHarness {
+func newMintingTestHarness(t *testing.T,
+	store tapgarden.MintingStore) *mintingTestHarness {
 
 	keyRing := tapgarden.NewMockKeyRing()
 	genSigner := tapgarden.NewMockGenSigner(keyRing)
@@ -112,7 +107,6 @@ func newMintingTestHarness(t *testing.T, store tapgarden.MintingStore,
 		T:            t,
 		store:        store,
 		treeStore:    &treeMgr,
-		ticker:       ticker.NewForce(interval),
 		wallet:       tapgarden.NewMockWalletAnchor(),
 		chain:        tapgarden.NewMockChainBridge(),
 		proofFiles:   &tapgarden.MockProofArchive{},
@@ -146,7 +140,6 @@ func (t *mintingTestHarness) refreshChainPlanter() {
 			ProofFiles:   t.proofFiles,
 			ProofWatcher: t.proofWatcher,
 		},
-		BatchTicker:  t.ticker,
 		ProofUpdates: t.proofFiles,
 		ErrChan:      t.errChan,
 	})
@@ -1399,7 +1392,6 @@ func testFinalizeWithTapscriptTree(t *mintingTestHarness) {
 // that are parametrized based on a fresh minting store.
 type mintingStoreTestCase struct {
 	name     string
-	interval time.Duration
 	testFunc func(t *mintingTestHarness)
 }
 
@@ -1407,27 +1399,22 @@ type mintingStoreTestCase struct {
 var testCases = []mintingStoreTestCase{
 	{
 		name:     "basic_asset_creation",
-		interval: defaultInterval,
 		testFunc: testBasicAssetCreation,
 	},
 	{
 		name:     "creation_by_minting_ticker",
-		interval: minterInterval,
 		testFunc: testMintingTicker,
 	},
 	{
 		name:     "minting_with_cancellation",
-		interval: minterInterval,
 		testFunc: testMintingCancelFinalize,
 	},
 	{
 		name:     "finalize_batch",
-		interval: minterInterval,
 		testFunc: testFinalizeBatch,
 	},
 	{
 		name:     "finalize_with_tapscript_tree",
-		interval: minterInterval,
 		testFunc: testFinalizeWithTapscriptTree,
 	},
 }
@@ -1443,9 +1430,7 @@ func TestBatchedAssetIssuance(t *testing.T) {
 		testCase := testCase
 
 		t.Run(testCase.name, func(t *testing.T) {
-			mintTest := newMintingTestHarness(
-				t, mintingStore, testCase.interval,
-			)
+			mintTest := newMintingTestHarness(t, mintingStore)
 			testCase.testFunc(mintTest)
 		})
 	}


### PR DESCRIPTION
Closes #820

Update the minting state machines to move batch funding into a separate command that can execute before batch finalization. Add a new command to supply group anchor witnesses before batch finalization.

Remaining TODOs:

- [x] derive seedling script keys in `prepAssetSeedling`
- [x] DB migration to add seedling script key reference field
- [x] Update DB queries to write & fetch seedling script key
- [x] Update DB queries to write & fetch batch TX
- [x] derive group internal key in `prepAssetSeedling`
- [x] Update DB queries to write & fetch seedling group internal key
- [ ] Extend `tapdb/asset_minting` tests to cover new query params
- [ ] Add tests for `tapdb/asset_minting/CommitBatchTx`
- [x] Resolve `FinalizeParams` handling wrt. `fundBatch`
- [x] Extend `tapgarden/planter_test` test to cover `FundBatch`
- [x] Implement `SealBatch`
- [x] Remove batch ticker from caretaker and `tapgarden` tests