### PR TITLE
rfqmath: clarify scale requirement in FixedPoint Mul and Div docs

### DIFF
--- a/rfqmath/fixed_point.go
+++ b/rfqmath/fixed_point.go
@@ -74,6 +74,9 @@ func (f FixedPoint[T]) ToFloat64() float64 {
 
 // Mul returns a new FixedPoint that is the result of multiplying the existing
 // int by the passed one.
+//
+// NOTE: This function assumes that the scales of the two FixedPoint values are
+// identical. If the scales differ, the result may be incorrect.
 func (f FixedPoint[T]) Mul(other FixedPoint[T]) FixedPoint[T] {
 	multiplier := NewInt[T]().FromFloat(math.Pow10(int(f.Scale)))
 
@@ -87,6 +90,9 @@ func (f FixedPoint[T]) Mul(other FixedPoint[T]) FixedPoint[T] {
 
 // Div returns a new FixedPoint that is the result of dividing the existing int
 // by the passed one.
+//
+// NOTE: This function assumes that the scales of the two FixedPoint values are
+// identical. If the scales differ, the result may be incorrect.
 func (f FixedPoint[T]) Div(other FixedPoint[T]) FixedPoint[T] {
 	multiplier := NewInt[T]().FromFloat(math.Pow10(int(f.Scale)))
 


### PR DESCRIPTION
This commit updates the documentation for `FixedPoint.Mul` and `FixedPoint.Div` to specify that these methods cannot be used with arguments having different scale values from the target fixed-point. This clarification helps prevent misuse of these methods.