### PR TITLE
Ensure that asset rate hint expiry timestamps are passed to price oracle

### DIFF
--- a/rfq/negotiator.go
+++ b/rfq/negotiator.go
@@ -450,11 +450,11 @@ func (n *Negotiator) HandleOutgoingSellOrder(order SellOrder) {
 		// We calculate a proposed ask price for our peer's
 		// consideration. If a price oracle is not specified we will
 		// skip this step.
-		var assetRate fn.Option[rfqmath.BigIntFixedPoint]
+		var assetRate fn.Option[rfqmsg.AssetRate]
 
 		if n.cfg.PriceOracle != nil {
 			// Query the price oracle for an asking price.
-			rate, _, err := n.queryAskFromPriceOracle(
+			rate, expiryUnix, err := n.queryAskFromPriceOracle(
 				order.Peer, order.AssetID, order.AssetGroupKey,
 				order.MaxAssetAmount,
 				fn.None[rfqmsg.AssetRate](),
@@ -466,7 +466,10 @@ func (n *Negotiator) HandleOutgoingSellOrder(order SellOrder) {
 				return
 			}
 
-			assetRate = fn.Some[rfqmath.BigIntFixedPoint](*rate)
+			expiry := time.Unix(int64(expiryUnix), 0)
+			assetRate = fn.Some[rfqmsg.AssetRate](
+				rfqmsg.NewAssetRate(*rate, expiry),
+			)
 		}
 
 		request, err := rfqmsg.NewSellRequest(

--- a/rfq/negotiator.go
+++ b/rfq/negotiator.go
@@ -107,8 +107,7 @@ func NewNegotiator(cfg NegotiatorCfg) (*Negotiator, error) {
 // an appropriate outgoing response message which should be sent to the peer.
 func (n *Negotiator) queryBidFromPriceOracle(peer route.Vertex,
 	assetId *asset.ID, assetGroupKey *btcec.PublicKey, assetAmount uint64,
-	assetRateHint fn.Option[rfqmsg.AssetRate]) (*rfqmath.BigIntFixedPoint,
-	uint64, error) {
+	assetRateHint fn.Option[rfqmsg.AssetRate]) (*rfqmsg.AssetRate, error) {
 
 	// TODO(ffranr): Optionally accept a peer's proposed ask price as an
 	//  arg to this func and pass it to the price oracle. The price oracle
@@ -124,28 +123,28 @@ func (n *Negotiator) queryBidFromPriceOracle(peer route.Vertex,
 		ctx, assetId, assetGroupKey, assetAmount, assetRateHint,
 	)
 	if err != nil {
-		return nil, 0, fmt.Errorf("failed to query price oracle for "+
+		return nil, fmt.Errorf("failed to query price oracle for "+
 			"bid: %w", err)
 	}
 
 	// Now we will check for an error in the response from the price oracle.
 	// If present, we will convert it to a string and return it as an error.
 	if oracleResponse.Err != nil {
-		return nil, 0, fmt.Errorf("failed to query price oracle for "+
+		return nil, fmt.Errorf("failed to query price oracle for "+
 			"bid price: %s", oracleResponse.Err)
 	}
 
 	// By this point, the price oracle did not return an error or a bid
 	// price. We will therefore return an error.
-	if oracleResponse.AssetRate.Coefficient.ToUint64() == 0 {
-		return nil, 0, fmt.Errorf("price oracle did not specify a " +
+	if oracleResponse.AssetRate.Rate.ToUint64() == 0 {
+		return nil, fmt.Errorf("price oracle did not specify a " +
 			"bid price")
 	}
 
 	// TODO(ffranr): Check that the bid price is reasonable.
 	// TODO(ffranr): Ensure that the expiry time is valid and sufficient.
 
-	return &oracleResponse.AssetRate, oracleResponse.Expiry, nil
+	return &oracleResponse.AssetRate, nil
 }
 
 // HandleOutgoingBuyOrder handles an outgoing buy order by constructing buy
@@ -166,7 +165,7 @@ func (n *Negotiator) HandleOutgoingBuyOrder(buyOrder BuyOrder) error {
 
 		if n.cfg.PriceOracle != nil {
 			// Query the price oracle for a bid price.
-			rate, expiryUnix, err := n.queryBidFromPriceOracle(
+			assetRate, err := n.queryBidFromPriceOracle(
 				*buyOrder.Peer, buyOrder.AssetID,
 				buyOrder.AssetGroupKey, buyOrder.MinAssetAmount,
 				fn.None[rfqmsg.AssetRate](),
@@ -180,10 +179,7 @@ func (n *Negotiator) HandleOutgoingBuyOrder(buyOrder BuyOrder) error {
 					"request: %v", err)
 			}
 
-			expiry := time.Unix(int64(expiryUnix), 0)
-			assetRateHint = fn.Some[rfqmsg.AssetRate](
-				rfqmsg.NewAssetRate(*rate, expiry),
-			)
+			assetRateHint = fn.Some[rfqmsg.AssetRate](*assetRate)
 		}
 
 		request, err := rfqmsg.NewBuyRequest(
@@ -220,8 +216,7 @@ func (n *Negotiator) HandleOutgoingBuyOrder(buyOrder BuyOrder) error {
 // peer.
 func (n *Negotiator) queryAskFromPriceOracle(peer *route.Vertex,
 	assetId *asset.ID, assetGroupKey *btcec.PublicKey, assetAmount uint64,
-	assetRateHint fn.Option[rfqmsg.AssetRate]) (
-	*rfqmath.BigIntFixedPoint, uint64, error) {
+	assetRateHint fn.Option[rfqmsg.AssetRate]) (*rfqmsg.AssetRate, error) {
 
 	// Query the price oracle for an asking price.
 	ctx, cancel := n.WithCtxQuitNoTimeout()
@@ -231,28 +226,28 @@ func (n *Negotiator) queryAskFromPriceOracle(peer *route.Vertex,
 		ctx, assetId, assetGroupKey, assetAmount, assetRateHint,
 	)
 	if err != nil {
-		return nil, 0, fmt.Errorf("failed to query price oracle for "+
+		return nil, fmt.Errorf("failed to query price oracle for "+
 			"ask price: %w", err)
 	}
 
 	// Now we will check for an error in the response from the price oracle.
 	// If present, we will convert it to a string and return it as an error.
 	if oracleResponse.Err != nil {
-		return nil, 0, fmt.Errorf("failed to query price oracle for "+
+		return nil, fmt.Errorf("failed to query price oracle for "+
 			"ask price: %s", oracleResponse.Err)
 	}
 
 	// By this point, the price oracle did not return an error or an asking
 	// price. We will therefore return an error.
-	if oracleResponse.AssetRate.Coefficient.ToUint64() == 0 {
-		return nil, 0, fmt.Errorf("price oracle did not specify an " +
+	if oracleResponse.AssetRate.Rate.Coefficient.ToUint64() == 0 {
+		return nil, fmt.Errorf("price oracle did not specify an " +
 			"asset to BTC rate")
 	}
 
 	// TODO(ffranr): Check that the asking price is reasonable.
 	// TODO(ffranr): Ensure that the expiry time is valid and sufficient.
 
-	return &oracleResponse.AssetRate, oracleResponse.Expiry, nil
+	return &oracleResponse.AssetRate, nil
 }
 
 // HandleIncomingBuyRequest handles an incoming asset buy quote request.
@@ -315,7 +310,7 @@ func (n *Negotiator) HandleIncomingBuyRequest(
 		defer n.Wg.Done()
 
 		// Query the price oracle for an asking price.
-		assetRate, rateExpiry, err := n.queryAskFromPriceOracle(
+		assetRate, err := n.queryAskFromPriceOracle(
 			nil, request.AssetID, request.AssetGroupKey,
 			request.AssetAmount, request.AssetRateHint,
 		)
@@ -335,8 +330,9 @@ func (n *Negotiator) HandleIncomingBuyRequest(
 		}
 
 		// Construct and send a buy accept message.
+		expiry := uint64(assetRate.Expiry.Unix())
 		msg := rfqmsg.NewBuyAcceptFromRequest(
-			request, *assetRate, rateExpiry,
+			request, assetRate.Rate, expiry,
 		)
 		sendOutgoingMsg(msg)
 	}()
@@ -410,7 +406,7 @@ func (n *Negotiator) HandleIncomingSellRequest(
 		// Query the price oracle for a bid price. This is the price we
 		// are willing to pay for the asset that our peer is trying to
 		// sell to us.
-		assetRate, rateExpiry, err := n.queryBidFromPriceOracle(
+		assetRate, err := n.queryBidFromPriceOracle(
 			request.Peer, request.AssetID, request.AssetGroupKey,
 			request.AssetAmount, request.AssetRateHint,
 		)
@@ -430,8 +426,9 @@ func (n *Negotiator) HandleIncomingSellRequest(
 		}
 
 		// Construct and send a sell accept message.
+		expiry := uint64(assetRate.Expiry.Unix())
 		msg := rfqmsg.NewSellAcceptFromRequest(
-			request, *assetRate, rateExpiry,
+			request, assetRate.Rate, expiry,
 		)
 		sendOutgoingMsg(msg)
 	}()
@@ -453,11 +450,11 @@ func (n *Negotiator) HandleOutgoingSellOrder(order SellOrder) {
 		// We calculate a proposed ask price for our peer's
 		// consideration. If a price oracle is not specified we will
 		// skip this step.
-		var assetRate fn.Option[rfqmsg.AssetRate]
+		var assetRateHint fn.Option[rfqmsg.AssetRate]
 
 		if n.cfg.PriceOracle != nil {
 			// Query the price oracle for an asking price.
-			rate, expiryUnix, err := n.queryAskFromPriceOracle(
+			assetRate, err := n.queryAskFromPriceOracle(
 				order.Peer, order.AssetID, order.AssetGroupKey,
 				order.MaxAssetAmount,
 				fn.None[rfqmsg.AssetRate](),
@@ -469,15 +466,12 @@ func (n *Negotiator) HandleOutgoingSellOrder(order SellOrder) {
 				return
 			}
 
-			expiry := time.Unix(int64(expiryUnix), 0)
-			assetRate = fn.Some[rfqmsg.AssetRate](
-				rfqmsg.NewAssetRate(*rate, expiry),
-			)
+			assetRateHint = fn.Some[rfqmsg.AssetRate](*assetRate)
 		}
 
 		request, err := rfqmsg.NewSellRequest(
 			*order.Peer, order.AssetID, order.AssetGroupKey,
-			order.MaxAssetAmount, assetRate,
+			order.MaxAssetAmount, assetRateHint,
 		)
 		if err != nil {
 			err := fmt.Errorf("unable to create sell request "+
@@ -574,7 +568,7 @@ func (n *Negotiator) HandleIncomingBuyAccept(msg rfqmsg.BuyAccept,
 		// We will sanity check that price by querying our price oracle
 		// for an ask price. We will then compare the ask price returned
 		// by the price oracle with the ask price provided by the peer.
-		assetRate, _, err := n.queryAskFromPriceOracle(
+		assetRate, err := n.queryAskFromPriceOracle(
 			&msg.Peer, msg.Request.AssetID, nil,
 			msg.Request.AssetAmount, fn.None[rfqmsg.AssetRate](),
 		)
@@ -608,7 +602,7 @@ func (n *Negotiator) HandleIncomingBuyAccept(msg rfqmsg.BuyAccept,
 			big.NewInt(0).SetUint64(n.cfg.AcceptPriceDeviationPpm),
 		)
 		acceptablePrice := msg.AssetRate.WithinTolerance(
-			*assetRate, tolerance,
+			assetRate.Rate, tolerance,
 		)
 		if !acceptablePrice {
 			// The price is not within the acceptable tolerance.
@@ -698,7 +692,7 @@ func (n *Negotiator) HandleIncomingSellAccept(msg rfqmsg.SellAccept,
 		// We will sanity check that price by querying our price oracle
 		// for a bid price. We will then compare the bid price returned
 		// by the price oracle with the bid price provided by the peer.
-		assetRate, _, err := n.queryBidFromPriceOracle(
+		assetRate, err := n.queryBidFromPriceOracle(
 			msg.Peer, msg.Request.AssetID, nil,
 			msg.Request.AssetAmount, msg.Request.AssetRateHint,
 		)
@@ -732,7 +726,7 @@ func (n *Negotiator) HandleIncomingSellAccept(msg rfqmsg.SellAccept,
 			big.NewInt(0).SetUint64(n.cfg.AcceptPriceDeviationPpm),
 		)
 		acceptablePrice := msg.AssetRate.WithinTolerance(
-			*assetRate, tolerance,
+			assetRate.Rate, tolerance,
 		)
 		if !acceptablePrice {
 			// The price is not within the acceptable bounds.

--- a/rfq/oracle.go
+++ b/rfq/oracle.go
@@ -106,8 +106,9 @@ type PriceOracle interface {
 	// The bid price is the amount the oracle suggests a peer should pay
 	// to another peer to receive the specified asset amount.
 	QueryBidPrice(ctx context.Context, assetId *asset.ID,
-		assetGroupKey *btcec.PublicKey,
-		assetAmount uint64) (*OracleResponse, error)
+		assetGroupKey *btcec.PublicKey, assetAmount uint64,
+		assetRateHint fn.Option[rfqmsg.AssetRate]) (
+		*OracleResponse, error)
 }
 
 // RpcPriceOracle is a price oracle that uses an external RPC server to get
@@ -279,8 +280,8 @@ func (r *RpcPriceOracle) QueryAskPrice(ctx context.Context,
 
 // QueryBidPrice returns a bid price for the given asset amount.
 func (r *RpcPriceOracle) QueryBidPrice(ctx context.Context, assetId *asset.ID,
-	assetGroupKey *btcec.PublicKey,
-	maxAssetAmount uint64) (*OracleResponse, error) {
+	assetGroupKey *btcec.PublicKey, maxAssetAmount uint64,
+	assetRateHint fn.Option[rfqmsg.AssetRate]) (*OracleResponse, error) {
 
 	// For now, we only support querying the ask price with an asset ID.
 	if assetId == nil {
@@ -296,6 +297,14 @@ func (r *RpcPriceOracle) QueryBidPrice(ctx context.Context, assetId *asset.ID,
 	// set the subject asset ID.
 	copy(subjectAssetId, assetId[:])
 
+	// Construct the RPC asset rates hint.
+	rpcAssetRatesHint, err := fn.MapOptionZ(
+		assetRateHint, oraclerpc.MarshalAssetRates,
+	).Unpack()
+	if err != nil {
+		return nil, err
+	}
+
 	req := &oraclerpc.QueryAssetRatesRequest{
 		TransactionType: oraclerpc.TransactionType_PURCHASE,
 		SubjectAsset: &oraclerpc.AssetSpecifier{
@@ -309,7 +318,7 @@ func (r *RpcPriceOracle) QueryBidPrice(ctx context.Context, assetId *asset.ID,
 				AssetId: paymentAssetId,
 			},
 		},
-		AssetRatesHint: nil,
+		AssetRatesHint: rpcAssetRatesHint,
 	}
 
 	// Perform query.
@@ -409,7 +418,8 @@ func (m *MockPriceOracle) QueryAskPrice(_ context.Context,
 
 // QueryBidPrice returns a bid price for the given asset amount.
 func (m *MockPriceOracle) QueryBidPrice(_ context.Context, _ *asset.ID,
-	_ *btcec.PublicKey, _ uint64) (*OracleResponse, error) {
+	_ *btcec.PublicKey, _ uint64,
+	_ fn.Option[rfqmsg.AssetRate]) (*OracleResponse, error) {
 
 	// Calculate the rate expiryDelay lifetime.
 	expiry := uint64(time.Now().Unix()) + m.expiryDelay

--- a/rfq/oracle_test.go
+++ b/rfq/oracle_test.go
@@ -262,6 +262,7 @@ func runQueryBidPriceTest(t *testing.T, tc *testCaseQueryBidPrice) {
 
 	resp, err := client.QueryBidPrice(
 		ctx, tc.assetId, tc.assetGroupKey, assetAmount,
+		fn.None[rfqmsg.AssetRate](),
 	)
 
 	// If we expect an error, ensure that it is returned.

--- a/rfq/oracle_test.go
+++ b/rfq/oracle_test.go
@@ -179,12 +179,11 @@ func runQueryAskPriceTest(t *testing.T, tc *testCaseQueryAskPrice) {
 	// The mock server should return the asset rates hint.
 	require.NotNil(t, resp.AssetRate)
 	require.Equal(
-		t, uint64(bidPrice), resp.AssetRate.Coefficient.ToUint64(),
+		t, uint64(bidPrice), resp.AssetRate.Rate.Coefficient.ToUint64(),
 	)
 
 	// Ensure that the expiry timestamp is in the future.
-	responseExpiry := time.Unix(int64(resp.Expiry), 0)
-	require.True(t, responseExpiry.After(time.Now()))
+	require.True(t, resp.AssetRate.Expiry.After(time.Now()))
 }
 
 // TestRpcPriceOracle tests the RPC price oracle client QueryAskPrice function.
@@ -276,11 +275,12 @@ func runQueryBidPriceTest(t *testing.T, tc *testCaseQueryBidPrice) {
 
 	// The mock server should return the asset rates hint.
 	require.NotNil(t, resp.AssetRate)
-	require.Equal(t, testAssetRate, resp.AssetRate.Coefficient.ToUint64())
+	require.Equal(
+		t, testAssetRate, resp.AssetRate.Rate.Coefficient.ToUint64(),
+	)
 
 	// Ensure that the expiry timestamp is in the future.
-	responseExpiry := time.Unix(int64(resp.Expiry), 0)
-	require.True(t, responseExpiry.After(time.Now()))
+	require.True(t, resp.AssetRate.Expiry.After(time.Now()))
 }
 
 // TestRpcPriceOracle tests the RPC price oracle client QueryBidPrice function.

--- a/rfq/oracle_test.go
+++ b/rfq/oracle_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/lightninglabs/taproot-assets/fn"
 	"github.com/lightninglabs/taproot-assets/internal/test"
 	"github.com/lightninglabs/taproot-assets/rfqmath"
+	"github.com/lightninglabs/taproot-assets/rfqmsg"
 	"github.com/lightninglabs/taproot-assets/taprpc/priceoraclerpc"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/stretchr/testify/require"
@@ -158,10 +159,12 @@ func runQueryAskPriceTest(t *testing.T, tc *testCaseQueryAskPrice) {
 	inAssetRate := rfqmath.NewBigIntFixedPoint(
 		tc.suggestedAssetRate, 3,
 	)
+	expiry := time.Now().Add(rfqmsg.DefaultQuoteLifetime).UTC()
+	assetRateHint := rfqmsg.NewAssetRate(inAssetRate, expiry)
 
 	resp, err := client.QueryAskPrice(
 		ctx, tc.assetId, tc.assetGroupKey, assetAmount,
-		fn.Some(inAssetRate),
+		fn.Some(assetRateHint),
 	)
 
 	// If we expect an error, ensure that it is returned.

--- a/rfqmsg/buy_accept.go
+++ b/rfqmsg/buy_accept.go
@@ -41,6 +41,8 @@ type BuyAccept struct {
 
 // NewBuyAcceptFromRequest creates a new instance of a quote accept message
 // given a quote request message.
+//
+// TODO(ffranr): Use new AssetRate type for assetRate arg.
 func NewBuyAcceptFromRequest(request BuyRequest,
 	assetRate rfqmath.BigIntFixedPoint, expiry uint64) *BuyAccept {
 

--- a/rfqmsg/buy_request.go
+++ b/rfqmsg/buy_request.go
@@ -8,7 +8,6 @@ import (
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/lightninglabs/taproot-assets/asset"
 	"github.com/lightninglabs/taproot-assets/fn"
-	"github.com/lightninglabs/taproot-assets/rfqmath"
 	"github.com/lightningnetwork/lnd/routing/route"
 	"github.com/lightningnetwork/lnd/tlv"
 )
@@ -52,20 +51,13 @@ type BuyRequest struct {
 // NewBuyRequest creates a new asset buy quote request.
 func NewBuyRequest(peer route.Vertex, assetID *asset.ID,
 	assetGroupKey *btcec.PublicKey, assetAmount uint64,
-	rateHint fn.Option[rfqmath.BigIntFixedPoint]) (*BuyRequest, error) {
+	assetRateHint fn.Option[AssetRate]) (*BuyRequest, error) {
 
 	id, err := NewID()
 	if err != nil {
 		return nil, fmt.Errorf("unable to generate random "+
 			"quote request id: %w", err)
 	}
-
-	// Construct a suggested asset rate if a rate hint is provided.
-	var assetRateHint fn.Option[AssetRate]
-	rateHint.WhenSome(func(rate rfqmath.BigIntFixedPoint) {
-		expiry := time.Now().Add(DefaultQuoteLifetime).UTC()
-		assetRateHint = fn.Some(NewAssetRate(rate, expiry))
-	})
 
 	return &BuyRequest{
 		Peer:          peer,

--- a/rfqmsg/buy_request.go
+++ b/rfqmsg/buy_request.go
@@ -70,8 +70,8 @@ func NewBuyRequest(peer route.Vertex, assetID *asset.ID,
 	}, nil
 }
 
-// NewBuyRequestMsgFromWire instantiates a new instance from a wire message.
-func NewBuyRequestMsgFromWire(wireMsg WireMessage,
+// NewBuyRequestFromWire instantiates a new instance from a wire message.
+func NewBuyRequestFromWire(wireMsg WireMessage,
 	msgData requestWireMsgData) (*BuyRequest, error) {
 
 	// Ensure that the message type is a quote request message.

--- a/rfqmsg/messages.go
+++ b/rfqmsg/messages.go
@@ -59,12 +59,12 @@ func NewID() (ID, error) {
 }
 
 // String returns the string representation of the ID.
-func (id ID) String() string {
+func (id *ID) String() string {
 	return hex.EncodeToString(id[:])
 }
 
 // Scid returns the short channel id (SCID) of the RFQ message.
-func (id ID) Scid() SerialisedScid {
+func (id *ID) Scid() SerialisedScid {
 	// Given valid RFQ message id, we then define a RFQ short channel id
 	// (SCID) by taking the last 8 bytes of the RFQ message id and
 	// interpreting them as a 64-bit integer.

--- a/rfqmsg/request.go
+++ b/rfqmsg/request.go
@@ -13,9 +13,9 @@ import (
 )
 
 const (
-	// defaultRequestExpiry is the default duration after which a quote
+	// DefaultQuoteLifetime is the default duration after which a quote
 	// request will expire.
-	defaultRequestExpiry = 10 * time.Minute
+	DefaultQuoteLifetime = 10 * time.Minute
 
 	// latestRequestWireMsgDataVersion is the latest supported quote request
 	// wire message data field version.
@@ -111,7 +111,7 @@ func newRequestWireMsgDataFromBuy(q BuyRequest) (requestWireMsgData, error) {
 	// TODO(ffranr): The expiry timestamp should be obtained from the
 	//  request message.
 	expiry := tlv.NewPrimitiveRecord[tlv.TlvType6](
-		uint64(time.Now().Add(defaultRequestExpiry).Unix()),
+		uint64(time.Now().Add(DefaultQuoteLifetime).Unix()),
 	)
 
 	assetMaxAmount := tlv.NewPrimitiveRecord[tlv.TlvType16](q.AssetAmount)
@@ -173,7 +173,7 @@ func newRequestWireMsgDataFromSell(q SellRequest) (requestWireMsgData, error) {
 
 	// Calculate the expiration unix timestamp in seconds.
 	expiry := tlv.NewPrimitiveRecord[tlv.TlvType6](
-		uint64(time.Now().Add(defaultRequestExpiry).Unix()),
+		uint64(time.Now().Add(DefaultQuoteLifetime).Unix()),
 	)
 
 	assetMaxAmount := tlv.NewPrimitiveRecord[tlv.TlvType16](q.AssetAmount)

--- a/rfqmsg/request.go
+++ b/rfqmsg/request.go
@@ -479,5 +479,5 @@ func NewIncomingRequestFromWire(wireMsg WireMessage) (IncomingMsg, error) {
 	}
 
 	// Otherwise, this is a sell request.
-	return NewSellRequestMsgFromWire(wireMsg, msgData)
+	return NewSellRequestFromWire(wireMsg, msgData)
 }

--- a/rfqmsg/request.go
+++ b/rfqmsg/request.go
@@ -475,7 +475,7 @@ func NewIncomingRequestFromWire(wireMsg WireMessage) (IncomingMsg, error) {
 	// If this is a buy request, then we will create a new buy request
 	// message.
 	if isBuyRequest {
-		return NewBuyRequestMsgFromWire(wireMsg, msgData)
+		return NewBuyRequestFromWire(wireMsg, msgData)
 	}
 
 	// Otherwise, this is a sell request.

--- a/rfqmsg/sell_accept.go
+++ b/rfqmsg/sell_accept.go
@@ -41,6 +41,8 @@ type SellAccept struct {
 
 // NewSellAcceptFromRequest creates a new instance of an asset sell quote accept
 // message given an asset sell quote request message.
+//
+// // TODO(ffranr): Use new AssetRate type for assetRate arg.
 func NewSellAcceptFromRequest(request SellRequest,
 	assetRate rfqmath.BigIntFixedPoint, expiry uint64) *SellAccept {
 

--- a/rfqmsg/sell_request.go
+++ b/rfqmsg/sell_request.go
@@ -71,8 +71,8 @@ func NewSellRequest(peer route.Vertex, assetID *asset.ID,
 	}, nil
 }
 
-// NewSellRequestMsgFromWire instantiates a new instance from a wire message.
-func NewSellRequestMsgFromWire(wireMsg WireMessage,
+// NewSellRequestFromWire instantiates a new instance from a wire message.
+func NewSellRequestFromWire(wireMsg WireMessage,
 	msgData requestWireMsgData) (*SellRequest, error) {
 
 	// Ensure that the message type is a quote request message.

--- a/rfqmsg/sell_request.go
+++ b/rfqmsg/sell_request.go
@@ -7,7 +7,6 @@ import (
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/lightninglabs/taproot-assets/asset"
 	"github.com/lightninglabs/taproot-assets/fn"
-	"github.com/lightninglabs/taproot-assets/rfqmath"
 	"github.com/lightningnetwork/lnd/routing/route"
 	"github.com/lightningnetwork/lnd/tlv"
 )
@@ -51,20 +50,12 @@ type SellRequest struct {
 // NewSellRequest creates a new asset sell quote request.
 func NewSellRequest(peer route.Vertex, assetID *asset.ID,
 	assetGroupKey *btcec.PublicKey, assetAmount uint64,
-	rateHint fn.Option[rfqmath.BigIntFixedPoint]) (*SellRequest,
-	error) {
+	assetRateHint fn.Option[AssetRate]) (*SellRequest, error) {
 
 	id, err := NewID()
 	if err != nil {
 		return nil, fmt.Errorf("unable to generate random id: %w", err)
 	}
-
-	// Construct a suggested asset rate if a rate hint is provided.
-	var assetRateHint fn.Option[AssetRate]
-	rateHint.WhenSome(func(rate rfqmath.BigIntFixedPoint) {
-		expiry := time.Now().Add(DefaultQuoteLifetime).UTC()
-		assetRateHint = fn.Some(NewAssetRate(rate, expiry))
-	})
 
 	return &SellRequest{
 		Peer:          peer,


### PR DESCRIPTION
This PR refines the RFQ code to ensure that asset rate expiry timestamps are correctly passed to and retrieved from the price oracle service.

Previously, rate expiry timestamps were not consistently provided to the price oracle.

### Key Changes

1. **New `AssetRate` Type**:  
   Introduces the `AssetRate` type to represent an asset's exchange rate to BTC, along with its expiration timestamp.
   
   ```go
   // AssetRate represents the exchange rate of an asset to BTC, encapsulating
   // both the rate in fixed-point format and an expiration timestamp.
   //
   // Combining these fields ensures that each rate is inherently tied to an
   // expiry, clarifying its validity period.
   type AssetRate struct {
       // Rate defines the exchange rate of asset units to BTC using a
       // fixed-point representation, ensuring precision for fractional asset
       // rates.
       Rate rfqmath.BigIntFixedPoint

       // Expiry indicates the UTC timestamp when this rate expires and should
       // no longer be considered valid.
       Expiry time.Time
   }
   ```

2. **Integration in Function Signatures and Request Structures**:  
   The `AssetRate` type is now used in the signatures of price oracle query functions and request message structures. This change standardizes the handling of asset rates with expiry, reducing ambiguity and potential errors related to rate validity.

By encapsulating asset rates with expiry timestamps, this PR improves the reliability and clarity of rate management in the RFQ flow.