### PR TITLE
Enhance Proof Delivery Resilience with ParSliceErrCollect in ChainPorter

### DIFF
--- a/fn/func.go
+++ b/fn/func.go
@@ -1,6 +1,10 @@
 package fn
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/lightningnetwork/lnd/fn"
+)
 
 // Reducer represents a function that takes an accumulator and the value, then
 // returns a new accumulator.
@@ -262,4 +266,20 @@ func Last[T any](xs []*T, pred func(*T) bool) (*T, error) {
 	}
 
 	return matches[len(matches)-1], nil
+}
+
+// KV is a generic struct that holds a key-value pair.
+type KV[K any, V any] struct {
+	Key   K
+	Value V
+}
+
+// PeekMap non-deterministically selects and returns a single key-value pair
+// from the given map.
+func PeekMap[K comparable, V any](m map[K]V) fn.Option[KV[K, V]] {
+	for k, v := range m {
+		return fn.Some(KV[K, V]{Key: k, Value: v})
+	}
+
+	return fn.None[KV[K, V]]()
 }


### PR DESCRIPTION
This PR updates the proof delivery process in `ChainPorter` by utilizing the newly introduced `ParSliceErrCollect` function. This change ensures that proof delivery continues even if an individual transfer output proof encounters an error, improving the reliability of the delivery process.

This change ensures that as many transfer output proofs as possible are delivered, even in the presence of errors.

### Changes
- **New Function**: Introduced `ParSliceErrCollect`, which collects errors during parallel processing without halting the entire operation.
- **ChainPorter**: Modified to use `ParSliceErrCollect` for parallel proof delivery, allowing the process to continue despite individual delivery failures.

Related to: https://github.com/lightninglabs/taproot-assets/issues/1082