### PR TITLE
rfq: fix potential nil pointer panic

### DIFF
--- a/rfq/negotiator.go
+++ b/rfq/negotiator.go
@@ -194,7 +194,9 @@ func (n *Negotiator) HandleOutgoingBuyOrder(buyOrder BuyOrder) error {
 					"request: %v", err)
 			}
 
-			assetRateHint = fn.Some[rfqmsg.AssetRate](*assetRate)
+			assetRateHint = fn.MaybeSome[rfqmsg.AssetRate](
+				assetRate,
+			)
 		}
 
 		// Construct a new buy request to send to the peer.


### PR DESCRIPTION
Fixes https://github.com/lightninglabs/taproot-assets/issues/1227.

Because we don't return if the error returned from the price oracle is non-nil, the asset rate might be nil in case we couldn't talk to the oracle. So we need to use fn.MaybeSome() instead of fn.Some() with a dereference.