### PR TITLE
Add lll linter to golangci-lint configuration

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -3,13 +3,13 @@ name: CI
 on:
   push:
     branches:
-      - "main"
+      - 'main'
   pull_request:
     branches:
-      - "*"
+      - '*'
   merge_group:
     branches:
-      - "main"
+      - 'main'
 
 defaults:
   run:
@@ -110,13 +110,13 @@ jobs:
       - name: Build default image
         uses: docker/build-push-action@v4
         with:
-          tags: "default-taproot-assets"
+          tags: 'default-taproot-assets'
 
       - name: Build dev image
         uses: docker/build-push-action@v4
         with:
           file: dev.Dockerfile
-          tags: "dev-taproot-assets"
+          tags: 'dev-taproot-assets'
 
   ########################
   # cross compilation
@@ -143,6 +143,8 @@ jobs:
     steps:
       - name: git checkout
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Setup go environment
         uses: ./.github/actions/setup-go

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 run:
   # timeout for analysis
-  deadline: 4m
+  timeout: 4m
 
 linters-settings:
   errorlint:
@@ -26,13 +26,18 @@ linters-settings:
   exhaustive:
     default-signifies-exhaustive: true
   gocritic:
-      enabled-checks:
-        - singleCaseSwitch
-        - ifElseChain
-        - assignOp
-        - unlambda
+    enabled-checks:
+      - singleCaseSwitch
+      - ifElseChain
+      - assignOp
+      - unlambda
   staticcheck:
-    checks: ["-SA1019"]
+    checks: ['-SA1019']
+  lll:
+    # Max line length, lines longer will be reported.
+    line-length: 80
+    # Tab width in spaces.
+    tab-width: 8
 
 linters:
   enable:
@@ -46,6 +51,7 @@ linters:
     - unconvert
     - nilerr
     - exhaustive
+    - lll
 
 issues:
   exclude-rules:
@@ -66,3 +72,4 @@ issues:
         - unused
         - deadcode
         - varcheck
+  new-from-rev: c118c9095a3175d1d311fa9bf6555b44aa8d3912

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -72,4 +72,4 @@ issues:
         - unused
         - deadcode
         - varcheck
-  new-from-rev: c118c9095a3175d1d311fa9bf6555b44aa8d3912
+  new-from-rev: c723abd3c9db8a6a2f3f1eaa85ce5aefb52c8170


### PR DESCRIPTION
The lll linter forces the code to be formatted with a maximum line length of 80 and a tab width of 8.

The `deadline` configuration is replaced with `timeout`. `deadline` is deprecated since v1.20 and will be removed in v1.57.0.

All line lengths in the repo are fixed where necessary, or ignored by adding a `nolint:lll` directive.