### PR TITLE
Fix proof storage clobber error for postgres backend

### DIFF
--- a/itest/addrs_test.go
+++ b/itest/addrs_test.go
@@ -603,7 +603,7 @@ func runMultiSendTest(ctxt context.Context, t *harnessTest, alice,
 	AssertAddrEvent(t.t, alice, aliceAddr2, 1, statusDetected)
 
 	// Mine a block to make sure the events are marked as confirmed.
-	_ = MineBlocks(t.t, t.lndHarness.Miner.Client, 1, 1)[0]
+	_ = MineBlocks(t.t, t.lndHarness.Miner.Client, 1, 1)
 
 	// Eventually the events should be marked as confirmed.
 	AssertAddrEventByStatus(t.t, bob, statusConfirmed, 2)

--- a/itest/assertions.go
+++ b/itest/assertions.go
@@ -818,7 +818,11 @@ func AssertAddrEventByStatus(t *testing.T, client taprpc.TaprootAssetsClient,
 			},
 		)
 		require.NoError(t, err)
-		require.Len(t, resp.Events, numEvents)
+
+		if len(resp.Events) != numEvents {
+			return fmt.Errorf("got %d events, wanted %d",
+				len(resp.Events), numEvents)
+		}
 
 		for _, event := range resp.Events {
 			if event.Status != filterStatus {
@@ -1410,7 +1414,7 @@ func AssertNumAssets(t *testing.T, ctx context.Context,
 	require.NoError(t, err)
 
 	// Ensure that the number of assets returned is correct.
-	require.Equal(t, numAssets, len(resp.Assets))
+	require.Len(t, resp.Assets, numAssets)
 
 	return resp
 }

--- a/tapdb/sqlc/querier.go
+++ b/tapdb/sqlc/querier.go
@@ -44,6 +44,7 @@ type Querier interface {
 	FetchAddrEventByAddrKeyAndOutpoint(ctx context.Context, arg FetchAddrEventByAddrKeyAndOutpointParams) (FetchAddrEventByAddrKeyAndOutpointRow, error)
 	FetchAddrs(ctx context.Context, arg FetchAddrsParams) ([]FetchAddrsRow, error)
 	FetchAllNodes(ctx context.Context) ([]MssmtNode, error)
+	FetchAssetID(ctx context.Context, arg FetchAssetIDParams) ([]int64, error)
 	FetchAssetMeta(ctx context.Context, metaID int64) (FetchAssetMetaRow, error)
 	FetchAssetMetaByHash(ctx context.Context, metaDataHash []byte) (FetchAssetMetaByHashRow, error)
 	FetchAssetMetaForAsset(ctx context.Context, assetID []byte) (FetchAssetMetaForAssetRow, error)
@@ -157,7 +158,6 @@ type Querier interface {
 	UpsertAssetGroupKey(ctx context.Context, arg UpsertAssetGroupKeyParams) (int64, error)
 	UpsertAssetGroupWitness(ctx context.Context, arg UpsertAssetGroupWitnessParams) (int64, error)
 	UpsertAssetMeta(ctx context.Context, arg UpsertAssetMetaParams) (int64, error)
-	UpsertAssetProof(ctx context.Context, arg UpsertAssetProofParams) error
 	UpsertAssetProofByID(ctx context.Context, arg UpsertAssetProofByIDParams) error
 	UpsertAssetWitness(ctx context.Context, arg UpsertAssetWitnessParams) error
 	UpsertChainTx(ctx context.Context, arg UpsertChainTxParams) (int64, error)

--- a/tapdb/sqlc/queries/assets.sql
+++ b/tapdb/sqlc/queries/assets.sql
@@ -669,9 +669,8 @@ UPDATE chain_txns
 SET block_height = $2, block_hash = $3, tx_index = $4
 WHERE txn_id in (SELECT txn_id FROM target_txn);
 
--- name: UpsertAssetProof :exec
-WITH target_asset(asset_id) AS (
-    SELECT asset_id
+-- name: FetchAssetID :many
+SELECT asset_id
     FROM assets
     JOIN script_keys 
         ON assets.script_key_id = script_keys.script_key_id
@@ -681,15 +680,7 @@ WITH target_asset(asset_id) AS (
         (script_keys.tweaked_script_key = sqlc.narg('tweaked_script_key')
             OR sqlc.narg('tweaked_script_key') IS NULL)
         AND (utxos.outpoint = sqlc.narg('outpoint')
-            OR sqlc.narg('outpoint') IS NULL)
-)
-INSERT INTO asset_proofs (
-    asset_id, proof_file
-) VALUES (
-    (SELECT asset_id FROM target_asset), @proof_file
-) ON CONFLICT (asset_id)
-    -- This is not a NOP, we always overwrite the proof with the new one.
-    DO UPDATE SET proof_file = EXCLUDED.proof_file;
+            OR sqlc.narg('outpoint') IS NULL);
 
 -- name: UpsertAssetProofByID :exec
 INSERT INTO asset_proofs (

--- a/tapdb/sqlerrors.go
+++ b/tapdb/sqlerrors.go
@@ -53,6 +53,13 @@ func parseSqliteError(sqliteErr *sqlite.Error) error {
 			DbError: sqliteErr,
 		}
 
+	// A write operation could not continue because of a conflict within the
+	// same database connection.
+	case sqlite3.SQLITE_LOCKED:
+		return &ErrDeadlockError{
+			DbError: sqliteErr,
+		}
+
 	// Generic error, need to parse the message further.
 	case sqlite3.SQLITE_ERROR:
 		errMsg := sqliteErr.Error()
@@ -85,6 +92,13 @@ func parsePostgresError(pqErr *pgconn.PgError) error {
 	// Unable to serialize the transaction, so we'll need to try again.
 	case pgerrcode.SerializationFailure:
 		return &ErrSerializationError{
+			DbError: pqErr,
+		}
+
+	// A write operation could not continue because of a conflict within the
+	// same database connection.
+	case pgerrcode.DeadlockDetected:
+		return &ErrDeadlockError{
 			DbError: pqErr,
 		}
 
@@ -126,11 +140,39 @@ func (e ErrSerializationError) Error() string {
 	return e.DbError.Error()
 }
 
+// ErrDeadlockError is an error type which represents a database agnostic
+// error where transactions have led to cyclic dependencies in lock acquisition.
+type ErrDeadlockError struct {
+	DbError error
+}
+
+// Unwrap returns the wrapped error.
+func (e ErrDeadlockError) Unwrap() error {
+	return e.DbError
+}
+
+// Error returns the error message.
+func (e ErrDeadlockError) Error() string {
+	return e.DbError.Error()
+}
+
 // IsSerializationError returns true if the given error is a serialization
 // error.
 func IsSerializationError(err error) bool {
 	var serializationError *ErrSerializationError
 	return errors.As(err, &serializationError)
+}
+
+// IsDeadlockError returns true if the given error is a deadlock error.
+func IsDeadlockError(err error) bool {
+	var deadlockError *ErrDeadlockError
+	return errors.As(err, &deadlockError)
+}
+
+// IsSerializationOrDeadlockError returns true if the given error is either a
+// deadlock error or a serialization error.
+func IsSerializationOrDeadlockError(err error) bool {
+	return IsDeadlockError(err) || IsSerializationError(err)
 }
 
 // ErrSchemaError is an error type which represents a database agnostic error


### PR DESCRIPTION
Fixes #951.
An (intermitent) failure popped up when running itest on the postgres backend.

This draft PR tries to solve this error, initially by unifying the behavior of both backends.

Currenlty the status is that this leads to an error later in the process (only for postgres), where the given number of events rhat exist with the given status is of by one.