### PR TITLE
Improve Clarity in ChainPorter State Names

### DIFF
--- a/itest/psbt_test.go
+++ b/itest/psbt_test.go
@@ -2968,7 +2968,7 @@ func testPsbtRelativeLockTimeSendProofFail(t *harnessTest) {
 
 	AssertSendEvents(
 		t.t, aliceScriptKeyBytes, sendEvents,
-		tapfreighter.SendStateLogCommit,
+		tapfreighter.SendStateStorePreBroadcast,
 		tapfreighter.SendStateWaitTxConf,
 	)
 

--- a/tapfreighter/chain_porter.go
+++ b/tapfreighter/chain_porter.go
@@ -443,7 +443,7 @@ func (p *ChainPorter) storeProofs(sendPkg *sendPackage) error {
 		log.Debugf("Not updating proofs as there are no active " +
 			"transfers")
 
-		sendPkg.SendState = SendStateReceiverProofTransfer
+		sendPkg.SendState = SendStateTransferProofs
 		return nil
 	}
 
@@ -532,7 +532,7 @@ func (p *ChainPorter) storeProofs(sendPkg *sendPackage) error {
 		}
 	}
 
-	sendPkg.SendState = SendStateReceiverProofTransfer
+	sendPkg.SendState = SendStateTransferProofs
 	return nil
 }
 
@@ -1164,8 +1164,8 @@ func (p *ChainPorter) stateStep(currentPkg sendPackage) (*sendPackage, error) {
 
 	// At this point, the transfer transaction is confirmed on-chain, and
 	// we've stored the sender and receiver proofs in the proof archive.
-	// We'll now attempt to transfer the receiver proof to the receiver.
-	case SendStateReceiverProofTransfer:
+	// We'll now attempt to transfer one or more proofs to the receiver(s).
+	case SendStateTransferProofs:
 		// We'll set the package state to complete early here so the
 		// main loop breaks out. We'll continue to attempt proof
 		// deliver in the background.
@@ -1181,7 +1181,7 @@ func (p *ChainPorter) stateStep(currentPkg sendPackage) (*sendPackage, error) {
 					"proof: %v", err)
 
 				p.publishSubscriberEvent(newAssetSendErrorEvent(
-					err, SendStateReceiverProofTransfer,
+					err, SendStateTransferProofs,
 					currentPkg,
 				))
 			}

--- a/tapfreighter/chain_porter.go
+++ b/tapfreighter/chain_porter.go
@@ -1031,16 +1031,16 @@ func (p *ChainPorter) stateStep(currentPkg sendPackage) (*sendPackage, error) {
 				"package: %w", err)
 		}
 
-		currentPkg.SendState = SendStateLogCommit
+		currentPkg.SendState = SendStateStorePreBroadcast
 
 		return &currentPkg, nil
 
-	// At this state, we have a final PSBT transaction which is fully
-	// signed. We'll write this to disk (the point of no return), then
-	// broadcast this to the network.
-	case SendStateLogCommit:
-		// Before we can broadcast, we want to find out the current
-		// height to pass as a height hint.
+	// In this state, the parcel state is stored before the fully signed
+	// transaction is broadcast to the mempool.
+	case SendStateStorePreBroadcast:
+		// We won't broadcast in this state, but in preparation for
+		// broadcasting, we will find out the current height to use as
+		// a height hint.
 		ctx, cancel := p.WithCtxQuit()
 		defer cancel()
 		currentHeight, err := p.cfg.ChainBridge.CurrentHeight(ctx)

--- a/tapfreighter/parcel.go
+++ b/tapfreighter/parcel.go
@@ -55,9 +55,9 @@ const (
 	// and receiver proofs to the proof archive.
 	SendStateStoreProofs
 
-	// SendStateReceiverProofTransfer is the state in which we will commence
-	// the receiver proof transfer process.
-	SendStateReceiverProofTransfer
+	// SendStateTransferProofs is the state where we attempt to transfer
+	// on-chain transaction proof(s) to the receiving party or parties.
+	SendStateTransferProofs
 
 	// SendStateComplete is the state which is reached once entire asset
 	// transfer process is complete.
@@ -88,8 +88,8 @@ func (s SendState) String() string {
 	case SendStateStoreProofs:
 		return "SendStateStoreProofs"
 
-	case SendStateReceiverProofTransfer:
-		return "SendStateReceiverProofTransfer"
+	case SendStateTransferProofs:
+		return "SendStateTransferProofs"
 
 	case SendStateComplete:
 		return "SendStateComplete"

--- a/tapfreighter/parcel.go
+++ b/tapfreighter/parcel.go
@@ -38,11 +38,9 @@ const (
 	// then finalize to place the necessary signatures in the transaction.
 	SendStateAnchorSign
 
-	// SendStateLogCommit is the final in memory state. In this state,
-	// we'll extract the signed transaction from the PSBT and log the
-	// transfer information to disk. At this point, after a restart, the
-	// transfer can be resumed.
-	SendStateLogCommit
+	// SendStateStorePreBroadcast is the state in which the finalized fully
+	// signed transaction is written to persistent storage before broadcast.
+	SendStateStorePreBroadcast
 
 	// SendStateBroadcast broadcasts the transfer transaction to the
 	// network, and imports the taproot output back into the wallet to
@@ -78,8 +76,8 @@ func (s SendState) String() string {
 	case SendStateAnchorSign:
 		return "SendStateAnchorSign"
 
-	case SendStateLogCommit:
-		return "SendStateLogCommit"
+	case SendStateStorePreBroadcast:
+		return "SendStateStorePreBroadcast"
 
 	case SendStateBroadcast:
 		return "SendStateBroadcast"
@@ -381,7 +379,7 @@ func (p *PreAnchoredParcel) pkg() *sendPackage {
 	// commitment.
 	return &sendPackage{
 		Parcel:         p,
-		SendState:      SendStateLogCommit,
+		SendState:      SendStateStorePreBroadcast,
 		VirtualPackets: p.virtualPackets,
 		PassiveAssets:  p.passiveAssets,
 		AnchorTx:       p.anchorTx,


### PR DESCRIPTION
This pull request includes two changes to the `ChainPorter` states to improve clarity and better reflect their functionality.

#### Changes:
1. **Rename `SendStateLogCommit` to `SendStateStorePreBroadcast`:**
   - The state `SendStateLogCommit` has been renamed to `SendStateStorePreBroadcast`.
   - This change clarifies that the state's functionality is to store data before broadcasting.

2. **Rename `SendStateReceiverProofTransfer` to `SendStateTransferProofs`:**
   - The state `SendStateReceiverProofTransfer` has been renamed to `SendStateTransferProofs`.
   - This change indicates that in this state, the `ChainPorter` may transfer multiple proofs, improving understanding of its purpose.

These changes enhance code readability and maintainability by providing more descriptive state names.