### PR TITLE
Fee bumping when fee estimation doesn't meet min relay fee

### DIFF
--- a/itest/test_list_on_test.go
+++ b/itest/test_list_on_test.go
@@ -82,6 +82,10 @@ var testCases = []*testCase{
 		test: testBasicSendUnidirectional,
 	},
 	{
+		name: "min relay fee bump",
+		test: testMinRelayFeeBump,
+	},
+	{
 		name: "restart receiver check balance",
 		test: testRestartReceiverCheckBalance,
 	},


### PR DESCRIPTION
Both the minting transaction and normal on chain transactions suffer from edge cases where the fee estimation comes up with a fee that doesn't meet the current min relay fee. This PR changes that behavior by checking the estimated fee against the min relay fee, and bumps the fee if it doesn't clear the minimum fee height implied by min relay fee.

fixes #1171