### PR TITLE
fn+proof: use GOMAXPROCS for worker pool size

### DIFF
--- a/fn/concurrency.go
+++ b/fn/concurrency.go
@@ -23,7 +23,7 @@ type ErrFunc[V any] func(context.Context, V) error
 // non-nil error (if any).
 func ParSlice[V any](ctx context.Context, s []V, f ErrFunc[V]) error {
 	errGroup, ctx := errgroup.WithContext(ctx)
-	errGroup.SetLimit(runtime.NumCPU())
+	errGroup.SetLimit(runtime.GOMAXPROCS(0))
 
 	for _, v := range s {
 		v := v
@@ -44,7 +44,7 @@ func ParSliceErrCollect[V any](ctx context.Context, s []V,
 	f ErrFunc[V]) (map[int]error, error) {
 
 	errGroup, ctx := errgroup.WithContext(ctx)
-	errGroup.SetLimit(runtime.NumCPU())
+	errGroup.SetLimit(runtime.GOMAXPROCS(0))
 
 	var instanceErrorsMutex sync.Mutex
 	instanceErrors := make(map[int]error, len(s))

--- a/proof/verifier.go
+++ b/proof/verifier.go
@@ -266,7 +266,7 @@ func (p *Proof) verifyAssetStateTransition(ctx context.Context,
 	// bail out as soon as any of the active goroutines encounters an
 	// error.
 	errGroup, ctx := errgroup.WithContext(ctx)
-	errGroup.SetLimit(runtime.NumCPU())
+	errGroup.SetLimit(runtime.GOMAXPROCS(0))
 
 	var assetsMtx sync.Mutex
 	for _, inputProof := range p.AdditionalInputs {


### PR DESCRIPTION
Noticed while reading #675 .

The impact of a mismatch between `runtime.NumCPU()` and `GOMAXPROCS` is a known issue:

https://github.com/golang/go/issues/33803

https://github.com/uber-go/automaxprocs

Tl;dr, if a user wants to limit the OS threads used by `tapd` and sets `GOMAXPROCS`, that will have no effect right now. Reading `GOMAXPROCS` is preferred to `runtime.NumCPU()` for setting the size of a CPU-bound worker pool. This matches `runtime.NumCPU()` by default.

https://pkg.go.dev/runtime#GOMAXPROCS