### PR TITLE
Remove duplicate comment words

### DIFF
--- a/asset/asset.go
+++ b/asset/asset.go
@@ -96,7 +96,7 @@ const (
 	// Encode normal is the normal encoding type for an asset.
 	EncodeNormal EncodeType = iota
 
-	// EncodeSegwit denotes that the witness vector field is not be be
+	// EncodeSegwit denotes that the witness vector field is not be
 	// encoded.
 	EncodeSegwit
 )

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -92,7 +92,7 @@ function check_tag_correct() {
     exit 0
   fi
 
-  # If a tag is specified, ensure that that tag is present and checked out.
+  # If a tag is specified, ensure that specified tag is present and checked out.
   if [[ $tag != $(git describe --tags) ]]; then
     red "tag $tag not checked out"
     exit 1

--- a/tapdb/interfaces.go
+++ b/tapdb/interfaces.go
@@ -49,7 +49,7 @@ type TxOptions interface {
 type BatchedTx[Q any] interface {
 	// ExecTx will execute the passed txBody, operating upon generic
 	// parameter Q (usually a storage interface) in a single transaction.
-	// The set of TxOptions are passed in in order to allow the caller to
+	// The set of TxOptions are passed in order to allow the caller to
 	// specify if a transaction should be read-only and optionally what
 	// type of concurrency control should be used.
 	ExecTx(ctx context.Context, txOptions TxOptions,

--- a/tapdb/universe_stats.go
+++ b/tapdb/universe_stats.go
@@ -127,7 +127,7 @@ const eventQueryBucket = time.Hour
 
 // newEventQuery creates a new event query from the given query.
 func newEventQuery(q universe.GroupedStatsQuery) eventQuery {
-	// For both the start and time time, we'll round down to the nearest
+	// For both the start and time, we'll round down to the nearest
 	// hour. This'll serve to bucket queries into hourly buckets.
 	startTime := q.StartTime.UTC().Truncate(eventQueryBucket).Unix()
 	endTime := q.EndTime.UTC().Truncate(eventQueryBucket).Unix()

--- a/tapgarden/caretaker.go
+++ b/tapgarden/caretaker.go
@@ -1440,7 +1440,7 @@ func GenHeaderVerifier(ctx context.Context,
 // assetGroupCacheSize is the size of the cache for group keys.
 const assetGroupCacheSize = 10000
 
-// emptyVal is a simple type def around struct{} to use as a dummy value in in
+// emptyVal is a simple type def around struct{} to use as a dummy value in
 // the cache.
 type emptyVal struct{}
 


### PR DESCRIPTION
Duplicate words are identified with the regex:

^[\s\t]*//.*\b(\w+)\b \1\b
^[\s\t]*#.*\b(\w+)\b \1\b

and removed
