### PR TITLE
Custom channel bug fixes

### DIFF
--- a/config.go
+++ b/config.go
@@ -127,6 +127,9 @@ func ParseUniversePublicAccessStatus(
 	case "w":
 		return UniversePublicAccessStatusWrite, nil
 
+	case "":
+		return UniversePublicAccessStatusNone, nil
+
 	default:
 		// This default case returns an error. It will capture the case
 		// where the CLI argument is present but unset (empty value).

--- a/rfqmsg/accept.go
+++ b/rfqmsg/accept.go
@@ -42,8 +42,12 @@ type acceptWireMsgData struct {
 	// Sig is a signature over the serialized contents of the message.
 	Sig tlv.RecordT[tlv.TlvType3, [64]byte]
 
+	// InOutRateTick is the tick rate for the accept, defined in
+	// in_asset/out_asset. This is only set in a buy accept message.
 	InOutRateTick acceptInOutRateTick
 
+	// OutInRateTick is the tick rate for the accept, defined in
+	// out_asset/in_asset. This is only set in a sell accept message.
 	OutInRateTick acceptOutInRateTick
 }
 

--- a/tapchannel/aux_closer.go
+++ b/tapchannel/aux_closer.go
@@ -258,7 +258,9 @@ func (a *AuxChanCloser) AuxCloseOutputs(
 		// anchor amt, then we'll just drop this allocation, and modify
 		// our asset allocation to match this value.
 		if amtAfterAnchor <= o.DustLimit {
-			localAlloc.BtcAmount = btcAmt
+			if localAlloc != nil {
+				localAlloc.BtcAmount = btcAmt
+			}
 			return
 		}
 
@@ -285,7 +287,10 @@ func (a *AuxChanCloser) AuxCloseOutputs(
 		// anchor amt, then we'll just drop this allocation, and modify
 		// our asset allocation to match this value.
 		if amtAfterAnchor <= o.DustLimit {
-			remoteAlloc.BtcAmount = btcAmt
+			if remoteAlloc != nil {
+				remoteAlloc.BtcAmount = btcAmt
+			}
+
 			return
 		}
 


### PR DESCRIPTION
Fixes the following issues:
 - A panic during co-op close when one side didn't have any balance at all
 - Format custom channel data to JSON in `PendingChannels` RPC
 - Fix HTLC being rejected due to asset precision rounding issue
 - Allow forwarding an asset-to-asset HTLC (single hop payment with asset channels on both sides)