### PR TITLE
Error `read stream occupied` when delivering proof via hashmail.

### DIFF
--- a/proof/courier.go
+++ b/proof/courier.go
@@ -439,9 +439,11 @@ func (h *HashMailBox) RecvAck(ctx context.Context, sid streamID) error {
 		return fmt.Errorf("unable to create read stream: %w", err)
 	}
 
+	log.Debugf("Exec stream Recv for receiver ACK (sid=%x)", sid[:])
 	msg, err := readStream.Recv()
 	if err != nil {
-		return err
+		return fmt.Errorf("failed on stream Recv (sid=%x): %w", sid[:],
+			err)
 	}
 
 	if bytes.Equal(msg.Msg, ackMsg) {
@@ -867,12 +869,19 @@ func (h *HashMailCourier) ensureConnect(ctx context.Context) error {
 func (h *HashMailCourier) DeliverProof(ctx context.Context,
 	recipient Recipient, proof *AnnotatedProof) error {
 
-	log.Infof("Attempting to deliver receiver proof for send of "+
-		"asset_id=%v, amt=%v", recipient.AssetID, recipient.Amount)
-
-	// Compute the stream IDs for the sender and receiver.
+	// Compute the stream IDs for the sender and receiver. Note that these
+	// stream IDs are derived from the recipient's script key only. Which
+	// means that stream IDs will be identical for multiple proofs sent to
+	// the same recipient.
 	senderStreamID := deriveSenderStreamID(recipient)
 	receiverStreamID := deriveReceiverStreamID(recipient)
+
+	log.Infof("Delivering proof to asset transfer receiver "+
+		"(amt=%v, asset_id=%v, script_pub_key=%x, "+
+		"sender_sid=%x, receiver_sid=%x)",
+		recipient.Amount, recipient.AssetID,
+		recipient.ScriptKey.SerializeCompressed(), senderStreamID,
+		receiverStreamID)
 
 	// Interact with the hashmail service using a backoff procedure to
 	// ensure that we don't overwhelm the service with delivery attempts.
@@ -901,8 +910,7 @@ func (h *HashMailCourier) DeliverProof(ctx context.Context,
 		// TODO(roasbeef): do ecies here
 		// (this ^ TODO relates to encrypting proofs for the receiver
 		// before uploading to the courier)
-		log.Infof("Sending receiver proof via sid=%x",
-			senderStreamID)
+		log.Infof("Writing proof to mailbox (sid=%x)", senderStreamID)
 		err = h.mailbox.WriteProof(
 			ctx, senderStreamID, proof.Blob,
 		)
@@ -913,8 +921,9 @@ func (h *HashMailCourier) DeliverProof(ctx context.Context,
 
 		// Wait to receive the ACK from the remote party over
 		// their stream.
-		log.Infof("Waiting (%v) for receiver ACK via sid=%x",
-			h.cfg.ReceiverAckTimeout, receiverStreamID)
+		log.Infof("Waiting for receiver ACK from hashmail courier "+
+			"(timeout=%v, sid=%x)", h.cfg.ReceiverAckTimeout,
+			receiverStreamID)
 
 		ctxTimeout, cancel := context.WithTimeout(
 			ctx, h.cfg.ReceiverAckTimeout,
@@ -922,9 +931,15 @@ func (h *HashMailCourier) DeliverProof(ctx context.Context,
 		defer cancel()
 		err = h.mailbox.RecvAck(ctxTimeout, receiverStreamID)
 		if err != nil {
-			return fmt.Errorf("failed to receive ACK from "+
-				"receiver within timeout: %w", err)
+
+			return fmt.Errorf("failed to receive hashmail ACK "+
+				"within timeout (sid=%x): %w", receiverStreamID,
+				err)
 		}
+
+		log.Infof("Received receiver ACK from hashmail courier "+
+			"(timeout=%v, sid=%x)", h.cfg.ReceiverAckTimeout,
+			receiverStreamID)
 
 		return nil
 	}
@@ -937,7 +952,7 @@ func (h *HashMailCourier) DeliverProof(ctx context.Context,
 			"failed: %w", err)
 	}
 
-	log.Infof("Received ACK from receiver! Cleaning up mailboxes...")
+	log.Infof("Received ACK from receiver. Cleaning up mailboxes.")
 
 	defer h.Close()
 


### PR DESCRIPTION
We've encountered an error where hashmail proof delivery fails with the error, `read stream occupied`:
```
2024-08-22 04:15:43.195 [DBG] PROF: Proof delivery failed with error. Backing off.
(transfer_type=send, locator_hash=60742286c57cac7fa478821acbf52253ae64ecac7c8c10df8e4a313c748ac940,
backoff=30s, attempt=0): error executing backoff procedure: backoff exec error:
failed to receive ACK from receiver within timeout: rpc error: code = Unknown desc = read stream occupied
```

My current theory is that we're attempting to send two different proofs to the same recipient simultaneously, which involves reading from the same hashmail mailbox in parallel.

If this is true, then we can't transfer multiple proofs to a single recipient in parallel using hashmail.

### Debugging Notes
```
for receiver ACK via sid=2a59fe87c9
---
The recv timeout is 6h:
Waiting (6h0m0s) for receiver ACK via sid=bc9
---
Trying to deliver two proofs:
Attempting to deliver proof (script_key=02de2d5
Attempting to deliver proof (script_key=026575d

To the same proof courier:
proof_courier_addr=hashmail://mailbox.terminal.lightning.today:443
---
If the recipient is the same for both proofs then the mailbox sid values will be
the same.
---
The first attempt (0) failed with the same error in alice.log:
2024-08-22 04:15:43.195 [DBG] PROF: Proof delivery failed with error. Backing off.
(transfer_type=send, locator_hash=60742286c57cac7fa478821acbf52253ae64ecac7c8c10df8e4a313c748ac940,
backoff=30s, attempt=0): error executing backoff procedure: backoff exec error:
failed to receive ACK from receiver within timeout: rpc error: code = Unknown desc = read stream occupied
---
the sender/recver sid values are based on the script key of the recipient only.
```