### PR TITLE
commitment: splits shouldn't inherit locktime from inputs

### DIFF
--- a/asset/asset.go
+++ b/asset/asset.go
@@ -1831,6 +1831,26 @@ func (a *Asset) Copy() *Asset {
 	return &assetCopy
 }
 
+// CopySpendTemplate is similar to Copy, but should be used when wanting to
+// spend an input asset in a new transaction. Compared to Copy, this method
+// also blanks out some other fields that shouldn't always be carried along for
+// a dependent spend.
+func (a *Asset) CopySpendTemplate() *Asset {
+	assetCopy := a.Copy()
+
+	// We nil out the split commitment root, as we don't need to carry that
+	// into the next spend.
+	assetCopy.SplitCommitmentRoot = nil
+
+	// We'll also make sure to clear out the lock time and relative lock
+	// time from the input. The input at this point is already valid, so we
+	// don't need to inherit the time lock encumbrance.
+	assetCopy.RelativeLockTime = 0
+	assetCopy.LockTime = 0
+
+	return assetCopy
+}
+
 // DeepEqual returns true if this asset is equal with the given asset.
 func (a *Asset) DeepEqual(o *Asset) bool {
 	return a.deepEqual(false, o)

--- a/asset/asset_test.go
+++ b/asset/asset_test.go
@@ -1194,3 +1194,25 @@ func TestNewAssetWithCustomVersion(t *testing.T) {
 
 	require.Equal(t, int(assetCustomVersion.Version), newVersion)
 }
+
+// TestCopySpendTemplate tests that the spend template is copied correctly.
+func TestCopySpendTemplate(t *testing.T) {
+	newAsset := RandAsset(t, Normal)
+	newAsset.SplitCommitmentRoot = mssmt.NewComputedNode(hashBytes1, 1337)
+	newAsset.RelativeLockTime = 1
+	newAsset.LockTime = 2
+
+	// The template should have the relevant set of fields blanked.
+	spendTemplate := newAsset.CopySpendTemplate()
+	require.Zero(t, spendTemplate.SplitCommitmentRoot)
+	require.Zero(t, spendTemplate.RelativeLockTime)
+	require.Zero(t, spendTemplate.LockTime)
+
+	// If blank these fields of the OG asset, then things should be
+	// identical.
+	newAsset.SplitCommitmentRoot = nil
+	newAsset.RelativeLockTime = 0
+	newAsset.LockTime = 0
+
+	require.True(t, newAsset.DeepEqual(spendTemplate))
+}

--- a/commitment/commitment_test.go
+++ b/commitment/commitment_test.go
@@ -657,6 +657,43 @@ func TestSplitCommitment(t *testing.T) {
 			err: nil,
 		},
 		{
+			name: "single input split commitment lock time input",
+			f: func() (*asset.Asset, *SplitLocator,
+				[]*SplitLocator) {
+
+				input := randAsset(
+					t, genesisNormal, groupKeyNormal,
+				)
+				input.Amount = 3
+				input.RelativeLockTime = 1
+				input.LockTime = 1
+
+				root := &SplitLocator{
+					OutputIndex: 0,
+					AssetID:     genesisNormal.ID(),
+					ScriptKey: asset.ToSerialized(
+						input.ScriptKey.PubKey,
+					),
+					Amount: 1,
+				}
+				external := []*SplitLocator{{
+					OutputIndex: 1,
+					AssetID:     genesisNormal.ID(),
+					ScriptKey:   asset.RandSerializedKey(t),
+					Amount:      1,
+				}, {
+
+					OutputIndex: 2,
+					AssetID:     genesisNormal.ID(),
+					ScriptKey:   asset.RandSerializedKey(t),
+					Amount:      1,
+				}}
+
+				return input, root, external
+			},
+			err: nil,
+		},
+		{
 			name: "no external splits",
 			f: func() (*asset.Asset, *SplitLocator, []*SplitLocator) {
 				input := randAsset(
@@ -870,6 +907,11 @@ func TestSplitCommitment(t *testing.T) {
 			for _, l := range append(external, root) {
 				require.Contains(t, split.SplitAssets, *l)
 				splitAsset := split.SplitAssets[*l]
+
+				// Make sure that the splits don't inherit lock
+				// time information from the root asset.
+				require.Zero(t, splitAsset.LockTime)
+				require.Zero(t, splitAsset.RelativeLockTime)
 
 				// If this is a leaf split, then we need to
 				// ensure that the prev ID is zero.

--- a/commitment/split.go
+++ b/commitment/split.go
@@ -210,6 +210,12 @@ func NewSplitCommitment(ctx context.Context, inputs []SplitCommitmentInput,
 		}}
 		assetSplit.SplitCommitmentRoot = nil
 
+		// We'll also make sure to clear out the lock time and relative
+		// lock time from the input. The input at this point is already
+		// valid, so we don't need to inherit the time lock encumbrance.
+		assetSplit.RelativeLockTime = 0
+		assetSplit.LockTime = 0
+
 		splitAssets[*locator] = &SplitAsset{
 			Asset:       *assetSplit,
 			OutputIndex: locator.OutputIndex,

--- a/commitment/split.go
+++ b/commitment/split.go
@@ -194,7 +194,7 @@ func NewSplitCommitment(ctx context.Context, inputs []SplitCommitmentInput,
 	remainingAmount := totalInputAmount
 	rootIdx := len(locators) - 1
 	addAssetSplit := func(locator *SplitLocator) error {
-		assetSplit := inputs[0].Asset.Copy()
+		assetSplit := inputs[0].Asset.CopySpendTemplate()
 		assetSplit.Amount = locator.Amount
 		assetSplit.Version = locator.AssetVersion
 
@@ -208,13 +208,6 @@ func NewSplitCommitment(ctx context.Context, inputs []SplitCommitmentInput,
 			TxWitness:       nil,
 			SplitCommitment: nil,
 		}}
-		assetSplit.SplitCommitmentRoot = nil
-
-		// We'll also make sure to clear out the lock time and relative
-		// lock time from the input. The input at this point is already
-		// valid, so we don't need to inherit the time lock encumbrance.
-		assetSplit.RelativeLockTime = 0
-		assetSplit.LockTime = 0
 
 		splitAssets[*locator] = &SplitAsset{
 			Asset:       *assetSplit,

--- a/proof/courier.go
+++ b/proof/courier.go
@@ -1473,7 +1473,11 @@ func (c *UniverseRpcCourier) publishSubscriberEvent(event fn.Event) {
 
 // Close closes the courier's connection to the remote gRPC service.
 func (c *UniverseRpcCourier) Close() error {
-	return c.rawConn.Close()
+	if c.rawConn != nil {
+		return c.rawConn.Close()
+	}
+
+	return nil
 }
 
 // A compile-time assertion to ensure the UniverseRpcCourier meets the

--- a/proof/verifier.go
+++ b/proof/verifier.go
@@ -385,8 +385,11 @@ func CreateOwnershipProofAsset(ownedAsset *asset.Asset,
 	// definitely not have a split commitment. Keeping the split commitment
 	// of the copied owned asset would lead to an issue with the
 	// non-inflation check we have in the VM that takes the split commitment
-	// root sum as the expected total output amount.
+	// root sum as the expected total output amount. We also clear any time
+	// locks, as they don't apply to the ownership proof.
 	outputAsset.SplitCommitmentRoot = nil
+	outputAsset.LockTime = 0
+	outputAsset.RelativeLockTime = 0
 
 	return prevId, outputAsset
 }

--- a/proof/verifier.go
+++ b/proof/verifier.go
@@ -375,21 +375,20 @@ func CreateOwnershipProofAsset(ownedAsset *asset.Asset,
 		),
 	}
 
-	outputAsset := ownedAsset.Copy()
-	outputAsset.ScriptKey = address.GenChallengeNUMS(challengeBytes)
-	outputAsset.PrevWitnesses = []asset.Witness{{
-		PrevID: &prevId,
-	}}
-
 	// The ownership proof needs to be a 1-in-1-out transaction. So it will
 	// definitely not have a split commitment. Keeping the split commitment
 	// of the copied owned asset would lead to an issue with the
 	// non-inflation check we have in the VM that takes the split commitment
 	// root sum as the expected total output amount. We also clear any time
 	// locks, as they don't apply to the ownership proof.
-	outputAsset.SplitCommitmentRoot = nil
-	outputAsset.LockTime = 0
-	outputAsset.RelativeLockTime = 0
+	//
+	// This is handled by CopySpendTemplate.
+	outputAsset := ownedAsset.CopySpendTemplate()
+
+	outputAsset.ScriptKey = address.GenChallengeNUMS(challengeBytes)
+	outputAsset.PrevWitnesses = []asset.Witness{{
+		PrevID: &prevId,
+	}}
 
 	return prevId, outputAsset
 }

--- a/tapfreighter/wallet.go
+++ b/tapfreighter/wallet.go
@@ -315,6 +315,11 @@ func createPassivePacket(params *address.ChainParams, passiveAsset *asset.Asset,
 	// asset.
 	outputAsset.SplitCommitmentRoot = nil
 
+	// If this was previously a time locked asset, it's now a simple asset.
+	// So we need to clear out the time locks as well.
+	outputAsset.LockTime = 0
+	outputAsset.RelativeLockTime = 0
+
 	// Clear the output asset witness data. We'll be creating a new witness.
 	outputAsset.PrevWitnesses = []asset.Witness{{
 		PrevID: &vInput.PrevID,

--- a/tapfreighter/wallet.go
+++ b/tapfreighter/wallet.go
@@ -309,16 +309,7 @@ func createPassivePacket(params *address.ChainParams, passiveAsset *asset.Asset,
 	}
 
 	// Specify virtual output.
-	outputAsset := passiveAsset.Copy()
-
-	// Clear the split commitment root, as we'll be transferring the whole
-	// asset.
-	outputAsset.SplitCommitmentRoot = nil
-
-	// If this was previously a time locked asset, it's now a simple asset.
-	// So we need to clear out the time locks as well.
-	outputAsset.LockTime = 0
-	outputAsset.RelativeLockTime = 0
+	outputAsset := passiveAsset.CopySpendTemplate()
 
 	// Clear the output asset witness data. We'll be creating a new witness.
 	outputAsset.PrevWitnesses = []asset.Witness{{


### PR DESCRIPTION
In this commit, we fix an existing bug related to lock times and split commitments. Before this commit, if an input had a relative lock time, then when we went to make the new split assets, we would _copy_ that value into the split. This isn't correct as the input is valid/confirmed, so we don't need to copy over the lock time information.

The prior behavior would cause certain classes of spends to fail, as we would be validating a new root asset that has no lock time, but the root asset split inserted into the split commitment would be carrying the old lock time. When verifying the split, we would set the lock times of the split to that of the new asset:
https://github.com/lightninglabs/taproot-assets/blob/e893dee87e9d8f0de53b8ee9e2527add80df6491/vm/vm.go#L305-L307.

As we copied over the lock time from the input, we would now effectively invalid the split commitment.

Fixes https://github.com/lightninglabs/taproot-assets/issues/1099