### PR TITLE
Add fixed-point `WithinTolerance` method and greater-than operators

### DIFF
--- a/rfq/negotiator.go
+++ b/rfq/negotiator.go
@@ -518,6 +518,8 @@ func expiryWithinBounds(expiryUnixTimestamp uint64,
 
 // priceWithinBounds returns true if the difference between the first price and
 // the second price is within the given tolerance (in parts per million (PPM)).
+//
+// TODO(ffranr): Replace with FixedPoint[T].WithinTolerance.
 func pricesWithinBounds(firstPrice lnwire.MilliSatoshi,
 	secondPrice lnwire.MilliSatoshi, tolerancePpm uint64) bool {
 

--- a/rfqmath/arithmetic.go
+++ b/rfqmath/arithmetic.go
@@ -33,6 +33,13 @@ type Int[N any] interface {
 	// Equals returns true if the two integers are equal.
 	Equals(other N) bool
 
+	// Gt returns true if the integer is greater than the other integer.
+	Gt(other N) bool
+
+	// Gte returns true if the integer is greater than or equal to the other
+	// integer.
+	Gte(other N) bool
+
 	// ToFloat converts the integer to a float.
 	ToFloat() float64
 
@@ -121,6 +128,17 @@ func (b GoInt[T]) Equals(other GoInt[T]) bool {
 	return b.value == other.value
 }
 
+// Gt returns true if the integer is greater than the other integer.
+func (b GoInt[T]) Gt(other GoInt[T]) bool {
+	return b.value > other.value
+}
+
+// Gte returns true if the integer is greater than or equal to the other
+// integer.
+func (b GoInt[T]) Gte(other GoInt[T]) bool {
+	return b.value >= other.value
+}
+
 // A compile-time constraint to ensure that the GoInt type implements the Int
 // interface.
 var _ Int[GoInt[uint]] = GoInt[uint]{}
@@ -206,6 +224,17 @@ func (b BigInt) ToUint64() uint64 {
 // Equals returns true if the two integers are equal.
 func (b BigInt) Equals(other BigInt) bool {
 	return b.value.Cmp(other.value) == 0
+}
+
+// Gt returns true if the integer is greater than the other integer.
+func (b BigInt) Gt(other BigInt) bool {
+	return b.value.Cmp(other.value) == 1
+}
+
+// Gte returns true if the integer is greater than or equal to the other
+// integer.
+func (b BigInt) Gte(other BigInt) bool {
+	return b.Equals(other) || b.Gt(other)
 }
 
 // A compile-time constraint to ensure that the BigInt type implements the Int

--- a/rfqmath/fixed_point.go
+++ b/rfqmath/fixed_point.go
@@ -103,6 +103,53 @@ func (f FixedPoint[T]) Equals(other FixedPoint[T]) bool {
 	return f.Coefficient.Equals(other.Coefficient) && f.Scale == other.Scale
 }
 
+// WithinTolerance returns true if the two FixedPoint values are within the
+// given tolerance (in parts per million (PPM)).
+func (f FixedPoint[T]) WithinTolerance(
+	other FixedPoint[T], tolerancePpm T) bool {
+
+	// Determine the larger scale between the two fixed-point numbers.
+	// Both values will be scaled to this larger scale to ensure a
+	// consistent comparison.
+	var largerScale uint8
+	if f.Scale > other.Scale {
+		largerScale = f.Scale
+	} else {
+		largerScale = other.Scale
+	}
+
+	subjectFp := f.ScaleTo(largerScale)
+	otherFp := other.ScaleTo(largerScale)
+
+	var (
+		// delta will be the absolute difference between the two
+		// coefficients.
+		delta T
+
+		// maxCoefficient is the larger of the two coefficients.
+		maxCoefficient T
+	)
+	if subjectFp.Coefficient.Gt(otherFp.Coefficient) {
+		delta = subjectFp.Coefficient.Sub(otherFp.Coefficient)
+		maxCoefficient = subjectFp.Coefficient
+	} else {
+		delta = otherFp.Coefficient.Sub(subjectFp.Coefficient)
+		maxCoefficient = otherFp.Coefficient
+	}
+
+	// Calculate the tolerance in absolute terms based on the largest
+	// coefficient.
+	//
+	// tolerancePpm is parts per million, therefore we multiply the delta by
+	// 1,000,000 instead of dividing the tolerance.
+	scaledDelta := delta.Mul(NewInt[T]().FromUint64(1_000_000))
+
+	// Compare the scaled delta to the product of the maximum coefficient
+	// and the tolerance.
+	toleranceCoefficient := maxCoefficient.Mul(tolerancePpm)
+	return toleranceCoefficient.Gte(scaledDelta)
+}
+
 // FixedPointFromUint64 creates a new FixedPoint from the given integer and
 // scale. Note that the input here should be *unscaled*.
 func FixedPointFromUint64[N Int[N]](value uint64, scale uint8) FixedPoint[N] {


### PR DESCRIPTION
This pull request introduces the following changes to the `rfqmath` library:

1. **FixedPoint[T].WithinTolerance method**  
   Adds the `WithinTolerance` method to the `FixedPoint[T]` type, allowing two fixed-point numbers to be checked for equality within a specified tolerance in Parts Per Million (PPM).

2. **Greater-than operators for integer types**  
   Adds support for handling the `>` and `>=` comparisons for integer types.

These changes are necessary towards closing https://github.com/lightninglabs/taproot-assets/issues/871.