### PR TITLE
Refactor GroupKeyReveal for multi-version support

### DIFF
--- a/asset/asset.go
+++ b/asset/asset.go
@@ -989,13 +989,6 @@ func (g *GroupKeyRevealV0) SetTapscriptRoot(tapscriptRoot []byte) {
 	g.tapscriptRoot = tapscriptRoot
 }
 
-// PendingGroupWitness specifies the asset group witness for an asset seedling
-// in an unsealed minting batch.
-type PendingGroupWitness struct {
-	GenID   ID
-	Witness wire.TxWitness
-}
-
 // GroupPubKey returns the group public key derived from the group key reveal.
 func (g *GroupKeyRevealV0) GroupPubKey(assetID ID) (*btcec.PublicKey, error) {
 	rawKey, err := g.RawKey().ToPubKey()
@@ -1542,6 +1535,13 @@ func DeriveGroupKey(genSigner GenesisSigner, genTx GroupVirtualTx,
 		TapscriptRoot: signDesc.TapTweak,
 		Witness:       witness,
 	}, nil
+}
+
+// PendingGroupWitness specifies the asset group witness for an asset seedling
+// in an unsealed minting batch.
+type PendingGroupWitness struct {
+	GenID   ID
+	Witness wire.TxWitness
 }
 
 // Asset represents a Taproot asset.

--- a/asset/asset.go
+++ b/asset/asset.go
@@ -996,17 +996,18 @@ func (g *GroupKeyRevealV0) GroupPubKey(assetID ID) (*btcec.PublicKey, error) {
 		return nil, fmt.Errorf("group reveal raw key invalid: %w", err)
 	}
 
-	return GroupPubKey(rawKey, assetID[:], g.TapscriptRoot())
+	return GroupPubKeyV0(rawKey, assetID[:], g.TapscriptRoot())
 }
 
-// GroupPubKey derives a tweaked group key from a public key and two tweaks;
-// the single tweak is the asset ID of the group anchor asset, and the tapTweak
-// is the root of a tapscript tree that commits to script-based conditions for
-// reissuing assets as part of this asset group. The tweaked key is defined by:
+// GroupPubKeyV0 derives a version 0 tweaked group key from a public key and two
+// tweaks; the single tweak is the asset ID of the group anchor asset, and the
+// tapTweak is the root of a tapscript tree that commits to script-based
+// conditions for reissuing assets as part of this asset group. The tweaked key
+// is defined by:
 //
 //	internalKey = rawKey + singleTweak * G
 //	tweakedGroupKey = TapTweak(internalKey, tapTweak)
-func GroupPubKey(rawKey *btcec.PublicKey, singleTweak, tapTweak []byte) (
+func GroupPubKeyV0(rawKey *btcec.PublicKey, singleTweak, tapTweak []byte) (
 	*btcec.PublicKey, error) {
 
 	if len(singleTweak) != sha256.Size {
@@ -1417,7 +1418,7 @@ func (req *GroupKeyRequest) BuildGroupVirtualTx(genBuilder GenesisTxBuilder) (
 	// Compute the tweaked group key and set it in the asset before
 	// creating the virtual minting transaction.
 	genesisTweak := req.AnchorGen.ID()
-	tweakedGroupKey, err := GroupPubKey(
+	tweakedGroupKey, err := GroupPubKeyV0(
 		req.RawKey.PubKey, genesisTweak[:], req.TapscriptRoot,
 	)
 	if err != nil {

--- a/asset/asset_test.go
+++ b/asset/asset_test.go
@@ -920,10 +920,10 @@ func TestAssetGroupKey(t *testing.T) {
 
 	// Group key tweaking should fail when given invalid tweaks.
 	badTweak := test.RandBytes(33)
-	_, err = GroupPubKey(groupPub, badTweak, badTweak)
+	_, err = GroupPubKeyV0(groupPub, badTweak, badTweak)
 	require.Error(t, err)
 
-	_, err = GroupPubKey(groupPub, groupTweak[:], badTweak)
+	_, err = GroupPubKeyV0(groupPub, groupTweak[:], badTweak)
 	require.Error(t, err)
 }
 

--- a/asset/mock.go
+++ b/asset/mock.go
@@ -971,13 +971,14 @@ func (tgr *TestGenesisReveal) ToGenesisReveal(t testing.TB) *Genesis {
 }
 
 func NewTestFromGroupKeyReveal(t testing.TB,
-	gkr *GroupKeyReveal) *TestGroupKeyReveal {
+	gkr GroupKeyReveal) *TestGroupKeyReveal {
 
 	t.Helper()
 
+	rawKey := gkr.RawKey()
 	return &TestGroupKeyReveal{
-		RawKey:        hex.EncodeToString(gkr.RawKey[:]),
-		TapscriptRoot: hex.EncodeToString(gkr.TapscriptRoot),
+		RawKey:        hex.EncodeToString(rawKey[:]),
+		TapscriptRoot: hex.EncodeToString(gkr.TapscriptRoot()),
 	}
 }
 
@@ -986,15 +987,12 @@ type TestGroupKeyReveal struct {
 	TapscriptRoot string `json:"tapscript_root"`
 }
 
-func (tgkr *TestGroupKeyReveal) ToGroupKeyReveal(t testing.TB) *GroupKeyReveal {
+func (tgkr *TestGroupKeyReveal) ToGroupKeyReveal(t testing.TB) GroupKeyReveal {
 	t.Helper()
 
 	rawKey := test.ParsePubKey(t, tgkr.RawKey)
 	tapscriptRoot, err := hex.DecodeString(tgkr.TapscriptRoot)
 	require.NoError(t, err)
 
-	return &GroupKeyReveal{
-		RawKey:        ToSerialized(rawKey),
-		TapscriptRoot: tapscriptRoot,
-	}
+	return NewGroupKeyRevealV0(ToSerialized(rawKey), tapscriptRoot)
 }

--- a/itest/assertions.go
+++ b/itest/assertions.go
@@ -1403,7 +1403,7 @@ func AssertGroupAnchor(t *testing.T, anchorGen *asset.Genesis,
 
 	// TODO(jhb): add tapscript root support
 	anchorTweak := anchorGen.ID()
-	computedGroupPubKey, err := asset.GroupPubKey(
+	computedGroupPubKey, err := asset.GroupPubKeyV0(
 		internalPubKey, anchorTweak[:], nil,
 	)
 	require.NoError(t, err)

--- a/proof/mint.go
+++ b/proof/mint.go
@@ -388,12 +388,11 @@ func committedProofs(baseProof *Proof, tapTreeRoot *commitment.TapCommitment,
 
 			err := groupAnchorVerifier(&newAsset.Genesis, groupKey)
 			if err == nil {
-				groupReveal := &asset.GroupKeyReveal{
-					RawKey: asset.ToSerialized(
-						groupKey.RawKey.PubKey,
-					),
-					TapscriptRoot: groupKey.TapscriptRoot,
-				}
+				rawKey := asset.ToSerialized(
+					groupKey.RawKey.PubKey,
+				)
+				groupReveal := asset.NewGroupKeyRevealV0(
+					rawKey, groupKey.TapscriptRoot)
 				assetProof.GroupKeyReveal = groupReveal
 			}
 		}

--- a/proof/mock.go
+++ b/proof/mock.go
@@ -39,10 +39,10 @@ func RandProof(t testing.TB, genesis asset.Genesis,
 		t, genesis, 1, 0, 0, tweakedScriptKey, nil,
 	)
 	groupKey := asset.RandGroupKey(t, genesis, protoAsset)
-	groupReveal := asset.GroupKeyReveal{
-		RawKey:        asset.ToSerialized(&groupKey.GroupPubKey),
-		TapscriptRoot: test.RandBytes(32),
-	}
+	groupReveal := asset.NewGroupKeyRevealV0(
+		asset.ToSerialized(&groupKey.GroupPubKey),
+		test.RandBytes(32),
+	)
 
 	amount := uint64(1)
 	mintCommitment, assets, err := commitment.Mint(
@@ -146,7 +146,7 @@ func RandProof(t testing.TB, genesis asset.Genesis,
 		},
 		ChallengeWitness: wire.TxWitness{[]byte("foo"), []byte("bar")},
 		GenesisReveal:    &genesis,
-		GroupKeyReveal:   &groupReveal,
+		GroupKeyReveal:   groupReveal,
 	}
 }
 

--- a/proof/proof.go
+++ b/proof/proof.go
@@ -301,11 +301,13 @@ type Proof struct {
 	// re-derivation of the asset group key.
 	GenesisReveal *asset.Genesis
 
-	// GroupKeyReveal is an optional set of bytes that represent the public
-	// key and Tapscript root used to derive the final tweaked group key for
-	// the asset group. This field must be provided for issuance proofs of
-	// grouped assets.
-	GroupKeyReveal *asset.GroupKeyReveal
+	// GroupKeyReveal contains the data required to derive the final tweaked
+	// group key for an asset group.
+	//
+	// NOTE: This field is mandatory for the group anchor (i.e., the initial
+	// minting tranche of an asset group). Subsequent minting tranches
+	// require only a valid signature for the previously revealed group key.
+	GroupKeyReveal asset.GroupKeyReveal
 
 	// UnknownOddTypes is a map of unknown odd types that were encountered
 	// during decoding. This map is used to preserve unknown types that we

--- a/proof/records.go
+++ b/proof/records.go
@@ -378,14 +378,14 @@ func GenesisRevealRecord(genesis **asset.Genesis) tlv.Record {
 	)
 }
 
-func GroupKeyRevealRecord(reveal **asset.GroupKeyReveal) tlv.Record {
+func GroupKeyRevealRecord(reveal *asset.GroupKeyReveal) tlv.Record {
 	recordSize := func() uint64 {
 		if reveal == nil || *reveal == nil {
 			return 0
 		}
 		r := *reveal
 		return uint64(
-			btcec.PubKeyBytesLenCompressed + len(r.TapscriptRoot),
+			btcec.PubKeyBytesLenCompressed + len(r.TapscriptRoot()),
 		)
 	}
 	return tlv.MakeDynamicRecord(

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -1817,9 +1817,10 @@ func (r *rpcServer) marshalProof(ctx context.Context, p *proof.Proof,
 
 	var GroupKeyReveal taprpc.GroupKeyReveal
 	if rpcGroupKey != nil {
+		rawKey := rpcGroupKey.RawKey()
 		GroupKeyReveal = taprpc.GroupKeyReveal{
-			RawGroupKey:   rpcGroupKey.RawKey[:],
-			TapscriptRoot: rpcGroupKey.TapscriptRoot,
+			RawGroupKey:   rawKey[:],
+			TapscriptRoot: rpcGroupKey.TapscriptRoot(),
 		}
 	}
 

--- a/tapdb/universe.go
+++ b/tapdb/universe.go
@@ -273,7 +273,7 @@ func upsertAssetGen(ctx context.Context, db UpsertAssetStore,
 		// key.
 		if genesisProof.GroupKeyReveal != nil {
 			reveal := genesisProof.GroupKeyReveal
-			rawKey, err := reveal.RawKey.ToPubKey()
+			rawKey, err := reveal.RawKey().ToPubKey()
 			if err != nil {
 				return 0, err
 			}
@@ -281,7 +281,7 @@ func upsertAssetGen(ctx context.Context, db UpsertAssetStore,
 			fullGroupKey.RawKey = keychain.KeyDescriptor{
 				PubKey: rawKey,
 			}
-			fullGroupKey.TapscriptRoot = reveal.TapscriptRoot
+			fullGroupKey.TapscriptRoot = reveal.TapscriptRoot()
 		}
 		_, err = upsertGroupKey(
 			ctx, fullGroupKey, db, genPointID, genAssetID,

--- a/tapdb/universe_test.go
+++ b/tapdb/universe_test.go
@@ -212,9 +212,9 @@ func randMintingLeaf(t *testing.T, assetGen asset.Genesis,
 
 		leaf.GroupKey = assetGroupKey
 		randProof.Asset.GroupKey = assetGroupKey
-		randProof.GroupKeyReveal = &asset.GroupKeyReveal{
-			RawKey: asset.ToSerialized(groupKey),
-		}
+		randProof.GroupKeyReveal = asset.NewGroupKeyRevealV0(
+			asset.ToSerialized(groupKey), nil,
+		)
 	}
 
 	leaf.Asset = &randProof.Asset

--- a/tapgarden/caretaker.go
+++ b/tapgarden/caretaker.go
@@ -1562,7 +1562,7 @@ func GenRawGroupAnchorVerifier(ctx context.Context) func(*asset.Genesis,
 		groupAnchor, err := groupAnchors.Get(assetGroupKey)
 		if err != nil {
 			singleTweak := gen.ID()
-			tweakedGroupKey, err := asset.GroupPubKey(
+			tweakedGroupKey, err := asset.GroupPubKeyV0(
 				groupKey.RawKey.PubKey, singleTweak[:],
 				groupKey.TapscriptRoot,
 			)


### PR DESCRIPTION
Rename the existing `GroupKeyReveal` struct to `GroupKeyRevealV0` and introduce a new `GroupKeyReveal` interface. This change enables adding new versions of `GroupKeyReveal` while retaining the V0 type for proper documentation of its behavior.

Support for `GroupKeyReveal` V0 will be preserved.