### PR TITLE
Add AcceptPriceDeviationPpm configuration

### DIFF
--- a/rfq/cli.go
+++ b/rfq/cli.go
@@ -22,6 +22,8 @@ const (
 type CliConfig struct {
 	PriceOracleAddress string `long:"priceoracleaddress" description:"Price oracle gRPC server address (rfqrpc://<hostname>:<port>). To use the integrated mock, use the following value: use_mock_price_oracle_service_promise_to_not_use_on_mainnet"`
 
+	AcceptPriceDeviationPpm uint64 `long:"acceptpricedeviationppm" description:"The default price deviation in parts per million that is accepted by the RFQ negotiator."`
+
 	SkipAcceptQuotePriceCheck bool `long:"skipacceptquotepricecheck" description:"Accept any price quote returned by RFQ peer, skipping price validation"`
 
 	MockOracleAssetsPerBTC uint64 `long:"mockoracleassetsperbtc" description:"Mock price oracle static asset units per BTC rate (for example number of USD cents per BTC if one asset unit represents a USD cent); whole numbers only, use either this or mockoraclesatsperasset depending on required precision"`

--- a/rfq/cli.go
+++ b/rfq/cli.go
@@ -22,7 +22,7 @@ const (
 type CliConfig struct {
 	PriceOracleAddress string `long:"priceoracleaddress" description:"Price oracle gRPC server address (rfqrpc://<hostname>:<port>). To use the integrated mock, use the following value: use_mock_price_oracle_service_promise_to_not_use_on_mainnet"`
 
-	AcceptPriceDeviationPpm uint64 `long:"acceptpricedeviationppm" description:"The default price deviation in parts per million that is accepted by the RFQ negotiator."`
+	AcceptPriceDeviationPpm uint64 `long:"acceptpricedeviationppm" description:"The default price deviation in parts per million that is accepted by the RFQ negotiator"`
 
 	SkipAcceptQuotePriceCheck bool `long:"skipacceptquotepricecheck" description:"Accept any price quote returned by RFQ peer, skipping price validation"`
 

--- a/rfq/manager.go
+++ b/rfq/manager.go
@@ -75,7 +75,7 @@ type ManagerCfg struct {
 	// into the manager once lnd and tapd are hooked together.
 	AliasManager ScidAliasManager
 
-	// The default price deviation in
+	// AcceptPriceDeviationPpm is the price deviation in
 	// parts per million that is accepted by the RFQ negotiator.
 	//
 	// Example: 50,000 ppm => price deviation is set to 5% .
@@ -224,11 +224,6 @@ func (m *Manager) startSubsystems(ctx context.Context) error {
 	if err := m.streamHandler.Start(); err != nil {
 		return fmt.Errorf("unable to start RFQ subsystem service: "+
 			"peer message stream handler: %w", err)
-	}
-
-	// If the accept price deviation is not set, set it to the default value.
-	if m.cfg.AcceptPriceDeviationPpm == 0 {
-		m.cfg.AcceptPriceDeviationPpm = DefaultAcceptPriceDeviationPpm
 	}
 
 	// Initialise and start the quote negotiator.

--- a/rfq/manager.go
+++ b/rfq/manager.go
@@ -75,6 +75,12 @@ type ManagerCfg struct {
 	// into the manager once lnd and tapd are hooked together.
 	AliasManager ScidAliasManager
 
+	// The default price deviation in
+	// parts per million that is accepted by the RFQ negotiator.
+	//
+	// Example: 50,000 ppm => price deviation is set to 5% .
+	AcceptPriceDeviationPpm uint64
+
 	// SkipAcceptQuotePriceCheck is a flag that, when set, will cause the
 	// RFQ negotiator to skip price validation on incoming quote accept
 	// messages (this means that the price oracle will not be queried).
@@ -220,13 +226,18 @@ func (m *Manager) startSubsystems(ctx context.Context) error {
 			"peer message stream handler: %w", err)
 	}
 
+	// If the accept price deviation is not set, set it to the default value.
+	if m.cfg.AcceptPriceDeviationPpm == 0 {
+		m.cfg.AcceptPriceDeviationPpm = DefaultAcceptPriceDeviationPpm
+	}
+
 	// Initialise and start the quote negotiator.
 	m.negotiator, err = NewNegotiator(
 		// nolint: lll
 		NegotiatorCfg{
 			PriceOracle:               m.cfg.PriceOracle,
 			OutgoingMessages:          m.outgoingMessages,
-			AcceptPriceDeviationPpm:   DefaultAcceptPriceDeviationPpm,
+			AcceptPriceDeviationPpm:   m.cfg.AcceptPriceDeviationPpm,
 			SkipAcceptQuotePriceCheck: m.cfg.SkipAcceptQuotePriceCheck,
 			ErrChan:                   m.subsystemErrChan,
 		},

--- a/sample-tapd.conf
+++ b/sample-tapd.conf
@@ -317,7 +317,8 @@
 ; use_mock_price_oracle_service_promise_to_not_use_on_mainnet
 ; experimental.rfq.priceoracleaddress=
 
-; The default price deviation inparts per million that is accepted by the RFQ negotiator.
+; The default price deviation inparts per million that is accepted by 
+; the RFQ negotiator.
 ; Example: 50,000 ppm => price deviation is set to 5% .
 ; experimental.rfq.acceptpricedeviationppm=50000
 

--- a/sample-tapd.conf
+++ b/sample-tapd.conf
@@ -310,12 +310,16 @@
 ; (latency, etc)
 ; prometheus.perfhistograms=false
 
-[experimental.rfq]
+[experimental]
 
 ; Price oracle gRPC server address (rfqrpc://<hostname>:<port>)
 ; To use the integrated mock, use the following value:
 ; use_mock_price_oracle_service_promise_to_not_use_on_mainnet
 ; experimental.rfq.priceoracleaddress=
+
+; The default price deviation inparts per million that is accepted by the RFQ negotiator.
+; Example: 50,000 ppm => price deviation is set to 5% .
+; experimental.rfq.acceptpricedeviationppm=50000
 
 ; Accept any price quote returned by RFQ peer, skipping price validation
 ; experimental.rfq.skipacceptquotepricecheck=false

--- a/tapcfg/config.go
+++ b/tapcfg/config.go
@@ -428,7 +428,11 @@ func DefaultConfig() Config {
 		AddrBook: &AddrBookConfig{
 			DisableSyncer: false,
 		},
-		Experimental: &ExperimentalConfig{},
+		Experimental: &ExperimentalConfig{
+			Rfq: rfq.CliConfig{
+				AcceptPriceDeviationPpm: rfq.DefaultAcceptPriceDeviationPpm,
+			},
+		},
 	}
 }
 

--- a/tapcfg/server.go
+++ b/tapcfg/server.go
@@ -373,6 +373,7 @@ func genServerConfig(cfg *Config, cfgLogger btclog.Logger,
 			ChannelLister:   walletAnchor,
 			AliasManager:    lndRouterClient,
 			// nolint: lll
+			AcceptPriceDeviationPpm:   rfqCfg.AcceptPriceDeviationPpm,
 			SkipAcceptQuotePriceCheck: rfqCfg.SkipAcceptQuotePriceCheck,
 			ErrChan:                   mainErrChan,
 		},

--- a/tapcfg/server.go
+++ b/tapcfg/server.go
@@ -373,7 +373,8 @@ func genServerConfig(cfg *Config, cfgLogger btclog.Logger,
 			ChannelLister:   walletAnchor,
 			AliasManager:    lndRouterClient,
 			// nolint: lll
-			AcceptPriceDeviationPpm:   rfqCfg.AcceptPriceDeviationPpm,
+			AcceptPriceDeviationPpm: rfqCfg.AcceptPriceDeviationPpm,
+			// nolint: lll
 			SkipAcceptQuotePriceCheck: rfqCfg.SkipAcceptQuotePriceCheck,
 			ErrChan:                   mainErrChan,
 		},


### PR DESCRIPTION
The AcceptPriceDeviationPpm is set at 5% and cannot be configured. This presents a certain price slippage risk for RFQ Swaps. Request to add this configuration option. The default value should be 50,000 (5%)