### PR TITLE
rfq: fix precision issue in HTLC compliance check

### DIFF
--- a/rfq/order.go
+++ b/rfq/order.go
@@ -297,6 +297,13 @@ func (c *AssetPurchasePolicy) CheckHtlcCompliance(
 		return fmt.Errorf("error summing asset balance: %w", err)
 	}
 
+	// Due to rounding errors, we may slightly underreport the incoming
+	// value of the asset. So we increase it by exactly one asset unit to
+	// ensure that we do not reject the HTLC in the "inbound amount cannot
+	// be less than outbound amount" check below.
+	roundingCorrection := rfqmath.NewBigIntFromUint64(1)
+	assetAmt = assetAmt.Add(roundingCorrection)
+
 	// Convert the inbound asset amount to millisatoshis and ensure that the
 	// outgoing HTLC amount is not more than the inbound asset amount.
 	assetAmtFp := new(rfqmath.BigIntFixedPoint).SetIntValue(assetAmt)


### PR DESCRIPTION
Due to the integer nature of asset units, when converting to milli-satoshi and back, we might be off by a fraction of an asset unit when comparing to the milli-satoshi amount of an HTLC. We'll add a single asset unit to the reported inbound amount when checking in-out amount compliance to allow for those asset rounding imprecisions. In a real-world scenario where an asset has a decimal display value of 6, this would result in an imprecision of fractions of cents and be earned back by the spread on the actual conversion itself.