### PR TITLE
Small fixes after recent PRs

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -20,6 +20,8 @@ env:
   GOPATH: /home/runner/work/go
 
   GO_VERSION: '1.22.3'
+  
+  LITD_ITEST_BRANCH: '0-19-staging'
 
 jobs:
   #######################
@@ -306,7 +308,11 @@ jobs:
         uses: ./.github/actions/setup-go
 
       - name: Clone Lit repository
-        run: git clone https://github.com/lightninglabs/lightning-terminal.git
+        uses: actions/checkout@v3
+        with:
+          repository: lightninglabs/lightning-terminal
+          ref: ${{ env.LITD_ITEST_BRANCH }}
+          path: lightning-terminal
 
       - name: Update go.mod to use the local Tap repository
         working-directory: ./lightning-terminal
@@ -316,7 +322,7 @@ jobs:
 
       - name: Install yarn
         run: npm install -g yarn
-          
+
       - name: setup nodejs
         uses: ./lightning-terminal/.github/actions/setup-node
         with:

--- a/itest/loadtest/config.go
+++ b/itest/loadtest/config.go
@@ -60,16 +60,18 @@ type BitcoinConfig struct {
 
 // PrometheusGatewayConfig defines exported config options for connecting to the
 // Prometheus PushGateway.
+//
+//nolint:lll
 type PrometheusGatewayConfig struct {
-	// nolint: lll
-	Enabled bool `long:"enabled" description:"Enable pushing metrics to Prometheus PushGateway"`
-	// nolint: lll
+	Enabled bool   `long:"enabled" description:"Enable pushing metrics to Prometheus PushGateway"`
 	Host    string `long:"host" description:"Prometheus PushGateway host address"`
 	Port    int    `long:"port" description:"Prometheus PushGateway port"`
 	PushURL string
 }
 
 // Config holds the main configuration for the performance testing binary.
+//
+//nolint:lll
 type Config struct {
 	// TestCases is a comma separated list of test cases that will be
 	// executed.
@@ -111,8 +113,6 @@ type Config struct {
 
 	// PrometheusGateway is the configuration for the Prometheus
 	// PushGateway.
-	//
-	// nolint: lll
 	PrometheusGateway *PrometheusGatewayConfig `group:"prometheus-gateway" namespace:"prometheus-gateway" description:"Prometheus PushGateway configuration"`
 }
 
@@ -185,9 +185,8 @@ func ValidateConfig(cfg Config) (*Config, error) {
 		gatewayPort := cfg.PrometheusGateway.Port
 
 		if gatewayHost == "" {
-			return nil, fmt.Errorf(
-				"gateway hostname may not be empty",
-			)
+			return nil, fmt.Errorf("gateway hostname may not be " +
+				"empty")
 		}
 
 		if gatewayPort == 0 {

--- a/itest/loadtest/load_test.go
+++ b/itest/loadtest/load_test.go
@@ -82,7 +82,8 @@ func TestPerformance(t *testing.T) {
 			t.Fatalf("test case %v failed", tc.name)
 		}
 
-		// Calculate the test duration and push metrics if the test case succeeded.
+		// Calculate the test duration and push metrics if the test case
+		// succeeded.
 		if cfg.PrometheusGateway.Enabled {
 			duration := time.Since(startTime).Seconds()
 
@@ -93,19 +94,22 @@ func TestPerformance(t *testing.T) {
 			// Update the metric with the test duration.
 			testDuration.WithLabelValues(label).Set(duration)
 
-			t.Logf("Pushing testDuration %v with label %v to gateway", duration, label)
+			t.Logf("Pushing testDuration %v with label %v to "+
+				"gateway", duration, label)
 
 			// Create a new pusher to push the metrics.
-			pusher := push.New(cfg.PrometheusGateway.PushURL, "load_test").
-				Collector(testDuration)
+			pusher := push.New(
+				cfg.PrometheusGateway.PushURL, "load_test",
+			).Collector(testDuration)
 
 			// Push the metrics to Prometheus PushGateway.
 			if err := pusher.Add(); err != nil {
-				t.Logf("Could not push metrics to Prometheus PushGateway: %v",
-					err)
+				t.Logf("Could not push metrics to Prometheus "+
+					"PushGateway: %v", err)
 			} else {
-				t.Logf("Metrics pushed for test case '%s': duration = %v seconds",
-					tc.name, duration)
+				t.Logf("Metrics pushed for test case '%s': "+
+					"duration = %v seconds", tc.name,
+					duration)
 			}
 		}
 	}


### PR DESCRIPTION
Fixes formatting of build tag excluded files the linter didn't pick up on.

And fixes the new itest to actually run against the correct `litd` branch (I missed that during review). At the same time we slightly optimize the litd itest build.