### PR TITLE
RFQ enrich incoming accept messages with sent requests

### DIFF
--- a/rfq/manager.go
+++ b/rfq/manager.go
@@ -344,8 +344,8 @@ func (m *Manager) handleIncomingMessage(incomingMsg rfqmsg.IncomingMsg) error {
 			// payment by the SCID alias through which it comes in
 			// and compare it to the one in the invoice.
 			err := m.addScidAlias(
-				uint64(msg.ShortChannelId()), *msg.AssetID,
-				msg.Peer,
+				uint64(msg.ShortChannelId()),
+				*msg.Request.AssetID, msg.Peer,
 			)
 			if err != nil {
 				m.cfg.ErrChan <- fmt.Errorf("error adding "+
@@ -431,7 +431,8 @@ func (m *Manager) handleOutgoingMessage(outgoingMsg rfqmsg.OutgoingMsg) error {
 		// make sure we can identify the forwarded asset payment by the
 		// outgoing SCID alias within the onion packet.
 		err := m.addScidAlias(
-			uint64(msg.ShortChannelId()), *msg.AssetID, msg.Peer,
+			uint64(msg.ShortChannelId()), *msg.Request.AssetID,
+			msg.Peer,
 		)
 		if err != nil {
 			return fmt.Errorf("error adding local alias: %w", err)

--- a/rfq/negotiator.go
+++ b/rfq/negotiator.go
@@ -609,7 +609,7 @@ func (n *Negotiator) HandleIncomingBuyAccept(msg rfqmsg.BuyAccept,
 		// for an ask price. We will then compare the ask price returned
 		// by the price oracle with the ask price provided by the peer.
 		oraclePrice, _, err := n.queryAskFromPriceOracle(
-			&msg.Peer, msg.AssetID, nil,
+			&msg.Peer, msg.Request.AssetID, nil,
 			msg.AssetAmount, nil,
 		)
 		if err != nil {
@@ -730,7 +730,7 @@ func (n *Negotiator) HandleIncomingSellAccept(msg rfqmsg.SellAccept,
 		// for a bid price. We will then compare the bid price returned
 		// by the price oracle with the bid price provided by the peer.
 		oraclePrice, _, err := n.queryBidFromPriceOracle(
-			msg.Peer, msg.AssetID, nil, msg.AssetAmount,
+			msg.Peer, msg.Request.AssetID, nil, msg.AssetAmount,
 		)
 		if err != nil {
 			// The price oracle returned an error. We will return

--- a/rfq/order.go
+++ b/rfq/order.go
@@ -101,7 +101,7 @@ func NewAssetSalePolicy(quote rfqmsg.BuyAccept) *AssetSalePolicy {
 		MaxAssetAmount: quote.AssetAmount,
 		AskPrice:       quote.AskPrice,
 		expiry:         quote.Expiry,
-		assetID:        quote.AssetID,
+		assetID:        quote.Request.AssetID,
 	}
 }
 

--- a/rfqmsg/buy_accept.go
+++ b/rfqmsg/buy_accept.go
@@ -185,6 +185,10 @@ type BuyAccept struct {
 	// Peer is the peer that sent the quote request.
 	Peer route.Vertex
 
+	// Request is the quote request message that this message responds to.
+	// This field is not included in the wire message.
+	Request BuyRequest
+
 	// AssetAmount is the amount of the asset that the accept message
 	// is for.
 	AssetAmount uint64
@@ -201,6 +205,7 @@ func NewBuyAcceptFromRequest(request BuyRequest, askPrice lnwire.MilliSatoshi,
 	return &BuyAccept{
 		Peer:        request.Peer,
 		AssetAmount: request.AssetAmount,
+		Request:     request,
 		buyAcceptMsgData: buyAcceptMsgData{
 			Version:  latestBuyAcceptVersion,
 			ID:       request.ID,

--- a/rfqmsg/sell_accept.go
+++ b/rfqmsg/sell_accept.go
@@ -2,12 +2,10 @@ package rfqmsg
 
 import (
 	"bytes"
-	"crypto/sha256"
 	"encoding/binary"
 	"fmt"
 	"io"
 
-	"github.com/lightninglabs/taproot-assets/asset"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/routing/route"
 	"github.com/lightningnetwork/lnd/tlv"
@@ -21,7 +19,6 @@ const (
 	TypeSellAcceptBidPrice  tlv.Type = 4
 	TypeSellAcceptExpiry    tlv.Type = 6
 	TypeSellAcceptSignature tlv.Type = 8
-	TypeSellAcceptAssetID   tlv.Type = 10
 )
 
 func TypeRecordSellAcceptVersion(version *WireMsgDataVersion) tlv.Record {
@@ -56,15 +53,6 @@ func TypeRecordSellAcceptSig(sig *[64]byte) tlv.Record {
 	return tlv.MakePrimitiveRecord(TypeSellAcceptSignature, sig)
 }
 
-func TypeRecordSellAcceptAssetID(assetID **asset.ID) tlv.Record {
-	const recordSize = sha256.Size
-
-	return tlv.MakeStaticRecord(
-		TypeSellAcceptAssetID, assetID, recordSize,
-		AssetIdEncoder, AssetIdDecoder,
-	)
-}
-
 const (
 	// latestSellAcceptVersion is the latest supported sell accept wire
 	// message data field version.
@@ -90,28 +78,17 @@ type sellAcceptMsgData struct {
 
 	// sig is a signature over the serialized contents of the message.
 	sig [64]byte
-
-	// AssetID is the asset ID of the asset that the accept message is for.
-	AssetID *asset.ID
 }
 
 // encodeRecords provides all TLV records for encoding.
 func (q *sellAcceptMsgData) encodeRecords() []tlv.Record {
-	records := []tlv.Record{
+	return []tlv.Record{
 		TypeRecordSellAcceptVersion(&q.Version),
 		TypeRecordSellAcceptID(&q.ID),
 		TypeRecordSellAcceptBidPrice(&q.BidPrice),
 		TypeRecordSellAcceptExpiry(&q.Expiry),
 		TypeRecordSellAcceptSig(&q.sig),
 	}
-
-	if q.AssetID != nil {
-		records = append(
-			records, TypeRecordSellAcceptAssetID(&q.AssetID),
-		)
-	}
-
-	return records
 }
 
 // decodeRecords provides all TLV records for decoding.
@@ -122,7 +99,6 @@ func (q *sellAcceptMsgData) decodeRecords() []tlv.Record {
 		TypeRecordSellAcceptBidPrice(&q.BidPrice),
 		TypeRecordSellAcceptExpiry(&q.Expiry),
 		TypeRecordSellAcceptSig(&q.sig),
-		TypeRecordSellAcceptAssetID(&q.AssetID),
 	}
 }
 
@@ -186,7 +162,6 @@ func NewSellAcceptFromRequest(request SellRequest, bidPrice lnwire.MilliSatoshi,
 			ID:       request.ID,
 			BidPrice: bidPrice,
 			Expiry:   expiry,
-			AssetID:  request.AssetID,
 		},
 	}
 }

--- a/rfqmsg/sell_accept.go
+++ b/rfqmsg/sell_accept.go
@@ -160,6 +160,10 @@ type SellAccept struct {
 	// Peer is the peer that sent the quote request.
 	Peer route.Vertex
 
+	// Request is the quote request message that this message responds to.
+	// This field is not included in the wire message.
+	Request SellRequest
+
 	// AssetAmount is the amount of the asset that the accept message
 	// is for.
 	AssetAmount uint64
@@ -176,6 +180,7 @@ func NewSellAcceptFromRequest(request SellRequest, bidPrice lnwire.MilliSatoshi,
 	return &SellAccept{
 		Peer:        request.Peer,
 		AssetAmount: request.AssetAmount,
+		Request:     request,
 		sellAcceptMsgData: sellAcceptMsgData{
 			Version:  latestSellAcceptVersion,
 			ID:       request.ID,

--- a/tapchannel/aux_traffic_shaper.go
+++ b/tapchannel/aux_traffic_shaper.go
@@ -244,16 +244,16 @@ func (s *AuxTrafficShaper) ProduceHtlcExtraData(totalAmount lnwire.MilliSatoshi,
 
 	// We now know how many units we need. We take the asset ID from the
 	// RFQ so the recipient can match it back to the quote.
-	if quote.AssetID == nil {
+	if quote.Request.AssetID == nil {
 		return 0, nil, fmt.Errorf("quote has no asset ID")
 	}
 
 	log.Debugf("Producing HTLC extra data for RFQ ID %x (SCID %d): "+
 		"asset ID %x, asset amount %d", rfqID[:], rfqID.Scid(),
-		quote.AssetID[:], numAssetUnits)
+		quote.Request.AssetID[:], numAssetUnits)
 
 	htlc.Amounts.Val.Balances = []*rfqmsg.AssetBalance{
-		rfqmsg.NewAssetBalance(*quote.AssetID, numAssetUnits),
+		rfqmsg.NewAssetBalance(*quote.Request.AssetID, numAssetUnits),
 	}
 
 	// Encode the updated HTLC TLV back into a blob and return it with the


### PR DESCRIPTION
In this PR, we enrich incoming accept messages with corresponding sent requests. This involves storing outbound requests before sending and matching incoming accept message responses based on the RFQ quote `ID`. This matching process is performed in the RFQ stream service, ensuring that other RFQ services only encounter accept messages with fully populated fields, including the new request field.

As a result, transporting the asset ID in the accept message is no longer necessary. The asset ID can be found in the request message.

Removing the asset ID field from the accept wire message is important because it is redundant and isn't clear whether it is `out_asset` or `in_asset`. It also does not have a asset group key counterpart.