### PR TITLE
tapgarden: check for ErrProofNotFound when checking for local proof file

### DIFF
--- a/tapgarden/custodian.go
+++ b/tapgarden/custodian.go
@@ -690,7 +690,11 @@ func (c *Custodian) checkProofAvailable(event *address.Event) (bool, error) {
 		Locator: locator,
 		Blob:    blob,
 	})
-	if err != nil {
+	switch {
+	case errors.Is(err, proof.ErrProofNotFound):
+		return false, nil
+
+	case err != nil:
 		return false, fmt.Errorf("error asserting proof in local "+
 			"archive: %w", err)
 	}


### PR DESCRIPTION
Otherwise, as `lookupProofFilePath` will return an error if the file isn't found (which wraps `proof.ErrProofNotFound`), then the custodian will potentially fail to start up.