### PR TITLE
rpc: try to catch EOF error from lnd sendpayment

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -7193,7 +7193,12 @@ func (r *rpcServer) SendPayment(req *tchrpc.SendPaymentRequest,
 
 		update, err := updateStream.Recv()
 		if err != nil {
-			return err
+			// Stream is closed; no more updates.
+			if err == io.EOF {
+				return nil
+			}
+			return fmt.Errorf("failed to receive payment "+
+				"update: %w", err)
 		}
 
 		err = stream.Send(&tchrpc.SendPaymentResponse{


### PR DESCRIPTION
A user observed that when using Python, they get an EOF even if the payment succeeds. My guess is that `lnd` has hung up, then we try to recv and get an EOF error. With this PR, we try to catch that EOF error and just return `nil`. 

One other idea: do we need to call `CloseSend` at the very end or in a defer?

Fixes: https://github.com/lightninglabs/taproot-assets/issues/1216