### PR TITLE
tapcfg: add flag to disable default federation server

### DIFF
--- a/sample-tapd.conf
+++ b/sample-tapd.conf
@@ -282,6 +282,10 @@
 ; Can be specified multiple times
 ; universe.federationserver=
 
+; If set, the default Universe server (available for testnet and mainnet) will
+; not be added to the list of universe servers on startup
+; universe.no-default-federation=false
+
 ; If set, the federation syncer will default to syncing all assets
 ; universe.sync-all-assets=false
 

--- a/tapcfg/config.go
+++ b/tapcfg/config.go
@@ -275,6 +275,8 @@ type UniverseConfig struct {
 
 	FederationServers []string `long:"federationserver" description:"The host:port of a Universe server peer with. These servers will be added as the default set of federation servers. Can be specified multiple times."`
 
+	NoDefaultFederation bool `long:"no-default-federation" description:"If set, the default Universe server (available for testnet and mainnet) will not be added to the list of universe servers on startup."`
+
 	SyncAllAssets bool `long:"sync-all-assets" description:"If set, the federation syncer will default to syncing all assets."`
 
 	PublicAccess string `long:"public-access" description:"The public access mode for the universe server, controlling whether remote parties can read from and/or write to this universe server over RPC if exposed to a public network interface. This can be unset, 'r', 'w', or 'rw'. If unset, public access is not enabled for the universe server. If 'r' is included, public access is allowed for read-only endpoints. If 'w' is included, public access is allowed for write endpoints."`

--- a/tapcfg/server.go
+++ b/tapcfg/server.go
@@ -187,12 +187,19 @@ func genServerConfig(cfg *Config, cfgLogger btclog.Logger,
 	federationMembers := cfg.Universe.FederationServers
 	switch cfg.ChainConf.Network {
 	case "mainnet":
-		cfgLogger.Infof("Configuring %v as initial Universe "+
-			"federation server", defaultMainnetFederationServer)
+		// Add our default mainnet federation server to the list of
+		// federation servers if not disabled by the user for privacy
+		// reasons.
+		if !cfg.Universe.NoDefaultFederation {
+			cfgLogger.Infof("Configuring %v as initial Universe "+
+				"federation server",
+				defaultMainnetFederationServer)
 
-		federationMembers = append(
-			federationMembers, defaultMainnetFederationServer,
-		)
+			federationMembers = append(
+				federationMembers,
+				defaultMainnetFederationServer,
+			)
+		}
 
 		// For mainnet, we need to overwrite the default universe proof
 		// courier address to use the mainnet server.
@@ -204,12 +211,19 @@ func genServerConfig(cfg *Config, cfgLogger btclog.Logger,
 		}
 
 	case "testnet":
-		cfgLogger.Infof("Configuring %v as initial Universe "+
-			"federation server", defaultTestnetFederationServer)
+		// Add our default testnet federation server to the list of
+		// federation servers if not disabled by the user for privacy
+		// reasons.
+		if !cfg.Universe.NoDefaultFederation {
+			cfgLogger.Infof("Configuring %v as initial Universe "+
+				"federation server",
+				defaultTestnetFederationServer)
 
-		federationMembers = append(
-			federationMembers, defaultTestnetFederationServer,
-		)
+			federationMembers = append(
+				federationMembers,
+				defaultTestnetFederationServer,
+			)
+		}
 
 	default:
 		// For any other network, such as regtest, we can't use a


### PR DESCRIPTION
Fixes https://github.com/lightninglabs/taproot-assets/issues/1024.

This commit adds a new universe.no-default-federation boolean flag that allows the user to disable adding the default federation server.