### PR TITLE
tapchannel: use taproot overlay chan type for asset chans

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/lightninglabs/lightning-node-connect/hashmailrpc v1.0.2
 	github.com/lightninglabs/lndclient v1.0.1-0.20240607082608-4ce52a1a3f27
 	github.com/lightninglabs/neutrino/cache v1.1.2
-	github.com/lightningnetwork/lnd v0.18.0-beta.rc3.0.20240625154246-4e968d9b520c
+	github.com/lightningnetwork/lnd v0.18.0-beta.rc4.0.20240627024114-9eec9b504509
 	github.com/lightningnetwork/lnd/cert v1.2.2
 	github.com/lightningnetwork/lnd/clock v1.1.1
 	github.com/lightningnetwork/lnd/fn v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -490,8 +490,8 @@ github.com/lightninglabs/protobuf-go-hex-display v1.30.0-hex-display h1:pRdza2wl
 github.com/lightninglabs/protobuf-go-hex-display v1.30.0-hex-display/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 github.com/lightningnetwork/lightning-onion v1.2.1-0.20230823005744-06182b1d7d2f h1:Pua7+5TcFEJXIIZ1I2YAUapmbcttmLj4TTi786bIi3s=
 github.com/lightningnetwork/lightning-onion v1.2.1-0.20230823005744-06182b1d7d2f/go.mod h1:c0kvRShutpj3l6B9WtTsNTBUtjSmjZXbJd9ZBRQOSKI=
-github.com/lightningnetwork/lnd v0.18.0-beta.rc3.0.20240625154246-4e968d9b520c h1:10hVKzgsnpuzOOgkYAhThUtDiq3fBBJBeZWdir+0ptk=
-github.com/lightningnetwork/lnd v0.18.0-beta.rc3.0.20240625154246-4e968d9b520c/go.mod h1:L3IArArdRrWtuw+wNsUlibuGmf/08Odsm/zo3+bPXuM=
+github.com/lightningnetwork/lnd v0.18.0-beta.rc4.0.20240627024114-9eec9b504509 h1:3Mf45BhHztEjofy0eYtaYM6hs+I/03/Z5AZ0W+zNdIU=
+github.com/lightningnetwork/lnd v0.18.0-beta.rc4.0.20240627024114-9eec9b504509/go.mod h1:L3IArArdRrWtuw+wNsUlibuGmf/08Odsm/zo3+bPXuM=
 github.com/lightningnetwork/lnd/cert v1.2.2 h1:71YK6hogeJtxSxw2teq3eGeuy4rHGKcFf0d0Uy4qBjI=
 github.com/lightningnetwork/lnd/cert v1.2.2/go.mod h1:jQmFn/Ez4zhDgq2hnYSw8r35bqGVxViXhX6Cd7HXM6U=
 github.com/lightningnetwork/lnd/clock v1.1.1 h1:OfR3/zcJd2RhH0RU+zX/77c0ZiOnIMsDIBjgjWdZgA0=

--- a/psbt_channel_funder.go
+++ b/psbt_channel_funder.go
@@ -96,7 +96,7 @@ func (l *LndPbstChannelFunder) OpenChannel(ctx context.Context,
 
 	// We'll map our high level params into a request for a: private,
 	// taproot channel, that uses the PSBT funding flow.
-	taprootCommitType := lnrpc.CommitmentType_SIMPLE_TAPROOT
+	taprootCommitType := lnrpc.CommitmentType_SIMPLE_TAPROOT_OVERLAY
 	openChanStream, errChan, err := l.lnd.Client.OpenChannelStream(
 		ctx, route.NewVertex(&req.PeerPub), req.ChanAmt, req.PushAmt,
 		true, lndclient.WithCommitmentType(&taprootCommitType),


### PR DESCRIPTION
With this change, we'll use explicit negotiation for the new asset chan
specific chan type.