### PR TITLE
Optimize Parcel Resumption and Reduce Blocking in ChainPorter

### DIFF
--- a/tapfreighter/chain_porter.go
+++ b/tapfreighter/chain_porter.go
@@ -132,7 +132,7 @@ func NewChainPorter(cfg *ChainPorterConfig) *ChainPorter {
 	)
 	return &ChainPorter{
 		cfg:             cfg,
-		outboundParcels: make(chan Parcel),
+		outboundParcels: make(chan Parcel, 10),
 		subscribers:     subscribers,
 		ContextGuard: &fn.ContextGuard{
 			DefaultTimeout: tapgarden.DefaultTimeout,

--- a/tapfreighter/chain_porter.go
+++ b/tapfreighter/chain_porter.go
@@ -155,7 +155,15 @@ func (p *ChainPorter) Start() error {
 			p.mainEventLoop()
 		}()
 
-		startErr = p.resumePendingParcels()
+		// Resume any pending parcels in a new goroutine so that we
+		// don't delay returning from the Start method. Without this
+		// goroutine the resumePendingParcels method would block on the
+		// buffering constraint of the outboundParcels channel.
+		p.Wg.Add(1)
+		go func() {
+			defer p.Wg.Done()
+			startErr = p.resumePendingParcels()
+		}()
 	})
 
 	return startErr

--- a/tapfreighter/chain_porter.go
+++ b/tapfreighter/chain_porter.go
@@ -150,7 +150,10 @@ func (p *ChainPorter) Start() error {
 
 		// Start the main chain porter goroutine.
 		p.Wg.Add(1)
-		go p.mainEventLoop()
+		go func() {
+			defer p.Wg.Done()
+			p.mainEventLoop()
+		}()
 
 		startErr = p.resumePendingParcels()
 	})
@@ -311,8 +314,6 @@ func (p *ChainPorter) QueryParcels(ctx context.Context,
 // requests, and attempt to complete a transfer. A response is sent back to the
 // caller if a transfer can be completed. Otherwise, an error is returned.
 func (p *ChainPorter) mainEventLoop() {
-	defer p.Wg.Done()
-
 	for {
 		select {
 		case outboundParcel := <-p.outboundParcels:


### PR DESCRIPTION
This PR addresses this concern by @jharveyb : https://github.com/lightninglabs/taproot-assets/pull/1055#discussion_r1708183895


### Changes

- **Improved Goroutine Management:** The `WaitGroup.Done()` call has been repositioned to align closely with the corresponding `WaitGroup.Add(1)` call, making the code easier to read and reducing the risk of errors.
  
- **Buffered Channel for Outbound Parcels:** A buffer has been added to the `outboundParcels` channel, allowing the system to handle new parcels without being blocked by pending ones, which enhances overall performance.

- **Concurrent Resumption of Pending Parcels:** The `ChainPorter.resumePendingParcels` method is now executed in a separate goroutine, ensuring that resuming pending parcels does not delay the startup process.