### PR TITLE
tapd: fix L1 assets balance calculation

### DIFF
--- a/tapchannel/aux_closer.go
+++ b/tapchannel/aux_closer.go
@@ -19,6 +19,7 @@ import (
 	"github.com/lightninglabs/taproot-assets/tapfreighter"
 	"github.com/lightninglabs/taproot-assets/tapgarden"
 	"github.com/lightninglabs/taproot-assets/tappsbt"
+	"github.com/lightninglabs/taproot-assets/tapscript"
 	"github.com/lightninglabs/taproot-assets/tapsend"
 	lfn "github.com/lightningnetwork/lnd/fn"
 	"github.com/lightningnetwork/lnd/input"
@@ -154,7 +155,7 @@ func createCloseAlloc(isLocal, isInitiator bool, closeAsset *asset.Asset,
 // fundingSpendwitness creates a complete witness to spend the OP_TRUE funding
 // script of an asset funding output.
 func fundingSpendWitness() lfn.Result[wire.TxWitness] {
-	fundingScriptTree := NewFundingScriptTree()
+	fundingScriptTree := tapscript.NewChannelFundingScriptTree()
 
 	tapscriptTree := fundingScriptTree.TapscriptTree
 	ctrlBlock := tapscriptTree.LeafMerkleProofs[0].ToControlBlock(
@@ -167,7 +168,7 @@ func fundingSpendWitness() lfn.Result[wire.TxWitness] {
 	}
 
 	return lfn.Ok(wire.TxWitness{
-		anyoneCanSpendScript(), ctrlBlockBytes,
+		tapscript.AnyoneCanSpendScript(), ctrlBlockBytes,
 	})
 }
 

--- a/tapchannel/aux_funding_controller.go
+++ b/tapchannel/aux_funding_controller.go
@@ -31,6 +31,7 @@ import (
 	"github.com/lightninglabs/taproot-assets/tapfreighter"
 	"github.com/lightninglabs/taproot-assets/tapgarden"
 	"github.com/lightninglabs/taproot-assets/tappsbt"
+	"github.com/lightninglabs/taproot-assets/tapscript"
 	"github.com/lightninglabs/taproot-assets/tapsend"
 	"github.com/lightninglabs/taproot-assets/vm"
 	"github.com/lightningnetwork/lnd/channeldb"
@@ -646,7 +647,7 @@ func (f *FundingController) fundVirtualPacket(ctx context.Context,
 
 	// Our funding script key will be the OP_TRUE addr that we'll use as
 	// the funding script on the asset level.
-	fundingScriptTree := NewFundingScriptTree()
+	fundingScriptTree := tapscript.NewChannelFundingScriptTree()
 	fundingTaprootKey, _ := schnorr.ParsePubKey(
 		schnorr.SerializePubKey(fundingScriptTree.TaprootKey),
 	)
@@ -1088,7 +1089,7 @@ func (f *FundingController) completeChannelFunding(ctx context.Context,
 	// With all the vPackets signed, we'll now anchor them to the funding
 	// PSBT. This'll update all the pkScripts for our funding output and
 	// change.
-	fundingScriptTree := NewFundingScriptTree()
+	fundingScriptTree := tapscript.NewChannelFundingScriptTree()
 	fundingScriptKey := asset.NewScriptKey(fundingScriptTree.TaprootKey)
 	fundingOutputProofs, err := f.anchorVPackets(
 		finalFundedPsbt, signedPkts, fundingScriptKey,

--- a/tapchannel/aux_sweeper.go
+++ b/tapchannel/aux_sweeper.go
@@ -22,6 +22,7 @@ import (
 	"github.com/lightninglabs/taproot-assets/tapfreighter"
 	"github.com/lightninglabs/taproot-assets/tapgarden"
 	"github.com/lightninglabs/taproot-assets/tappsbt"
+	"github.com/lightninglabs/taproot-assets/tapscript"
 	"github.com/lightninglabs/taproot-assets/tapsend"
 	lfn "github.com/lightningnetwork/lnd/fn"
 	"github.com/lightningnetwork/lnd/input"
@@ -910,7 +911,7 @@ func (a *AuxSweeper) importCommitTx(req lnwallet.ResolutionReq,
 
 	// Just in case we don't know about it already, we'll import the
 	// funding script key.
-	fundingScriptTree := NewFundingScriptTree()
+	fundingScriptTree := tapscript.NewChannelFundingScriptTree()
 	fundingTaprootKey, _ := schnorr.ParsePubKey(
 		schnorr.SerializePubKey(fundingScriptTree.TaprootKey),
 	)

--- a/tapdb/sqlc/queries/assets.sql
+++ b/tapdb/sqlc/queries/assets.sql
@@ -332,7 +332,11 @@ JOIN managed_utxos utxos
                 utxos.lease_expiry <= @now)
            ELSE TRUE
        END
-WHERE spent = FALSE 
+JOIN script_keys
+    ON assets.script_key_id = script_keys.script_key_id
+WHERE spent = FALSE AND 
+        (script_keys.tweaked_script_key != sqlc.narg('exclude_key') OR
+                sqlc.narg('exclude_key') IS NULL)
 GROUP BY assets.genesis_id, genesis_info_view.asset_id,
          genesis_info_view.asset_tag, genesis_info_view.meta_hash,
          genesis_info_view.asset_type, genesis_info_view.output_index,
@@ -357,7 +361,11 @@ JOIN managed_utxos utxos
                 utxos.lease_expiry <= @now)
            ELSE TRUE
        END
-WHERE spent = FALSE 
+JOIN script_keys
+    ON assets.script_key_id = script_keys.script_key_id
+WHERE spent = FALSE AND 
+        (script_keys.tweaked_script_key != sqlc.narg('exclude_key') OR
+                sqlc.narg('exclude_key') IS NULL)
 GROUP BY key_group_info_view.tweaked_group_key;
 
 -- name: FetchGroupedAssets :many

--- a/tapscript/script.go
+++ b/tapscript/script.go
@@ -1,13 +1,13 @@
-package tapchannel
+package tapscript
 
 import (
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/lightningnetwork/lnd/input"
 )
 
-// anyoneCanSpendScript is a simple script that allows anyone to spend the
+// AnyoneCanSpendScript is a simple script that allows anyone to spend the
 // output.
-func anyoneCanSpendScript() []byte {
+func AnyoneCanSpendScript() []byte {
 	return []byte{txscript.OP_TRUE}
 }
 
@@ -17,15 +17,15 @@ type FundingScriptTree struct {
 	input.ScriptTree
 }
 
-// NewFundingScriptTree creates a new funding script tree for a custom channel
-// asset-level script key. The script tree is constructed with a simple OP_TRUE
-// script that allows anyone to spend the output. This simplifies the funding
-// process as no signatures for the asset-level witnesses need to be exchanged.
-// This is still safe because the BTC level multi-sig output is still protected
-// by a 2-of-2 MuSig2 output.
-func NewFundingScriptTree() *FundingScriptTree {
+// NewChannelFundingScriptTree creates a new funding script tree for a custom
+// channel asset-level script key. The script tree is constructed with a simple
+// OP_TRUE script that allows anyone to spend the output. This simplifies the
+// funding process as no signatures for the asset-level witnesses need to be
+// exchanged. This is still safe because the BTC level multi-sig output is still
+// protected by a 2-of-2 MuSig2 output.
+func NewChannelFundingScriptTree() *FundingScriptTree {
 	// First, we'll generate our OP_TRUE script.
-	fundingScript := anyoneCanSpendScript()
+	fundingScript := AnyoneCanSpendScript()
 	fundingTapLeaf := txscript.NewBaseTapLeaf(fundingScript)
 
 	// With the funding script derived, we'll now create the tapscript tree

--- a/tapscript/script_test.go
+++ b/tapscript/script_test.go
@@ -1,0 +1,28 @@
+package tapscript
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestNewChannelFundingScriptTree tests the NewChannelFundingScriptTree
+// function. We use this function to filter out assets used for custom channel
+// funding from the balance queries. Therefor the script key cannot change since
+// this would lead to inconsistencies in the balance queries.
+func TestNewChannelFundingScriptTree(t *testing.T) {
+	// This key, threaded through asset.NewScriptKey() would start with 02.
+	// We don't do that here so we compare it to the expected compressed
+	// form of the public key.
+	expectedTaprootKeyHex := "0350aaeb166f4234650d84a2d8a130987aeaf695020" +
+		"6e0905401ee74ff3f8d18e6"
+	expectedTaprootKeyBytes, err := hex.DecodeString(expectedTaprootKeyHex)
+	require.NoError(t, err)
+
+	fundingScriptTree := NewChannelFundingScriptTree()
+	taprootKey := fundingScriptTree.TaprootKey
+
+	serializedTaprootKey := taprootKey.SerializeCompressed()
+	require.Equal(t, expectedTaprootKeyBytes, serializedTaprootKey)
+}


### PR DESCRIPTION
This commits modifies the SQL queries `QueryAssetBalancesByGroup` and
`QueryAssetBalancesByAsset` to allow an `exclude_key` parameter to
exclude assets with that key from the balance calculation.

`assetsStore.QueryBalancesByAsset` and
`assetsStore.QueryAssetBalancesByGroup` use this parameter to exclude
assets that are specifically used for funding custom channels. The
balance of these assets should be reported through the L2 channel
balance and not through the L1 asset balance.