### PR TITLE
taprpc: Set dec display when metadata is empty

### DIFF
--- a/itest/assertions.go
+++ b/itest/assertions.go
@@ -228,6 +228,25 @@ func AssetVersionCheck(version taprpc.AssetVersion) AssetCheck {
 	}
 }
 
+// AssetDecimalDisplayCheck returns a check function that tests an asset's
+// decimal display value. The check function requires that the rpc Asset has a
+// non-nil decimal display value.
+func AssetDecimalDisplayCheck(decDisplay uint32) AssetCheck {
+	return func(a *taprpc.Asset) error {
+		if a.DecimalDisplay == nil {
+			return fmt.Errorf("asset decimal display is nil")
+		}
+
+		if a.DecimalDisplay.DecimalDisplay != decDisplay {
+			return fmt.Errorf("unexpected asset decimal display, "+
+				"got %v wanted %v", a.DecimalDisplay,
+				decDisplay)
+		}
+
+		return nil
+	}
+}
+
 // GroupAssetsByName converts an unordered list of assets to a map of lists of
 // assets, where all assets in a list have the same name.
 func GroupAssetsByName(assets []*taprpc.Asset) map[string][]*taprpc.Asset {
@@ -1816,6 +1835,9 @@ func AssertAssetsMinted(t *testing.T, tapClient TapdClient,
 			),
 			AssetGroupTapscriptRootCheck(
 				assetRequest.Asset.GroupTapscriptRoot,
+			),
+			AssetDecimalDisplayCheck(
+				assetRequest.Asset.DecimalDisplay,
 			),
 		)
 

--- a/itest/asset_meta_test.go
+++ b/itest/asset_meta_test.go
@@ -173,7 +173,9 @@ func testMintAssetWithDecimalDisplayMetaField(t *harnessTest) {
 	require.ErrorContains(t.t, err, "decimal display does not match")
 
 	// If we update the decimal display to match the group anchor, minting
-	// should succeed.
+	// should succeed. We also unset the metadata to ensure that the decimal
+	// display is set as the sole JSON object if needed.
+	secondAssetReq.Asset.AssetMeta.Data = []byte{}
 	secondAssetReq.Asset.DecimalDisplay = firstAsset.DecimalDisplay
 	MintAssetsConfirmBatch(
 		t.t, t.lndHarness.Miner.Client, t.tapd,

--- a/itest/utils.go
+++ b/itest/utils.go
@@ -411,6 +411,9 @@ func FinalizeBatchUnconfirmed(t *testing.T, minerClient *rpcclient.Client,
 			AssetGroupTapscriptRootCheck(
 				assetRequest.Asset.GroupTapscriptRoot,
 			),
+			AssetDecimalDisplayCheck(
+				assetRequest.Asset.DecimalDisplay,
+			),
 		)
 	}
 

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -526,6 +526,16 @@ func (r *rpcServer) MintAsset(ctx context.Context,
 			Type: metaType,
 		}
 
+		// If a custom decimal display was requested correctly, but no
+		// metadata was provided, we'll set the metadata to an empty
+		// JSON object. The decimal display will be added as the only
+		// object.
+		if metaType == proof.MetaJson && req.Asset.DecimalDisplay != 0 {
+			if len(req.Asset.AssetMeta.Data) == 0 {
+				seedlingMeta.Data = []byte("{}")
+			}
+		}
+
 		err = seedlingMeta.Validate()
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Resolves #972 by setting the dec display as the only JSON object when the given metadata is empty. The RPC request that causes this behavior is tested in the meta itest, and I manually tested the CLI for:

- Non-zero dec display, empty metadata, JSON meta type -> correct `taprpc.AssetMeta` struct is passed to the RPC, asset listed correctly after minting (this was with the exact CLI cmd Leo posted).
- zero dec display, empty metadata, JSON meta type -> rejected for empty metadata
- unknown meta type, empty metadata -> rejected for empty metadata (IIUC this was the existing behavior)