### PR TITLE
version: bump to version v0.5.0-alpha.rc1

### DIFF
--- a/version.go
+++ b/version.go
@@ -42,17 +42,17 @@ const (
 	AppMajor uint = 0
 
 	// AppMinor defines the minor version of this binary.
-	AppMinor uint = 4
+	AppMinor uint = 5
 
 	// AppPatch defines the application patch for this binary.
-	AppPatch uint = 1
+	AppPatch uint = 0
 
 	// AppStatus defines the release status of this binary (e.g. beta).
 	AppStatus = "alpha"
 
 	// AppPreRelease defines the pre-release version of this binary.
 	// It MUST only contain characters from the semantic versioning spec.
-	AppPreRelease = ""
+	AppPreRelease = "rc1"
 
 	// GitTagIncludeStatus indicates whether the status should be included
 	// in the git tag name.


### PR DESCRIPTION
Prepare for tagging a first RC of `v0.5.0-alpha`.

To be merged **AFTER** https://github.com/lightninglabs/taproot-assets/pull/1209.

Requesting review from the whole team to share the joy of achieving this milestone.