### PR TITLE
[wallet]: fix signing interaction with lnd, allowing restore from seed

### DIFF
--- a/docs/examples/basic-price-oracle/go.mod
+++ b/docs/examples/basic-price-oracle/go.mod
@@ -92,11 +92,11 @@ require (
 	github.com/kkdai/bstream v1.0.0 // indirect
 	github.com/lib/pq v1.10.9 // indirect
 	github.com/lightninglabs/gozmq v0.0.0-20191113021534-d20a764486bf // indirect
-	github.com/lightninglabs/lndclient v0.18.4-5 // indirect
+	github.com/lightninglabs/lndclient v0.18.4-7 // indirect
 	github.com/lightninglabs/neutrino v0.16.1-0.20240425105051-602843d34ffd // indirect
 	github.com/lightninglabs/neutrino/cache v1.1.2 // indirect
 	github.com/lightningnetwork/lightning-onion v1.2.1-0.20240712235311-98bd56499dfb // indirect
-	github.com/lightningnetwork/lnd v0.18.3-beta.rc3.0.20241120143113-9246d5c51cd2 // indirect
+	github.com/lightningnetwork/lnd v0.18.4-beta.rc1 // indirect
 	github.com/lightningnetwork/lnd/clock v1.1.1 // indirect
 	github.com/lightningnetwork/lnd/fn v1.2.3 // indirect
 	github.com/lightningnetwork/lnd/healthcheck v1.2.5 // indirect

--- a/docs/examples/basic-price-oracle/go.sum
+++ b/docs/examples/basic-price-oracle/go.sum
@@ -418,8 +418,8 @@ github.com/lightninglabs/gozmq v0.0.0-20191113021534-d20a764486bf/go.mod h1:vxmQ
 github.com/lightninglabs/lightning-node-connect v0.2.5-alpha h1:ZRVChwczFXK0CEbxOCWwUA6TIZvrkE0APd1T3WjFAwg=
 github.com/lightninglabs/lightning-node-connect/hashmailrpc v1.0.2 h1:Er1miPZD2XZwcfE4xoS5AILqP1mj7kqnhbBSxW9BDxY=
 github.com/lightninglabs/lightning-node-connect/hashmailrpc v1.0.2/go.mod h1:antQGRDRJiuyQF6l+k6NECCSImgCpwaZapATth2Chv4=
-github.com/lightninglabs/lndclient v0.18.4-5 h1:KokX5ZlFuZEmtD7sHWg1cXzee0ZsnBWuSKV9/RcTEv4=
-github.com/lightninglabs/lndclient v0.18.4-5/go.mod h1:tafbfrisn1Iwt3em3nYWdE06C8jpoZtpNyiSB485OCg=
+github.com/lightninglabs/lndclient v0.18.4-7 h1:3lV3jeaL66wtxFeR+7YTo+1ZJ8YzD3gYHG8U9yas3YM=
+github.com/lightninglabs/lndclient v0.18.4-7/go.mod h1:qaIx+eqEV+Bdf1j7GVeJiDqJbtZXsr9XTfHu/8HmgQU=
 github.com/lightninglabs/neutrino v0.16.1-0.20240425105051-602843d34ffd h1:D8aRocHpoCv43hL8egXEMYyPmyOiefFHZ66338KQB2s=
 github.com/lightninglabs/neutrino v0.16.1-0.20240425105051-602843d34ffd/go.mod h1:x3OmY2wsA18+Kc3TSV2QpSUewOCiscw2mKpXgZv2kZk=
 github.com/lightninglabs/neutrino/cache v1.1.2 h1:C9DY/DAPaPxbFC+xNNEI/z1SJY9GS3shmlu5hIQ798g=
@@ -428,8 +428,8 @@ github.com/lightninglabs/protobuf-go-hex-display v1.33.0-hex-display h1:Y2WiPkBS
 github.com/lightninglabs/protobuf-go-hex-display v1.33.0-hex-display/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 github.com/lightningnetwork/lightning-onion v1.2.1-0.20240712235311-98bd56499dfb h1:yfM05S8DXKhuCBp5qSMZdtSwvJ+GFzl94KbXMNB1JDY=
 github.com/lightningnetwork/lightning-onion v1.2.1-0.20240712235311-98bd56499dfb/go.mod h1:c0kvRShutpj3l6B9WtTsNTBUtjSmjZXbJd9ZBRQOSKI=
-github.com/lightningnetwork/lnd v0.18.3-beta.rc3.0.20241120143113-9246d5c51cd2 h1:zGnSH1gTpPA637465d5tp7VkdWw5sVyWZxxmfZ0rKo4=
-github.com/lightningnetwork/lnd v0.18.3-beta.rc3.0.20241120143113-9246d5c51cd2/go.mod h1:nPRQzLla5uHPQFyyZn8r9Vgddkd23PBUDa9rggEPOfY=
+github.com/lightningnetwork/lnd v0.18.4-beta.rc1 h1:z6hFKvtbfo8udPrIb81GbSoKlUWd06d4LRxTkD19IMQ=
+github.com/lightningnetwork/lnd v0.18.4-beta.rc1/go.mod h1:nPRQzLla5uHPQFyyZn8r9Vgddkd23PBUDa9rggEPOfY=
 github.com/lightningnetwork/lnd/clock v1.1.1 h1:OfR3/zcJd2RhH0RU+zX/77c0ZiOnIMsDIBjgjWdZgA0=
 github.com/lightningnetwork/lnd/clock v1.1.1/go.mod h1:mGnAhPyjYZQJmebS7aevElXKTFDuO+uNFFfMXK1W8xQ=
 github.com/lightningnetwork/lnd/fn v1.2.3 h1:Q1OrgNSgQynVheBNa16CsKVov1JI5N2AR6G07x9Mles=

--- a/go.mod
+++ b/go.mod
@@ -26,9 +26,9 @@ require (
 	github.com/lib/pq v1.10.9
 	github.com/lightninglabs/aperture v0.3.2-beta.0.20241015115230-d59b5514c19a
 	github.com/lightninglabs/lightning-node-connect/hashmailrpc v1.0.2
-	github.com/lightninglabs/lndclient v0.18.4-5
+	github.com/lightninglabs/lndclient v0.18.4-7
 	github.com/lightninglabs/neutrino/cache v1.1.2
-	github.com/lightningnetwork/lnd v0.18.3-beta.rc3.0.20241120143113-9246d5c51cd2
+	github.com/lightningnetwork/lnd v0.18.4-beta.rc1
 	github.com/lightningnetwork/lnd/cert v1.2.2
 	github.com/lightningnetwork/lnd/clock v1.1.1
 	github.com/lightningnetwork/lnd/fn v1.2.3

--- a/go.sum
+++ b/go.sum
@@ -486,8 +486,8 @@ github.com/lightninglabs/lightning-node-connect v0.2.5-alpha h1:ZRVChwczFXK0CEbx
 github.com/lightninglabs/lightning-node-connect v0.2.5-alpha/go.mod h1:A9Pof9fETkH+F67BnOmrBDThPKstqp73wlImWOZvTXQ=
 github.com/lightninglabs/lightning-node-connect/hashmailrpc v1.0.2 h1:Er1miPZD2XZwcfE4xoS5AILqP1mj7kqnhbBSxW9BDxY=
 github.com/lightninglabs/lightning-node-connect/hashmailrpc v1.0.2/go.mod h1:antQGRDRJiuyQF6l+k6NECCSImgCpwaZapATth2Chv4=
-github.com/lightninglabs/lndclient v0.18.4-5 h1:KokX5ZlFuZEmtD7sHWg1cXzee0ZsnBWuSKV9/RcTEv4=
-github.com/lightninglabs/lndclient v0.18.4-5/go.mod h1:tafbfrisn1Iwt3em3nYWdE06C8jpoZtpNyiSB485OCg=
+github.com/lightninglabs/lndclient v0.18.4-7 h1:3lV3jeaL66wtxFeR+7YTo+1ZJ8YzD3gYHG8U9yas3YM=
+github.com/lightninglabs/lndclient v0.18.4-7/go.mod h1:qaIx+eqEV+Bdf1j7GVeJiDqJbtZXsr9XTfHu/8HmgQU=
 github.com/lightninglabs/neutrino v0.16.1-0.20240425105051-602843d34ffd h1:D8aRocHpoCv43hL8egXEMYyPmyOiefFHZ66338KQB2s=
 github.com/lightninglabs/neutrino v0.16.1-0.20240425105051-602843d34ffd/go.mod h1:x3OmY2wsA18+Kc3TSV2QpSUewOCiscw2mKpXgZv2kZk=
 github.com/lightninglabs/neutrino/cache v1.1.2 h1:C9DY/DAPaPxbFC+xNNEI/z1SJY9GS3shmlu5hIQ798g=
@@ -496,8 +496,8 @@ github.com/lightninglabs/protobuf-go-hex-display v1.33.0-hex-display h1:Y2WiPkBS
 github.com/lightninglabs/protobuf-go-hex-display v1.33.0-hex-display/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 github.com/lightningnetwork/lightning-onion v1.2.1-0.20240712235311-98bd56499dfb h1:yfM05S8DXKhuCBp5qSMZdtSwvJ+GFzl94KbXMNB1JDY=
 github.com/lightningnetwork/lightning-onion v1.2.1-0.20240712235311-98bd56499dfb/go.mod h1:c0kvRShutpj3l6B9WtTsNTBUtjSmjZXbJd9ZBRQOSKI=
-github.com/lightningnetwork/lnd v0.18.3-beta.rc3.0.20241120143113-9246d5c51cd2 h1:zGnSH1gTpPA637465d5tp7VkdWw5sVyWZxxmfZ0rKo4=
-github.com/lightningnetwork/lnd v0.18.3-beta.rc3.0.20241120143113-9246d5c51cd2/go.mod h1:nPRQzLla5uHPQFyyZn8r9Vgddkd23PBUDa9rggEPOfY=
+github.com/lightningnetwork/lnd v0.18.4-beta.rc1 h1:z6hFKvtbfo8udPrIb81GbSoKlUWd06d4LRxTkD19IMQ=
+github.com/lightningnetwork/lnd v0.18.4-beta.rc1/go.mod h1:nPRQzLla5uHPQFyyZn8r9Vgddkd23PBUDa9rggEPOfY=
 github.com/lightningnetwork/lnd/cert v1.2.2 h1:71YK6hogeJtxSxw2teq3eGeuy4rHGKcFf0d0Uy4qBjI=
 github.com/lightningnetwork/lnd/cert v1.2.2/go.mod h1:jQmFn/Ez4zhDgq2hnYSw8r35bqGVxViXhX6Cd7HXM6U=
 github.com/lightningnetwork/lnd/clock v1.1.1 h1:OfR3/zcJd2RhH0RU+zX/77c0ZiOnIMsDIBjgjWdZgA0=

--- a/itest/send_test.go
+++ b/itest/send_test.go
@@ -1954,6 +1954,91 @@ func testSendNoCourierUniverseImport(t *harnessTest) {
 	AssertSendEventsComplete(t.t, receiveAddr.ScriptKey, sendEvents)
 }
 
+// testRestoreLndFromSeed tests that we can restore an LND node from a seed and
+// then continue to interact with assets previously minted on the node.
+func testRestoreLndFromSeed(t *harnessTest) {
+	// We create a new lnd node from a seed, so we can restore it with the
+	// same seed later.
+	password := []byte("somepassword")
+	seedLnd, mnemonic, _ := t.lndHarness.NewNodeWithSeed(
+		"seed-lnd", lndDefaultArgs, password, false,
+	)
+	t.lndHarness.FundCoins(btcutil.SatoshiPerBitcoin, seedLnd)
+
+	// We're going to restart Bob at some point, so we don't do a deferred
+	// shutdown here.
+	bob := setupTapdHarness(t.t, t, seedLnd, t.universeServer)
+
+	// We mint a batch of normal assets with enough units to allow us to
+	// send it around a few times.
+	rpcAssets := MintAssetsConfirmBatch(
+		t.t, t.lndHarness.Miner().Client, bob,
+		[]*mintrpc.MintAssetRequest{issuableAssets[0]},
+	)
+
+	var (
+		alice    = t.tapd
+		ctxb     = context.Background()
+		rpcAsset = rpcAssets[0]
+		genInfo  = rpcAsset.AssetGenesis
+	)
+
+	// We send some of the minted assets to our default tapd node.
+	const sendAmount = 123
+	aliceAddr, err := alice.NewAddr(ctxb, &taprpc.NewAddrRequest{
+		AssetId: genInfo.AssetId,
+		Amt:     sendAmount,
+	})
+	require.NoError(t.t, err)
+
+	AssertAddrCreated(t.t, alice, rpcAsset, aliceAddr)
+
+	sendResp, sendEvents := sendAssetsToAddr(t, bob, aliceAddr)
+
+	ConfirmAndAssertOutboundTransfer(
+		t.t, t.lndHarness.Miner().Client, bob, sendResp,
+		genInfo.AssetId,
+		[]uint64{rpcAsset.Amount - sendAmount, sendAmount}, 0, 1,
+	)
+	AssertNonInteractiveRecvComplete(t.t, alice, 1)
+	AssertSendEventsComplete(t.t, aliceAddr.ScriptKey, sendEvents)
+
+	// We now restore Bob's lnd node from the seed.
+	require.NoError(t.t, bob.stop(false))
+	require.NoError(t.t, seedLnd.Shutdown())
+
+	// Starting the node again should restore it to the same state as
+	// before. This takes a couple of seconds, so let's log that we're
+	// waiting for the node to start.
+	t.Logf("Restoring node from seed, this may take a few seconds...")
+	seedLnd = t.lndHarness.RestoreNodeWithSeed(
+		"lnd-seed-restored", lndDefaultArgs, password, mnemonic, "",
+		2500, nil,
+	)
+	require.NoError(t.t, updateConfigWithNode(bob.clientCfg, seedLnd))
+
+	require.NoError(t.t, bob.start(false))
+
+	// Let's make sure we properly clean up the node at the end of the test.
+	defer func() {
+		require.NoError(t.t, bob.stop(!*noDelete))
+	}()
+
+	// Send more assets after restoring the node.
+	aliceAddr, err = alice.NewAddr(ctxb, &taprpc.NewAddrRequest{
+		AssetId: genInfo.AssetId,
+		Amt:     sendAmount,
+	})
+	require.NoError(t.t, err)
+
+	AssertAddrCreated(t.t, alice, rpcAsset, aliceAddr)
+
+	sendAsset(
+		t, bob, withReceiverAddresses(aliceAddr),
+		withError("invalid transfer asset witness"),
+	)
+}
+
 // addProofTestVectorFromFile adds a proof test vector by extracting it from the
 // proof file found at the given asset ID and script key.
 func addProofTestVectorFromFile(t *testing.T, testName string,

--- a/itest/send_test.go
+++ b/itest/send_test.go
@@ -2033,10 +2033,15 @@ func testRestoreLndFromSeed(t *harnessTest) {
 
 	AssertAddrCreated(t.t, alice, rpcAsset, aliceAddr)
 
-	sendAsset(
-		t, bob, withReceiverAddresses(aliceAddr),
-		withError("invalid transfer asset witness"),
+	sendResp, sendEvents = sendAssetsToAddr(t, bob, aliceAddr)
+
+	ConfirmAndAssertOutboundTransfer(
+		t.t, t.lndHarness.Miner().Client, bob, sendResp,
+		genInfo.AssetId,
+		[]uint64{rpcAsset.Amount - sendAmount*2, sendAmount}, 1, 2,
 	)
+	AssertNonInteractiveRecvComplete(t.t, alice, 2)
+	AssertSendEventsComplete(t.t, aliceAddr.ScriptKey, sendEvents)
 }
 
 // addProofTestVectorFromFile adds a proof test vector by extracting it from the

--- a/itest/test_list_on_test.go
+++ b/itest/test_list_on_test.go
@@ -324,6 +324,10 @@ var testCases = []*testCase{
 		name: "ownership verification",
 		test: testOwnershipVerification,
 	},
+	{
+		name: "asset signing after lnd restore from seed",
+		test: testRestoreLndFromSeed,
+	},
 }
 
 var optionalTestCases = []*testCase{

--- a/virtual_tx_signer.go
+++ b/virtual_tx_signer.go
@@ -29,7 +29,7 @@ func NewLndRpcVirtualTxSigner(lnd *lndclient.LndServices) *LndRpcVirtualTxSigner
 func (l *LndRpcVirtualTxSigner) SignVirtualTx(signDesc *lndclient.SignDescriptor,
 	tx *wire.MsgTx, prevOut *wire.TxOut) (*schnorr.Signature, error) {
 
-	sigs, err := l.lnd.Signer.SignOutputRaw(
+	sigs, err := l.lnd.Signer.SignOutputRawKeyLocator(
 		context.Background(), tx, []*lndclient.SignDescriptor{signDesc},
 		[]*wire.TxOut{prevOut},
 	)


### PR DESCRIPTION
Fixes https://github.com/lightninglabs/taproot-assets/issues/1208.

Depends on https://github.com/lightninglabs/lndclient/pull/203.

Fixes an issue with how we tell `lnd` what key to sign. This basically boils down to a weird behavior in `lndclient` that we now circumvent with a new signing method.