### PR TITLE
CI: push coverage file for unit tests

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -232,6 +232,7 @@ jobs:
         if: matrix.unit_type == 'unit-cover'
         with:
           path-to-profile: coverage.txt
+          flag-name: 'unit'
           parallel: true
 
   ########################
@@ -289,3 +290,13 @@ jobs:
           name: logs-itest-postgres
           path: logs-itest-postgres.zip
           retention-days: 5
+
+    # Notify about the completion of all coverage collecting jobs.
+  finish:
+    if: ${{ always() }}
+    needs: [unit-test]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: shogo82148/actions-goveralls@v1
+        with:
+          parallel-finished: true

--- a/make/testing_flags.mk
+++ b/make/testing_flags.mk
@@ -4,6 +4,7 @@ RPC_TAGS = autopilotrpc chainrpc invoicesrpc peersrpc routerrpc signrpc verrpc w
 LOG_TAGS =
 TEST_FLAGS =
 ITEST_FLAGS = -logoutput
+COVER_PKG = $$(go list -deps -tags="$(DEV_TAGS)" ./... | grep '$(PKG)' | grep -v taprpc)
 COVER_HTML = go tool cover -html=coverage.txt -o coverage.html
 POSTGRES_START_DELAY = 5
 


### PR DESCRIPTION
Second attempt to update CI so that coverage info for unit tests is uploaded to Coveralls (and could be displayed for future PRs).

I looked at the setup for btcd:

https://github.com/btcsuite/btcd/blob/master/.github/workflows/go.yml

https://github.com/btcsuite/btcd/blob/b161cd6a199b4e35acec66afc5aad221f05fe1e3/Makefile#L109

I think we don't need to change directory into subfolders for unit tests since we don't have sub-packages in this repo?

Itest coverage may more involved so deferring that for a separate PR.