### PR TITLE
itest: small fixes for tapd load test

### DIFF
--- a/itest/loadtest/mint_batch_test.go
+++ b/itest/loadtest/mint_batch_test.go
@@ -164,5 +164,5 @@ func mintTest(t *testing.T, ctx context.Context, cfg *Config) {
 	})
 	require.True(t, correctOp)
 
-	itest.SyncUniverses(ctx, t, alice, bob, aliceHost, cfg.TestTimeout)
+	itest.SyncUniverses(ctx, t, bob, alice, aliceHost, cfg.TestTimeout)
 }

--- a/itest/utils.go
+++ b/itest/utils.go
@@ -147,7 +147,7 @@ func MineBlocks(t *testing.T, client *rpcclient.Client,
 	var blockHashes []*chainhash.Hash
 
 	switch backend.(type) {
-	case rpcclient.BitcoindVersion:
+	case *rpcclient.BitcoindVersion:
 		addr, err := btcutil.DecodeAddress(
 			regtestMiningAddr, regtestParams,
 		)


### PR DESCRIPTION
When building images off the _**main**_ branch, I found that the load test pod was incapable of correctly determining the _**bitcoind**_ backend version:

```
➜  ✗ kubectl logs -f tapd-loadtest-orchestrator-job-11-zm76d
=== RUN   TestPerformance
=== RUN   TestPerformance/mint
=== NAME  TestPerformance
    utils.go:149:
        	Error Trace:	/app/itest/utils.go:149
        	            				/app/itest/loadtest/utils.go:121
        	            				/app/itest/loadtest/mint_batch_test.go:28
        	            				/app/itest/loadtest/load_test.go:57
        	Error:      	unknown chain backend: %v
        	Test:       	TestPerformance
        	Messages:   	bitcoind v25.0.0 and above
=== NAME  TestPerformance/mint
    testing.go:1490: test executed panic(nil) or runtime.Goexit: subtest may have called FailNow on a parent test
--- FAIL: TestPerformance (0.18s)
    --- FAIL: TestPerformance/mint (0.18s)
FAIL
```

Also, encountered the following error:
```
Error:      	Error "rpc error: code = Unknown desc = cannot add ourselves as a federation member" does not contain "universe server already added"

```
We used to run the following in the `mint` test:
```
_, err = bob.AddFederationServer(
    ctx, &unirpc.AddFederationServerRequest{
        Servers: []*unirpc.UniverseFederationServer{
            {
                Host: aliceHost,
            },
        },
    },
)
```
So we can just update the `itest.SyncUniverses(...)` call to maintain this behavior.