### PR TITLE
tapdb: add anchor point to SetSpent, remove LIMIT 1

### DIFF
--- a/tapdb/assets_store.go
+++ b/tapdb/assets_store.go
@@ -2727,8 +2727,9 @@ func (a *AssetStore) ConfirmParcelDelivery(ctx context.Context,
 		for idx := range inputs {
 			spentAssetIDs[idx], err = q.SetAssetSpent(
 				ctx, SetAssetSpentParams{
-					ScriptKey:  inputs[idx].ScriptKey,
-					GenAssetID: inputs[idx].AssetID,
+					ScriptKey:   inputs[idx].ScriptKey,
+					GenAssetID:  inputs[idx].AssetID,
+					AnchorPoint: inputs[idx].AnchorPoint,
 				},
 			)
 			if err != nil {

--- a/tapdb/assets_store_test.go
+++ b/tapdb/assets_store_test.go
@@ -633,15 +633,19 @@ func (a *assetGenerator) genAssets(t *testing.T, assetStore *AssetStore,
 		require.NoError(t, err)
 
 		if desc.spent {
+			opBytes, err := encodeOutpoint(desc.anchorPoint)
+			require.NoError(t, err)
+
 			var (
 				scriptKey = newAsset.ScriptKey.PubKey
 				id        = newAsset.ID()
 			)
 			params := SetAssetSpentParams{
-				ScriptKey:  scriptKey.SerializeCompressed(),
-				GenAssetID: id[:],
+				ScriptKey:   scriptKey.SerializeCompressed(),
+				GenAssetID:  id[:],
+				AnchorPoint: opBytes,
 			}
-			_, err := assetStore.db.SetAssetSpent(ctx, params)
+			_, err = assetStore.db.SetAssetSpent(ctx, params)
 			require.NoError(t, err)
 		}
 

--- a/tapdb/sqlc/queries/assets.sql
+++ b/tapdb/sqlc/queries/assets.sql
@@ -292,11 +292,12 @@ WITH target_asset(asset_id) AS (
       ON assets.script_key_id = script_keys.script_key_id
     JOIN genesis_assets
       ON assets.genesis_id = genesis_assets.gen_asset_id
+    JOIN managed_utxos utxos
+         ON assets.anchor_utxo_id = utxos.utxo_id AND
+            (utxos.outpoint = sqlc.narg('anchor_point') OR
+             sqlc.narg('anchor_point') IS NULL)
     WHERE script_keys.tweaked_script_key = @script_key
      AND genesis_assets.asset_id = @gen_asset_id
-    -- TODO(guggero): Fix this by disallowing multiple assets with the same
-    -- script key!
-    LIMIT 1
 )
 UPDATE assets
 SET spent = TRUE


### PR DESCRIPTION
Discovered while adding more assertions in the `litd` custom channel itests.

This commit fixes two things:
 - Because we could have multiple assets with the same script key, but in different anchor transactions, we also need to include the anchor outpoint of the input we want to mark as spent. Otherwise a duplicate script key (e.g. a second TAP channel funding script key, which is identical for every channel as it's just OP_TRUE) couldn't be set as spent anymore.
 - Remove the TODO and LIMIT 1 workaround, since we now have a proper unique index preventing duplicate script keys _WITHIN THE SAME ANCHOR OUTPUT_.
