### PR TITLE
tapchannel: import funding output proofs for responder during co-op close

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/lightninglabs/lightning-node-connect/hashmailrpc v1.0.2
 	github.com/lightninglabs/lndclient v1.0.1-0.20240607082608-4ce52a1a3f27
 	github.com/lightninglabs/neutrino/cache v1.1.2
-	github.com/lightningnetwork/lnd v0.18.0-beta.rc4.0.20240627024114-9eec9b504509
+	github.com/lightningnetwork/lnd v0.18.0-beta.rc4.0.20240702183719-8d838801616a
 	github.com/lightningnetwork/lnd/cert v1.2.2
 	github.com/lightningnetwork/lnd/clock v1.1.1
 	github.com/lightningnetwork/lnd/fn v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -490,8 +490,8 @@ github.com/lightninglabs/protobuf-go-hex-display v1.30.0-hex-display h1:pRdza2wl
 github.com/lightninglabs/protobuf-go-hex-display v1.30.0-hex-display/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 github.com/lightningnetwork/lightning-onion v1.2.1-0.20230823005744-06182b1d7d2f h1:Pua7+5TcFEJXIIZ1I2YAUapmbcttmLj4TTi786bIi3s=
 github.com/lightningnetwork/lightning-onion v1.2.1-0.20230823005744-06182b1d7d2f/go.mod h1:c0kvRShutpj3l6B9WtTsNTBUtjSmjZXbJd9ZBRQOSKI=
-github.com/lightningnetwork/lnd v0.18.0-beta.rc4.0.20240627024114-9eec9b504509 h1:3Mf45BhHztEjofy0eYtaYM6hs+I/03/Z5AZ0W+zNdIU=
-github.com/lightningnetwork/lnd v0.18.0-beta.rc4.0.20240627024114-9eec9b504509/go.mod h1:L3IArArdRrWtuw+wNsUlibuGmf/08Odsm/zo3+bPXuM=
+github.com/lightningnetwork/lnd v0.18.0-beta.rc4.0.20240702183719-8d838801616a h1:nb03C8JKvMAeFqGRLncnLJx0Og8CWSdNd5Cw3P/vVRo=
+github.com/lightningnetwork/lnd v0.18.0-beta.rc4.0.20240702183719-8d838801616a/go.mod h1:L3IArArdRrWtuw+wNsUlibuGmf/08Odsm/zo3+bPXuM=
 github.com/lightningnetwork/lnd/cert v1.2.2 h1:71YK6hogeJtxSxw2teq3eGeuy4rHGKcFf0d0Uy4qBjI=
 github.com/lightningnetwork/lnd/cert v1.2.2/go.mod h1:jQmFn/Ez4zhDgq2hnYSw8r35bqGVxViXhX6Cd7HXM6U=
 github.com/lightningnetwork/lnd/clock v1.1.1 h1:OfR3/zcJd2RhH0RU+zX/77c0ZiOnIMsDIBjgjWdZgA0=

--- a/tapcfg/server.go
+++ b/tapcfg/server.go
@@ -447,6 +447,13 @@ func genServerConfig(cfg *Config, cfgLogger btclog.Logger,
 			AddrBook:           addrBook,
 			TxSender:           chainPorter,
 			DefaultCourierAddr: proofCourierAddr,
+			ProofArchive:       proofArchive,
+			ProofFetcher:       proofCourierDispatcher,
+			HeaderVerifier:     headerVerifier,
+			GroupVerifier: tapgarden.GenGroupVerifier(
+				context.Background(), assetMintingStore,
+			),
+			ChainBridge: chainBridge,
 		},
 	)
 	auxSweeper := tapchannel.NewAuxSweeper(

--- a/tapchannel/aux_sweeper.go
+++ b/tapchannel/aux_sweeper.go
@@ -757,15 +757,18 @@ func (a *AuxSweeper) importCommitScriptKeys(req lnwallet.ResolutionReq) error {
 
 // importOutputProofs imports the output proofs into the pending asset funding
 // into our local database. This preps us to be able to detect force closes.
-func (a *AuxSweeper) importOutputProofs(scid lnwire.ShortChannelID,
-	outputProofs []*proof.Proof) error {
+func importOutputProofs(scid lnwire.ShortChannelID,
+	outputProofs []*proof.Proof, courierAddr *url.URL,
+	proofDispatch proof.CourierDispatch, chainBridge tapgarden.ChainBridge,
+	headerVerifier proof.HeaderVerifier, groupVerifier proof.GroupVerifier,
+	proofArchive proof.Archiver) error {
 
 	// TODO(roasbeef): should be part of post confirmation funding validate
 	// (chanvalidate)
 
 	// First, we'll make a courier to use in fetching the proofs we need.
-	proofFetcher, err := a.cfg.ProofFetcher.NewCourier(
-		a.cfg.DefaultCourierAddr, proof.Recipient{},
+	proofFetcher, err := proofDispatch.NewCourier(
+		courierAddr, proof.Recipient{},
 	)
 	if err != nil {
 		return fmt.Errorf("unable to create proof courier: %w", err)
@@ -814,13 +817,13 @@ func (a *AuxSweeper) importOutputProofs(scid lnwire.ShortChannelID,
 		// Before we combine the proofs below, we'll be sure to update
 		// the transition proof to include the proper block+merkle
 		// proof information.
-		blockHash, err := a.cfg.ChainBridge.GetBlockHash(
+		blockHash, err := chainBridge.GetBlockHash(
 			ctxb, int64(scid.BlockHeight),
 		)
 		if err != nil {
 			return fmt.Errorf("unable to get block hash: %w", err)
 		}
-		block, err := a.cfg.ChainBridge.GetBlock(ctxb, blockHash)
+		block, err := chainBridge.GetBlock(ctxb, blockHash)
 		if err != nil {
 			return fmt.Errorf("unable to get block: %w", err)
 		}
@@ -858,9 +861,9 @@ func (a *AuxSweeper) importOutputProofs(scid lnwire.ShortChannelID,
 		}
 
 		fundingUTXO := proofToImport.Asset
-		err = a.cfg.ProofArchive.ImportProofs(
-			ctxb, a.cfg.HeaderVerifier, proof.DefaultMerkleVerifier,
-			a.cfg.GroupVerifier, a.cfg.ChainBridge, false,
+		err = proofArchive.ImportProofs(
+			ctxb, headerVerifier, proof.DefaultMerkleVerifier,
+			groupVerifier, chainBridge, false,
 			&proof.AnnotatedProof{
 				//nolint:lll
 				Locator: proof.Locator{
@@ -932,8 +935,11 @@ func (a *AuxSweeper) importCommitTx(req lnwallet.ResolutionReq,
 	// for the funding transaction here so we can properly recognize the
 	// spent input below.
 	if !req.Initiator {
-		err := a.importOutputProofs(
+		err := importOutputProofs(
 			req.ShortChanID, maps.Values(fundingInputProofs),
+			a.cfg.DefaultCourierAddr, a.cfg.ProofFetcher,
+			a.cfg.ChainBridge, a.cfg.HeaderVerifier,
+			a.cfg.GroupVerifier, a.cfg.ProofArchive,
 		)
 		if err != nil {
 			return fmt.Errorf("unable to import output "+

--- a/tapchannel/aux_sweeper.go
+++ b/tapchannel/aux_sweeper.go
@@ -793,10 +793,15 @@ func importOutputProofs(scid lnwire.ShortChannelID,
 			return fmt.Errorf("unable to convert script key to "+
 				"pubkey: %w", err)
 		}
+
 		inputProofLocator := proof.Locator{
 			AssetID:   &proofPrevID.ID,
 			ScriptKey: *scriptKey,
 			OutPoint:  &proofPrevID.OutPoint,
+		}
+		if proofToImport.Asset.GroupKey != nil {
+			groupKey := proofToImport.Asset.GroupKey.GroupPubKey
+			inputProofLocator.GroupKey = &groupKey
 		}
 
 		log.Infof("Fetching funding input proof, locator=%v",


### PR DESCRIPTION
Otherwise, the transfer insert for the responder may fail as they don't
have the funding output in their database, so shipping the transfer
fails as it can't find the proof.

Fixes https://github.com/lightninglabs/taproot-assets/issues/985.