### PR TITLE
Track HTLCs in rfq policies

### DIFF
--- a/chain_bridge.go
+++ b/chain_bridge.go
@@ -18,6 +18,7 @@ import (
 	"github.com/lightninglabs/taproot-assets/tapgarden"
 	"github.com/lightningnetwork/lnd/chainntnfs"
 	"github.com/lightningnetwork/lnd/funding"
+	"github.com/lightningnetwork/lnd/lnrpc/routerrpc"
 	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/routing/route"
@@ -376,9 +377,19 @@ func (l *LndRouterClient) DeleteLocalAlias(ctx context.Context, alias,
 	return l.lnd.Router.XDeleteLocalChanAlias(ctx, alias, baseScid)
 }
 
+// SubscribeHtlcEvents subscribes to a stream of events related to
+// HTLC updates.
+func (l *LndRouterClient) SubscribeHtlcEvents(
+	ctx context.Context) (<-chan *routerrpc.HtlcEvent,
+	<-chan error, error) {
+
+	return l.lnd.Router.SubscribeHtlcEvents(ctx)
+}
+
 // Ensure LndRouterClient implements the rfq.HtlcInterceptor interface.
 var _ rfq.HtlcInterceptor = (*LndRouterClient)(nil)
 var _ rfq.ScidAliasManager = (*LndRouterClient)(nil)
+var _ rfq.HtlcSubscriber = (*LndRouterClient)(nil)
 
 // LndInvoicesClient is an LND invoices RPC client.
 type LndInvoicesClient struct {

--- a/rfq/manager.go
+++ b/rfq/manager.go
@@ -72,6 +72,10 @@ type ManagerCfg struct {
 	// intercept and accept/reject HTLCs.
 	HtlcInterceptor HtlcInterceptor
 
+	// HtlcSubscriber is a subscriber that is used to retrieve live HTLC
+	// event updates.
+	HtlcSubscriber HtlcSubscriber
+
 	// PriceOracle is the price oracle that the RFQ manager will use to
 	// determine whether a quote is accepted or rejected.
 	PriceOracle PriceOracle
@@ -207,6 +211,7 @@ func (m *Manager) startSubsystems(ctx context.Context) error {
 	m.orderHandler, err = NewOrderHandler(OrderHandlerCfg{
 		CleanupInterval:  CacheCleanupInterval,
 		HtlcInterceptor:  m.cfg.HtlcInterceptor,
+		HtlcSubscriber:   m.cfg.HtlcSubscriber,
 		AcceptHtlcEvents: m.acceptHtlcEvents,
 	})
 	if err != nil {

--- a/rfq/order.go
+++ b/rfq/order.go
@@ -14,6 +14,7 @@ import (
 	"github.com/lightninglabs/taproot-assets/rfqmath"
 	"github.com/lightninglabs/taproot-assets/rfqmsg"
 	"github.com/lightningnetwork/lnd/input"
+	"github.com/lightningnetwork/lnd/lnrpc/routerrpc"
 	"github.com/lightningnetwork/lnd/lnutils"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwire"
@@ -842,4 +843,13 @@ type HtlcInterceptor interface {
 	// InterceptHtlcs intercepts HTLCs, using the handling function provided
 	// to respond to HTLCs.
 	InterceptHtlcs(context.Context, lndclient.HtlcInterceptHandler) error
+}
+
+// HtlcSubscriber is an interface that contains the function necessary for
+// retrieving live HTLC event updates.
+type HtlcSubscriber interface {
+	// SubscribeHtlcEvents subscribes to a stream of events related to
+	// HTLC updates.
+	SubscribeHtlcEvents(ctx context.Context) (<-chan *routerrpc.HtlcEvent,
+		<-chan error, error)
 }

--- a/tapcfg/server.go
+++ b/tapcfg/server.go
@@ -395,6 +395,7 @@ func genServerConfig(cfg *Config, cfgLogger btclog.Logger,
 		rfq.ManagerCfg{
 			PeerMessenger:   msgTransportClient,
 			HtlcInterceptor: lndRouterClient,
+			HtlcSubscriber:  lndRouterClient,
 			PriceOracle:     priceOracle,
 			ChannelLister:   walletAnchor,
 			AliasManager:    lndRouterClient,


### PR DESCRIPTION
## Description

This PR adds a simple in-memory tracking of accepted htlcs in the RFQ policy level. HTLCs that passed the policy check are now tracked by each policy, possibly affecting future policy check outcomes (depends on individual policy's implementation)