### PR TITLE
tapchannel: ensure genesis proofs for input assets already known

### DIFF
--- a/address/book.go
+++ b/address/book.go
@@ -195,10 +195,10 @@ func NewBook(cfg BookConfig) *Book {
 	}
 }
 
-// queryAssetInfo attempts to locate asset genesis information by querying
+// QueryAssetInfo attempts to locate asset genesis information by querying
 // geneses already known to this node. If asset issuance was not previously
 // verified, we then query universes in our federation for issuance proofs.
-func (b *Book) queryAssetInfo(ctx context.Context,
+func (b *Book) QueryAssetInfo(ctx context.Context,
 	id asset.ID) (*asset.AssetGroup, error) {
 
 	// Check if we know of this asset ID already.
@@ -262,7 +262,7 @@ func (b *Book) NewAddress(ctx context.Context, addrVersion Version,
 
 	// Before we proceed and make new keys, make sure that we actually know
 	// of this asset ID, or can import it.
-	if _, err := b.queryAssetInfo(ctx, assetID); err != nil {
+	if _, err := b.QueryAssetInfo(ctx, assetID); err != nil {
 		return nil, fmt.Errorf("unable to make address for unknown "+
 			"asset %x: %w", assetID[:], err)
 	}
@@ -300,7 +300,7 @@ func (b *Book) NewAddressWithKeys(ctx context.Context, addrVersion Version,
 	// Before we proceed, we'll make sure that the asset group is known to
 	// the local store. Otherwise, we can't make an address as we haven't
 	// bootstrapped it.
-	assetGroup, err := b.queryAssetInfo(ctx, assetID)
+	assetGroup, err := b.QueryAssetInfo(ctx, assetID)
 	if err != nil {
 		return nil, err
 	}

--- a/tapcfg/server.go
+++ b/tapcfg/server.go
@@ -433,6 +433,7 @@ func genServerConfig(cfg *Config, cfgLogger btclog.Logger,
 			RfqManager:         rfqManager,
 			TxSender:           chainPorter,
 			DefaultCourierAddr: proofCourierAddr,
+			AssetSyncer:        addrBook,
 		},
 	)
 	auxTrafficShaper := tapchannel.NewAuxTrafficShaper(

--- a/tapchannel/aux_traffic_shaper.go
+++ b/tapchannel/aux_traffic_shaper.go
@@ -268,8 +268,9 @@ func (s *AuxTrafficShaper) ProduceHtlcExtraData(totalAmount lnwire.MilliSatoshi,
 	}
 
 	log.Debugf("Producing HTLC extra data for RFQ ID %x (SCID %d): "+
-		"asset ID %x, asset amount %d", rfqID[:], rfqID.Scid(),
-		quote.Request.AssetID[:], numAssetUnits)
+		"asset ID %x, btc_amt=%v, asset amount %d", rfqID[:],
+		rfqID.Scid(), quote.Request.AssetID[:], totalAmount,
+		numAssetUnits)
 
 	htlc.Amounts.Val.Balances = []*rfqmsg.AssetBalance{
 		rfqmsg.NewAssetBalance(*quote.Request.AssetID, numAssetUnits),


### PR DESCRIPTION
With this commit, we partially address https://github.com/lightninglabs/taproot-assets/issues/1026 by ensuring that when we
receive an incoming funding request, then we've already verified the
genesis proofs of the incoming asset.

If we haven't verified the proofs yet, then we'll try to fetch from a
remote universe. Otherwise, this check will be a noop.