### PR TITLE
Mint with external asset group PSBT signer

### DIFF
--- a/tapgarden/planter.go
+++ b/tapgarden/planter.go
@@ -766,6 +766,13 @@ func buildGroupReqs(genesisPoint wire.OutPoint, assetOutputIndex uint32,
 		}
 	}
 
+	// Verify consistency: ensure the number of group key requests matches
+	// the number of group VM transactions.
+	if len(groupReqs) != len(genTXs) {
+		return nil, nil, fmt.Errorf("mismatched number of group " +
+			"requests and virtual TXs")
+	}
+
 	return groupReqs, genTXs, nil
 }
 
@@ -1051,11 +1058,6 @@ func listBatches(ctx context.Context, batchStore MintingStore,
 		if err != nil {
 			return nil, fmt.Errorf("unable to build group "+
 				"requests: %w", err)
-		}
-
-		if len(groupReqs) != len(genTXs) {
-			return nil, fmt.Errorf("mismatched number of group " +
-				"requests and virtual TXs")
 		}
 
 		// Copy existing seedlngs into the unsealed seedling map; we'll
@@ -1626,10 +1628,6 @@ func (c *ChainPlanter) sealBatch(ctx context.Context, params SealParams,
 	if err != nil {
 		return nil, fmt.Errorf("unable to build group requests: "+
 			"%w", err)
-	}
-	if len(groupReqs) != len(genTXs) {
-		return nil, fmt.Errorf("mismatched number of group requests " +
-			"and virtual TXs")
 	}
 
 	// Each provided group witness must have a corresponding seedling in the


### PR DESCRIPTION
This PR updates the `ChainPlanter` to enable the extraction of data required for an external signer to generate and produce the asset group witness.

This is a work in progress, and I am seeking early feedback on the approach. It follows the solution implementation proposed here: https://github.com/lightninglabs/taproot-assets/issues/1207

I think `SeedlingExternalSealPkg` should contain everything that the external signer needs to sign the PSBT.