### PR TITLE
tapchannel: use new context for call to unlockLeases

### DIFF
--- a/tapchannel/aux_funding_controller.go
+++ b/tapchannel/aux_funding_controller.go
@@ -1395,14 +1395,13 @@ func (f *FundingController) processFundingReq(fundingFlows fundingFlowIndex,
 	// We'll use this closure to ensure that we'll always unlock the inputs
 	// if we encounter an error below.
 	unlockLeases := func() {
-		err := fundingState.unlockInputs(fundReq.ctx, f.cfg.ChainWallet)
+		ctxb := context.Background()
+		err := fundingState.unlockInputs(ctxb, f.cfg.ChainWallet)
 		if err != nil {
 			log.Errorf("unable to unlock inputs: %v", err)
 		}
 
-		err = fundingState.unlockAssetInputs(
-			fundReq.ctx, f.cfg.CoinSelector,
-		)
+		err = fundingState.unlockAssetInputs(ctxb, f.cfg.CoinSelector)
 		if err != nil {
 			log.Errorf("Unable to unlock asset inputs: %v", err)
 		}


### PR DESCRIPTION
If the funding attempt takes a while and/or the users cancels the original request, if we're using the context passed along, then we may fail to actually unlock all the inputs:
```
2024-08-03 13:13:54.004 [ERR] TCHN: unable to unlock inputs: unable to unlock outpoint X:2: error listing existing leases: rpc error: code = Canceled desc = context canceled
2024-08-03 13:13:54.004 [DBG] TCHN: unlocking asset inputs: ([]wire.OutPoint) (len=1 cap=1) {
 (wire.OutPoint) X:1
}

2024-08-03 13:13:54.004 [ERR] TCHN: Unable to unlock asset inputs: unable to unlock asset outpoints [X:1]: unable to release coins: context canceled
```

This commit fixes that by using a fresh context.