### PR TITLE
tapdb: fix bug w.r.t null bool handling, allow InsertScriptKey to allow flipping known to true 

### DIFF
--- a/tapdb/addrs.go
+++ b/tapdb/addrs.go
@@ -467,7 +467,9 @@ func (t *TapAddressBook) QueryAddrs(ctx context.Context,
 				return fmt.Errorf("unable to make addr: %w", err)
 			}
 
-			declaredKnown := addr.ScriptKeyDeclaredKnown.Valid
+			declaredKnown := extractBool(
+				addr.ScriptKeyDeclaredKnown,
+			)
 			addrs = append(addrs, address.AddrWithKeyInfo{
 				Tap: tapAddr,
 				ScriptKeyTweak: asset.TweakedScriptKey{
@@ -620,9 +622,11 @@ func fetchAddr(ctx context.Context, db AddrBook, params *address.ChainParams,
 	return &address.AddrWithKeyInfo{
 		Tap: tapAddr,
 		ScriptKeyTweak: asset.TweakedScriptKey{
-			RawKey:        scriptKeyDesc,
-			Tweak:         dbAddr.ScriptKeyTweak,
-			DeclaredKnown: dbAddr.ScriptKeyDeclaredKnown.Valid,
+			RawKey: scriptKeyDesc,
+			Tweak:  dbAddr.ScriptKeyTweak,
+			DeclaredKnown: extractBool(
+				dbAddr.ScriptKeyDeclaredKnown,
+			),
 		},
 		InternalKeyDesc:  internalKeyDesc,
 		TaprootOutputKey: *taprootOutputKey,

--- a/tapdb/addrs.go
+++ b/tapdb/addrs.go
@@ -689,6 +689,7 @@ func (t *TapAddressBook) InsertScriptKey(ctx context.Context,
 			return fmt.Errorf("error inserting internal key: %w",
 				err)
 		}
+
 		_, err = q.UpsertScriptKey(ctx, NewScriptKey{
 			InternalKeyID:    internalKeyID,
 			TweakedScriptKey: scriptKey.PubKey.SerializeCompressed(),

--- a/tapdb/asset_minting.go
+++ b/tapdb/asset_minting.go
@@ -666,7 +666,9 @@ func fetchAssetSeedlings(ctx context.Context, q PendingAssetStore,
 				PubKey:     scriptKeyInternalPub,
 			}
 			scriptKeyTweak := dbSeedling.ScriptKeyTweak
-			declaredKnown := dbSeedling.ScriptKeyDeclaredKnown.Valid
+			declaredKnown := extractBool(
+				dbSeedling.ScriptKeyDeclaredKnown,
+			)
 			seedling.ScriptKey = asset.ScriptKey{
 				PubKey: tweakedScriptKey,
 				TweakedScriptKey: &asset.TweakedScriptKey{
@@ -800,7 +802,7 @@ func fetchAssetSprouts(ctx context.Context, q PendingAssetStore,
 				Family: keychain.KeyFamily(sprout.ScriptKeyFam),
 			},
 		}
-		declaredKnown := sprout.ScriptKeyDeclaredKnown.Valid
+		declaredKnown := extractBool(sprout.ScriptKeyDeclaredKnown)
 		scriptKey := asset.ScriptKey{
 			PubKey: tweakedScriptKey,
 			TweakedScriptKey: &asset.TweakedScriptKey{

--- a/tapdb/assets_common.go
+++ b/tapdb/assets_common.go
@@ -459,7 +459,7 @@ func fetchScriptKey(ctx context.Context, q FetchScriptKeyStore,
 				Index: uint32(dbKey.KeyIndex),
 			},
 		},
-		DeclaredKnown: dbKey.DeclaredKnown.Valid,
+		DeclaredKnown: extractBool(dbKey.DeclaredKnown),
 	}
 
 	return scriptKey, nil

--- a/tapdb/assets_store.go
+++ b/tapdb/assets_store.go
@@ -727,7 +727,7 @@ func (a *AssetStore) dbAssetsToChainAssets(dbAssets []ConfirmedAsset,
 		if err != nil {
 			return nil, err
 		}
-		declaredKnown := sprout.ScriptKeyDeclaredKnown.Valid
+		declaredKnown := extractBool(sprout.ScriptKeyDeclaredKnown)
 		scriptKey := asset.ScriptKey{
 			PubKey: scriptKeyPub,
 			TweakedScriptKey: &asset.TweakedScriptKey{
@@ -2686,7 +2686,7 @@ func fetchAssetTransferOutputs(ctx context.Context, q ActiveAssetsStore,
 				err)
 		}
 
-		declaredKnown := dbOut.ScriptKeyDeclaredKnown.Valid
+		declaredKnown := extractBool(dbOut.ScriptKeyDeclaredKnown)
 		outputAnchor := tapfreighter.Anchor{
 			Value: btcutil.Amount(
 				dbOut.AnchorValue,
@@ -3035,7 +3035,7 @@ func (a *AssetStore) LogAnchorTxConfirm(ctx context.Context,
 				out.OutputType == int16(tappsbt.TypeSplitRoot)
 			isBurn := !isNumsKey && len(witnessData) > 0 &&
 				asset.IsBurnKey(scriptPubKey, witnessData[0])
-			isKnown := out.ScriptKeyDeclaredKnown.Valid
+			isKnown := extractBool(out.ScriptKeyDeclaredKnown)
 			skipAssetCreation := !isTombstone && !isBurn &&
 				!out.ScriptKeyLocal && !isKnown
 

--- a/tapdb/sqlc/assets.sql.go
+++ b/tapdb/sqlc/assets.sql.go
@@ -2880,7 +2880,15 @@ INSERT INTO script_keys (
 )  ON CONFLICT (tweaked_script_key)
     -- As a NOP, we just set the script key to the one that triggered the
     -- conflict.
-    DO UPDATE SET tweaked_script_key = EXCLUDED.tweaked_script_key
+    DO UPDATE SET 
+      tweaked_script_key = EXCLUDED.tweaked_script_key,
+      -- If the script key was previously unknown, we'll update to the new
+      -- value.
+      declared_known = CASE
+                         WHEN script_keys.declared_known IS NULL OR script_keys.declared_known = FALSE
+                         THEN COALESCE(EXCLUDED.declared_known, script_keys.declared_known)
+                         ELSE script_keys.declared_known
+                       END
 RETURNING script_key_id
 `
 

--- a/tapdb/sqlc/queries/assets.sql
+++ b/tapdb/sqlc/queries/assets.sql
@@ -854,7 +854,15 @@ INSERT INTO script_keys (
 )  ON CONFLICT (tweaked_script_key)
     -- As a NOP, we just set the script key to the one that triggered the
     -- conflict.
-    DO UPDATE SET tweaked_script_key = EXCLUDED.tweaked_script_key
+    DO UPDATE SET 
+      tweaked_script_key = EXCLUDED.tweaked_script_key,
+      -- If the script key was previously unknown, we'll update to the new
+      -- value.
+      declared_known = CASE
+                         WHEN script_keys.declared_known IS NULL OR script_keys.declared_known = FALSE
+                         THEN COALESCE(EXCLUDED.declared_known, script_keys.declared_known)
+                         ELSE script_keys.declared_known
+                       END
 RETURNING script_key_id;
 
 -- name: FetchScriptKeyIDByTweakedKey :one

--- a/tapdb/sqlutils.go
+++ b/tapdb/sqlutils.go
@@ -103,6 +103,13 @@ func extractSqlInt16[T constraints.Integer](num sql.NullInt16) T {
 	return T(num.Int16)
 }
 
+// extractBool turns a NullBool into a boolean. This can be useful when reading
+// directly from the database, as this function handles extracting the inner
+// value from the "option"-like struct.
+func extractBool(b sql.NullBool) bool {
+	return b.Bool
+}
+
 // readOutPoint reads the next sequence of bytes from r as an OutPoint.
 //
 // NOTE: This function is intended to be used along with the wire.WriteOutPoint


### PR DESCRIPTION
In this commit, we fix some incorrect handling on null bool in SQL, that
looks to be mostly benign. Before this commit, instead of doing `.Bool`,
we did `.Valid`. The latter is only useful to check if something is
zero, or NULL. In this case, we can just go with the bool value
directly.

Then, we update `InsertScriptKey` to allow flipping known to
true, if it was false before.

This is useful as at times a script key from a smart contract might have
been inserting on disk, but with declared known as false. Then if we
tried to insert it again, with known as true, the upsert logic would end
up making no change on disk.

Note that without the initial bug fix, the test added in the last commit 
would fail. 