### PR TITLE
tapcli: add --show_leased flag to assets list subcommand

### DIFF
--- a/cmd/tapcli/assets.go
+++ b/cmd/tapcli/assets.go
@@ -47,6 +47,7 @@ var (
 	assetGroupedAssetName        = "grouped_asset"
 	assetShowWitnessName         = "show_witness"
 	assetShowSpentName           = "show_spent"
+	assetShowLeasedName          = "show_leased"
 	assetShowUnconfMintsName     = "show_unconfirmed_mints"
 	assetGroupKeyName            = "group_key"
 	assetGroupAnchorName         = "group_anchor"
@@ -556,6 +557,10 @@ var listAssetsCommand = cli.Command{
 			Usage: "include fully spent assets in the list",
 		},
 		cli.BoolFlag{
+			Name:  assetShowLeasedName,
+			Usage: "include leased assets in the list",
+		},
+		cli.BoolFlag{
 			Name: assetShowUnconfMintsName,
 			Usage: "include freshly minted and not yet confirmed " +
 				"assets in the list",
@@ -574,6 +579,7 @@ func listAssets(ctx *cli.Context) error {
 	resp, err := client.ListAssets(ctxc, &taprpc.ListAssetRequest{
 		WithWitness:             ctx.Bool(assetShowWitnessName),
 		IncludeSpent:            ctx.Bool(assetShowSpentName),
+		IncludeLeased:           ctx.Bool(assetShowLeasedName),
 		IncludeUnconfirmedMints: ctx.Bool(assetShowUnconfMintsName),
 	})
 	if err != nil {

--- a/tapchannel/aux_funding_controller.go
+++ b/tapchannel/aux_funding_controller.go
@@ -1126,8 +1126,9 @@ func (f *FundingController) completeChannelFunding(ctx context.Context,
 	case <-fundingState.fundingFinalizedSignal:
 
 	case <-time.After(ackTimeout):
-		return nil, fmt.Errorf("didn't receive funding ack after %v",
-			ackTimeout)
+		return nil, fmt.Errorf("didn't receive funding ack after %v: "+
+			"remote node didn't respond in time or doesn't "+
+			"support Taproot Asset Channels", ackTimeout)
 
 	case <-f.Quit:
 	}


### PR DESCRIPTION
Fixes https://github.com/lightninglabs/taproot-assets/issues/1038.

Adds the missing `--show_leased` flag to the `tapcli assets list` subcommand.