### PR TITLE
multi: specify proof courier proof recipient at delivery or receive

### DIFF
--- a/proof/courier_test.go
+++ b/proof/courier_test.go
@@ -41,9 +41,9 @@ func TestUniverseRpcCourierLocalArchiveShortCut(t *testing.T) {
 
 	localArchive.proofs.Store(locHash, proofBlob)
 
+	recipient := Recipient{}
 	courier := &UniverseRpcCourier{
-		recipient: Recipient{},
-		client:    nil,
+		client: nil,
 		cfg: &CourierCfg{
 			LocalArchive: localArchive,
 		},
@@ -58,7 +58,7 @@ func TestUniverseRpcCourierLocalArchiveShortCut(t *testing.T) {
 
 	// If we attempt to receive a proof that the local archive has, we
 	// expect to get it back.
-	annotatedProof, err := courier.ReceiveProof(ctxt, locator)
+	annotatedProof, err := courier.ReceiveProof(ctxt, recipient, locator)
 	require.NoError(t, err)
 
 	require.Equal(t, proofBlob, annotatedProof.Blob)
@@ -67,7 +67,7 @@ func TestUniverseRpcCourierLocalArchiveShortCut(t *testing.T) {
 	// should end up in the code path that attempts to fetch the proof from
 	// the universe. Since we don't want to set up a full universe server
 	// in the test, we just make sure we get an error from that code path.
-	_, err = courier.ReceiveProof(ctxt, Locator{
+	_, err = courier.ReceiveProof(ctxt, recipient, Locator{
 		AssetID:   fn.Ptr(genesis.ID()),
 		ScriptKey: *proof.Asset.ScriptKey.PubKey,
 	})

--- a/proof/mock.go
+++ b/proof/mock.go
@@ -443,7 +443,7 @@ type MockProofCourierDispatcher struct {
 
 // NewCourier instantiates a new courier service handle given a service
 // URL address.
-func (m *MockProofCourierDispatcher) NewCourier(*url.URL, Recipient) (Courier,
+func (m *MockProofCourierDispatcher) NewCourier(*url.URL) (Courier,
 	error) {
 
 	return m.Courier, nil
@@ -479,7 +479,7 @@ func (m *MockProofCourier) Stop() error {
 // DeliverProof attempts to delivery a proof to the receiver, using the
 // information in the Addr type.
 func (m *MockProofCourier) DeliverProof(_ context.Context,
-	proof *AnnotatedProof) error {
+	_ Recipient, proof *AnnotatedProof) error {
 
 	m.Lock()
 	defer m.Unlock()
@@ -492,7 +492,7 @@ func (m *MockProofCourier) DeliverProof(_ context.Context,
 // ReceiveProof attempts to obtain a proof as identified by the passed
 // locator from the source encapsulated within the specified address.
 func (m *MockProofCourier) ReceiveProof(_ context.Context,
-	loc Locator) (*AnnotatedProof, error) {
+	_ Recipient, loc Locator) (*AnnotatedProof, error) {
 
 	m.Lock()
 	defer m.Unlock()

--- a/tapchannel/aux_sweeper.go
+++ b/tapchannel/aux_sweeper.go
@@ -801,21 +801,20 @@ func importOutputProofs(scid lnwire.ShortChannelID,
 
 		// First, we'll make a courier to use in fetching the proofs we
 		// need.
-		proofFetcher, err := proofDispatch.NewCourier(
-			courierAddr, proof.Recipient{
-				ScriptKey: scriptKey,
-				AssetID:   proofPrevID.ID,
-				Amount:    proofToImport.Asset.Amount,
-			},
-		)
+		proofFetcher, err := proofDispatch.NewCourier(courierAddr)
 		if err != nil {
 			return fmt.Errorf("unable to create proof courier: %w",
 				err)
 		}
 
 		ctxb := context.Background()
+		recipient := proof.Recipient{
+			ScriptKey: scriptKey,
+			AssetID:   proofPrevID.ID,
+			Amount:    proofToImport.Asset.Amount,
+		}
 		prefixProof, err := proofFetcher.ReceiveProof(
-			ctxb, inputProofLocator,
+			ctxb, recipient, inputProofLocator,
 		)
 
 		// Always attempt to close the courier, even if we encounter an

--- a/tapfreighter/chain_porter.go
+++ b/tapfreighter/chain_porter.go
@@ -819,13 +819,8 @@ func (p *ChainPorter) transferReceiverProof(pkg *sendPackage) error {
 
 		// Initiate proof courier service handle from the proof
 		// courier address found in the Tap address.
-		recipient := proof.Recipient{
-			ScriptKey: key,
-			AssetID:   *receiverProof.AssetID,
-			Amount:    out.Amount,
-		}
 		courier, err := p.cfg.ProofCourierDispatcher.NewCourier(
-			proofCourierAddr, recipient,
+			proofCourierAddr,
 		)
 		if err != nil {
 			return fmt.Errorf("unable to initiate proof courier "+
@@ -841,7 +836,12 @@ func (p *ChainPorter) transferReceiverProof(pkg *sendPackage) error {
 		p.subscriberMtx.Unlock()
 
 		// Deliver proof to proof courier service.
-		err = courier.DeliverProof(ctx, receiverProof)
+		recipient := proof.Recipient{
+			ScriptKey: key,
+			AssetID:   *receiverProof.AssetID,
+			Amount:    out.Amount,
+		}
+		err = courier.DeliverProof(ctx, recipient, receiverProof)
 
 		// If the proof courier returned a backoff error, then
 		// we'll just return nil here so that we can retry

--- a/tapgarden/custodian.go
+++ b/tapgarden/custodian.go
@@ -563,13 +563,8 @@ func (c *Custodian) receiveProof(addr *address.Tap, op wire.OutPoint,
 
 	// Initiate proof courier service handle from the proof courier address
 	// found in the Tap address.
-	recipient := proof.Recipient{
-		ScriptKey: &addr.ScriptKey,
-		AssetID:   assetID,
-		Amount:    addr.Amount,
-	}
 	courier, err := c.cfg.ProofCourierDispatcher.NewCourier(
-		&addr.ProofCourierAddr, recipient,
+		&addr.ProofCourierAddr,
 	)
 	if err != nil {
 		return fmt.Errorf("unable to initiate proof courier service "+
@@ -593,13 +588,18 @@ func (c *Custodian) receiveProof(addr *address.Tap, op wire.OutPoint,
 	}
 
 	// Attempt to receive proof via proof courier service.
+	recipient := proof.Recipient{
+		ScriptKey: &addr.ScriptKey,
+		AssetID:   assetID,
+		Amount:    addr.Amount,
+	}
 	loc := proof.Locator{
 		AssetID:   &assetID,
 		GroupKey:  addr.GroupKey,
 		ScriptKey: addr.ScriptKey,
 		OutPoint:  &op,
 	}
-	addrProof, err := courier.ReceiveProof(ctx, loc)
+	addrProof, err := courier.ReceiveProof(ctx, recipient, loc)
 	if err != nil {
 		return fmt.Errorf("unable to receive proof using courier: %w",
 			err)

--- a/tapgarden/custodian_test.go
+++ b/tapgarden/custodian_test.go
@@ -644,7 +644,8 @@ func TestTransactionHandling(t *testing.T) {
 	h.walletAnchor.Transactions = append(h.walletAnchor.Transactions, *tx)
 
 	mockProof := randProof(t, outputIdx, tx.Tx, genesis[0], addrs[0])
-	err := h.courier.DeliverProof(nil, mockProof)
+	recipient := proof.Recipient{}
+	err := h.courier.DeliverProof(nil, recipient, mockProof)
 	require.NoError(t, err)
 
 	require.NoError(t, h.c.Start())
@@ -708,6 +709,7 @@ func runTransactionConfirmedOnlyTest(t *testing.T, withRestart bool) {
 	// need to signal an unconfirmed transaction for each of them now.
 	outputIndexes := make([]int, numAddrs)
 	transactions := make([]*lndclient.Transaction, numAddrs)
+	recipient := proof.Recipient{}
 	for idx := range addrs {
 		outputIndex, tx := randWalletTx(addrs[idx])
 		outputIndexes[idx] = outputIndex
@@ -719,7 +721,7 @@ func runTransactionConfirmedOnlyTest(t *testing.T, withRestart bool) {
 		mockProof := randProof(
 			t, outputIndexes[idx], tx.Tx, genesis[idx], addrs[idx],
 		)
-		_ = h.courier.DeliverProof(nil, mockProof)
+		_ = h.courier.DeliverProof(nil, recipient, mockProof)
 	}
 
 	// We want events to be created for each address, they should be in the


### PR DESCRIPTION
Related to https://github.com/lightninglabs/taproot-assets/issues/1082

This commit enables establishing a connection to a proof courier service without specifying a particular recipient (proof owner). This change allows us to:

* Share proof courier service connections among multiple recipient peers.

* Test connections to the proof courier service earlier in the process, before the proof owner recipient is specified. This test can now occur before the anchor transaction broadcast in the ChainPorter's state machine.