### PR TITLE
makefile: fix `build-itest` command failure when `vendor` dir present

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ build-itest:
 	CGO_ENABLED=0 $(GOBUILD) -tags="integration" -o itest/btcd-itest $(BTCD_PKG)
 
 	@$(call print, "Building itest lnd.")
-	CGO_ENABLED=0 $(GOBUILD) -tags="$(ITEST_TAGS)" -o itest/lnd-itest $(DEV_LDFLAGS) $(LND_PKG)/cmd/lnd
+	CGO_ENABLED=0 $(GOBUILD) -mod=mod -tags="$(ITEST_TAGS)" -o itest/lnd-itest $(DEV_LDFLAGS) $(LND_PKG)/cmd/lnd
 
 build-loadtest:
 	CGO_ENABLED=0 $(GOTEST) -c -tags="$(LOADTEST_TAGS)" -o loadtest $(PKG)/itest/loadtest


### PR DESCRIPTION
This commit addresses a specific issue encountered when executing the `build-itest` command in environments where a project's `vendor` directory exists. Previously, the command failed because the application `github.com/lightningnetwork/lnd/cmd/lnd` was not located within the `vendor` directory, leading to an unsuccessful build process.

The fix implemented involves modifying the Go build command to include the `-mod=mod` flag. This adjustment ensures that the build process automatically downloads any missing modules, circumventing the need for the application to be physically present in the `vendor` directory. It is important to note that directly including `lnd/cmd` or `lnd/cmd/lnd` within the `vendor` directory is not feasible, as the former is not a package, and the latter is an application.