### PR TITLE
tapchannel: update lnd dep and fix bug in breach handling 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/lightninglabs/lightning-node-connect/hashmailrpc v1.0.2
 	github.com/lightninglabs/lndclient v1.0.1-0.20240607082608-4ce52a1a3f27
 	github.com/lightninglabs/neutrino/cache v1.1.2
-	github.com/lightningnetwork/lnd v0.18.0-beta.rc3.0.20240621201817-374abfc804b7
+	github.com/lightningnetwork/lnd v0.18.0-beta.rc3.0.20240625154246-4e968d9b520c
 	github.com/lightningnetwork/lnd/cert v1.2.2
 	github.com/lightningnetwork/lnd/clock v1.1.1
 	github.com/lightningnetwork/lnd/fn v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -490,8 +490,8 @@ github.com/lightninglabs/protobuf-go-hex-display v1.30.0-hex-display h1:pRdza2wl
 github.com/lightninglabs/protobuf-go-hex-display v1.30.0-hex-display/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 github.com/lightningnetwork/lightning-onion v1.2.1-0.20230823005744-06182b1d7d2f h1:Pua7+5TcFEJXIIZ1I2YAUapmbcttmLj4TTi786bIi3s=
 github.com/lightningnetwork/lightning-onion v1.2.1-0.20230823005744-06182b1d7d2f/go.mod h1:c0kvRShutpj3l6B9WtTsNTBUtjSmjZXbJd9ZBRQOSKI=
-github.com/lightningnetwork/lnd v0.18.0-beta.rc3.0.20240621201817-374abfc804b7 h1:kyr2B486cn8VYbAkEgv/q0f2j9iL5LUpMAOADyNptgw=
-github.com/lightningnetwork/lnd v0.18.0-beta.rc3.0.20240621201817-374abfc804b7/go.mod h1:L3IArArdRrWtuw+wNsUlibuGmf/08Odsm/zo3+bPXuM=
+github.com/lightningnetwork/lnd v0.18.0-beta.rc3.0.20240625154246-4e968d9b520c h1:10hVKzgsnpuzOOgkYAhThUtDiq3fBBJBeZWdir+0ptk=
+github.com/lightningnetwork/lnd v0.18.0-beta.rc3.0.20240625154246-4e968d9b520c/go.mod h1:L3IArArdRrWtuw+wNsUlibuGmf/08Odsm/zo3+bPXuM=
 github.com/lightningnetwork/lnd/cert v1.2.2 h1:71YK6hogeJtxSxw2teq3eGeuy4rHGKcFf0d0Uy4qBjI=
 github.com/lightningnetwork/lnd/cert v1.2.2/go.mod h1:jQmFn/Ez4zhDgq2hnYSw8r35bqGVxViXhX6Cd7HXM6U=
 github.com/lightningnetwork/lnd/clock v1.1.1 h1:OfR3/zcJd2RhH0RU+zX/77c0ZiOnIMsDIBjgjWdZgA0=

--- a/server.go
+++ b/server.go
@@ -1110,13 +1110,13 @@ func (s *Server) ResolveContract(req lnwallet.ResolutionReq,
 }
 
 // DeriveSweepAddr takes a set of inputs, and the change address we'd use to
-// sweep them, and maybe results an extra sweep output that we should add to
+// sweep them, and maybe results in an extra sweep output that we should add to
 // the sweeping transaction.
 func (s *Server) DeriveSweepAddr(inputs []input.Input,
 	change lnwallet.AddrWithKey) lfn.Result[sweep.SweepOutput] {
 
 	srvrLog.Infof("DeriveSweepAddr called, inputs=%v, change=%v",
-		spew.Sdump(inputs), change)
+		spew.Sdump(inputs), spew.Sdump(change))
 
 	if err := s.waitForReady(); err != nil {
 		return lfn.Err[sweep.SweepOutput](err)

--- a/tapchannel/aux_sweeper.go
+++ b/tapchannel/aux_sweeper.go
@@ -686,9 +686,14 @@ func localCommitScriptKey(localKey, revokeKey *btcec.PublicKey,
 func deriveCommitKeys(req lnwallet.ResolutionReq) (*asset.ScriptKey,
 	*asset.ScriptKey, error) {
 
+	// This might be a breach case we need to handle. In this case, our
+	// output is the remote output and their output is local here.
+	// Therefore, we'll try to use the BreachCsvDelay if present,
+	// otherwise, we'll stick with the main one specified.
+	toLocalCsvDelay := req.BreachCsvDelay.UnwrapOr(req.CsvDelay)
 	localScriptTree, err := localCommitScriptKey(
 		req.KeyRing.ToLocalKey, req.KeyRing.RevocationKey,
-		req.CsvDelay,
+		toLocalCsvDelay,
 	).Unpack()
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to create local "+

--- a/tapfreighter/chain_porter.go
+++ b/tapfreighter/chain_porter.go
@@ -14,6 +14,7 @@ import (
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
+	"github.com/davecgh/go-spew/spew"
 	"github.com/lightninglabs/taproot-assets/asset"
 	"github.com/lightninglabs/taproot-assets/fn"
 	"github.com/lightninglabs/taproot-assets/proof"
@@ -552,7 +553,8 @@ func (p *ChainPorter) fetchInputProof(ctx context.Context,
 		ctx, inputProofLocator,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("error fetching input proof: %w", err)
+		return nil, fmt.Errorf("error fetching input proof -- "+
+			"locator=%v: %w", spew.Sdump(inputProofLocator), err)
 	}
 	inputProofFile := proof.NewEmptyFile(proof.V0)
 	err = inputProofFile.Decode(bytes.NewReader(inputProofBytes))


### PR DESCRIPTION
In this commit, we fix a bug in breach handling by ensuring we use the proper CSV delay when making the local commitment script key. Without this, we won't recognize an output as ours, and will fail to insert the justice transaction into the database. 