### PR TITLE
Add asset specifier

### DIFF
--- a/address/address.go
+++ b/address/address.go
@@ -276,7 +276,11 @@ func (a *Tap) AttachGenesis(gen asset.Genesis) {
 // TapCommitmentKey is the key that maps to the root commitment for the asset
 // group specified by a Taproot Asset address.
 func (a *Tap) TapCommitmentKey() [32]byte {
-	return asset.TapCommitmentKey(a.AssetID, a.GroupKey)
+	assetSpecifier := asset.NewSpecifierOptionalGroupPubKey(
+		a.AssetID, a.GroupKey,
+	)
+
+	return asset.TapCommitmentKey(assetSpecifier)
 }
 
 // AssetCommitmentKey is the key that maps to the asset leaf for the asset

--- a/asset/asset.go
+++ b/asset/asset.go
@@ -2011,6 +2011,12 @@ func (a *Asset) Leaf() (*mssmt.LeafNode, error) {
 	return mssmt.NewLeafNode(buf.Bytes(), a.Amount), nil
 }
 
+// Specifier returns the asset's specifier.
+func (a *Asset) Specifier() Specifier {
+	id := a.Genesis.ID()
+	return NewSpecifierOptionalGroupKey(id, a.GroupKey)
+}
+
 // Validate ensures that an asset is valid.
 func (a *Asset) Validate() error {
 	// TODO(ffranr): Add validation check for remaining fields.

--- a/asset/asset.go
+++ b/asset/asset.go
@@ -93,10 +93,10 @@ const (
 type EncodeType uint8
 
 const (
-	// Encode normal is the normal encoding type for an asset.
+	// EncodeNormal normal is the normal encoding type for an asset.
 	EncodeNormal EncodeType = iota
 
-	// EncodeSegwit denotes that the witness vector field is not be be
+	// EncodeSegwit denotes that the witness vector field is not to be
 	// encoded.
 	EncodeSegwit
 )

--- a/asset/asset.go
+++ b/asset/asset.go
@@ -1552,23 +1552,38 @@ func New(genesis Genesis, amount, locktime, relativeLocktime uint64,
 }
 
 // TapCommitmentKey is the key that maps to the root commitment for a specific
-// asset group within a TapCommitment.
+// asset within a TapCommitment.
 //
 // NOTE: This function is also used outside the asset package.
-func TapCommitmentKey(assetID ID, groupKey *btcec.PublicKey) [32]byte {
-	if groupKey == nil {
-		return assetID
+func TapCommitmentKey(assetSpecifier Specifier) [32]byte {
+	var commitmentKey [32]byte
+
+	switch {
+	case assetSpecifier.HasGroupPubKey():
+		assetSpecifier.WhenGroupPubKey(func(pubKey btcec.PublicKey) {
+			serializedPubKey := schnorr.SerializePubKey(&pubKey)
+			commitmentKey = sha256.Sum256(serializedPubKey)
+		})
+
+	case assetSpecifier.HasId():
+		assetSpecifier.WhenId(func(id ID) {
+			commitmentKey = id
+		})
+
+	default:
+		// We should never reach this point as the asset specifier
+		// should always have either a group public key, an asset ID, or
+		// both.
+		panic("invalid asset specifier")
 	}
-	return sha256.Sum256(schnorr.SerializePubKey(groupKey))
+
+	return commitmentKey
 }
 
 // TapCommitmentKey is the key that maps to the root commitment for a specific
 // asset group within a TapCommitment.
 func (a *Asset) TapCommitmentKey() [32]byte {
-	if a.GroupKey == nil {
-		return TapCommitmentKey(a.Genesis.ID(), nil)
-	}
-	return TapCommitmentKey(a.Genesis.ID(), &a.GroupKey.GroupPubKey)
+	return TapCommitmentKey(a.Specifier())
 }
 
 // AssetCommitmentKey returns a key which can be used to locate an

--- a/commitment/asset.go
+++ b/commitment/asset.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/lightninglabs/taproot-assets/asset"
 	"github.com/lightninglabs/taproot-assets/fn"
 	"github.com/lightninglabs/taproot-assets/mssmt"
@@ -151,16 +150,15 @@ func parseCommon(assets ...*asset.Asset) (*AssetCommitment, error) {
 		assetsMap[key] = newAsset
 	}
 
-	var groupPubKey *btcec.PublicKey
-	if assetGroupKey != nil {
-		groupPubKey = &assetGroupKey.GroupPubKey
-	}
-
 	// The tapKey here is what will be used to place this asset commitment
 	// into the top-level Taproot Asset commitment. For assets without a
 	// group key, then this will be the normal asset ID. Otherwise, this'll
 	// be the sha256 of the group key.
-	tapKey := asset.TapCommitmentKey(firstAssetID, groupPubKey)
+	assetSpecifier := asset.NewSpecifierOptionalGroupKey(
+		firstAssetID, assetGroupKey,
+	)
+
+	tapKey := asset.TapCommitmentKey(assetSpecifier)
 
 	return &AssetCommitment{
 		Version:   maxVersion,

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -3202,11 +3202,14 @@ func (r *rpcServer) BurnAsset(ctx context.Context,
 		"burn_amount=%d)", assetID[:], serializedGroupKey,
 		in.AmountToBurn)
 
+	assetSpecifier := asset.NewSpecifierOptionalGroupPubKey(
+		assetID, groupKey,
+	)
+
 	fundResp, err := r.cfg.AssetWallet.FundBurn(
 		ctx, &tapsend.FundingDescriptor{
-			ID:       assetID,
-			GroupKey: groupKey,
-			Amount:   in.AmountToBurn,
+			AssetSpecifier: assetSpecifier,
+			Amount:         in.AmountToBurn,
 		},
 	)
 	if err != nil {

--- a/tapdb/assets_store.go
+++ b/tapdb/assets_store.go
@@ -803,14 +803,14 @@ func (a *AssetStore) constraintsToDbFilter(
 				query.MinAnchorHeight,
 			)
 		}
-		if query.AssetID != nil {
-			assetID := query.AssetID[:]
-			assetFilter.AssetIDFilter = assetID
-		}
-		if query.GroupKey != nil {
-			groupKey := query.GroupKey.SerializeCompressed()
-			assetFilter.KeyGroupFilter = groupKey
-		}
+
+		// Add asset ID bytes and group key bytes to the filter. These
+		// byte arrays are empty if the asset ID or group key is not
+		// specified in the query.
+		assetIDBytes, groupKeyBytes := query.AssetSpecifier.AsBytes()
+		assetFilter.AssetIDFilter = assetIDBytes
+		assetFilter.KeyGroupFilter = groupKeyBytes
+
 		// TODO(roasbeef): only want to allow asset ID or other and not
 		// both?
 

--- a/tapdb/assets_store_test.go
+++ b/tapdb/assets_store_test.go
@@ -280,7 +280,6 @@ func TestImportAssetProof(t *testing.T) {
 
 	// Add a random asset and corresponding proof into the database.
 	testAsset, testProof := dbHandle.AddRandomAssetProof(t)
-	assetID := testAsset.ID()
 	initialBlob := testProof.Blob
 
 	// We should now be able to retrieve the set of all assets inserted on
@@ -313,11 +312,8 @@ func TestImportAssetProof(t *testing.T) {
 	// We should also be able to fetch the created asset above based on
 	// either the asset ID, or key group via the main coin selection
 	// routine.
-	var assetConstraints tapfreighter.CommitmentConstraints
-	if testAsset.GroupKey != nil {
-		assetConstraints.GroupKey = &testAsset.GroupKey.GroupPubKey
-	} else {
-		assetConstraints.AssetID = &assetID
+	assetConstraints := tapfreighter.CommitmentConstraints{
+		AssetSpecifier: testAsset.Specifier(),
 	}
 	selectedAssets, err := assetStore.ListEligibleCoins(
 		ctxb, assetConstraints,
@@ -659,16 +655,20 @@ func (a *assetGenerator) genAssets(t *testing.T, assetStore *AssetStore,
 	}
 }
 
-func (a *assetGenerator) bindAssetID(i int, op wire.OutPoint) *asset.ID {
+func (a *assetGenerator) assetSpecifierAssetID(i int,
+	op wire.OutPoint) asset.Specifier {
+
 	gen := a.assetGens[i]
 	gen.FirstPrevOut = op
 
 	id := gen.ID()
 
-	return &id
+	return asset.NewSpecifierFromId(id)
 }
 
-func (a *assetGenerator) bindGroupKey(i int, op wire.OutPoint) *btcec.PublicKey {
+func (a *assetGenerator) assetSpecifierGroupKey(i int,
+	op wire.OutPoint) asset.Specifier {
+
 	gen := a.assetGens[i]
 	gen.FirstPrevOut = op
 	genTweak := gen.ID()
@@ -677,8 +677,9 @@ func (a *assetGenerator) bindGroupKey(i int, op wire.OutPoint) *btcec.PublicKey 
 
 	internalPriv := input.TweakPrivKey(&groupPriv, genTweak[:])
 	tweakedPriv := txscript.TweakTaprootPrivKey(*internalPriv, nil)
+	groupPubKey := tweakedPriv.PubKey()
 
-	return tweakedPriv.PubKey()
+	return asset.NewSpecifierFromGroupKey(*groupPubKey)
 }
 
 // TestFetchAllAssets tests that the different AssetQueryFilters work as
@@ -1000,7 +1001,7 @@ func TestSelectCommitment(t *testing.T) {
 				},
 			},
 			constraints: tapfreighter.CommitmentConstraints{
-				AssetID: assetGen.bindAssetID(
+				AssetSpecifier: assetGen.assetSpecifierAssetID(
 					0, assetGen.anchorPoints[0],
 				),
 				MinAmt: 2,
@@ -1022,7 +1023,7 @@ func TestSelectCommitment(t *testing.T) {
 				},
 			},
 			constraints: tapfreighter.CommitmentConstraints{
-				AssetID: assetGen.bindAssetID(
+				AssetSpecifier: assetGen.assetSpecifierAssetID(
 					0, assetGen.anchorPoints[0],
 				),
 				MinAmt: 10,
@@ -1043,7 +1044,7 @@ func TestSelectCommitment(t *testing.T) {
 				},
 			},
 			constraints: tapfreighter.CommitmentConstraints{
-				AssetID: assetGen.bindAssetID(
+				AssetSpecifier: assetGen.assetSpecifierAssetID(
 					1, assetGen.anchorPoints[1],
 				),
 				MinAmt: 10,
@@ -1074,7 +1075,7 @@ func TestSelectCommitment(t *testing.T) {
 				},
 			},
 			constraints: tapfreighter.CommitmentConstraints{
-				GroupKey: assetGen.bindGroupKey(
+				AssetSpecifier: assetGen.assetSpecifierGroupKey(
 					0, assetGen.anchorPoints[0],
 				),
 				MinAmt: 1,
@@ -1104,7 +1105,7 @@ func TestSelectCommitment(t *testing.T) {
 				},
 			},
 			constraints: tapfreighter.CommitmentConstraints{
-				AssetID: assetGen.bindAssetID(
+				AssetSpecifier: assetGen.assetSpecifierAssetID(
 					0, assetGen.anchorPoints[0],
 				),
 				MinAmt: 2,
@@ -1146,7 +1147,7 @@ func TestSelectCommitment(t *testing.T) {
 				},
 			},
 			constraints: tapfreighter.CommitmentConstraints{
-				GroupKey: assetGen.bindGroupKey(
+				AssetSpecifier: assetGen.assetSpecifierGroupKey(
 					0, assetGen.anchorPoints[0],
 				),
 				MinAmt: 1,

--- a/tapfreighter/coin_select.go
+++ b/tapfreighter/coin_select.go
@@ -52,9 +52,8 @@ func (s *CoinSelect) SelectCoins(ctx context.Context,
 	}
 
 	listConstraints := CommitmentConstraints{
-		GroupKey: constraints.GroupKey,
-		AssetID:  constraints.AssetID,
-		MinAmt:   1,
+		AssetSpecifier: constraints.AssetSpecifier,
+		MinAmt:         1,
 	}
 	eligibleCommitments, err := s.coinLister.ListEligibleCoins(
 		ctx, listConstraints,

--- a/tapfreighter/interface.go
+++ b/tapfreighter/interface.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/btcutil/psbt"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
@@ -28,13 +27,8 @@ import (
 //
 // NOTE: Only the GroupKey or the AssetID should be set.
 type CommitmentConstraints struct {
-	// GroupKey is the required group key. This is an optional field, if
-	// set then the asset returned may have a distinct asset ID to the one
-	// specified below.
-	GroupKey *btcec.PublicKey
-
-	// AssetID is the asset ID that needs to be satisfied.
-	AssetID *asset.ID
+	// AssetSpecifier specifies the asset.
+	AssetSpecifier asset.Specifier
 
 	// MinAmt is the minimum amount that an asset commitment needs to hold
 	// to satisfy the constraints.
@@ -47,13 +41,8 @@ type CommitmentConstraints struct {
 
 // String returns the string representation of the commitment constraints.
 func (c *CommitmentConstraints) String() string {
-	var groupKeyBytes, assetIDBytes []byte
-	if c.GroupKey != nil {
-		groupKeyBytes = c.GroupKey.SerializeCompressed()
-	}
-	if c.AssetID != nil {
-		assetIDBytes = c.AssetID[:]
-	}
+	assetIDBytes, groupKeyBytes := c.AssetSpecifier.AsBytes()
+
 	return fmt.Sprintf("group_key=%x, asset_id=%x, min_amt=%d",
 		groupKeyBytes, assetIDBytes, c.MinAmt)
 }

--- a/tapfreighter/wallet.go
+++ b/tapfreighter/wallet.go
@@ -362,20 +362,11 @@ func (f *AssetWallet) FundPacket(ctx context.Context,
 		return nil, address.ErrMismatchedHRP
 	}
 
-	// Extract the asset ID and group key from the funding descriptor.
-	assetId := fundDesc.AssetSpecifier.UnwrapIdToPtr()
-	if assetId == nil {
-		return nil, fmt.Errorf("unable to unwrap asset ID")
-	}
-
-	groupKey := fundDesc.AssetSpecifier.UnwrapGroupKeyToPtr()
-
 	// We need to find a commitment that has enough assets to satisfy this
 	// send request. We'll map the address to a set of constraints, so we
 	// can use that to do Taproot asset coin selection.
 	constraints := CommitmentConstraints{
-		GroupKey:            groupKey,
-		AssetID:             assetId,
+		AssetSpecifier:      fundDesc.AssetSpecifier,
 		MinAmt:              fundDesc.Amount,
 		Bip86ScriptKeysOnly: true,
 	}
@@ -410,15 +401,12 @@ func (f *AssetWallet) FundBurn(ctx context.Context,
 		return nil, err
 	}
 
-	groupKey := fundDesc.AssetSpecifier.UnwrapGroupKeyToPtr()
-
 	// We need to find a commitment that has enough assets to satisfy this
 	// send request. We'll map the address to a set of constraints, so we
 	// can use that to do Taproot asset coin selection.
 	constraints := CommitmentConstraints{
-		GroupKey: groupKey,
-		AssetID:  assetId,
-		MinAmt:   fundDesc.Amount,
+		AssetSpecifier: fundDesc.AssetSpecifier,
+		MinAmt:         fundDesc.Amount,
 	}
 	selectedCommitments, err := f.cfg.CoinSelector.SelectCoins(
 		ctx, constraints, PreferMaxAmount, commitment.TapCommitmentV2,

--- a/tapsend/send.go
+++ b/tapsend/send.go
@@ -172,7 +172,12 @@ type FundingDescriptor struct {
 // TapCommitmentKey is the key that maps to the root commitment for the asset
 // group specified by a recipient descriptor.
 func (r *FundingDescriptor) TapCommitmentKey() [32]byte {
-	return asset.TapCommitmentKey(r.ID, r.GroupKey)
+	assetSpecifier := asset.NewIdSpecifier(r.ID)
+	if r.GroupKey != nil {
+		assetSpecifier = asset.NewSpecifier(r.ID, *r.GroupKey)
+	}
+
+	return asset.TapCommitmentKey(assetSpecifier)
 }
 
 // DescribeRecipients extracts the recipient descriptors from a Taproot Asset

--- a/tapsend/send_test.go
+++ b/tapsend/send_test.go
@@ -1810,10 +1810,13 @@ func TestAddressValidInput(t *testing.T) {
 }
 
 func addrToFundDesc(addr address.Tap) *tapsend.FundingDescriptor {
+	assetSpecifier := asset.NewSpecifierOptionalGroupPubKey(
+		addr.AssetID, addr.GroupKey,
+	)
+
 	return &tapsend.FundingDescriptor{
-		ID:       addr.AssetID,
-		GroupKey: addr.GroupKey,
-		Amount:   addr.Amount,
+		AssetSpecifier: assetSpecifier,
+		Amount:         addr.Amount,
 	}
 }
 
@@ -2419,7 +2422,7 @@ func TestValidateAnchorOutputs(t *testing.T) {
 	vOutCommitmentProof := proof.CommitmentProof{
 		Proof: commitment.Proof{
 			TaprootAssetProof: commitment.
-				TaprootAssetProof{
+			TaprootAssetProof{
 				Version: asset1Commitment.Version,
 			},
 		},

--- a/tapsend/send_test.go
+++ b/tapsend/send_test.go
@@ -2421,8 +2421,7 @@ func TestValidateAnchorOutputs(t *testing.T) {
 
 	vOutCommitmentProof := proof.CommitmentProof{
 		Proof: commitment.Proof{
-			TaprootAssetProof: commitment.
-			TaprootAssetProof{
+			TaprootAssetProof: commitment.TaprootAssetProof{
 				Version: asset1Commitment.Version,
 			},
 		},


### PR DESCRIPTION
Closes https://github.com/lightninglabs/taproot-assets/issues/834

This PR introduces a new type named `AssetSpecifier` within the `asset` package. The `AssetSpecifier` type is designed to facilitate the conveyance of either an asset ID, an asset group public key, or both, throughout our codebase.

To demonstrate the utility of `AssetSpecifier`, this PR incorporates it in two key areas: coin selection and the derivation of tap commitment keys. While there are numerous potential applications for this new type across our project, this PR deliberately focuses on a select few to maintain brevity. The integration of `AssetSpecifier` sets the stage for future code contributions to leverage this type.