### PR TITLE
ci: run only custom_channels LiT itests

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -334,7 +334,7 @@ jobs:
 
       - name: Run LiT itests
         working-directory: ./lightning-terminal
-        run: make itest
+        run: make itest icase=custom_channels
 
       - name: Run LiT unit tests
         working-directory: ./lightning-terminal


### PR DESCRIPTION
Some lightning-terminal (LiT) itests are currently flaky. This commit restricts CI to running only the `custom_channels` subset of LiT itests.