### PR TITLE
server+tapchannel: modify PaymentBandwidth to return link bandwidth

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/lightninglabs/lightning-node-connect/hashmailrpc v1.0.2
 	github.com/lightninglabs/lndclient v1.0.1-0.20240607082608-4ce52a1a3f27
 	github.com/lightninglabs/neutrino/cache v1.1.2
-	github.com/lightningnetwork/lnd v0.18.0-beta.rc3.0.20240604145823-53dbd1ee66d0
+	github.com/lightningnetwork/lnd v0.18.0-beta.rc3.0.20240621142354-5fc4d4b1ec2b
 	github.com/lightningnetwork/lnd/cert v1.2.2
 	github.com/lightningnetwork/lnd/clock v1.1.1
 	github.com/lightningnetwork/lnd/fn v1.0.8

--- a/go.sum
+++ b/go.sum
@@ -490,8 +490,8 @@ github.com/lightninglabs/protobuf-go-hex-display v1.30.0-hex-display h1:pRdza2wl
 github.com/lightninglabs/protobuf-go-hex-display v1.30.0-hex-display/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 github.com/lightningnetwork/lightning-onion v1.2.1-0.20230823005744-06182b1d7d2f h1:Pua7+5TcFEJXIIZ1I2YAUapmbcttmLj4TTi786bIi3s=
 github.com/lightningnetwork/lightning-onion v1.2.1-0.20230823005744-06182b1d7d2f/go.mod h1:c0kvRShutpj3l6B9WtTsNTBUtjSmjZXbJd9ZBRQOSKI=
-github.com/lightningnetwork/lnd v0.18.0-beta.rc3.0.20240604145823-53dbd1ee66d0 h1:5AhC7M7KvlFMBmGSdedps2CrsAoB8+rXM3zQ78ovxpw=
-github.com/lightningnetwork/lnd v0.18.0-beta.rc3.0.20240604145823-53dbd1ee66d0/go.mod h1:ZZ8c08GgxS6bbtPQv8hPZYB4m2SrhBQJa3N+JgnpR0o=
+github.com/lightningnetwork/lnd v0.18.0-beta.rc3.0.20240621142354-5fc4d4b1ec2b h1:lXQjDLthlVKX2cR1cZzoRDhB/n1WsVm9FeiWv894d8U=
+github.com/lightningnetwork/lnd v0.18.0-beta.rc3.0.20240621142354-5fc4d4b1ec2b/go.mod h1:ZZ8c08GgxS6bbtPQv8hPZYB4m2SrhBQJa3N+JgnpR0o=
 github.com/lightningnetwork/lnd/cert v1.2.2 h1:71YK6hogeJtxSxw2teq3eGeuy4rHGKcFf0d0Uy4qBjI=
 github.com/lightningnetwork/lnd/cert v1.2.2/go.mod h1:jQmFn/Ez4zhDgq2hnYSw8r35bqGVxViXhX6Cd7HXM6U=
 github.com/lightningnetwork/lnd/clock v1.1.1 h1:OfR3/zcJd2RhH0RU+zX/77c0ZiOnIMsDIBjgjWdZgA0=

--- a/log.go
+++ b/log.go
@@ -53,12 +53,12 @@ var (
 	// SetupLoggers function should always be called as soon as possible to
 	// finish setting them up properly with a root logger.
 	tapdLog = addTapPkgLogger("TAPD")
-	srvrLog = addTapPkgLogger("SRVR")
+	srvrLog = addTapPkgLogger("TSVR")
 	rpcsLog = addTapPkgLogger("RPCS")
 )
 
 // genSubLogger creates a logger for a subsystem. We provide an instance of a
-// signal.Interceptor to be able to shutdown in the case of a critical error.
+// signal.Interceptor to be able to shut down in the case of a critical error.
 func genSubLogger(root *build.RotatingLogWriter,
 	interceptor signal.Interceptor) func(string) btclog.Logger {
 

--- a/server.go
+++ b/server.go
@@ -996,8 +996,8 @@ func (s *Server) HandleTraffic(cid lnwire.ShortChannelID,
 // called first.
 //
 // NOTE: This method is part of the routing.TlvTrafficShaper interface.
-func (s *Server) PaymentBandwidth(htlcBlob,
-	commitmentBlob lfn.Option[tlv.Blob]) (lnwire.MilliSatoshi, error) {
+func (s *Server) PaymentBandwidth(htlcBlob, commitmentBlob lfn.Option[tlv.Blob],
+	linkBandwidth lnwire.MilliSatoshi) (lnwire.MilliSatoshi, error) {
 
 	srvrLog.Debugf("PaymentBandwidth called, htlcBlob=%v, "+
 		"commitmentBlob=%v", spew.Sdump(htlcBlob),
@@ -1007,7 +1007,9 @@ func (s *Server) PaymentBandwidth(htlcBlob,
 		return 0, err
 	}
 
-	return s.cfg.AuxTrafficShaper.PaymentBandwidth(htlcBlob, commitmentBlob)
+	return s.cfg.AuxTrafficShaper.PaymentBandwidth(
+		htlcBlob, commitmentBlob, linkBandwidth,
+	)
 }
 
 // ProduceHtlcExtraData is a function that, based on the previous custom record

--- a/tapchannel/aux_leaf_creator.go
+++ b/tapchannel/aux_leaf_creator.go
@@ -164,6 +164,13 @@ func (c *AuxLeafCreator) FetchLeavesFromCommit(chanState *channeldb.OpenChannel,
 		if htlc.Incoming {
 			htlcOutputs := incomingHtlcs[htlcIdx].Outputs
 			auxLeaf := incomingHtlcLeaves[htlcIdx].AuxLeaf
+
+			// If this HTLC doesn't have any auxiliary leaves, it's
+			// not an asset HTLC, so we can skip it.
+			if len(htlcOutputs) == 0 {
+				continue
+			}
+
 			leaf, err := CreateSecondLevelHtlcTx(
 				chanState, com.CommitTx, htlc.Amt.ToSatoshis(),
 				keys, c.cfg.ChainParams, htlcOutputs,
@@ -188,6 +195,13 @@ func (c *AuxLeafCreator) FetchLeavesFromCommit(chanState *channeldb.OpenChannel,
 		} else {
 			htlcOutputs := outgoingHtlcs[htlcIdx].Outputs
 			auxLeaf := outgoingHtlcLeaves[htlcIdx].AuxLeaf
+
+			// If this HTLC doesn't have any auxiliary leaves, it's
+			// not an asset HTLC, so we can skip it.
+			if len(htlcOutputs) == 0 {
+				continue
+			}
+
 			leaf, err := CreateSecondLevelHtlcTx(
 				chanState, com.CommitTx, htlc.Amt.ToSatoshis(),
 				keys, c.cfg.ChainParams, htlcOutputs,

--- a/tapchannel/aux_traffic_shaper.go
+++ b/tapchannel/aux_traffic_shaper.go
@@ -134,6 +134,12 @@ func (s *AuxTrafficShaper) PaymentBandwidth(htlcBlob,
 	commitmentBytes := commitmentBlob.UnsafeFromSome()
 	htlcBytes := htlcBlob.UnsafeFromSome()
 
+	// Sometimes the blob is set but actually empty, in which case we also
+	// don't have any information about the channel.
+	if len(commitmentBytes) == 0 || len(htlcBytes) == 0 {
+		return linkBandwidth, nil
+	}
+
 	commitment, err := cmsg.DecodeCommitment(commitmentBytes)
 	if err != nil {
 		return 0, fmt.Errorf("error decoding commitment blob: %w", err)

--- a/tapchannel/aux_traffic_shaper.go
+++ b/tapchannel/aux_traffic_shaper.go
@@ -120,13 +120,15 @@ func (s *AuxTrafficShaper) HandleTraffic(_ lnwire.ShortChannelID,
 // should be handled by the traffic shaper, the HandleTraffic method should be
 // called first.
 func (s *AuxTrafficShaper) PaymentBandwidth(htlcBlob,
-	commitmentBlob lfn.Option[tlv.Blob]) (lnwire.MilliSatoshi, error) {
+	commitmentBlob lfn.Option[tlv.Blob],
+	linkBandwidth lnwire.MilliSatoshi) (lnwire.MilliSatoshi, error) {
 
-	// This method shouldn't be called if we don't have a commitment blob
-	// available (i.e., the channel is not a custom channel).
+	// If the commitment or HTLC blob is not set, we don't have any
+	// information about the channel and cannot determine the available
+	// bandwidth from a taproot asset perspective. We return the link
+	// bandwidth as a fallback.
 	if commitmentBlob.IsNone() || htlcBlob.IsNone() {
-		return 0, fmt.Errorf("no commitment or TLV blob available " +
-			"for custom channel bandwidth estimation")
+		return linkBandwidth, nil
 	}
 
 	commitmentBytes := commitmentBlob.UnsafeFromSome()


### PR DESCRIPTION
Dependant on https://github.com/lightningnetwork/lnd/pull/8852
Requires LND version bump once the above PR is merged. Will remove from draft when ready for merge.

This PR is ready for review now.

In this PR, the traffic shaper's `PaymentBandwidth` method is modified to return the link bandwidth if the tap channel commitment blob or HTLC record is absent.

This modification ensures the traffic shaper returns the correct bandwidth for tap channels used as standard BTC lightning channels, ignoring any committed taproot assets.