### PR TITLE
Coveralls support

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -249,7 +249,15 @@ jobs:
         uses: ./.github/actions/setup-go
 
       - name: run itest
-        run: make itest
+        run: make itest cover=1
+
+      - name: Send coverage
+        if: ${{ contains(matrix.args, 'cover=1') }}
+        uses: shogo82148/actions-goveralls@v1
+        with:
+          path-to-profile: coverage.txt
+          flag-name: 'itest-${{ matrix.name }}'
+          parallel: true
 
       - name: Zip log files on failure
         if: ${{ failure() }}
@@ -290,3 +298,13 @@ jobs:
           name: logs-itest-postgres
           path: logs-itest-postgres.zip
           retention-days: 5
+
+    # Notify about the completion of all coverage collecting jobs.
+  finish:
+    if: ${{ always() }}
+    needs: [unit-test, integration-test]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: shogo82148/actions-goveralls@v1
+        with:
+          parallel-finished: true

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -232,6 +232,7 @@ jobs:
         if: matrix.unit_type == 'unit-cover'
         with:
           path-to-profile: coverage.txt
+          flag-name: 'unit'
           parallel: true
 
   ########################

--- a/Makefile
+++ b/Makefile
@@ -193,12 +193,14 @@ itest-trace: build-itest itest-only-trace
 itest-only: aperture-dir
 	@$(call print, "Running integration tests with ${backend} backend.")
 	rm -rf itest/regtest; date
-	$(GOTEST) ./itest -v -tags="$(ITEST_TAGS)" $(TEST_FLAGS) $(ITEST_FLAGS) -btcdexec=./btcd-itest -logdir=regtest
+	$(GOTEST) ./itest -v -tags="$(ITEST_TAGS)" $(TEST_FLAGS) $(ITEST_FLAGS) $(ITEST_COVERAGE) -btcdexec=./btcd-itest -logdir=regtest
+	$(COLLECT_ITEST_COVERAGE)
 
 itest-only-trace: aperture-dir
 	@$(call print, "Running integration tests with ${backend} backend.")
 	rm -rf itest/regtest; date
-	$(GOTEST) ./itest -v -tags="$(ITEST_TAGS)" $(TEST_FLAGS) $(ITEST_FLAGS) -loglevel=trace -btcdexec=./btcd-itest -logdir=regtest
+	$(GOTEST) ./itest -v -tags="$(ITEST_TAGS)" $(TEST_FLAGS) $(ITEST_FLAGS) $(ITEST_COVERAGE) -loglevel=trace -btcdexec=./btcd-itest -logdir=regtest
+	$(COLLECT_ITEST_COVERAGE)
 
 aperture-dir:
 ifeq ($(UNAME_S),Linux)

--- a/make/testing_flags.mk
+++ b/make/testing_flags.mk
@@ -4,6 +4,8 @@ RPC_TAGS = autopilotrpc chainrpc invoicesrpc peersrpc routerrpc signrpc verrpc w
 LOG_TAGS =
 TEST_FLAGS =
 ITEST_FLAGS = -logoutput
+ITEST_COVERAGE =
+COLLECT_ITEST_COVERAGE =
 COVER_HTML = go tool cover -html=coverage.txt -o coverage.html
 POSTGRES_START_DELAY = 5
 
@@ -55,6 +57,12 @@ endif
 
 ifneq ($(tags),)
 DEV_TAGS += ${tags}
+endif
+
+# Enable integration test coverage (requires Go >= 1.20.0).
+ifneq ($(cover),)
+ITEST_COVERAGE = -cover
+COLLECT_ITEST_COVERAGE = go tool covdata textfmt -i=itest/cover -o coverage.txt
 endif
 
 # Define the log tags that will be applied only when running unit tests. If none


### PR DESCRIPTION
First attempt to update CI so that coverage info for unit tests + itests is uploaded to Coveralls (and could be displayed for future PRs).

I looked at the setup for btcd:

https://github.com/btcsuite/btcd/blob/master/.github/workflows/go.yml

https://github.com/btcsuite/btcd/blob/b161cd6a199b4e35acec66afc5aad221f05fe1e3/Makefile#L109

I think we don't need to change directory into subfolders for unit tests since we don't have sub-packages in this repo?

For the itest coverage, I looked at the PR adding that for LND:

https://github.com/lightningnetwork/lnd/pull/7364

But the way itests are run there is different (via script), so I think the coverage output ends up in a different place.

When playing with this locally I couldn't get the itest coverage data to be written in the correct location, so I think that's the last missing piece.