### PR TITLE
Fix LitD itest CI

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -317,7 +317,7 @@ jobs:
       - name: Update go.mod to use the local Tap repository
         working-directory: ./lightning-terminal
         run: |
-          go mod edit -replace=github.com/lightning-labs/taproot-assets=../
+          go mod edit -replace=github.com/lightninglabs/taproot-assets=../
           go mod tidy
 
       - name: Install yarn


### PR DESCRIPTION
## Description

This PR fixes a typo in the `go.mod` replace directive for the taproot-assets dependency