### PR TITLE
Update release notes template re timestamps

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,7 +29,7 @@ jobs:
         run: |
           expected_tag=$(./scripts/get-git-tag-name.sh version.go)
           actual_tag=${{ env.RELEASE_VERSION }}
-          
+
           if [ "$actual_tag" = "$expected_tag" ]; then
             echo "Git tag release string is as expected."
           else
@@ -87,14 +87,17 @@ jobs:
 
             ## Verifying the Release Timestamp 
 
-            From this new version onwards, in addition time-stamping the _git tag_ with [OpenTimestamps](https://opentimestamps.org/), we'll also now timestamp the manifest file along with its signature. Two new files are now included along with the rest of our release artifacts: ` manifest-roasbeef-${{ env.RELEASE_VERSION }}.txt.asc.ots`.
+            In addition to time-stamping the _git tag_ with [OpenTimestamps](https://opentimestamps.org/), we also timestamp the manifest file along with its signature. Two files are included in our release artifacts: `manifest-roasbeef-${{ env.RELEASE_VERSION }}.sig.ots` and `manifest-${{ env.RELEASE_VERSION }}.txt.ots`.
 
             Assuming you have the opentimestamps client installed locally, the timestamps can be verified with the following commands: 
             ```
             ots verify manifest-roasbeef-${{ env.RELEASE_VERSION }}.sig.ots -f manifest-roasbeef-${{ env.RELEASE_VERSION }}.sig
+            ots verify manifest-${{ env.RELEASE_VERSION }}.txt.ots -f manifest-${{ env.RELEASE_VERSION }}.txt
             ```
 
-            Alternatively, [the OpenTimestamps website](https://opentimestamps.org/) can be used to verify timestamps if one doesn't have a `bitcoind` instance accessible locally.
+            Alternatively, [the OpenTimestamps website](https://opentimestamps.org/) can be used to verify these timestamps if one doesn't have a `bitcoind` instance accessible locally.
+
+            Assuming you are using the [OpenTimestamps `ots-git-gpg-wrapper`](https://github.com/opentimestamps/opentimestamps-client/blob/master/doc/git-integration.md#usage) you can verify the timestamp of the _git tag_ by  verifying the tag as explained in _Verifying the Release Binaries_.
 
             These timestamps should give users confidence in the integrity of this release even after the key that signed the release expires. 
 


### PR DESCRIPTION
The release notes template has been updated to improve the paragraph on
timestamps. It now correctly specifies both ots artifacts and how to use
them to verify the timestamps of the manifest and its signature.

Secondly, the template now explains how the timestamp of the _git tag_
can be verified by using the OpenTimestamps git wrapper.