### PR TITLE
Reattempt proof delivery on node restart

### DIFF
--- a/fn/option.go
+++ b/fn/option.go
@@ -59,7 +59,7 @@ func (o Option[A]) UnwrapOr(a A) A {
 	return a
 }
 
-// UnwrapPtr is used to extract a reference to a value from an option, and we
+// UnwrapToPtr is used to extract a reference to a value from an option, and we
 // supply an empty pointer in the case when the Option is empty.
 func (o Option[A]) UnwrapToPtr() *A {
 	var v *A

--- a/itest/psbt_test.go
+++ b/itest/psbt_test.go
@@ -1042,8 +1042,8 @@ func testPsbtMultiSend(t *harnessTest) {
 	ctxt, cancel := context.WithTimeout(ctxb, defaultWaitTimeout)
 	defer cancel()
 
-	// Now that we have the asset created, we'll make a new node that'll
-	// serve as the node which'll receive the assets.
+	// With the asset created, we'll set up a new node that will act as the
+	// receiver of the transfer.
 	secondTapd := setupTapdHarness(
 		t.t, t, t.lndHarness.Bob, t.universeServer,
 	)

--- a/itest/send_test.go
+++ b/itest/send_test.go
@@ -16,6 +16,7 @@ import (
 	wrpc "github.com/lightninglabs/taproot-assets/taprpc/assetwalletrpc"
 	"github.com/lightninglabs/taproot-assets/taprpc/mintrpc"
 	"github.com/lightninglabs/taproot-assets/taprpc/tapdevrpc"
+	unirpc "github.com/lightninglabs/taproot-assets/taprpc/universerpc"
 	"github.com/lightningnetwork/lnd/lntest/wait"
 	"github.com/stretchr/testify/require"
 )
@@ -662,6 +663,194 @@ func testReattemptFailedSendHashmailCourier(t *harnessTest) {
 	_ = MineBlocks(t.t, t.lndHarness.Miner.Client, 1, 1)
 
 	wg.Wait()
+}
+
+// testReattemptProofTransferOnTapdRestart tests that a failed attempt at
+// transferring a transfer output proof to a proof courier will be reattempted
+// by the sending tapd node upon restart. This test targets the universe
+// courier.
+func testReattemptProofTransferOnTapdRestart(t *harnessTest) {
+	var (
+		ctxb = context.Background()
+		wg   sync.WaitGroup
+	)
+
+	// For this test we will use the universe server as the proof courier.
+	proofCourier := t.universeServer
+
+	// Make a new tapd node which will send an asset to a receiving tapd
+	// node.
+	sendTapd := setupTapdHarness(
+		t.t, t, t.lndHarness.Bob, t.universeServer,
+		func(params *tapdHarnessParams) {
+			params.expectErrExit = true
+			params.proofCourier = proofCourier
+		},
+	)
+	defer func() {
+		// Any node that has been started within an itest should be
+		// explicitly stopped within the same itest.
+		require.NoError(t.t, sendTapd.stop(!*noDelete))
+	}()
+
+	// Use the primary tapd node as the receiver node.
+	recvTapd := t.tapd
+
+	// Use the sending node to mint an asset for sending.
+	rpcAssets := MintAssetsConfirmBatch(
+		t.t, t.lndHarness.Miner.Client, sendTapd,
+		[]*mintrpc.MintAssetRequest{simpleAssets[0]},
+	)
+
+	genInfo := rpcAssets[0].AssetGenesis
+
+	// After minting an asset with the sending node, we need to synchronize
+	// the Universe state to ensure the receiving node is updated and aware
+	// of the asset.
+	t.syncUniverseState(sendTapd, recvTapd, len(rpcAssets))
+
+	// Create a new address for the receiver node. We will use the universe
+	// server as the proof courier.
+	proofCourierAddr := fmt.Sprintf(
+		"%s://%s", proof.UniverseRpcCourierType,
+		proofCourier.service.rpcHost(),
+	)
+	t.Logf("Proof courier address: %s", proofCourierAddr)
+
+	recvAddr, err := recvTapd.NewAddr(ctxb, &taprpc.NewAddrRequest{
+		AssetId:          genInfo.AssetId,
+		Amt:              10,
+		ProofCourierAddr: proofCourierAddr,
+	})
+	require.NoError(t.t, err)
+	AssertAddrCreated(t.t, recvTapd, rpcAssets[0], recvAddr)
+
+	// Soon we will be attempting to send an asset to the receiver node. We
+	// want the attempt to fail until we restart the sending node.
+	// Therefore, we will take the proof courier service offline.
+	t.Log("Stopping proof courier service")
+	require.NoError(t.t, proofCourier.Stop())
+
+	// Now that the proof courier service is offline, the sending node's
+	// attempt to transfer the asset proof should fail.
+	//
+	// We will soon start the asset transfer process. However, before we
+	// start, we subscribe to the send events from the sending tapd node so
+	// that we can be sure that a transfer has been attempted.
+	events := SubscribeSendEvents(t.t, sendTapd)
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		// Define a target event selector to match the backoff wait
+		// event. This function selects for a specific event type.
+		targetEventSelector := func(
+			event *tapdevrpc.SendAssetEvent) bool {
+
+			return AssertSendEventProofTransferBackoffWaitTypeSend(
+				t, event,
+			)
+		}
+
+		// Expected number of events is one less than the number of
+		// tries because the first attempt does not count as a backoff
+		// event.
+		nodeBackoffCfg :=
+			sendTapd.clientCfg.UniverseRpcCourier.BackoffCfg
+		expectedEventCount := nodeBackoffCfg.NumTries - 1
+
+		// Context timeout scales with expected number of events.
+		timeout := time.Duration(expectedEventCount) *
+			defaultProofTransferReceiverAckTimeout
+
+		// Allow for some margin for the operations that aren't pure
+		// waiting on the receiver ACK.
+		timeout += timeoutMargin
+
+		assertAssetNtfsEvent(
+			t, events, timeout, targetEventSelector,
+			expectedEventCount,
+		)
+	}()
+
+	// Start asset transfer and then mine to confirm the associated on-chain
+	// tx. The on-chain tx should be mined successfully, but we expect the
+	// asset proof transfer to be unsuccessful.
+	sendResp, _ := sendAssetsToAddr(t, sendTapd, recvAddr)
+	MineBlocks(t.t, t.lndHarness.Miner.Client, 1, 1)
+
+	// Wait to ensure that the asset transfer attempt has been made.
+	wg.Wait()
+
+	// Stop the sending tapd node. This downtime will give us the
+	// opportunity to restart the proof courier service.
+	t.Log("Stopping sending tapd node")
+	require.NoError(t.t, sendTapd.stop(false))
+
+	// Restart the proof courier service.
+	t.Log("Starting proof courier service")
+	require.NoError(t.t, proofCourier.Start(nil))
+	t.Logf("Proof courier address: %s", proofCourier.service.rpcHost())
+
+	// Ensure that the proof courier address has not changed on restart.
+	// The port is currently selected opportunistically.
+	// If the proof courier address has changed the tap address will be
+	// stale.
+	newProofCourierAddr := fmt.Sprintf(
+		"%s://%s", proof.UniverseRpcCourierType,
+		proofCourier.service.rpcHost(),
+	)
+	require.Equal(t.t, proofCourierAddr, newProofCourierAddr)
+
+	// Identify receiver's asset transfer output.
+	require.Len(t.t, sendResp.Transfer.Outputs, 2)
+	recvOutput := sendResp.Transfer.Outputs[0]
+
+	// If the script key of the output is local to the sending node, then
+	// the receiver's output is the second output.
+	if recvOutput.ScriptKeyIsLocal {
+		recvOutput = sendResp.Transfer.Outputs[1]
+	}
+
+	// Formulate a universe key to query the proof courier for the asset
+	// transfer proof.
+	uniKey := unirpc.UniverseKey{
+		Id: &unirpc.ID{
+			Id: &unirpc.ID_AssetId{
+				AssetId: genInfo.AssetId,
+			},
+			ProofType: unirpc.ProofType_PROOF_TYPE_TRANSFER,
+		},
+		LeafKey: &unirpc.AssetKey{
+			Outpoint: &unirpc.AssetKey_OpStr{
+				OpStr: recvOutput.Anchor.Outpoint,
+			},
+			ScriptKey: &unirpc.AssetKey_ScriptKeyBytes{
+				ScriptKeyBytes: recvOutput.ScriptKey,
+			},
+		},
+	}
+
+	// Ensure that the transfer proof has not reached the proof courier yet.
+	resp, err := proofCourier.service.QueryProof(ctxb, &uniKey)
+	require.Nil(t.t, resp)
+	require.ErrorContains(t.t, err, "no universe proof found")
+
+	// Restart the sending tapd node. The node should reattempt to transfer
+	// the asset proof to the proof courier.
+	t.Log("Restarting sending tapd node")
+	require.NoError(t.t, sendTapd.start(false))
+
+	require.Eventually(t.t, func() bool {
+		resp, err = proofCourier.service.QueryProof(ctxb, &uniKey)
+		return err == nil && resp != nil
+	}, defaultWaitTimeout, 200*time.Millisecond)
+
+	// TODO(ffranr): Modify the receiver node proof retrieval backoff
+	//  schedule such that we can assert that the transfer fully completes
+	//  in a timely and predictable manner.
+	//  AssertNonInteractiveRecvComplete(t.t, recvTapd, 1)
 }
 
 // testReattemptFailedSendUniCourier tests that a failed attempt at

--- a/itest/send_test.go
+++ b/itest/send_test.go
@@ -573,7 +573,8 @@ func testBasicSendPassiveAsset(t *harnessTest) {
 
 // testReattemptFailedSendHashmailCourier tests that a failed attempt at
 // sending an asset proof will be reattempted by the tapd node. This test
-// targets the hashmail courier.
+// targets the hashmail courier. The proof courier is specified in the test
+// list entry.
 func testReattemptFailedSendHashmailCourier(t *harnessTest) {
 	var (
 		ctxb = context.Background()
@@ -654,11 +655,6 @@ func testReattemptFailedSendHashmailCourier(t *harnessTest) {
 
 	// Simulate a failed attempt at sending the asset proof by stopping
 	// the receiver node.
-	//
-	// The receiving tapd node does not return a proof received confirmation
-	// message via the universe RPC courier. We can simulate a proof
-	// transfer failure by stopping the courier service directly and not the
-	// receiving tapd node.
 	require.NoError(t.t, t.tapd.stop(false))
 
 	// Send asset and then mine to confirm the associated on-chain tx.
@@ -751,11 +747,6 @@ func testReattemptFailedSendUniCourier(t *harnessTest) {
 
 	// Simulate a failed attempt at sending the asset proof by stopping
 	// the proof courier service.
-	//
-	// In following the hashmail proof courier protocol, the receiver node
-	// returns a proof received confirmation message via the courier.
-	// We can simulate a proof transfer failure by stopping the receiving
-	// tapd node. The courier service should still be operational.
 	require.NoError(t.t, t.proofCourier.Stop())
 
 	// Send asset and then mine to confirm the associated on-chain tx.
@@ -765,9 +756,9 @@ func testReattemptFailedSendUniCourier(t *harnessTest) {
 	wg.Wait()
 }
 
-// testReattemptFailedReceiveUniCourier tests that a failed attempt at
-// receiving an asset proof will be reattempted by the receiving tapd node. This
-// test targets the universe proof courier.
+// testReattemptFailedReceiveUniCourier ensures that a failed attempt to receive
+// an asset proof is retried by the receiving Tapd node.  This test focuses on
+// the universe proof courier.
 func testReattemptFailedReceiveUniCourier(t *harnessTest) {
 	ctxb := context.Background()
 

--- a/itest/test_list_on_test.go
+++ b/itest/test_list_on_test.go
@@ -93,6 +93,10 @@ var testCases = []*testCase{
 		test: testReattemptFailedSendUniCourier,
 	},
 	{
+		name: "reattempt proof transfer on tapd restart",
+		test: testReattemptProofTransferOnTapdRestart,
+	},
+	{
 		name: "reattempt failed receive uni courier",
 		test: testReattemptFailedReceiveUniCourier,
 	},

--- a/tapdb/multiverse.go
+++ b/tapdb/multiverse.go
@@ -841,8 +841,8 @@ func (b *MultiverseStore) RootNodes(ctx context.Context,
 }
 
 // FetchProofLeaf returns a proof leaf for the target key. If the key doesn't
-// have a script key specified, then all the proof leafs for the minting
-// outpoint will be returned. If neither are specified, then all inserted proof
+// have a script key specified, then all the proof leafs for the outpoint will
+// be returned. If neither are specified, then all inserted proof
 // leafs will be returned.
 func (b *MultiverseStore) FetchProofLeaf(ctx context.Context,
 	id universe.Identifier,

--- a/tapfreighter/chain_porter.go
+++ b/tapfreighter/chain_porter.go
@@ -656,8 +656,10 @@ func (p *ChainPorter) transferReceiverProof(pkg *sendPackage) error {
 		}
 
 		if !shouldDeliverProof {
-			log.Debugf("Not delivering proof for output with "+
-				"script key %x", key.SerializeCompressed())
+			log.Debugf("Not delivering transfer ouput proof "+
+				"(proof_delivery_status=%v, script_key=%x)",
+				out.ProofDeliveryComplete,
+				key.SerializeCompressed())
 			return nil
 		}
 

--- a/tapfreighter/chain_porter.go
+++ b/tapfreighter/chain_porter.go
@@ -148,7 +148,7 @@ func (p *ChainPorter) Start() error {
 
 		// Start the main chain porter goroutine.
 		p.Wg.Add(1)
-		go p.assetsPorter()
+		go p.mainEventLoop()
 
 		// Identify any pending parcels that need to be resumed and add
 		// them to the exportReqs channel so they can be processed by
@@ -239,10 +239,10 @@ func (p *ChainPorter) QueryParcels(ctx context.Context,
 	)
 }
 
-// assetsPorter is the main goroutine of the ChainPorter. This takes in incoming
+// mainEventLoop is the main goroutine of the ChainPorter. This takes a parcel
 // requests, and attempt to complete a transfer. A response is sent back to the
 // caller if a transfer can be completed. Otherwise, an error is returned.
-func (p *ChainPorter) assetsPorter() {
+func (p *ChainPorter) mainEventLoop() {
 	defer p.Wg.Done()
 
 	for {

--- a/tapfreighter/chain_porter.go
+++ b/tapfreighter/chain_porter.go
@@ -1061,6 +1061,9 @@ func (p *ChainPorter) stateStep(currentPkg sendPackage) (*sendPackage, error) {
 
 		log.Infof("Committing pending parcel to disk")
 
+		// Write the parcel to disk as a pending parcel. This step also
+		// records the transfer details (e.g., reference to the anchor
+		// transaction ID, transfer outputs and inputs) to the database.
 		err = p.cfg.ExportLog.LogPendingParcel(
 			ctx, parcel, defaultWalletLeaseIdentifier,
 			time.Now().Add(defaultBroadcastCoinLeaseDuration),

--- a/tapfreighter/interface.go
+++ b/tapfreighter/interface.go
@@ -252,6 +252,14 @@ type TransferOutput struct {
 // ShouldDeliverProof returns true if a proof corresponding to the subject
 // transfer output should be delivered to a peer.
 func (out *TransferOutput) ShouldDeliverProof() (bool, error) {
+	// If any proof delivery is already complete (some true), no further
+	// delivery is needed. However, if the proof delivery status is
+	// unset (none), we won't use that status in determining whether proof
+	// delivery is necessary. The field may not be set yet.
+	if out.ProofDeliveryComplete.UnwrapOr(false) {
+		return false, nil
+	}
+
 	// If the proof courier address is unspecified, we don't need to deliver
 	// a proof.
 	if len(out.ProofCourierAddr) == 0 {

--- a/tapgarden/custodian.go
+++ b/tapgarden/custodian.go
@@ -605,7 +605,7 @@ func (c *Custodian) receiveProof(addr *address.Tap, op wire.OutPoint,
 			err)
 	}
 
-	log.Debugf("Received proof for: script_key=%x, asset_id=%x",
+	log.Debugf("Proof received (script_key=%x, asset_id=%x)",
 		scriptKeyBytes, assetID[:])
 
 	ctx, cancel = c.CtxBlocking()


### PR DESCRIPTION
Some of the commits in this PR refactor the code for clarity and don't modify functionality.

The overall goal of this PR is to ensure that we don't try to deliver proofs which have already been delivered. And that we reattempt proof delivery on node restart.

Related to https://github.com/lightninglabs/taproot-assets/issues/1009

