### PR TITLE
Store transfer output proof delivery status

### DIFF
--- a/tapdb/assets_store_test.go
+++ b/tapdb/assets_store_test.go
@@ -1386,6 +1386,7 @@ func TestAssetExportLog(t *testing.T) {
 			// The receiver wants a V0 asset version.
 			AssetVersion: asset.V0,
 			ProofSuffix:  receiverBlob,
+			Position:     0,
 		}, {
 			Anchor: tapfreighter.Anchor{
 				Value: 1000,
@@ -1420,6 +1421,7 @@ func TestAssetExportLog(t *testing.T) {
 			// asset version.
 			AssetVersion: asset.V1,
 			ProofSuffix:  senderBlob,
+			Position:     1,
 		}},
 	}
 	require.NoError(t, assetsStore.LogPendingParcel(

--- a/tapdb/assets_store_test.go
+++ b/tapdb/assets_store_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha256"
+	"database/sql"
 	"math/rand"
 	"sort"
 	"testing"
@@ -1896,4 +1897,242 @@ func TestFetchGroupedAssets(t *testing.T) {
 	equalityCheck(allAssets[1].Asset, groupedAssets[0])
 	equalityCheck(allAssets[2].Asset, groupedAssets[1])
 	equalityCheck(allAssets[3].Asset, groupedAssets[2])
+}
+
+// TestTransferOutputProofDeliveryStatus tests that we can properly set the
+// proof delivery status of a transfer output.
+func TestTransferOutputProofDeliveryStatus(t *testing.T) {
+	t.Parallel()
+
+	// First, we'll create a new assets store. We'll use this to store the
+	// asset and the outbound parcel in the database.
+	_, assetsStore, db := newAssetStore(t)
+	ctx := context.Background()
+
+	// Generate a single asset.
+	targetScriptKey := asset.NewScriptKeyBip86(keychain.KeyDescriptor{
+		PubKey: test.RandPubKey(t),
+		KeyLocator: keychain.KeyLocator{
+			Family: test.RandInt[keychain.KeyFamily](),
+			Index:  uint32(test.RandInt[int32]()),
+		},
+	})
+
+	assetVersionV0 := asset.V0
+
+	const numAssets = 1
+	assetGen := newAssetGenerator(t, numAssets, 1)
+	assetGen.genAssets(t, assetsStore, []assetDesc{
+		{
+			assetGen:    assetGen.assetGens[0],
+			anchorPoint: assetGen.anchorPoints[0],
+
+			// This is the script key of the asset we'll be
+			// modifying.
+			scriptKey: &targetScriptKey,
+
+			amt:          16,
+			assetVersion: &assetVersionV0,
+		},
+	})
+
+	// Formulate a spend delta outbound parcel. This parcel will be stored
+	// in the database. We will then manipulate the proof delivery status
+	// of the first transfer output.
+	//
+	// First, we'll generate a new anchor transaction for use in the parcel.
+	newAnchorTx := wire.NewMsgTx(2)
+	newAnchorTx.AddTxIn(&wire.TxIn{})
+	newAnchorTx.TxIn[0].SignatureScript = []byte{}
+	newAnchorTx.AddTxOut(&wire.TxOut{
+		PkScript: bytes.Repeat([]byte{0x01}, 34),
+		Value:    1000,
+	})
+	anchorTxHash := newAnchorTx.TxHash()
+
+	// Next, we'll generate script keys for the two transfer outputs.
+	newScriptKey := asset.NewScriptKeyBip86(keychain.KeyDescriptor{
+		PubKey: test.RandPubKey(t),
+		KeyLocator: keychain.KeyLocator{
+			Index:  uint32(rand.Int31()),
+			Family: keychain.KeyFamily(rand.Int31()),
+		},
+	})
+
+	newScriptKey2 := asset.NewScriptKeyBip86(keychain.KeyDescriptor{
+		PubKey: test.RandPubKey(t),
+		KeyLocator: keychain.KeyLocator{
+			Index:  uint32(rand.Int31()),
+			Family: keychain.KeyFamily(rand.Int31()),
+		},
+	})
+
+	// The outbound parcel will split the asset into two outputs. The first
+	// will have an amount of 9, and the second will have the remainder of
+	// the asset amount.
+	newAmt := 9
+
+	senderBlob := bytes.Repeat([]byte{0x01}, 100)
+	receiverBlob := bytes.Repeat([]byte{0x02}, 100)
+
+	newWitness := asset.Witness{
+		PrevID:          &asset.PrevID{},
+		TxWitness:       [][]byte{{0x01}, {0x02}},
+		SplitCommitment: nil,
+	}
+
+	// Mock proof courier address.
+	proofCourierAddrBytes := []byte("universerpc://localhost:10009")
+
+	// Fetch the asset that was previously generated.
+	allAssets, err := assetsStore.FetchAllAssets(ctx, true, false, nil)
+	require.NoError(t, err)
+	require.Len(t, allAssets, numAssets)
+
+	inputAsset := allAssets[0]
+
+	// Construct the outbound parcel that will be stored in the database.
+	spendDelta := &tapfreighter.OutboundParcel{
+		AnchorTx:           newAnchorTx,
+		AnchorTxHeightHint: 1450,
+		ChainFees:          int64(100),
+		Inputs: []tapfreighter.TransferInput{{
+			PrevID: asset.PrevID{
+				OutPoint: wire.OutPoint{
+					Hash:  assetGen.anchorTxs[0].TxHash(),
+					Index: 0,
+				},
+				ID: inputAsset.ID(),
+				ScriptKey: asset.ToSerialized(
+					inputAsset.ScriptKey.PubKey,
+				),
+			},
+			Amount: inputAsset.Amount,
+		}},
+		Outputs: []tapfreighter.TransferOutput{{
+			Anchor: tapfreighter.Anchor{
+				Value: 1000,
+				OutPoint: wire.OutPoint{
+					Hash:  anchorTxHash,
+					Index: 0,
+				},
+				InternalKey: keychain.KeyDescriptor{
+					PubKey: test.RandPubKey(t),
+					KeyLocator: keychain.KeyLocator{
+						Family: keychain.KeyFamily(
+							rand.Int31(),
+						),
+						Index: uint32(
+							test.RandInt[int32](),
+						),
+					},
+				},
+				TaprootAssetRoot: bytes.Repeat([]byte{0x1}, 32),
+				MerkleRoot:       bytes.Repeat([]byte{0x1}, 32),
+			},
+			ScriptKey:             newScriptKey,
+			ScriptKeyLocal:        false,
+			Amount:                uint64(newAmt),
+			LockTime:              1337,
+			RelativeLockTime:      31337,
+			WitnessData:           []asset.Witness{newWitness},
+			SplitCommitmentRoot:   nil,
+			AssetVersion:          asset.V0,
+			ProofSuffix:           receiverBlob,
+			ProofCourierAddr:      proofCourierAddrBytes,
+			ProofDeliveryComplete: fn.Some[bool](false),
+			Position:              0,
+		}, {
+			Anchor: tapfreighter.Anchor{
+				Value: 1000,
+				OutPoint: wire.OutPoint{
+					Hash:  anchorTxHash,
+					Index: 1,
+				},
+				InternalKey: keychain.KeyDescriptor{
+					PubKey: test.RandPubKey(t),
+					KeyLocator: keychain.KeyLocator{
+						Family: keychain.KeyFamily(
+							rand.Int31(),
+						),
+						Index: uint32(
+							test.RandInt[int32](),
+						),
+					},
+				},
+				TaprootAssetRoot: bytes.Repeat([]byte{0x1}, 32),
+				MerkleRoot:       bytes.Repeat([]byte{0x1}, 32),
+			},
+			ScriptKey:           newScriptKey2,
+			ScriptKeyLocal:      true,
+			Amount:              inputAsset.Amount - uint64(newAmt),
+			WitnessData:         []asset.Witness{newWitness},
+			SplitCommitmentRoot: nil,
+			AssetVersion:        asset.V1,
+			ProofSuffix:         senderBlob,
+			Position:            1,
+		}},
+	}
+
+	// Store the outbound parcel in the database.
+	leaseOwner := fn.ToArray[[32]byte](test.RandBytes(32))
+	leaseExpiry := time.Now().Add(time.Hour)
+	require.NoError(t, assetsStore.LogPendingParcel(
+		ctx, spendDelta, leaseOwner, leaseExpiry,
+	))
+
+	// At this point, we should be able to query for the log parcel, by
+	// looking for all unconfirmed transfers.
+	assetTransfers, err := db.QueryAssetTransfers(ctx, TransferQuery{})
+	require.NoError(t, err)
+	require.Len(t, assetTransfers, 1)
+
+	// We should also be able to find the transfer outputs.
+	transferOutputs, err := db.FetchTransferOutputs(
+		ctx, assetTransfers[0].ID,
+	)
+	require.NoError(t, err)
+	require.Len(t, transferOutputs, 2)
+
+	// Let's confirm that the proof has not been delivered for the first
+	// transfer output and that the proof delivery status for the second
+	// transfer output is still unset.
+	require.Equal(
+		t, sqlBool(false), transferOutputs[0].ProofDeliveryComplete,
+	)
+	require.Equal(
+		t, sql.NullBool{}, transferOutputs[1].ProofDeliveryComplete,
+	)
+
+	// We will now set the status of the transfer output proof to
+	// "delivered".
+	//
+	// nolint: lll
+	err = db.SetTransferOutputProofDeliveryStatus(
+		ctx, OutputProofDeliveryStatus{
+			DeliveryComplete:         sqlBool(true),
+			SerializedAnchorOutpoint: transferOutputs[0].AnchorOutpoint,
+			Position:                 transferOutputs[0].Position,
+		},
+	)
+	require.NoError(t, err)
+
+	// We will check to ensure that the transfer output proof delivery
+	// status has been updated correctly.
+	transferOutputs, err = db.FetchTransferOutputs(
+		ctx, assetTransfers[0].ID,
+	)
+	require.NoError(t, err)
+	require.Len(t, transferOutputs, 2)
+
+	// The proof delivery status of the first output should be set to
+	// delivered (true).
+	require.Equal(
+		t, sqlBool(true), transferOutputs[0].ProofDeliveryComplete,
+	)
+
+	// The proof delivery status of the second output should be unset.
+	require.Equal(
+		t, sql.NullBool{}, transferOutputs[1].ProofDeliveryComplete,
+	)
 }

--- a/tapdb/migrations.go
+++ b/tapdb/migrations.go
@@ -22,7 +22,7 @@ const (
 	// daemon.
 	//
 	// NOTE: This MUST be updated when a new migration is added.
-	LatestMigrationVersion = 21
+	LatestMigrationVersion = 22
 )
 
 // MigrationTarget is a functional option that can be passed to applyMigrations

--- a/tapdb/sqlc/migrations/000022_transfer_outputs_proof_delivered.down.sql
+++ b/tapdb/sqlc/migrations/000022_transfer_outputs_proof_delivered.down.sql
@@ -1,0 +1,10 @@
+-- Remove the unique constraint on the `transfer_id` and `position` columns in
+-- the `asset_transfer_outputs` table.
+DROP INDEX asset_transfer_outputs_transfer_id_position_unique;
+
+-- Remove the `proof_delivery_complete` column from the `asset_transfer_outputs`
+-- table.
+ALTER TABLE asset_transfer_outputs DROP COLUMN proof_delivery_complete;
+
+-- Remove the `position` column from the `asset_transfer_outputs` table.
+ALTER TABLE asset_transfer_outputs DROP COLUMN position;

--- a/tapdb/sqlc/migrations/000022_transfer_outputs_proof_delivered.up.sql
+++ b/tapdb/sqlc/migrations/000022_transfer_outputs_proof_delivered.up.sql
@@ -1,0 +1,28 @@
+-- Add a column to track if the proof has been delivered for an asset transfer
+-- output.
+ALTER TABLE asset_transfer_outputs
+ADD COLUMN proof_delivery_complete BOOL;
+
+-- Add column `position` which indicates the index of the output in the list of
+-- outputs for a given transfer. This index position in conjunction with the
+-- transfer id can be used to uniquely identify a transfer output.
+--
+-- We'll be inserting an actual value in the next query, so we just start
+-- with -1.
+ALTER TABLE asset_transfer_outputs
+ADD COLUMN position INTEGER NOT NULL DEFAULT -1;
+
+-- Update the position to be the same as the output id for existing entries.
+-- We'll use the position integer as a uniquely identifiable number of an output
+-- within a transfer, so setting the default to the output_id is just to make
+-- sure we have a unique value that also satisfies the unique constraint we add
+-- below.
+UPDATE asset_transfer_outputs SET position = CAST(output_id AS INTEGER)
+WHERE position = -1;
+
+-- We enforce a unique constraint such that for a given transfer, the position
+-- of an output is unique.
+CREATE UNIQUE INDEX asset_transfer_outputs_transfer_id_position_unique
+ON asset_transfer_outputs (
+    transfer_id, position
+);

--- a/tapdb/sqlc/models.go
+++ b/tapdb/sqlc/models.go
@@ -135,6 +135,8 @@ type AssetTransferOutput struct {
 	ProofCourierAddr         []byte
 	LockTime                 sql.NullInt32
 	RelativeLockTime         sql.NullInt32
+	ProofDeliveryComplete    sql.NullBool
+	Position                 int32
 }
 
 type AssetWitness struct {

--- a/tapdb/sqlc/querier.go
+++ b/tapdb/sqlc/querier.go
@@ -148,6 +148,7 @@ type Querier interface {
 	ReAnchorPassiveAssets(ctx context.Context, arg ReAnchorPassiveAssetsParams) error
 	SetAddrManaged(ctx context.Context, arg SetAddrManagedParams) error
 	SetAssetSpent(ctx context.Context, arg SetAssetSpentParams) (int64, error)
+	SetTransferOutputProofDeliveryStatus(ctx context.Context, arg SetTransferOutputProofDeliveryStatusParams) error
 	UniverseLeaves(ctx context.Context) ([]UniverseLeafe, error)
 	UniverseRoots(ctx context.Context, arg UniverseRootsParams) ([]UniverseRootsRow, error)
 	UpdateBatchGenesisTx(ctx context.Context, arg UpdateBatchGenesisTxParams) error

--- a/tapfreighter/chain_porter.go
+++ b/tapfreighter/chain_porter.go
@@ -643,47 +643,16 @@ func (p *ChainPorter) transferReceiverProof(pkg *sendPackage) error {
 	deliver := func(ctx context.Context, out TransferOutput) error {
 		key := out.ScriptKey.PubKey
 
-		// If this is an output that is going to our own node/wallet,
-		// we don't need to transfer the proof.
-		if out.ScriptKey.TweakedScriptKey != nil && out.ScriptKeyLocal {
-			log.Debugf("Not transferring proof for local output "+
-				"script key %x", key.SerializeCompressed())
-			return nil
-		}
-
-		// Un-spendable means this is a tombstone output resulting from
-		// a split.
-		unSpendable, err := out.ScriptKey.IsUnSpendable()
+		// We'll first check to see if the proof should be delivered.
+		shouldDeliverProof, err := out.ShouldDeliverProof()
 		if err != nil {
-			return fmt.Errorf("error checking if script key is "+
-				"unspendable: %w", err)
-		}
-		if unSpendable {
-			log.Debugf("Not transferring proof for un-spendable "+
-				"output script key %x",
-				key.SerializeCompressed())
-			return nil
+			return fmt.Errorf("error determining if proof should "+
+				"be delivered: %w", err)
 		}
 
-		// Burns are also always kept local and not sent to any
-		// receiver.
-		if len(out.WitnessData) > 0 && asset.IsBurnKey(
-			out.ScriptKey.PubKey, out.WitnessData[0],
-		) {
-
-			log.Debugf("Not transferring proof for burn script "+
-				"key %x", key.SerializeCompressed())
-			return nil
-		}
-
-		// We can only deliver proofs for outputs that have a proof
-		// courier address. If an output doesn't have one, we assume it
-		// is an interactive send where the recipient is already aware
-		// of the proof or learns of it through another channel.
-		if len(out.ProofCourierAddr) == 0 {
-			log.Debugf("Not transferring proof for output with "+
-				"script key %x as it has no proof courier "+
-				"address", key.SerializeCompressed())
+		if !shouldDeliverProof {
+			log.Debugf("Not delivering proof for output with "+
+				"script key %x", key.SerializeCompressed())
 			return nil
 		}
 

--- a/tapfreighter/interface.go
+++ b/tapfreighter/interface.go
@@ -415,6 +415,10 @@ type ExportLog interface {
 	// transactions for re-broadcast.
 	PendingParcels(context.Context) ([]*OutboundParcel, error)
 
+	// ConfirmProofDelivery marks a transfer output proof as successfully
+	// transferred.
+	ConfirmProofDelivery(context.Context, wire.OutPoint, uint64) error
+
 	// ConfirmParcelDelivery marks a spend event on disk as confirmed. This
 	// updates the on-chain reference information on disk to point to this
 	// new spend.

--- a/tapfreighter/interface.go
+++ b/tapfreighter/interface.go
@@ -246,6 +246,18 @@ type TransferOutput struct {
 	// ProofCourierAddr is the bytes encoded proof courier service address
 	// associated with this output.
 	ProofCourierAddr []byte
+
+	// ProofDeliveryComplete is a flag that indicates whether the proof
+	// delivery for this output is complete.
+	//
+	// This field can take one of the following values:
+	// - None: A proof will not be delivered to a counterparty.
+	// - False: The proof has not yet been delivered successfully.
+	// - True: The proof has been delivered to the recipient.
+	ProofDeliveryComplete fn.Option[bool]
+
+	// Position is the position of the output in the transfer output list.
+	Position uint64
 }
 
 // ShouldDeliverProof returns true if a proof corresponding to the subject


### PR DESCRIPTION
### Summary

This PR is work towards fixing https://github.com/lightninglabs/taproot-assets/issues/1009 (making the proof transfer process more robust).

This pull request adds a new `proof_deliver_complete` column to the `asset_transfer_outputs` table. It includes updates to the table schema, modifications to SQL statements, and adjustments to unit tests. Additionally, it integrates changes to the `tapfreighter` component for logging proof delivery confirmations.

### Changes

1. **Schema Update**:
   - Added the `proof_deliver_complete` column to the `asset_transfer_outputs` table.
   
2. **SQL Statement Modifications**:
   - Updated the row insertion and retrieval SQL statements to include the `proof_deliver_complete` column.
   - Added a new SQL statement specifically for modifying the `proof_deliver_complete` column.
   
3. **Field Population**:
   - Set the `proof_deliver_complete` field for new transfer output rows.
   - Ensured the `proof_deliver_complete` field is populated when reading from the database.

6. **Proof Delivery Logging**:
   - Added a `ConfirmProofDelivery` method to the `tapfreighter` export log.
   - The `ConfirmProofDelivery` function is called after a proof has been successfully delivered to a remote peer.
   
7. **Unit Test Adjustment**:
   - Modified a unit test to verify that a transfer output proof is correctly flagged as confirmed.