### PR TITLE
GitHub: fix release script by updating GH action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -49,11 +49,10 @@ jobs:
         run: make release tag=${{ env.RELEASE_VERSION }}
 
       - name: Create Release
-        uses: lightninglabs/gh-actions/action-gh-release@2021.01.25.00
+        uses: lightninglabs/gh-actions/action-gh-release@2024.07.24.00
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ env.RELEASE_VERSION }}
           name: ${{ env.RELEASE_VERSION }}
           draft: true
           prerelease: false


### PR DESCRIPTION
Fixes the creation of the GitHub release draft creation on tag push (see failed attempt here: )

I confirmed this works by pushing a tag to my personal fork of `lnd`: https://github.com/guggero/lnd/actions/runs/10058716669/job/27802410976
Corresponding `lnd` pull request: https://github.com/lightningnetwork/lnd/pull/8927
