### PR TITLE
[tapsend]: Enforce unique script keys

### DIFF
--- a/itest/assertions.go
+++ b/itest/assertions.go
@@ -1108,7 +1108,10 @@ func AssertAssetOutboundTransferWithOutputs(t *testing.T,
 			out := transfer.Outputs[idx]
 			require.Contains(t, outpoints, out.Anchor.Outpoint)
 			require.Contains(t, scripts, string(out.ScriptKey))
-			require.Equal(t, expectedAmounts[idx], out.Amount)
+			require.Equalf(
+				t, expectedAmounts[idx], out.Amount,
+				"expected amounts: %v, transfer: %v",
+				expectedAmounts, toJSON(t, transfer))
 		}
 
 		firstIn := transfer.Inputs[0]

--- a/itest/send_test.go
+++ b/itest/send_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/lightninglabs/taproot-assets/taprpc/mintrpc"
 	"github.com/lightninglabs/taproot-assets/taprpc/tapdevrpc"
 	unirpc "github.com/lightninglabs/taproot-assets/taprpc/universerpc"
+	"github.com/lightninglabs/taproot-assets/tapsend"
 	"github.com/lightningnetwork/lnd/lntest/wait"
 	"github.com/stretchr/testify/require"
 )
@@ -101,6 +102,16 @@ func testBasicSendUnidirectional(t *harnessTest) {
 		AssetVersion: rpcAssets[0].Version,
 	})
 	require.NoError(t.t, err)
+
+	// Before we start sending, we test that we aren't allowed to send to
+	// the same address more than once within the same transfer.
+	_, err = t.tapd.SendAsset(ctxb, &taprpc.SendAssetRequest{
+		TapAddrs: []string{
+			bobAddr.Encoded,
+			bobAddr.Encoded,
+		},
+	})
+	require.ErrorContains(t.t, err, tapsend.ErrDuplicateScriptKeys.Error())
 
 	for i := 0; i < numSends; i++ {
 		t.t.Logf("Performing send procedure: %d", i)

--- a/proof/proof_test.go
+++ b/proof/proof_test.go
@@ -758,6 +758,8 @@ func TestProofVerification(t *testing.T) {
 
 	t.Logf("Proof asset JSON: %s", assetJSON)
 
+	// If we have a challenge witness, we can verify that without having the
+	// previous proof.
 	if len(p.ChallengeWitness) > 0 {
 		_, err = p.Verify(
 			context.Background(), nil, MockHeaderVerifier,
@@ -765,6 +767,11 @@ func TestProofVerification(t *testing.T) {
 		)
 		require.NoError(t, err)
 	}
+
+	// Verifying the inclusion and exclusion proofs can also be done without
+	// the previous proof.
+	_, err = p.VerifyProofs()
+	require.NoError(t, err)
 
 	// Ensure that verification of a proof of unknown version fails.
 	p.Version = TransitionVersion(212)

--- a/tapfreighter/coin_select.go
+++ b/tapfreighter/coin_select.go
@@ -67,8 +67,14 @@ func (s *CoinSelect) SelectCoins(ctx context.Context,
 		return nil, ErrMatchingAssetsNotFound
 	}
 
-	log.Infof("Identified %v eligible asset inputs for send of %d to %v",
-		len(eligibleCommitments), constraints.MinAmt, constraints)
+	anchorInputs := fn.Map(
+		eligibleCommitments, func(c *AnchoredCommitment) string {
+			return c.AnchorPoint.String()
+		},
+	)
+	log.Infof("Identified %v eligible asset inputs for send of %d to %v: "+
+		"%v", len(anchorInputs), constraints.MinAmt,
+		constraints.String(), anchorInputs)
 
 	// Only select coins anchored in a compatible commitment.
 	compatibleCommitments := fn.Filter(

--- a/tapfreighter/wallet.go
+++ b/tapfreighter/wallet.go
@@ -752,7 +752,7 @@ func (f *AssetWallet) fundPacketWithInputs(ctx context.Context,
 	}
 
 	if err := tapsend.PrepareOutputAssets(ctx, vPkt); err != nil {
-		return nil, fmt.Errorf("unable to create split commit: %w", err)
+		return nil, fmt.Errorf("unable to prepare outputs: %w", err)
 	}
 
 	return &FundedVPacket{

--- a/tapfreighter/wallet.go
+++ b/tapfreighter/wallet.go
@@ -129,6 +129,10 @@ type Wallet interface {
 	// address.ErrInternalKeyNotFound is returned.
 	FetchInternalKeyLocator(ctx context.Context,
 		rawKey *btcec.PublicKey) (keychain.KeyLocator, error)
+
+	// ReleaseCoins releases/unlocks coins that were previously leased and
+	// makes them available for coin selection again.
+	ReleaseCoins(ctx context.Context, utxoOutpoints ...wire.OutPoint) error
 }
 
 // AddrBook is an interface that provides access to the address book.
@@ -1460,6 +1464,14 @@ func (f *AssetWallet) FetchInternalKeyLocator(ctx context.Context,
 	rawKey *btcec.PublicKey) (keychain.KeyLocator, error) {
 
 	return f.cfg.AddrBook.FetchInternalKeyLocator(ctx, rawKey)
+}
+
+// ReleaseCoins releases/unlocks coins that were previously leased and makes
+// them available for coin selection again.
+func (f *AssetWallet) ReleaseCoins(ctx context.Context,
+	utxoOutpoints ...wire.OutPoint) error {
+
+	return f.cfg.CoinSelector.ReleaseCoins(ctx, utxoOutpoints...)
 }
 
 // addAnchorPsbtInputs adds anchor information from all inputs to the PSBT

--- a/tappsbt/interface.go
+++ b/tappsbt/interface.go
@@ -321,6 +321,25 @@ func (p *VPacket) AssetID() (asset.ID, error) {
 	return firstID, nil
 }
 
+// AssetSpecifier returns the asset specifier for the asset being spent by the
+// first input of the virtual transaction. It returns an error if the asset ID
+// of the virtual transaction is not set or if the asset of the first input is
+// not set.
+func (p *VPacket) AssetSpecifier() (asset.Specifier, error) {
+	assetID, err := p.AssetID()
+	if err != nil {
+		return asset.Specifier{}, err
+	}
+
+	if p.Inputs[0].Asset() == nil {
+		return asset.Specifier{}, fmt.Errorf("no asset set for input 0")
+	}
+
+	return asset.NewSpecifier(
+		&assetID, nil, p.Inputs[0].Asset().GroupKey, true,
+	)
+}
+
 // Anchor is a struct that contains all the information about an anchor output.
 type Anchor struct {
 	// Value is output value of the anchor output.

--- a/tappsbt/interface_test.go
+++ b/tappsbt/interface_test.go
@@ -1,0 +1,83 @@
+package tappsbt
+
+import (
+	"testing"
+
+	"github.com/lightninglabs/taproot-assets/asset"
+	"github.com/lightninglabs/taproot-assets/internal/test"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAssetSpecifier tests the AssetSpecifier method of the VPacket struct.
+func TestAssetSpecifier(t *testing.T) {
+	groupPubKey := test.RandPubKey(t)
+	groupKey := &asset.GroupKey{
+		GroupPubKey: *groupPubKey,
+	}
+
+	tests := []struct {
+		name      string
+		vPacket   *VPacket
+		expectErr bool
+		expected  asset.Specifier
+	}{
+		{
+			name: "valid input with group key",
+			vPacket: &VPacket{
+				Inputs: []*VInput{
+					{
+						asset: &asset.Asset{
+							GroupKey: groupKey,
+						},
+						PrevID: asset.PrevID{
+							ID: asset.ID{1, 2, 3},
+						},
+					},
+				},
+			},
+			expected: asset.NewSpecifierOptionalGroupPubKey(
+				asset.ID{1, 2, 3}, groupPubKey,
+			),
+		},
+		{
+			name: "valid input with asset ID only",
+			vPacket: &VPacket{
+				Inputs: []*VInput{
+					{
+						asset: &asset.Asset{},
+						PrevID: asset.PrevID{
+							ID: asset.ID{1, 2, 3},
+						},
+					},
+				},
+			},
+			expected: asset.NewSpecifierFromId(asset.ID{1, 2, 3}),
+		},
+		{
+			name:      "no inputs",
+			vPacket:   &VPacket{},
+			expectErr: true,
+		},
+		{
+			name: "no asset set for input",
+			vPacket: &VPacket{
+				Inputs: []*VInput{
+					{},
+				},
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(tt *testing.T) {
+			specifier, err := tc.vPacket.AssetSpecifier()
+			if tc.expectErr {
+				require.Error(tt, err)
+			} else {
+				require.NoError(tt, err)
+				require.Equal(tt, tc.expected, specifier)
+			}
+		})
+	}
+}

--- a/tapsend/send.go
+++ b/tapsend/send.go
@@ -735,8 +735,8 @@ func SignVirtualTransaction(vPkt *tappsbt.VPacket, signer tapscript.Signer,
 	// Construct input set from all input assets.
 	prevAssets := make(commitment.InputSet, len(inputs))
 	for idx := range vPkt.Inputs {
-		input := vPkt.Inputs[idx]
-		prevAssets[input.PrevID] = input.Asset()
+		vIn := vPkt.Inputs[idx]
+		prevAssets[vIn.PrevID] = vIn.Asset()
 	}
 
 	// Create a Taproot Asset virtual transaction representing the asset


### PR DESCRIPTION
Fixes https://github.com/lightninglabs/taproot-assets/issues/1168 (or at least prevents it from happening in the future).

This PR enforces script keys to be unique per top-level MS-SMT tree (assetID/groupKey) within a single transfer.

To be able to test this properly, we also make sure selected UTXOs are released by the freighter if the shipment of a parcel results in an error.
That change then impacts some assumptions in the integration tests, which requires additional commits to fix.