### PR TITLE
tapgarden: list batches correctly after asset transfer

### DIFF
--- a/itest/test_list_on_test.go
+++ b/itest/test_list_on_test.go
@@ -14,6 +14,10 @@ var testCases = []*testCase{
 		test: testMintBatchResume,
 	},
 	{
+		name: "mint batch and transfer",
+		test: testMintBatchAndTransfer,
+	},
+	{
 		name: "asset meta validation",
 		test: testAssetMeta,
 	},

--- a/proof/mock.go
+++ b/proof/mock.go
@@ -22,6 +22,7 @@ import (
 	"github.com/lightninglabs/taproot-assets/internal/test"
 	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/lightningnetwork/lnd/lnutils"
+	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/stretchr/testify/require"
 )
 
@@ -258,14 +259,56 @@ var _ ChainLookupGenerator = (*mockChainLookup)(nil)
 
 // MockProofArchive is a map that implements the Archiver interface.
 type MockProofArchive struct {
-	proofs lnutils.SyncMap[[32]byte, Blob]
+	proofs   lnutils.SyncMap[[32]byte, Blob]
+	locators lnutils.SyncMap[[132]byte, [32]byte]
 }
 
 // NewMockProofArchive creates a new mock proof archive.
 func NewMockProofArchive() *MockProofArchive {
 	return &MockProofArchive{
-		proofs: lnutils.SyncMap[[32]byte, Blob]{},
+		proofs:   lnutils.SyncMap[[32]byte, Blob]{},
+		locators: lnutils.SyncMap[[132]byte, [32]byte]{},
 	}
+}
+
+// storeLocator stores the locator as a byte array to allow for pattern matching
+// over the locators for the stored proofs, similar to the FileArchiver
+// implementation of FetchIssuanceProof.
+func (m *MockProofArchive) storeLocator(id Locator) error {
+	var locBuf bytes.Buffer
+
+	if id.AssetID == nil {
+		return fmt.Errorf("missing asset ID")
+	}
+
+	locBuf.Write(id.AssetID[:])
+	if id.GroupKey != nil {
+		locBuf.Write(id.GroupKey.SerializeCompressed())
+	} else {
+		locBuf.Write(bytes.Repeat([]byte{0x00}, 33))
+	}
+
+	locBuf.Write(id.ScriptKey.SerializeCompressed())
+	if id.OutPoint != nil {
+		err := lnwire.WriteOutPoint(&locBuf, *id.OutPoint)
+		if err != nil {
+			return err
+		}
+	} else {
+		locBuf.Write(bytes.Repeat([]byte{0x00}, 34))
+	}
+
+	var locArray [132]byte
+	copy(locArray[:], locBuf.Bytes())
+
+	locHash, err := id.Hash()
+	if err != nil {
+		return err
+	}
+
+	m.locators.Store(locArray, locHash)
+
+	return nil
 }
 
 // FetchProof fetches a proof for an asset uniquely identified by the passed
@@ -284,6 +327,66 @@ func (m *MockProofArchive) FetchProof(_ context.Context,
 	}
 
 	return proof, nil
+}
+
+// FetchIssuanceProof fetches the issuance proof for an asset, given the
+// anchor point of the issuance (NOT the genesis point for the asset).
+//
+// If a proof cannot be found, then ErrProofNotFound should be returned.
+func (m *MockProofArchive) FetchIssuanceProof(_ context.Context,
+	id asset.ID, anchorOutpoint wire.OutPoint) (Blob, error) {
+
+	var outpointBuf bytes.Buffer
+	err := lnwire.WriteOutPoint(&outpointBuf, anchorOutpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	// Mimic the pattern matching done with proof file paths in
+	// FileArchiver.FetchIssuanceProof().
+	matchingHashes := make([][32]byte, 0)
+	locMatcher := func(locBytes [132]byte, locHash [32]byte) error {
+		if bytes.Equal(locBytes[:32], id[:]) &&
+			bytes.Equal(locBytes[98:], outpointBuf.Bytes()) {
+
+			matchingHashes = append(matchingHashes, locHash)
+		}
+
+		return nil
+	}
+
+	m.locators.ForEach(locMatcher)
+	if len(matchingHashes) == 0 {
+		return nil, ErrProofNotFound
+	}
+
+	matchingProofs := make([]Blob, 0)
+	for _, locHash := range matchingHashes {
+		proof, ok := m.proofs.Load(locHash)
+		if !ok {
+			return nil, ErrProofNotFound
+		}
+
+		matchingProofs = append(matchingProofs, proof)
+	}
+
+	switch {
+	case len(matchingProofs) == 1:
+		return matchingProofs[0], nil
+
+	// Multiple proofs, return the smallest one.
+	default:
+		minProofIdx := 0
+		minProofSize := len(matchingProofs[minProofIdx])
+		for idx, proof := range matchingProofs {
+			if len(proof) < minProofSize {
+				minProofSize = len(proof)
+				minProofIdx = idx
+			}
+		}
+
+		return matchingProofs[minProofIdx], nil
+	}
 }
 
 // HasProof returns true if the proof for the given locator exists.
@@ -314,6 +417,11 @@ func (m *MockProofArchive) ImportProofs(_ context.Context, _ HeaderVerifier,
 	proofs ...*AnnotatedProof) error {
 
 	for _, proof := range proofs {
+		err := m.storeLocator(proof.Locator)
+		if err != nil {
+			return fmt.Errorf("mock archive failed: %w", err)
+		}
+
 		locHash, err := proof.Locator.Hash()
 		if err != nil {
 			return err

--- a/tapdb/assets_store.go
+++ b/tapdb/assets_store.go
@@ -1299,6 +1299,18 @@ func locatorToProofQuery(locator proof.Locator) (FetchAssetProof, error) {
 	return args, nil
 }
 
+// FetchIssuanceProof fetches the issuance proof for an asset, given the
+// anchor point of the issuance (NOT the genesis point for the asset). For the
+// AssetStore, we leave this unimplemented as we will only use this feature from
+// the FileArchiver.
+//
+// NOTE: This implements the proof.Archiver interface.
+func (a *AssetStore) FetchIssuanceProof(ctx context.Context, id asset.ID,
+	anchorOutpoint wire.OutPoint) (proof.Blob, error) {
+
+	return nil, proof.ErrProofNotFound
+}
+
 // HasProof returns true if the proof for the given locator exists. This is
 // intended to be a performance optimized lookup compared to fetching a proof
 // and checking for ErrProofNotFound.

--- a/tapgarden/interface.go
+++ b/tapgarden/interface.go
@@ -262,6 +262,11 @@ type MintingStore interface {
 	FetchGroupByGroupKey(ctx context.Context,
 		groupKey *btcec.PublicKey) (*asset.AssetGroup, error)
 
+	// FetchScriptKeyByTweakedKey fetches the populated script key given the
+	// tweaked script key.
+	FetchScriptKeyByTweakedKey(ctx context.Context,
+		tweakedKey *btcec.PublicKey) (*asset.TweakedScriptKey, error)
+
 	// FetchAssetMeta fetches the meta reveal for an asset genesis.
 	FetchAssetMeta(ctx context.Context, ID asset.ID) (*proof.MetaReveal,
 		error)

--- a/tapgarden/planter.go
+++ b/tapgarden/planter.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"sync"
 	"time"
 
@@ -724,10 +725,150 @@ func freezeMintingBatch(ctx context.Context, batchStore MintingStore,
 	)
 }
 
+// filterFinalizedBatches separates a set of batches into two sets based on
+// their batch state.
+func filterFinalizedBatches(batches []*MintingBatch) ([]*MintingBatch,
+	[]*MintingBatch) {
+
+	finalized := []*MintingBatch{}
+	nonFinalized := []*MintingBatch{}
+
+	fn.ForEach(batches, func(batch *MintingBatch) {
+		switch batch.State() {
+		case BatchStateFinalized:
+			finalized = append(finalized, batch)
+		default:
+			nonFinalized = append(nonFinalized, batch)
+		}
+	})
+
+	return finalized, nonFinalized
+}
+
+// fetchFinalizedBatch fetches the assets of a batch in their genesis state,
+// given a batch populated with seedlings.
+func fetchFinalizedBatch(ctx context.Context, batchStore MintingStore,
+	archiver proof.Archiver, batch *MintingBatch) (*MintingBatch, error) {
+
+	// Collect genesis TX information from the batch to build the proof
+	// locators.
+	anchorOutputIndex := extractAnchorOutputIndex(batch.GenesisPacket)
+	signedTx, err := psbt.Extract(batch.GenesisPacket.Pkt)
+	if err != nil {
+		return nil, err
+	}
+
+	genOutpoint := extractGenesisOutpoint(signedTx)
+	genScript := signedTx.TxOut[anchorOutputIndex].PkScript
+	anchorOutpoint := wire.OutPoint{
+		Hash:  signedTx.TxHash(),
+		Index: anchorOutputIndex,
+	}
+
+	batchAssets := make([]*asset.Asset, 0, len(batch.Seedlings))
+	assetMetas := make(AssetMetas)
+	for _, seedling := range batch.Seedlings {
+		gen := seedling.Genesis(genOutpoint, anchorOutputIndex)
+		issuanceProof, err := archiver.FetchIssuanceProof(
+			ctx, gen.ID(), anchorOutpoint,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		proofFile, err := issuanceProof.AsFile()
+		if err != nil {
+			return nil, err
+		}
+
+		if proofFile.NumProofs() != 1 {
+			return nil, fmt.Errorf("expected single proof for " +
+				"issuance proof")
+		}
+
+		rawProof, err := proofFile.RawLastProof()
+		if err != nil {
+			return nil, err
+		}
+
+		// Decode the sprouted asset from the issuance proof.
+		var sproutedAsset asset.Asset
+		assetRecord := proof.AssetLeafRecord(&sproutedAsset)
+		err = proof.SparseDecode(bytes.NewReader(rawProof), assetRecord)
+		if err != nil {
+			return nil, fmt.Errorf("unable to decode issuance "+
+				"proof: %w", err)
+		}
+
+		if !sproutedAsset.IsGenesisAsset() {
+			return nil, fmt.Errorf("decoded asset is not a " +
+				"genesis asset")
+		}
+
+		// Populate the key info for the script key and group key.
+		if sproutedAsset.ScriptKey.PubKey == nil {
+			return nil, fmt.Errorf("decoded asset is missing " +
+				"script key")
+		}
+
+		tweakedScriptKey, err := batchStore.FetchScriptKeyByTweakedKey(
+			ctx, sproutedAsset.ScriptKey.PubKey,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		sproutedAsset.ScriptKey.TweakedScriptKey = tweakedScriptKey
+		if sproutedAsset.GroupKey != nil {
+			assetGroup, err := batchStore.FetchGroupByGroupKey(
+				ctx, &sproutedAsset.GroupKey.GroupPubKey,
+			)
+			if err != nil {
+				return nil, err
+			}
+
+			sproutedAsset.GroupKey = assetGroup.GroupKey
+		}
+
+		batchAssets = append(batchAssets, &sproutedAsset)
+		scriptKey := asset.ToSerialized(sproutedAsset.ScriptKey.PubKey)
+		assetMetas[scriptKey] = seedling.Meta
+	}
+
+	// Verify that we can reconstruct the genesis output script used in the
+	// anchor TX.
+	batchSibling := batch.TapSibling()
+	var tapSibling *chainhash.Hash
+	if len(batchSibling) != 0 {
+		var err error
+		tapSibling, err = chainhash.NewHash(batchSibling)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	tapCommitment, err := VerifyOutputScript(
+		batch.BatchKey.PubKey, tapSibling, genScript, batchAssets,
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	// With the batch assets validated, construct the populated finalized
+	// batch.
+	batch.Seedlings = nil
+	finalizedBatch := batch.Copy()
+	finalizedBatch.RootAssetCommitment = tapCommitment
+	finalizedBatch.AssetMetas = assetMetas
+
+	return finalizedBatch, nil
+}
+
 // ListBatches returns the single batch specified by the batch key, or the set
 // of batches not yet finalized on disk.
 func listBatches(ctx context.Context, batchStore MintingStore,
-	genBuilder asset.GenesisTxBuilder,
+	archiver proof.Archiver, genBuilder asset.GenesisTxBuilder,
 	params ListBatchesParams) ([]*VerboseBatch, error) {
 
 	var (
@@ -747,12 +888,54 @@ func listBatches(ctx context.Context, batchStore MintingStore,
 		return nil, err
 	}
 
-	verboseBatches := fn.Map(batches, func(b *MintingBatch) *VerboseBatch {
-		return &VerboseBatch{
-			MintingBatch:      b,
-			UnsealedSeedlings: nil,
+	var (
+		finalBatches, nonFinalBatches = filterFinalizedBatches(batches)
+		verboseBatches                []*VerboseBatch
+	)
+
+	switch {
+	case len(finalBatches) == 0:
+		verboseBatches = fn.Map(batches,
+			func(b *MintingBatch) *VerboseBatch {
+				return &VerboseBatch{
+					MintingBatch:      b,
+					UnsealedSeedlings: nil,
+				}
+			},
+		)
+
+	// For finalized batches, we need to fetch the assets from the proof
+	// archiver, not the DB.
+	default:
+		finalizedBatches := make([]*MintingBatch, 0, len(finalBatches))
+		for _, batch := range finalBatches {
+			finalizedBatch, err := fetchFinalizedBatch(
+				ctx, batchStore, archiver, batch,
+			)
+			if err != nil {
+				return nil, err
+			}
+
+			finalizedBatches = append(
+				finalizedBatches, finalizedBatch,
+			)
 		}
-	})
+
+		// Re-sort the batches by creation time for consistent display.
+		allBatches := append(nonFinalBatches, finalizedBatches...)
+		slices.SortFunc(allBatches, func(a, b *MintingBatch) int {
+			return a.CreationTime.Compare(b.CreationTime)
+		})
+
+		verboseBatches = fn.Map(allBatches,
+			func(b *MintingBatch) *VerboseBatch {
+				return &VerboseBatch{
+					MintingBatch:      b,
+					UnsealedSeedlings: nil,
+				}
+			},
+		)
+	}
 
 	// Return the batches without any extra asset group info.
 	if !params.Verbose {
@@ -787,11 +970,9 @@ func listBatches(ctx context.Context, batchStore MintingStore,
 		// Before we can build the group key requests for each seedling,
 		// we must fetch the genesis point and anchor index for the
 		// batch.
-		anchorOutputIndex := uint32(0)
-		if currentBatch.GenesisPacket.ChangeOutputIndex == 0 {
-			anchorOutputIndex = 1
-		}
-
+		anchorOutputIndex := extractAnchorOutputIndex(
+			currentBatch.GenesisPacket,
+		)
 		genesisPoint := extractGenesisOutpoint(
 			currentBatch.GenesisPacket.Pkt.UnsignedTx,
 		)
@@ -1030,8 +1211,8 @@ func (c *ChainPlanter) gardener() {
 
 				ctx, cancel := c.WithCtxQuit()
 				batches, err := listBatches(
-					ctx, c.cfg.Log, c.cfg.GenTxBuilder,
-					*listBatchesParams,
+					ctx, c.cfg.Log, c.cfg.ProofFiles,
+					c.cfg.GenTxBuilder, *listBatchesParams,
 				)
 				cancel()
 				if err != nil {
@@ -1311,11 +1492,9 @@ func (c *ChainPlanter) sealBatch(ctx context.Context, params SealParams,
 
 	// Before we can build the group key requests for each seedling, we must
 	// fetch the genesis point and anchor index for the batch.
-	anchorOutputIndex := uint32(0)
-	if workingBatch.GenesisPacket.ChangeOutputIndex == 0 {
-		anchorOutputIndex = 1
-	}
-
+	anchorOutputIndex := extractAnchorOutputIndex(
+		workingBatch.GenesisPacket,
+	)
 	genesisPoint := extractGenesisOutpoint(
 		workingBatch.GenesisPacket.Pkt.UnsignedTx,
 	)

--- a/tapgarden/planter.go
+++ b/tapgarden/planter.go
@@ -587,13 +587,7 @@ func buildGroupReqs(genesisPoint wire.OutPoint, assetOutputIndex uint32,
 
 	for _, seedlingName := range orderedSeedlings {
 		seedling := groupSeedlings[seedlingName]
-
-		assetGen := asset.Genesis{
-			FirstPrevOut: genesisPoint,
-			Tag:          seedling.AssetName,
-			OutputIndex:  assetOutputIndex,
-			Type:         seedling.AssetType,
-		}
+		assetGen := seedling.Genesis(genesisPoint, assetOutputIndex)
 
 		// If the seedling has a meta data reveal set, then we'll bind
 		// that by including the hash of the meta data in the asset

--- a/tapgarden/planter_test.go
+++ b/tapgarden/planter_test.go
@@ -99,7 +99,7 @@ type mintingTestHarness struct {
 
 	planter *tapgarden.ChainPlanter
 
-	proofFiles *tapgarden.MockProofArchive
+	proofFiles *proof.MockProofArchive
 
 	proofWatcher *tapgarden.MockProofWatcher
 
@@ -116,6 +116,7 @@ func newMintingTestHarness(t *testing.T,
 	keyRing := tapgarden.NewMockKeyRing()
 	genSigner := tapgarden.NewMockGenSigner(keyRing)
 	treeMgr := tapgarden.NewFallibleTapscriptTreeMgr(store)
+	archiver := proof.NewMockProofArchive()
 
 	return &mintingTestHarness{
 		T:            t,
@@ -123,7 +124,7 @@ func newMintingTestHarness(t *testing.T,
 		treeStore:    &treeMgr,
 		wallet:       tapgarden.NewMockWalletAnchor(),
 		chain:        tapgarden.NewMockChainBridge(),
-		proofFiles:   &tapgarden.MockProofArchive{},
+		proofFiles:   archiver,
 		proofWatcher: &tapgarden.MockProofWatcher{},
 		keyRing:      keyRing,
 		genSigner:    genSigner,

--- a/tapgarden/seedling.go
+++ b/tapgarden/seedling.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"fmt"
 
+	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/taproot-assets/asset"
 	"github.com/lightninglabs/taproot-assets/proof"
 	"github.com/lightningnetwork/lnd/keychain"
@@ -197,6 +198,24 @@ func (c Seedling) validateGroupKey(group asset.AssetGroup,
 	}
 
 	return nil
+}
+
+// Genesis reconstructs the asset genesis for a seedling.
+func (c Seedling) Genesis(genOutpoint wire.OutPoint,
+	genIndex uint32) asset.Genesis {
+
+	gen := asset.Genesis{
+		FirstPrevOut: genOutpoint,
+		Tag:          c.AssetName,
+		OutputIndex:  genIndex,
+		Type:         c.AssetType,
+	}
+
+	if c.Meta != nil {
+		gen.MetaHash = c.Meta.MetaHash()
+	}
+
+	return gen
 }
 
 // HasGroupKey checks if a seedling specifies a particular group key.


### PR DESCRIPTION
Fixes #986 .

As detailed in #986, recent changes around how batches are created updated the way we store seedlings; specifically when we store script keys and group keys. Changes were made to how batches were displayed, and those changes broke the display of batches minted with tapd versions 0.3.3 or earlier.

Further investigation showed that the `ListBatches` RPC (and matching CLI command) displayed incorrect information once assets from a batch had been transferred.

To fix this, we can re-read the assets minted in a batch from their issuance proofs that we stored on disk when finalizing the batch.