### PR TITLE
makefile+scripts: specify Go version for building release binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ release-install:
 release:
 	@$(call print, "Releasing tapd and tapcli binaries.")
 	$(VERSION_CHECK)
-	./scripts/release.sh build-release "$(VERSION_TAG)" "$(BUILD_SYSTEM)" "$(RELEASE_TAGS)" "$(RELEASE_LDFLAGS)"
+	./scripts/release.sh build-release "$(VERSION_TAG)" "$(BUILD_SYSTEM)" "$(RELEASE_TAGS)" "$(RELEASE_LDFLAGS)" "$(GO_VERSION)"
 
 release-tag:
 	@$(call print, "Adding release tag.")

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -118,11 +118,23 @@ function check_tag_correct() {
 
 # build_release builds the actual release binaries.
 #   arguments: <version-tag> <build-system(s)> <build-tags> <ldflags>
+#              <go-version>
 function build_release() {
   local tag=$1
   local sys=$2
   local buildtags=$3
   local ldflags=$4
+  local goversion=$5
+
+  # Check if the active Go version matches the specified Go version.
+  active_go_version=$(go version | awk '{print $3}' | sed 's/go//')
+  if [ "$active_go_version" != "$goversion" ]; then
+    echo "Error: active Go version ($active_go_version) does not match \
+required Go version ($goversion)."
+    exit 1
+  fi
+
+  echo "Building release for tag $tag with Go version $goversion"
 
   green " - Packaging vendor"
   go mod vendor


### PR DESCRIPTION
Closes https://github.com/lightninglabs/taproot-assets/issues/1045

To ensure our release binaries are reproducible, they must be built with a specific version of Go. This commit sets the `GOTOOLCHAIN` environment variable when building release binaries, ensuring that the build command uses the targeted Go version.

The `GOTOOLCHAIN` environment variable is supported only in Go version 1.21 or newer. This commit verifies that the invoked Go version meets this requirement.