### PR TITLE
Enhance Proof Courier Handlers with Lazy Connection Attempts for HashMail and UniverseRPC

### DIFF
--- a/proof/courier_test.go
+++ b/proof/courier_test.go
@@ -43,10 +43,9 @@ func TestUniverseRpcCourierLocalArchiveShortCut(t *testing.T) {
 
 	recipient := Recipient{}
 	courier := &UniverseRpcCourier{
-		client: nil,
-		cfg: &CourierCfg{
-			LocalArchive: localArchive,
-		},
+		client:        nil,
+		cfg:           &UniverseRpcCourierCfg{},
+		localArchive:  localArchive,
 		rawConn:       nil,
 		backoffHandle: nil,
 		subscribers:   nil,

--- a/proof/mock.go
+++ b/proof/mock.go
@@ -444,8 +444,8 @@ type MockProofCourierDispatcher struct {
 
 // NewCourier instantiates a new courier service handle given a service
 // URL address.
-func (m *MockProofCourierDispatcher) NewCourier(*url.URL) (Courier,
-	error) {
+func (m *MockProofCourierDispatcher) NewCourier(context.Context,
+	*url.URL, bool) (Courier, error) {
 
 	return m.Courier, nil
 }

--- a/proof/verifier.go
+++ b/proof/verifier.go
@@ -504,8 +504,8 @@ type GroupAnchorVerifier func(gen *asset.Genesis,
 // *proofVerificationOpts.
 type ProofVerificationOption func(p *proofVerificationParams)
 
-// proofVerificationParams is a struct containing various options that may be used
-// during proof verification
+// proofVerificationParams is a struct containing various options that may be
+// used during proof verification
 type proofVerificationParams struct {
 	// ChallengeBytes is an optional field that is used when verifying an
 	// ownership proof. This field is only populated when the corresponding

--- a/tapchannel/aux_sweeper.go
+++ b/tapchannel/aux_sweeper.go
@@ -801,13 +801,15 @@ func importOutputProofs(scid lnwire.ShortChannelID,
 
 		// First, we'll make a courier to use in fetching the proofs we
 		// need.
-		proofFetcher, err := proofDispatch.NewCourier(courierAddr)
+		ctxb := context.Background()
+		proofFetcher, err := proofDispatch.NewCourier(
+			ctxb, courierAddr, true,
+		)
 		if err != nil {
 			return fmt.Errorf("unable to create proof courier: %w",
 				err)
 		}
 
-		ctxb := context.Background()
 		recipient := proof.Recipient{
 			ScriptKey: scriptKey,
 			AssetID:   proofPrevID.ID,

--- a/tapfreighter/chain_porter.go
+++ b/tapfreighter/chain_porter.go
@@ -820,7 +820,7 @@ func (p *ChainPorter) transferReceiverProof(pkg *sendPackage) error {
 		// Initiate proof courier service handle from the proof
 		// courier address found in the Tap address.
 		courier, err := p.cfg.ProofCourierDispatcher.NewCourier(
-			proofCourierAddr,
+			ctx, proofCourierAddr, true,
 		)
 		if err != nil {
 			return fmt.Errorf("unable to initiate proof courier "+

--- a/tapgarden/custodian.go
+++ b/tapgarden/custodian.go
@@ -564,7 +564,7 @@ func (c *Custodian) receiveProof(addr *address.Tap, op wire.OutPoint,
 	// Initiate proof courier service handle from the proof courier address
 	// found in the Tap address.
 	courier, err := c.cfg.ProofCourierDispatcher.NewCourier(
-		&addr.ProofCourierAddr,
+		ctx, &addr.ProofCourierAddr, true,
 	)
 	if err != nil {
 		return fmt.Errorf("unable to initiate proof courier service "+


### PR DESCRIPTION
This PR introduces updates to the HashMail and UniverseRPC proof courier handlers, specifically making connection attempts optionally lazy. The changes are aimed at enhancing the robustness of the connection handling process by integrating these attempts into the backoff procedure where feasible.