### PR TITLE
Custom channel testing bugfixes

### DIFF
--- a/config.go
+++ b/config.go
@@ -197,8 +197,6 @@ type Config struct {
 
 	UniverseStats universe.Telemetry
 
-	AuxLeafCreator *tapchannel.AuxLeafCreator
-
 	AuxLeafSigner *tapchannel.AuxLeafSigner
 
 	AuxFundingController *tapchannel.FundingController

--- a/fn/errors.go
+++ b/fn/errors.go
@@ -2,6 +2,7 @@ package fn
 
 import (
 	"context"
+	"errors"
 	"strings"
 
 	"google.golang.org/grpc/codes"
@@ -43,4 +44,43 @@ func IsRpcErr(err error, candidate error) bool {
 	}
 
 	return strings.Contains(err.Error(), candidate.Error())
+}
+
+// CriticalError is an error type that should be used for errors that are
+// critical and should cause the application to exit.
+type CriticalError struct {
+	Err error
+}
+
+// NewCriticalError creates a new CriticalError instance.
+func NewCriticalError(err error) *CriticalError {
+	return &CriticalError{Err: err}
+}
+
+// Error implements the error interface.
+func (e *CriticalError) Error() string {
+	return e.Err.Error()
+}
+
+// Unwrap implements the errors.Wrapper interface.
+func (e *CriticalError) Unwrap() error {
+	return e.Err
+}
+
+// ErrorAs behaves the same as `errors.As` except there's no need to declare
+// the target error as a variable first.
+// Instead of writing:
+//
+//	var targetErr *TargetErr
+//	errors.As(err, &targetErr)
+//
+// We can write:
+//
+//	lnutils.ErrorAs[*TargetErr](err)
+//
+// To save us from declaring the target error variable.
+func ErrorAs[Target error](err error) bool {
+	var targetErr Target
+
+	return errors.As(err, &targetErr)
 }

--- a/itest/tapd_harness.go
+++ b/itest/tapd_harness.go
@@ -222,8 +222,9 @@ func newTapdHarness(t *testing.T, ht *harnessTest, cfg tapdConfig,
 	// Set the experimental config for the RFQ service.
 	tapCfg.Experimental = &tapcfg.ExperimentalConfig{
 		Rfq: rfq.CliConfig{
-			PriceOracleAddress:   rfq.MockPriceOracleServiceAddress,
-			MockOracleCentPerSat: 5_820_600,
+			//nolint:lll
+			PriceOracleAddress:     rfq.MockPriceOracleServiceAddress,
+			MockOracleAssetsPerBTC: 5_820_600,
 		},
 	}
 

--- a/rfq/cli.go
+++ b/rfq/cli.go
@@ -7,6 +7,12 @@ import (
 const (
 	MockPriceOracleServiceAddress = "use_mock_price_oracle_service_" +
 		"promise_to_not_use_on_mainnet"
+
+	// MinAssetsPerBTC is the minimum number of asset units that one BTC
+	// should cost. If the value is lower, then one asset unit would cost
+	// too much to be able to represent small amounts of satoshis. With this
+	// value, one asset unit would still cost 1k sats.
+	MinAssetsPerBTC = 100_000
 )
 
 // CliConfig is a struct that holds tapd cli configuration options for the RFQ
@@ -18,7 +24,9 @@ type CliConfig struct {
 
 	SkipAcceptQuotePriceCheck bool `long:"skipacceptquotepricecheck" description:"Accept any price quote returned by RFQ peer, skipping price validation"`
 
-	MockOracleCentPerSat uint64 `long:"mockoraclecentpersat" description:"Mock price oracle static USD cent per sat rate"`
+	MockOracleAssetsPerBTC uint64 `long:"mockoracleassetsperbtc" description:"Mock price oracle static asset units per BTC rate (for example number of USD cents per BTC if one asset unit represents a USD cent); whole numbers only, use either this or mockoraclesatsperasset depending on required precision"`
+
+	MockOracleSatsPerAsset uint64 `long:"mockoraclesatsperasset" description:"Mock price oracle static satoshis per asset unit rate (for example number of satoshis to pay for one USD cent if one asset unit represents a USD cent); whole numbers only, use either this or mockoracleassetsperbtc depending on required precision"`
 }
 
 // Validate returns an error if the configuration is invalid.
@@ -26,10 +34,11 @@ func (c *CliConfig) Validate() error {
 	// If the user has specified a mock oracle USD per BTC rate but the
 	// price oracle address is not the mock price oracle service address,
 	// then we'll return an error.
-	if c.MockOracleCentPerSat > 0 &&
+	if (c.MockOracleAssetsPerBTC > 0 || c.MockOracleSatsPerAsset > 0) &&
 		c.PriceOracleAddress != MockPriceOracleServiceAddress {
 
-		return fmt.Errorf("mockoraclecentpersat can only be used "+
+		return fmt.Errorf("mockoracleassetsperbtc or "+
+			"mockoraclesatsperasset can only be used "+
 			"with the mock price oracle service, set "+
 			"priceoracleaddress to %s",
 			MockPriceOracleServiceAddress)
@@ -39,10 +48,33 @@ func (c *CliConfig) Validate() error {
 	// has not set the mock oracle USD per BTC rate, then we'll return an
 	// error.
 	if c.PriceOracleAddress == MockPriceOracleServiceAddress &&
-		c.MockOracleCentPerSat == 0 {
+		c.MockOracleAssetsPerBTC == 0 && c.MockOracleSatsPerAsset == 0 {
 
-		return fmt.Errorf("mockoraclecentpersat must be set when " +
+		return fmt.Errorf("mockoracleassetsperbtc or " +
+			"mockoraclesatsperasset must be set when " +
 			"using the mock price oracle service")
+	}
+
+	// Only one of the mock oracle rates can be set.
+	if c.MockOracleAssetsPerBTC > 0 && c.MockOracleSatsPerAsset > 0 {
+		return fmt.Errorf("only one of mockoracleassetsperbtc or " +
+			"mockoraclesatsperasset can be set")
+	}
+
+	// The MockOracleAssetsPerBTC is more precise for tracking the actual
+	// BTC price but less optimal for just specifying a dummy or test rate
+	// for an asset that isn't BTC. The smaller the value, the more one
+	// asset costs. If we allowed a value of 1, then one asset unit would
+	// cost 1 BTC, which cannot really easily be transported over the
+	// network. So we require a value of at least 100k, which would still
+	// mean that one asset unit costs 1k sats.
+	if c.MockOracleAssetsPerBTC > 0 &&
+		c.MockOracleAssetsPerBTC < MinAssetsPerBTC {
+
+		return fmt.Errorf("mockoracleassetsperbtc must be at least "+
+			"%d asset units per BTC, otherwise one asset "+
+			"unit would cost more than 1k sats per unit",
+			MinAssetsPerBTC)
 	}
 
 	// Ensure that if the price oracle address not the mock price oracle

--- a/rfq/oracle.go
+++ b/rfq/oracle.go
@@ -383,6 +383,17 @@ func NewMockPriceOracle(expiryDelay, assetsPerBTC uint64) *MockPriceOracle {
 	}
 }
 
+// NewMockPriceOracleSatPerAsset creates a new mock price oracle with a
+// specified satoshis per asset rate.
+func NewMockPriceOracleSatPerAsset(expiryDelay uint64,
+	satPerAsset btcutil.Amount) *MockPriceOracle {
+
+	return &MockPriceOracle{
+		expiryDelay:  expiryDelay,
+		mSatPerAsset: lnwire.NewMSatFromSatoshis(satPerAsset),
+	}
+}
+
 // QueryAskPrice returns the ask price for the given asset amount.
 func (m *MockPriceOracle) QueryAskPrice(_ context.Context,
 	_ *asset.ID, _ *btcec.PublicKey, _ uint64,

--- a/rfq/oracle.go
+++ b/rfq/oracle.go
@@ -368,15 +368,18 @@ var _ PriceOracle = (*RpcPriceOracle)(nil)
 // MockPriceOracle is a mock implementation of the PriceOracle interface.
 // It returns the suggested rate as the exchange rate.
 type MockPriceOracle struct {
-	expiryDelay uint64
-	usdPerBTC   uint64
+	expiryDelay  uint64
+	mSatPerAsset lnwire.MilliSatoshi
 }
 
 // NewMockPriceOracle creates a new mock price oracle.
-func NewMockPriceOracle(expiryDelay, usdPerBTC uint64) *MockPriceOracle {
+func NewMockPriceOracle(expiryDelay, assetsPerBTC uint64) *MockPriceOracle {
+	mSatPerAsset := lnwire.NewMSatFromSatoshis(btcutil.SatoshiPerBitcoin) /
+		lnwire.MilliSatoshi(assetsPerBTC)
+
 	return &MockPriceOracle{
-		expiryDelay: expiryDelay,
-		usdPerBTC:   usdPerBTC,
+		expiryDelay:  expiryDelay,
+		mSatPerAsset: mSatPerAsset,
 	}
 }
 
@@ -388,11 +391,8 @@ func (m *MockPriceOracle) QueryAskPrice(_ context.Context,
 	// Calculate the rate expiryDelay lifetime.
 	expiry := uint64(time.Now().Unix()) + m.expiryDelay
 
-	mSatPerUsd := lnwire.NewMSatFromSatoshis(btcutil.SatoshiPerBitcoin) /
-		lnwire.MilliSatoshi(m.usdPerBTC)
-
 	return &OracleAskResponse{
-		AskPrice: &mSatPerUsd,
+		AskPrice: &m.mSatPerAsset,
 		Expiry:   expiry,
 	}, nil
 }
@@ -404,11 +404,8 @@ func (m *MockPriceOracle) QueryBidPrice(_ context.Context, _ *asset.ID,
 	// Calculate the rate expiryDelay lifetime.
 	expiry := uint64(time.Now().Unix()) + m.expiryDelay
 
-	mSatPerUsd := lnwire.NewMSatFromSatoshis(btcutil.SatoshiPerBitcoin) /
-		lnwire.MilliSatoshi(m.usdPerBTC)
-
 	return &OracleBidResponse{
-		BidPrice: &mSatPerUsd,
+		BidPrice: &m.mSatPerAsset,
 		Expiry:   expiry,
 	}, nil
 }

--- a/sample-tapd.conf
+++ b/sample-tapd.conf
@@ -320,5 +320,13 @@
 ; Accept any price quote returned by RFQ peer, skipping price validation
 ; experimental.rfq.skipacceptquotepricecheck=false
 
-; Mock price oracle static USD cent per sat rate
-; experimental.rfq.mockoraclecentpersat=
+; Mock price oracle static asset units per BTC rate (for example number of USD
+; cents per BTC if one asset unit represents a USD cent); whole numbers only,
+; use either this or mockoraclesatsperasset depending on required precision
+; experimental.rfq.mockoracleassetsperbtc=
+
+; Mock price oracle static satoshis per asset unit rate (for example number of
+; satoshis to pay for one USD cent if one asset unit represents a USD cent);
+; whole numbers only, use either this or mockoracleassetsperbtc depending on
+; required precision
+; experimental.rfq.mockoraclesatsperasset=

--- a/server.go
+++ b/server.go
@@ -15,6 +15,7 @@ import (
 	"github.com/davecgh/go-spew/spew"
 	proxy "github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/lightninglabs/lndclient"
+	"github.com/lightninglabs/taproot-assets/address"
 	"github.com/lightninglabs/taproot-assets/fn"
 	"github.com/lightninglabs/taproot-assets/monitoring"
 	"github.com/lightninglabs/taproot-assets/perms"
@@ -55,6 +56,8 @@ type Server struct {
 	// work.
 	ready chan bool
 
+	chainParams *address.ChainParams
+
 	cfg *Config
 
 	*rpcServer
@@ -65,11 +68,12 @@ type Server struct {
 }
 
 // NewServer creates a new server given the passed config.
-func NewServer(cfg *Config) *Server {
+func NewServer(chainParams *address.ChainParams, cfg *Config) *Server {
 	return &Server{
-		cfg:   cfg,
-		ready: make(chan bool),
-		quit:  make(chan struct{}, 1),
+		chainParams: chainParams,
+		cfg:         cfg,
+		ready:       make(chan bool),
+		quit:        make(chan struct{}, 1),
 	}
 }
 

--- a/server.go
+++ b/server.go
@@ -863,11 +863,9 @@ func (s *Server) PackSigs(
 
 	srvrLog.Debugf("PackSigs called")
 
-	if err := s.waitForReady(); err != nil {
-		return lfn.None[tlv.Blob](), err
-	}
-
-	return s.cfg.AuxLeafSigner.PackSigs(blob)
+	// We don't need to wait for the server to be ready here, as the
+	// PackSigs method is fully stateless.
+	return tapchannel.PackSigs(blob)
 }
 
 // UnpackSigs takes a packed blob of signatures and returns the original
@@ -879,11 +877,9 @@ func (s *Server) UnpackSigs(blob lfn.Option[tlv.Blob]) ([]lfn.Option[tlv.Blob],
 
 	srvrLog.Debugf("UnpackSigs called")
 
-	if err := s.waitForReady(); err != nil {
-		return nil, err
-	}
-
-	return s.cfg.AuxLeafSigner.UnpackSigs(blob)
+	// We don't need to wait for the server to be ready here, as the
+	// UnpackSigs method is fully stateless.
+	return tapchannel.UnpackSigs(blob)
 }
 
 // VerifySecondLevelSigs attempts to synchronously verify a batch of aux sig
@@ -895,12 +891,10 @@ func (s *Server) VerifySecondLevelSigs(chanState *channeldb.OpenChannel,
 
 	srvrLog.Debugf("VerifySecondLevelSigs called")
 
-	if err := s.waitForReady(); err != nil {
-		return err
-	}
-
-	return s.cfg.AuxLeafSigner.VerifySecondLevelSigs(
-		chanState, commitTx, verifyJob,
+	// We don't need to wait for the server to be ready here, as the
+	// VerifySecondLevelSigs method is fully stateless.
+	return tapchannel.VerifySecondLevelSigs(
+		s.chainParams, chanState, commitTx, verifyJob,
 	)
 }
 
@@ -1089,8 +1083,8 @@ func (s *Server) FinalizeClose(desc chancloser.AuxCloseDesc,
 
 // ResolveContract attempts to obtain a resolution blob for the specified
 // contract.
-func (s *Server) ResolveContract(req lnwallet.ResolutionReq,
-) lfn.Result[tlv.Blob] {
+func (s *Server) ResolveContract(
+	req lnwallet.ResolutionReq) lfn.Result[tlv.Blob] {
 
 	srvrLog.Infof("ResolveContract called, req=%v", spew.Sdump(req))
 

--- a/tapcfg/config.go
+++ b/tapcfg/config.go
@@ -111,6 +111,11 @@ const (
 	// wait for before considering a transaction safely buried in the chain.
 	defaultReOrgSafeDepth = 6
 
+	// testnetDefaultReOrgSafeDepth is the default number of confirmations
+	// we'll wait before considering a transaction safely buried in the
+	// testnet chain.
+	testnetDefaultReOrgSafeDepth = 120
+
 	// defaultUniverseMaxQps is the default maximum number of queries per
 	// second for the universe server. This permis 100 queries per second
 	// by default.
@@ -275,7 +280,7 @@ type UniverseConfig struct {
 	UniverseQueriesBurst int `long:"req-burst-budget" description:"The burst budget for the universe query rate limiting."`
 }
 
-// AddressConfig is the config that houses any address Book related config
+// AddrBookConfig is the config that houses any address Book related config
 // values.
 type AddrBookConfig struct {
 	DisableSyncer bool `long:"disable-syncer" description:"If true, tapd will not try to sync issuance proofs for unknown assets when creating an address."`
@@ -838,6 +843,14 @@ func ValidateConfig(cfg Config, cfgLogger btclog.Logger) (*Config, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error in experimental command line "+
 			"config: %w", err)
+	}
+
+	// Use a way higher re-org safe depth value for testnet (if the user
+	// didn't specify a custom value).
+	if cfg.ActiveNetParams.Net == chaincfg.TestNet3Params.Net &&
+		cfg.ReOrgSafeDepth == defaultReOrgSafeDepth {
+
+		cfg.ReOrgSafeDepth = testnetDefaultReOrgSafeDepth
 	}
 
 	// All good, return the sanitized result.

--- a/tapcfg/server.go
+++ b/tapcfg/server.go
@@ -633,7 +633,7 @@ func CreateServerFromConfig(cfg *Config, cfgLogger btclog.Logger,
 		LetsEncryptDomain:          cfg.RpcConf.LetsEncryptDomain,
 	}
 
-	return tap.NewServer(serverCfg), nil
+	return tap.NewServer(&serverCfg.ChainParams, serverCfg), nil
 }
 
 // ConfigureSubServer updates a Taproot Asset server with the given CLI config.

--- a/tapcfg/server.go
+++ b/tapcfg/server.go
@@ -406,11 +406,6 @@ func genServerConfig(cfg *Config, cfgLogger btclog.Logger,
 		},
 	)
 
-	auxLeafCreator := tapchannel.NewAuxLeafCreator(
-		&tapchannel.LeafCreatorConfig{
-			ChainParams: &tapChainParams,
-		},
-	)
 	auxLeafSigner := tapchannel.NewAuxLeafSigner(
 		&tapchannel.LeafSignerConfig{
 			ChainParams: &tapChainParams,
@@ -554,7 +549,6 @@ func genServerConfig(cfg *Config, cfgLogger btclog.Logger,
 		UniverseQueriesPerSecond: cfg.Universe.UniverseQueriesPerSecond,
 		UniverseQueriesBurst:     cfg.Universe.UniverseQueriesBurst,
 		RfqManager:               rfqManager,
-		AuxLeafCreator:           auxLeafCreator,
 		AuxLeafSigner:            auxLeafSigner,
 		AuxFundingController:     auxFundingController,
 		AuxChanCloser:            auxChanCloser,

--- a/tapchannel/aux_traffic_shaper.go
+++ b/tapchannel/aux_traffic_shaper.go
@@ -256,6 +256,17 @@ func (s *AuxTrafficShaper) ProduceHtlcExtraData(totalAmount lnwire.MilliSatoshi,
 		return 0, nil, fmt.Errorf("quote has no asset ID")
 	}
 
+	// If the number of asset units to send is zero due to integer division
+	// and insufficient asset unit precision vs. satoshis, we cannot send
+	// this payment. This should only happen if the amount to pay is very
+	// small (small satoshi or sub satoshi total value) or the price oracle
+	// has given a very high price for the asset.
+	if numAssetUnits == 0 {
+		return 0, nil, fmt.Errorf("asset unit price (%d mSat per "+
+			"asset unit) too high to represent HTLC value of %v",
+			mSatPerAssetUnit, totalAmount)
+	}
+
 	log.Debugf("Producing HTLC extra data for RFQ ID %x (SCID %d): "+
 		"asset ID %x, asset amount %d", rfqID[:], rfqID.Scid(),
 		quote.Request.AssetID[:], numAssetUnits)


### PR DESCRIPTION
Fixes #1007.
Fixes #1006.
Fixes #1010.

Also adds a fix for the startup dependency issue between `lnd` and `tapd`: Apparently it's possible that `lnd` wants to force close channels before the RPC server is fully started. That then calls into the aux leaf creator which blocks until `tapd` thinks it's fully started (which in turn depends on a successful connection to `lnd`'s RPC).
By making the aux leaf creator fully stateless and allowing some methods of the aux leaf signer that are stateless to be called early, we should be able to fix this startup dependency issue.