### PR TITLE
github: check out release tag before building

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,6 +42,9 @@ jobs:
         with:
           go-version: '${{ env.GO_VERSION }}'
 
+      - name: checkout release tag
+        run: git checkout ${{ env.RELEASE_VERSION }}
+
       - name: build release for all architectures
         run: make release tag=${{ env.RELEASE_VERSION }}
 


### PR DESCRIPTION
Fixes the release build, see failed run here: https://github.com/lightninglabs/taproot-assets/actions/runs/9698686675/job/26765815638