### PR TITLE
min_relay_fee check during channel funding

### DIFF
--- a/docs/examples/basic-price-oracle/go.mod
+++ b/docs/examples/basic-price-oracle/go.mod
@@ -92,7 +92,7 @@ require (
 	github.com/kkdai/bstream v1.0.0 // indirect
 	github.com/lib/pq v1.10.9 // indirect
 	github.com/lightninglabs/gozmq v0.0.0-20191113021534-d20a764486bf // indirect
-	github.com/lightninglabs/lndclient v0.18.4-1 // indirect
+	github.com/lightninglabs/lndclient v0.18.4-3 // indirect
 	github.com/lightninglabs/neutrino v0.16.1-0.20240425105051-602843d34ffd // indirect
 	github.com/lightninglabs/neutrino/cache v1.1.2 // indirect
 	github.com/lightningnetwork/lightning-onion v1.2.1-0.20240712235311-98bd56499dfb // indirect

--- a/docs/examples/basic-price-oracle/go.sum
+++ b/docs/examples/basic-price-oracle/go.sum
@@ -418,8 +418,8 @@ github.com/lightninglabs/gozmq v0.0.0-20191113021534-d20a764486bf/go.mod h1:vxmQ
 github.com/lightninglabs/lightning-node-connect v0.2.5-alpha h1:ZRVChwczFXK0CEbxOCWwUA6TIZvrkE0APd1T3WjFAwg=
 github.com/lightninglabs/lightning-node-connect/hashmailrpc v1.0.2 h1:Er1miPZD2XZwcfE4xoS5AILqP1mj7kqnhbBSxW9BDxY=
 github.com/lightninglabs/lightning-node-connect/hashmailrpc v1.0.2/go.mod h1:antQGRDRJiuyQF6l+k6NECCSImgCpwaZapATth2Chv4=
-github.com/lightninglabs/lndclient v0.18.4-1 h1:k2UnxHGNH243NRe5/dL2sKgrxc8WMHbFQRdnCtfilwc=
-github.com/lightninglabs/lndclient v0.18.4-1/go.mod h1:/HLqmZGL9MtP8F1g+laq+L9VrsugBN5tsTct3C5wWCg=
+github.com/lightninglabs/lndclient v0.18.4-3 h1:Xk3ZuCQE4ZlF70jaToryL2MvRcryiE0zTfUjJbmzUBY=
+github.com/lightninglabs/lndclient v0.18.4-3/go.mod h1:/HLqmZGL9MtP8F1g+laq+L9VrsugBN5tsTct3C5wWCg=
 github.com/lightninglabs/neutrino v0.16.1-0.20240425105051-602843d34ffd h1:D8aRocHpoCv43hL8egXEMYyPmyOiefFHZ66338KQB2s=
 github.com/lightninglabs/neutrino v0.16.1-0.20240425105051-602843d34ffd/go.mod h1:x3OmY2wsA18+Kc3TSV2QpSUewOCiscw2mKpXgZv2kZk=
 github.com/lightninglabs/neutrino/cache v1.1.2 h1:C9DY/DAPaPxbFC+xNNEI/z1SJY9GS3shmlu5hIQ798g=

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/lib/pq v1.10.9
 	github.com/lightninglabs/aperture v0.3.2-beta.0.20241015115230-d59b5514c19a
 	github.com/lightninglabs/lightning-node-connect/hashmailrpc v1.0.2
-	github.com/lightninglabs/lndclient v0.18.4-1
+	github.com/lightninglabs/lndclient v0.18.4-3
 	github.com/lightninglabs/neutrino/cache v1.1.2
 	github.com/lightningnetwork/lnd v0.18.3-beta.rc3.0.20241025090009-615f3d633e61
 	github.com/lightningnetwork/lnd/cert v1.2.2

--- a/go.sum
+++ b/go.sum
@@ -486,8 +486,8 @@ github.com/lightninglabs/lightning-node-connect v0.2.5-alpha h1:ZRVChwczFXK0CEbx
 github.com/lightninglabs/lightning-node-connect v0.2.5-alpha/go.mod h1:A9Pof9fETkH+F67BnOmrBDThPKstqp73wlImWOZvTXQ=
 github.com/lightninglabs/lightning-node-connect/hashmailrpc v1.0.2 h1:Er1miPZD2XZwcfE4xoS5AILqP1mj7kqnhbBSxW9BDxY=
 github.com/lightninglabs/lightning-node-connect/hashmailrpc v1.0.2/go.mod h1:antQGRDRJiuyQF6l+k6NECCSImgCpwaZapATth2Chv4=
-github.com/lightninglabs/lndclient v0.18.4-1 h1:k2UnxHGNH243NRe5/dL2sKgrxc8WMHbFQRdnCtfilwc=
-github.com/lightninglabs/lndclient v0.18.4-1/go.mod h1:/HLqmZGL9MtP8F1g+laq+L9VrsugBN5tsTct3C5wWCg=
+github.com/lightninglabs/lndclient v0.18.4-3 h1:Xk3ZuCQE4ZlF70jaToryL2MvRcryiE0zTfUjJbmzUBY=
+github.com/lightninglabs/lndclient v0.18.4-3/go.mod h1:/HLqmZGL9MtP8F1g+laq+L9VrsugBN5tsTct3C5wWCg=
 github.com/lightninglabs/neutrino v0.16.1-0.20240425105051-602843d34ffd h1:D8aRocHpoCv43hL8egXEMYyPmyOiefFHZ66338KQB2s=
 github.com/lightninglabs/neutrino v0.16.1-0.20240425105051-602843d34ffd/go.mod h1:x3OmY2wsA18+Kc3TSV2QpSUewOCiscw2mKpXgZv2kZk=
 github.com/lightninglabs/neutrino/cache v1.1.2 h1:C9DY/DAPaPxbFC+xNNEI/z1SJY9GS3shmlu5hIQ798g=

--- a/tapcfg/config.go
+++ b/tapcfg/config.go
@@ -186,8 +186,8 @@ var (
 	// required in lnd to run tapd.
 	minimalCompatibleVersion = &verrpc.Version{
 		AppMajor: 0,
-		AppMinor: 17,
-		AppPatch: 99,
+		AppMinor: 18,
+		AppPatch: 4,
 
 		// We don't actually require the invoicesrpc calls. But if we
 		// try to use lndclient on an lnd that doesn't have it enabled,

--- a/tapchannel/aux_funding_controller.go
+++ b/tapchannel/aux_funding_controller.go
@@ -1354,6 +1354,18 @@ func (f *FundingController) processFundingReq(fundingFlows fundingFlowIndex,
 			fundReq.PeerPub.SerializeCompressed())
 	}
 
+	// Before we proceed, we'll make sure the fee rate we're using is above
+	// the min relay fee.
+	minRelayFee, err := f.cfg.ChainWallet.MinRelayFee(fundReq.ctx)
+	if err != nil {
+		return fmt.Errorf("unable to establish min_relay_fee: %w",
+			err)
+	}
+	if fundReq.FeeRate.FeePerKWeight() < minRelayFee {
+		return fmt.Errorf("fee rate %v too low, min_relay_fee: %v",
+			fundReq.FeeRate.FeePerKWeight(), minRelayFee)
+	}
+
 	// To start, we'll make a new pending asset funding desc. This'll be
 	// our scratch pad during the asset funding process.
 	tempPID, err := newPendingChanID()

--- a/tapgarden/interface.go
+++ b/tapgarden/interface.go
@@ -372,6 +372,10 @@ type WalletAnchor interface {
 	// relevant to the wallet are sent over.
 	SubscribeTransactions(context.Context) (<-chan lndclient.Transaction,
 		<-chan error, error)
+
+	// MinRelayFee returns the current minimum relay fee based on
+	// our chain backend in sat/kw.
+	MinRelayFee(ctx context.Context) (chainfee.SatPerKWeight, error)
 }
 
 // KeyRing is a mirror of the keychain.KeyRing interface, with the addition of

--- a/tapgarden/mock.go
+++ b/tapgarden/mock.go
@@ -302,6 +302,14 @@ func (m *MockWalletAnchor) ListTransactions(ctx context.Context, _, _ int32,
 	return m.Transactions, nil
 }
 
+// MinRelayFee estimates the minimum fee rate required for a
+// transaction.
+func (m *MockWalletAnchor) MinRelayFee(
+	ctx context.Context) (chainfee.SatPerKWeight, error) {
+
+	return chainfee.SatPerKWeight(10), nil
+}
+
 type MockChainBridge struct {
 	FeeEstimateSignal chan struct{}
 	PublishReq        chan *wire.MsgTx

--- a/wallet_anchor.go
+++ b/wallet_anchor.go
@@ -218,6 +218,14 @@ func (l *LndRpcWalletAnchor) ListChannels(
 	return l.lnd.Client.ListChannels(ctx, true, false)
 }
 
+// MinRelayFee estimates the minimum fee rate required for a
+// transaction.
+func (l *LndRpcWalletAnchor) MinRelayFee(
+	ctx context.Context) (chainfee.SatPerKWeight, error) {
+
+	return l.lnd.WalletKit.MinRelayFee(ctx)
+}
+
 // A compile time assertion to ensure LndRpcWalletAnchor meets the
 // tapgarden.WalletAnchor interface.
 var _ tapgarden.WalletAnchor = (*LndRpcWalletAnchor)(nil)


### PR DESCRIPTION
This PR adds `MinRelayFee` to the `WalletAnchor` and uses it during tapchannel funding to check whether the feerate meets the minimum relay fee.

fixes: #1105

~~This PR depends on  https://github.com/lightninglabs/lndclient/pull/200 and uses a pseudoversion of that package.~~

~~go.mod should be changed before merging this PR,~~