### PR TITLE
tapdb: backup sqlite db before running database migration

### DIFF
--- a/sample-tapd.conf
+++ b/sample-tapd.conf
@@ -218,6 +218,9 @@
 ; Skip applying migrations on startup
 ; sqlite.skipmigrations=false
 
+; Skip database backup before schema migration
+; sqlite.skipmigrationdbbackup=false
+
 ; The full path to the database
 ; sqlite.dbfile=~/.tapd/data/testnet/tapd.db
 


### PR DESCRIPTION
This commit adds functionality to back up any existing SQLite database file before attempting a database migration.

The process involves creating a backup file, migrating the database, and removing the backup if no changes occurred to the 
database file. This approach avoids unnecessary backups but results in a backup being created and deleted each time tapd starts.