### PR TITLE
tapcfg: allow to configure lnd RPC timeout, increase default val

### DIFF
--- a/proof/courier.go
+++ b/proof/courier.go
@@ -550,7 +550,7 @@ type BackoffCfg struct {
 
 	// BackoffResetWait is the amount of time we'll wait before
 	// resetting the backoff counter to its initial state.
-	BackoffResetWait time.Duration `long:"backoffresetwait" description:"The amount of time to wait before resetting the backoff counter."`
+	BackoffResetWait time.Duration `long:"backoffresetwait" description:"The amount of time to wait before resetting the backoff counter. Valid time units are {s, m, h}."`
 
 	// NumTries is the number of times we'll try to deliver the proof to the
 	// receiver before the BackoffResetWait delay is enforced.
@@ -558,11 +558,11 @@ type BackoffCfg struct {
 
 	// InitialBackoff is the initial backoff time we'll use to wait before
 	// retrying to deliver the proof to the receiver.
-	InitialBackoff time.Duration `long:"initialbackoff" description:"The initial backoff time to wait before retrying to deliver the proof to the receiver."`
+	InitialBackoff time.Duration `long:"initialbackoff" description:"The initial backoff time to wait before retrying to deliver the proof to the receiver. Valid time units are {s, m, h}."`
 
 	// MaxBackoff is the maximum backoff time we'll use to wait before
 	// retrying to deliver the proof to the receiver.
-	MaxBackoff time.Duration `long:"maxbackoff" description:"The maximum backoff time to wait before retrying to deliver the proof to the receiver."`
+	MaxBackoff time.Duration `long:"maxbackoff" description:"The maximum backoff time to wait before retrying to deliver the proof to the receiver. Valid time units are {s, m, h}."`
 }
 
 // BackoffHandler is a handler for the backoff procedure.
@@ -755,7 +755,7 @@ func NewBackoffHandler(cfg *BackoffCfg,
 type HashMailCourierCfg struct {
 	// ReceiverAckTimeout is the maximum time we'll wait for the receiver to
 	// acknowledge the proof.
-	ReceiverAckTimeout time.Duration `long:"receiveracktimeout" description:"The maximum time to wait for the receiver to acknowledge the proof."`
+	ReceiverAckTimeout time.Duration `long:"receiveracktimeout" description:"The maximum time to wait for the receiver to acknowledge the proof. Valid time units are {s, m, h}."`
 
 	// BackoffCfg configures the behaviour of the proof delivery
 	// functionality.

--- a/proof/courier.go
+++ b/proof/courier.go
@@ -542,6 +542,8 @@ func (e *BackoffExecError) Error() string {
 }
 
 // BackoffCfg configures the behaviour of the proof delivery backoff procedure.
+//
+// nolint:lll
 type BackoffCfg struct {
 	// SkipInitDelay is a flag that indicates whether we should skip the
 	// initial delay before attempting to deliver the proof to the receiver
@@ -752,6 +754,8 @@ func NewBackoffHandler(cfg *BackoffCfg,
 }
 
 // HashMailCourierCfg is the config for the hashmail proof courier.
+//
+// nolint:lll
 type HashMailCourierCfg struct {
 	// ReceiverAckTimeout is the maximum time we'll wait for the receiver to
 	// acknowledge the proof.

--- a/sample-tapd.conf
+++ b/sample-tapd.conf
@@ -59,7 +59,8 @@
 ; proofcourieraddr=universerpc://testnet.universe.lightning.finance:10029
 
 ; The number of seconds the custodian waits after identifying an asset transfer
-; on-chain and before retrieving the corresponding proof
+; on-chain and before retrieving the corresponding proof. Valid time units are
+; {s, m, h}.
 ; custodianproofretrievaldelay=5s
 
 ; Network to run on (mainnet, regtest, testnet, simnet, signet)
@@ -94,7 +95,8 @@
 ; Use first --tlsextradomain as Common Name instead, if set
 ; tlsdisableautofill=false
 
-; The duration for which the auto-generated TLS certificate will be valid for
+; The duration for which the auto-generated TLS certificate will be valid for.
+; Valid time units are {s, m, h}.
 ; tlscertduration=10080h
 
 ; Disable REST API
@@ -103,12 +105,13 @@
 ; Disable TLS for REST connections
 ; no-rest-tls=false
 
-; The ping interval for REST based WebSocket connections
-; Set to 0 to disable sending ping messages from the server side
+; The ping interval for REST based WebSocket connections. Set to 0 to disable
+; sending ping messages from the server side. Valid time units are {s, m, h}.
 ; ws-ping-interval=30s
 
 ; The time we wait for a pong response message on REST based WebSocket
-; connections before the connection is closed as inactive
+; connections before the connection is closed as inactive. Valid time units are
+; {s, m, h}.
 ; ws-pong-wait=5s
 
 ; Path to write the admin macaroon for tapd's RPC and REST services if it
@@ -154,25 +157,27 @@
 
 [hashmailcourier]
 
-; The maximum time to wait for the receiver to acknowledge the proof
+; The maximum time to wait for the receiver to acknowledge the proof. Valid time
+; units are {s, m, h}.
 ; hashmailcourier.receiveracktimeout=6h
 
 ; Skip the initial delay before attempting to deliver the proof to the receiver
 ; or receiving from the sender
 ; hashmailcourier.skipinitdelay=false
 
-; The amount of time to wait before resetting the backoff counter
+; The amount of time to wait before resetting the backoff counter. Valid time
+; units are {s, m, h}.
 ; hashmailcourier.backoffresetwait=10m
 
 ; The number of proof delivery attempts before the backoff counter is reset
 ; hashmailcourier.numtries=2000
 
 ; The initial backoff time to wait before retrying to deliver the proof to the
-; receiver
+; receiver. Valid time units are {s, m, h}.
 ; hashmailcourier.initialbackoff=30s
 
 ; The maximum backoff time to wait before retrying to deliver the proof to the
-; receiver
+; receiver. Valid time units are {s, m, h}.
 ; hashmailcourier.maxbackoff=5m
 
 [universerpccourier]
@@ -181,18 +186,19 @@
 ; or receiving from the sender
 ; universerpccourier.skipinitdelay=false
 
-; The amount of time to wait before resetting the backoff counter
+; The amount of time to wait before resetting the backoff counter. Valid time
+; units are {s, m, h}.
 ; universerpccourier.backoffresetwait=10m
 
 ; The number of proof delivery attempts before the backoff counter is reset
 ; universerpccourier.numtries=2000
 
 ; The initial backoff time to wait before retrying to deliver the proof to the
-; receiver
+; receiver. Valid time units are {s, m, h}.
 ; universerpccourier.initialbackoff=30s
 
 ; The maximum backoff time to wait before retrying to deliver the proof to the
-; receiver
+; receiver. Valid time units are {s, m, h}.
 ; universerpccourier.maxbackoff=5m
 
 [lnd]
@@ -214,7 +220,8 @@
 ; lnd.tlspath=
 
 ; The timeout to use for RPC requests to lnd; a sufficiently long duration
-; should be chosen to avoid issues with slow responses
+; should be chosen to avoid issues with slow responses. Valid time units are
+; {s, m, h}.
 ; lnd.rpctimeout=1m
 
 [sqlite]
@@ -254,10 +261,12 @@
 ; Max number of idle connections to keep in the connection pool
 ; postgres.maxidleconnections=
 
-; Max amount of time a connection can be reused for before it is closed
+; Max amount of time a connection can be reused for before it is closed. Valid
+; time units are {s, m, h}.
 ; postgres.connmaxlifetime=
 
-; Max amount of time a connection can be idle for before it is closed
+; Max amount of time a connection can be idle for before it is closed. Valid
+; time units are {s, m, h}.
 ; postgres.connmaxidletime=
 
 ; Whether to require using SSL (mode: require) when connecting to the server
@@ -265,7 +274,7 @@
 
 [universe]
 
-; Amount of time to wait between universe syncs
+; Amount of time to wait between universe syncs. Valid time units are {s, m, h}.
 ; universe.syncinterval=10m
 
 ; The host:port of a Universe server peer with
@@ -285,7 +294,8 @@
 ; If 'w' is included, public access is allowed for write endpoints
 ; universe.public-access=
 
-; The amount of time to cache stats for before refreshing them
+; The amount of time to cache stats for before refreshing them. Valid time units
+; are {s, m, h}.
 ; universe.stats-cache-duration=
 
 ; The maximum number of queries per second across the set of active universe

--- a/sample-tapd.conf
+++ b/sample-tapd.conf
@@ -213,6 +213,10 @@
 ; Path to lnd tls certificate
 ; lnd.tlspath=
 
+; The timeout to use for RPC requests to lnd; a sufficiently long duration
+; should be chosen to avoid issues with slow responses
+; lnd.rpctimeout=1m
+
 [sqlite]
 
 ; Skip applying migrations on startup

--- a/tapcfg/config.go
+++ b/tapcfg/config.go
@@ -130,6 +130,10 @@ const (
 	// waits having identified an asset transfer on-chain and before
 	// retrieving the corresponding proof via the proof courier service.
 	defaultProofRetrievalDelay = 5 * time.Second
+
+	// defaultLndRPCTimeout is the default timeout we'll use for RPC
+	// requests to lnd.
+	defaultLndRPCTimeout = 1 * time.Minute
 )
 
 var (
@@ -258,6 +262,9 @@ type LndConfig struct {
 	MacaroonPath string `long:"macaroonpath" description:"The full path to the single macaroon to use, either the admin.macaroon or a custom baked one. Cannot be specified at the same time as macaroondir. A custom macaroon must contain ALL permissions required for all subservers to work, otherwise permission errors will occur."`
 
 	TLSPath string `long:"tlspath" description:"Path to lnd tls certificate"`
+
+	// RPCTimeout is the timeout we'll use for RPC requests to lnd.
+	RPCTimeout time.Duration `long:"rpctimeout" description:"The timeout to use for RPC requests to lnd; a sufficiently long duration should be chosen to avoid issues with slow responses"`
 }
 
 // UniverseConfig is the config that houses any Universe related config
@@ -385,6 +392,7 @@ func DefaultConfig() Config {
 		Lnd: &LndConfig{
 			Host:         "localhost:10009",
 			MacaroonPath: defaultLndMacaroonPath,
+			RPCTimeout:   defaultLndRPCTimeout,
 		},
 		DatabaseBackend: DatabaseBackendSqlite,
 		Sqlite: &tapdb.SqliteConfig{
@@ -1150,5 +1158,6 @@ func getLnd(network string, cfg *LndConfig,
 		BlockUntilChainSynced: true,
 		BlockUntilUnlocked:    true,
 		CallerCtx:             ctxc,
+		RPCTimeout:            cfg.RPCTimeout,
 	})
 }

--- a/tapcfg/config.go
+++ b/tapcfg/config.go
@@ -224,12 +224,12 @@ type RpcConfig struct {
 	TLSExtraDomains    []string      `long:"tlsextradomain" description:"Adds an extra domain to the generated certificate"`
 	TLSAutoRefresh     bool          `long:"tlsautorefresh" description:"Re-generate TLS certificate and key if the IPs or domains are changed"`
 	TLSDisableAutofill bool          `long:"tlsdisableautofill" description:"Do not include the interface IPs or the system hostname in TLS certificate, use first --tlsextradomain as Common Name instead, if set"`
-	TLSCertDuration    time.Duration `long:"tlscertduration" description:"The duration for which the auto-generated TLS certificate will be valid for"`
+	TLSCertDuration    time.Duration `long:"tlscertduration" description:"The duration for which the auto-generated TLS certificate will be valid for. Valid time units are {s, m, h}."`
 
 	DisableRest    bool          `long:"norest" description:"Disable REST API"`
 	DisableRestTLS bool          `long:"no-rest-tls" description:"Disable TLS for REST connections"`
-	WSPingInterval time.Duration `long:"ws-ping-interval" description:"The ping interval for REST based WebSocket connections, set to 0 to disable sending ping messages from the server side"`
-	WSPongWait     time.Duration `long:"ws-pong-wait" description:"The time we wait for a pong response message on REST based WebSocket connections before the connection is closed as inactive"`
+	WSPingInterval time.Duration `long:"ws-ping-interval" description:"The ping interval for REST based WebSocket connections, set to 0 to disable sending ping messages from the server side. Valid time units are {s, m, h}."`
+	WSPongWait     time.Duration `long:"ws-pong-wait" description:"The time we wait for a pong response message on REST based WebSocket connections before the connection is closed as inactive. Valid time units are {s, m, h}."`
 
 	MacaroonPath string `long:"macaroonpath" description:"Path to write the admin macaroon for tapd's RPC and REST services if it doesn't exist"`
 	NoMacaroons  bool   `long:"no-macaroons" description:"Disable macaroon authentication, can only be used if server is not listening on a public interface."`
@@ -264,7 +264,7 @@ type LndConfig struct {
 	TLSPath string `long:"tlspath" description:"Path to lnd tls certificate"`
 
 	// RPCTimeout is the timeout we'll use for RPC requests to lnd.
-	RPCTimeout time.Duration `long:"rpctimeout" description:"The timeout to use for RPC requests to lnd; a sufficiently long duration should be chosen to avoid issues with slow responses"`
+	RPCTimeout time.Duration `long:"rpctimeout" description:"The timeout to use for RPC requests to lnd; a sufficiently long duration should be chosen to avoid issues with slow responses. Valid time units are {s, m, h}."`
 }
 
 // UniverseConfig is the config that houses any Universe related config
@@ -272,7 +272,7 @@ type LndConfig struct {
 //
 // nolint: lll
 type UniverseConfig struct {
-	SyncInterval time.Duration `long:"syncinterval" description:"Amount of time to wait between universe syncs"`
+	SyncInterval time.Duration `long:"syncinterval" description:"Amount of time to wait between universe syncs. Valid time units are {s, m, h}."`
 
 	FederationServers []string `long:"federationserver" description:"The host:port of a Universe server peer with. These servers will be added as the default set of federation servers. Can be specified multiple times."`
 
@@ -280,7 +280,7 @@ type UniverseConfig struct {
 
 	PublicAccess string `long:"public-access" description:"The public access mode for the universe server, controlling whether remote parties can read from and/or write to this universe server over RPC if exposed to a public network interface. This can be unset, 'r', 'w', or 'rw'. If unset, public access is not enabled for the universe server. If 'r' is included, public access is allowed for read-only endpoints. If 'w' is included, public access is allowed for write endpoints."`
 
-	StatsCacheDuration time.Duration `long:"stats-cache-duration" description:"The amount of time to cache stats for before refreshing them."`
+	StatsCacheDuration time.Duration `long:"stats-cache-duration" description:"The amount of time to cache stats for before refreshing them. Valid time units are {s, m, h}."`
 
 	UniverseQueriesPerSecond rate.Limit `long:"max-qps" description:"The maximum number of queries per second across the set of active universe queries that is permitted. Anything above this starts to get rate limited."`
 
@@ -329,7 +329,7 @@ type Config struct {
 	HashMailCourier         *proof.HashMailCourierCfg    `group:"hashmailcourier" namespace:"hashmailcourier"`
 	UniverseRpcCourier      *proof.UniverseRpcCourierCfg `group:"universerpccourier" namespace:"universerpccourier"`
 
-	CustodianProofRetrievalDelay time.Duration `long:"custodianproofretrievaldelay" description:"The number of seconds the custodian waits after identifying an asset transfer on-chain and before retrieving the corresponding proof."`
+	CustodianProofRetrievalDelay time.Duration `long:"custodianproofretrievaldelay" description:"The number of seconds the custodian waits after identifying an asset transfer on-chain and before retrieving the corresponding proof. Valid time units are {s, m, h}."`
 
 	ChainConf *ChainConfig
 	RpcConf   *RpcConfig

--- a/tapcfg/config.go
+++ b/tapcfg/config.go
@@ -1,3 +1,4 @@
+// nolint:lll
 package tapcfg
 
 import (
@@ -269,8 +270,6 @@ type LndConfig struct {
 
 // UniverseConfig is the config that houses any Universe related config
 // values.
-//
-// nolint: lll
 type UniverseConfig struct {
 	SyncInterval time.Duration `long:"syncinterval" description:"Amount of time to wait between universe syncs. Valid time units are {s, m, h}."`
 
@@ -304,8 +303,6 @@ func (c *ExperimentalConfig) Validate() error {
 }
 
 // Config is the main config for the tapd cli command.
-//
-// nolint: lll
 type Config struct {
 	ShowVersion bool `long:"version" description:"Display version information and exit"`
 
@@ -436,7 +433,6 @@ func DefaultConfig() Config {
 		AddrBook: &AddrBookConfig{
 			DisableSyncer: false,
 		},
-		// nolint: lll
 		Experimental: &ExperimentalConfig{
 			Rfq: rfq.CliConfig{
 				AcceptPriceDeviationPpm: rfq.DefaultAcceptPriceDeviationPpm,

--- a/tapdb/postgres.go
+++ b/tapdb/postgres.go
@@ -43,6 +43,8 @@ var (
 )
 
 // PostgresConfig holds the postgres database configuration.
+//
+// nolint:lll
 type PostgresConfig struct {
 	SkipMigrations     bool          `long:"skipmigrations" description:"Skip applying migrations on startup."`
 	Host               string        `long:"host" description:"Database server hostname."`

--- a/tapdb/postgres.go
+++ b/tapdb/postgres.go
@@ -52,8 +52,8 @@ type PostgresConfig struct {
 	DBName             string        `long:"dbname" description:"Database name to use."`
 	MaxOpenConnections int           `long:"maxconnections" description:"Max open connections to keep alive to the database server."`
 	MaxIdleConnections int           `long:"maxidleconnections" description:"Max number of idle connections to keep in the connection pool."`
-	ConnMaxLifetime    time.Duration `long:"connmaxlifetime" description:"Max amount of time a connection can be reused for before it is closed."`
-	ConnMaxIdleTime    time.Duration `long:"connmaxidletime" description:"Max amount of time a connection can be idle for before it is closed."`
+	ConnMaxLifetime    time.Duration `long:"connmaxlifetime" description:"Max amount of time a connection can be reused for before it is closed. Valid time units are {s, m, h}."`
+	ConnMaxIdleTime    time.Duration `long:"connmaxidletime" description:"Max amount of time a connection can be idle for before it is closed. Valid time units are {s, m, h}."`
 	RequireSSL         bool          `long:"requiressl" description:"Whether to require using SSL (mode: require) when connecting to the server."`
 }
 


### PR DESCRIPTION
This fixes an issue where tapd would shut down because querying channels on a slow lnd would time out:

```
2024-10-30 10:06:21.535 [DBG] STAT: Setting the taproot-assets sub-server as errored: received critical error from sub-server (taproot-assets), shutting down: failed to handle outgoing message: error adding local alias: add alias: error listing local channels: rpc error: code = DeadlineExceeded desc = context deadline exceeded
```

Will add a similar PR to `litd`, as there the `lndclient` is created in a single place for all sub servers, so this daemon specific value would be ignored.