### PR TITLE
makefile: targets for itest w/ race detection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,13 @@ build-itest:
 	@$(call print, "Building itest lnd.")
 	CGO_ENABLED=0 $(GOBUILD) -mod=mod -tags="$(ITEST_TAGS)" -o itest/lnd-itest $(DEV_LDFLAGS) $(LND_PKG)/cmd/lnd
 
+build-itest-race:
+	@$(call print, "Building itest btcd.")
+	CGO_ENABLED=0 $(GOBUILD) -tags="integration" -o itest/btcd-itest $(BTCD_PKG)
+
+	@$(call print, "Building itest lnd.")
+	CGO_ENABLED=1 $(GOBUILD) -race -mod=mod -tags="$(ITEST_TAGS)" -o itest/lnd-itest $(DEV_LDFLAGS) $(LND_PKG)/cmd/lnd
+
 build-loadtest:
 	CGO_ENABLED=0 $(GOTEST) -c -tags="$(LOADTEST_TAGS)" -o loadtest $(PKG)/itest/loadtest
 
@@ -184,12 +191,19 @@ unit-race:
 
 itest: build-itest itest-only
 
+itest-race: build-itest-race itest-race-only
+
 itest-trace: build-itest itest-only-trace
 
 itest-only: aperture-dir
 	@$(call print, "Running integration tests with ${backend} backend.")
 	rm -rf itest/regtest; date
 	$(GOTEST) ./itest -v -tags="$(ITEST_TAGS)" $(TEST_FLAGS) $(ITEST_FLAGS) -btcdexec=./btcd-itest -logdir=regtest
+
+itest-race-only: aperture-dir
+	@$(call print, "Running integration tests with ${backend} backend.")
+	rm -rf itest/regtest; date
+	$(GOTEST) -race ./itest -v -tags="$(ITEST_TAGS)" $(TEST_FLAGS) $(ITEST_FLAGS) -btcdexec=./btcd-itest -logdir=regtest
 
 itest-only-trace: aperture-dir
 	@$(call print, "Running integration tests with ${backend} backend.")


### PR DESCRIPTION
This PR adds three targets for race detection:

- `build-itest-race` builds itest btcd and itest lnd, but only the
  latter with the `race` flag set.
- `itest-race-only` runs itests with the `race` flag set.
- `itest-race` runs `build-itest-race` and `itest-race-only`
  consecutively.

It is uncertain whether we need to build lnd with the `race` flag set. Race conditions should  already have been found during CI of lnd itself. This would only detect edge cases where the race condition is triggerd by something in tapd.

Running itests with this setup results in a context timeout. It seems to be sensitive to that. So before we can do proper race detection, we need to fix that.