### PR TITLE
taprpc: decimal display requires JSON meta

### DIFF
--- a/itest/asset_meta_test.go
+++ b/itest/asset_meta_test.go
@@ -172,11 +172,20 @@ func testMintAssetWithDecimalDisplayMetaField(t *harnessTest) {
 	_, err = t.tapd.MintAsset(ctxt, secondAssetReq)
 	require.ErrorContains(t.t, err, "decimal display does not match")
 
+	// Requesting a decimal display without specifying the metadata type as
+	// JSON should fail.
+	secondAssetReq.Asset.DecimalDisplay = firstAsset.DecimalDisplay
+	secondAssetReq.Asset.AssetMeta = nil
+
+	_, err = t.tapd.MintAsset(ctxt, secondAssetReq)
+	require.ErrorContains(t.t, err, "decimal display requires JSON")
+
 	// If we update the decimal display to match the group anchor, minting
 	// should succeed. We also unset the metadata to ensure that the decimal
 	// display is set as the sole JSON object if needed.
-	secondAssetReq.Asset.AssetMeta.Data = []byte{}
-	secondAssetReq.Asset.DecimalDisplay = firstAsset.DecimalDisplay
+	secondAssetReq.Asset.AssetMeta = &taprpc.AssetMeta{
+		Type: taprpc.AssetMetaType_META_TYPE_JSON,
+	}
 	MintAssetsConfirmBatch(
 		t.t, t.lndHarness.Miner.Client, t.tapd,
 		[]*mintrpc.MintAssetRequest{secondAssetReq},

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -505,6 +505,14 @@ func (r *rpcServer) MintAsset(ctx context.Context,
 	}
 
 	var seedlingMeta *proof.MetaReveal
+
+	// If a custom decimal display is set, the meta type must also be set to
+	// JSON.
+	if req.Asset.DecimalDisplay != 0 && req.Asset.AssetMeta == nil {
+		return nil, fmt.Errorf("decimal display requires JSON asset " +
+			"metadata")
+	}
+
 	if req.Asset.AssetMeta != nil {
 		// Ensure that the meta type is valid.
 		metaType, err := proof.IsValidMetaType(req.Asset.AssetMeta.Type)


### PR DESCRIPTION
Follow-on to #979 .

For minting via RPC, there was a missing check to prevent the decimal display value from being dropped before reaching the minter.