### PR TITLE
[custom channels]: add decimal display to channel funding blob

### DIFF
--- a/address/address.go
+++ b/address/address.go
@@ -14,7 +14,6 @@ import (
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
-	"github.com/decred/dcrd/dcrec/secp256k1/v4"
 	"github.com/lightninglabs/taproot-assets/asset"
 	"github.com/lightninglabs/taproot-assets/commitment"
 	"github.com/lightninglabs/taproot-assets/fn"
@@ -536,49 +535,4 @@ func DecodeAddress(addr string, net *ChainParams) (*Tap, error) {
 	}
 
 	return &a, nil
-}
-
-// GenChallengeNUMS generates a variant of the NUMS script key that is modified
-// by the provided challenge.
-//
-//	The resulting scriptkey is:
-//	res := NUMS + challenge*G
-func GenChallengeNUMS(challengeBytesOpt fn.Option[[32]byte]) asset.ScriptKey {
-	var (
-		nums, g, res btcec.JacobianPoint
-		challenge    secp256k1.ModNScalar
-	)
-
-	if challengeBytesOpt.IsNone() {
-		return asset.NUMSScriptKey
-	}
-
-	var challengeBytes [32]byte
-
-	challengeBytesOpt.WhenSome(func(b [32]byte) {
-		challengeBytes = b
-	})
-
-	// Convert the NUMS key to a Jacobian point.
-	asset.NUMSPubKey.AsJacobian(&nums)
-
-	// Multiply G by 1 to get G as a Jacobian point.
-	secp256k1.ScalarBaseMultNonConst(
-		new(secp256k1.ModNScalar).SetInt(1), &g,
-	)
-
-	// Convert the challenge to a scalar.
-	challenge.SetByteSlice(challengeBytes[:])
-
-	// Calculate res = challenge * G.
-	secp256k1.ScalarMultNonConst(&challenge, &g, &res)
-
-	// Calculate res = nums + res.
-	secp256k1.AddNonConst(&nums, &res, &res)
-
-	res.ToAffine()
-
-	resultPubKey := btcec.NewPublicKey(&res.X, &res.Y)
-
-	return asset.NewScriptKey(resultPubKey)
 }

--- a/address/address.go
+++ b/address/address.go
@@ -17,6 +17,7 @@ import (
 	"github.com/lightninglabs/taproot-assets/asset"
 	"github.com/lightninglabs/taproot-assets/commitment"
 	"github.com/lightninglabs/taproot-assets/fn"
+	"github.com/lightninglabs/taproot-assets/taprpc"
 	"github.com/lightningnetwork/lnd/tlv"
 )
 
@@ -535,4 +536,41 @@ func DecodeAddress(addr string, net *ChainParams) (*Tap, error) {
 	}
 
 	return &a, nil
+}
+
+// UnmarshalVersion parses an address version from the RPC variant.
+func UnmarshalVersion(version taprpc.AddrVersion) (Version, error) {
+	// For now, we'll only support two address versions. The ones in the
+	// future should be reserved for future use, so we disallow unknown
+	// versions.
+	switch version {
+	case taprpc.AddrVersion_ADDR_VERSION_UNSPECIFIED:
+		return V1, nil
+
+	case taprpc.AddrVersion_ADDR_VERSION_V0:
+		return V0, nil
+
+	case taprpc.AddrVersion_ADDR_VERSION_V1:
+		return V1, nil
+
+	default:
+		return 0, fmt.Errorf("unknown address version: %v", version)
+	}
+}
+
+// MarshalVersion marshals the native address version into the RPC variant.
+func MarshalVersion(version Version) (taprpc.AddrVersion, error) {
+	// For now, we'll only support two address versions. The ones in the
+	// future should be reserved for future use, so we disallow unknown
+	// versions.
+	switch version {
+	case V0:
+		return taprpc.AddrVersion_ADDR_VERSION_V0, nil
+
+	case V1:
+		return taprpc.AddrVersion_ADDR_VERSION_V1, nil
+
+	default:
+		return 0, fmt.Errorf("unknown address version: %v", version)
+	}
 }

--- a/address/address_test.go
+++ b/address/address_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
-	"github.com/decred/dcrd/dcrec/secp256k1/v4"
 	"github.com/lightninglabs/taproot-assets/asset"
 	"github.com/lightninglabs/taproot-assets/commitment"
 	"github.com/lightninglabs/taproot-assets/fn"
@@ -499,64 +498,6 @@ func TestBIPTestVectors(t *testing.T) {
 
 			runBIPTestVector(tt, testVectors)
 		})
-	}
-}
-
-// TestGenChallengeNUMS tests the generation of NUMS challenges.
-func TestGenChallengeNUMS(t *testing.T) {
-	t.Parallel()
-
-	gx, gy := secp256k1.Params().Gx, secp256k1.Params().Gy
-
-	// addG is a helper function that adds G to the given public key.
-	addG := func(p *btcec.PublicKey) *btcec.PublicKey {
-		x, y := secp256k1.S256().Add(p.X(), p.Y(), gx, gy)
-		var xFieldVal, yFieldVal secp256k1.FieldVal
-		xFieldVal.SetByteSlice(x.Bytes())
-		yFieldVal.SetByteSlice(y.Bytes())
-		return btcec.NewPublicKey(&xFieldVal, &yFieldVal)
-	}
-
-	testCases := []struct {
-		name        string
-		challenge   fn.Option[[32]byte]
-		expectedKey asset.ScriptKey
-	}{
-		{
-			name:        "no challenge",
-			challenge:   fn.None[[32]byte](),
-			expectedKey: asset.NUMSScriptKey,
-		},
-		{
-			name: "challenge is scalar 1",
-			challenge: fn.Some([32]byte{
-				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
-			}),
-			expectedKey: asset.NewScriptKey(addG(asset.NUMSPubKey)),
-		},
-		{
-			name: "challenge is scalar 2",
-			challenge: fn.Some([32]byte{
-				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02,
-			}),
-			expectedKey: asset.NewScriptKey(
-				addG(addG(asset.NUMSPubKey)),
-			),
-		},
-	}
-
-	for _, tc := range testCases {
-		result := GenChallengeNUMS(tc.challenge)
-		require.Equal(
-			t, tc.expectedKey.PubKey.SerializeCompressed(),
-			result.PubKey.SerializeCompressed(),
-		)
 	}
 }
 

--- a/asset/witness_test.go
+++ b/asset/witness_test.go
@@ -1,0 +1,66 @@
+package asset
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/decred/dcrd/dcrec/secp256k1/v4"
+	"github.com/lightninglabs/taproot-assets/fn"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGenChallengeNUMS tests the generation of NUMS challenges.
+func TestGenChallengeNUMS(t *testing.T) {
+	t.Parallel()
+
+	gx, gy := secp256k1.Params().Gx, secp256k1.Params().Gy
+
+	// addG is a helper function that adds G to the given public key.
+	addG := func(p *btcec.PublicKey) *btcec.PublicKey {
+		x, y := secp256k1.S256().Add(p.X(), p.Y(), gx, gy)
+		var xFieldVal, yFieldVal secp256k1.FieldVal
+		xFieldVal.SetByteSlice(x.Bytes())
+		yFieldVal.SetByteSlice(y.Bytes())
+		return btcec.NewPublicKey(&xFieldVal, &yFieldVal)
+	}
+
+	testCases := []struct {
+		name        string
+		challenge   fn.Option[[32]byte]
+		expectedKey ScriptKey
+	}{
+		{
+			name:        "no challenge",
+			challenge:   fn.None[[32]byte](),
+			expectedKey: NUMSScriptKey,
+		},
+		{
+			name: "challenge is scalar 1",
+			challenge: fn.Some([32]byte{
+				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
+			}),
+			expectedKey: NewScriptKey(addG(NUMSPubKey)),
+		},
+		{
+			name: "challenge is scalar 2",
+			challenge: fn.Some([32]byte{
+				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02,
+			}),
+			expectedKey: NewScriptKey(addG(addG(NUMSPubKey))),
+		},
+	}
+
+	for _, tc := range testCases {
+		result := GenChallengeNUMS(tc.challenge)
+		require.Equal(
+			t, tc.expectedKey.PubKey.SerializeCompressed(),
+			result.PubKey.SerializeCompressed(),
+		)
+	}
+}

--- a/proof/verifier.go
+++ b/proof/verifier.go
@@ -13,7 +13,6 @@ import (
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/davecgh/go-spew/spew"
-	"github.com/lightninglabs/taproot-assets/address"
 	"github.com/lightninglabs/taproot-assets/asset"
 	"github.com/lightninglabs/taproot-assets/commitment"
 	"github.com/lightninglabs/taproot-assets/fn"
@@ -385,7 +384,7 @@ func CreateOwnershipProofAsset(ownedAsset *asset.Asset,
 	// This is handled by CopySpendTemplate.
 	outputAsset := ownedAsset.CopySpendTemplate()
 
-	outputAsset.ScriptKey = address.GenChallengeNUMS(challengeBytes)
+	outputAsset.ScriptKey = asset.GenChallengeNUMS(challengeBytes)
 	outputAsset.PrevWitnesses = []asset.Witness{{
 		PrevID: &prevId,
 	}}

--- a/rfqmsg/custom_channel_data.go
+++ b/rfqmsg/custom_channel_data.go
@@ -21,10 +21,11 @@ type JsonAssetGenesis struct {
 // JsonAssetUtxo is a struct that represents the UTXO information of an asset
 // within a channel.
 type JsonAssetUtxo struct {
-	Version      int64            `json:"version"`
-	AssetGenesis JsonAssetGenesis `json:"asset_genesis"`
-	Amount       uint64           `json:"amount"`
-	ScriptKey    string           `json:"script_key"`
+	Version        int64            `json:"version"`
+	AssetGenesis   JsonAssetGenesis `json:"asset_genesis"`
+	Amount         uint64           `json:"amount"`
+	ScriptKey      string           `json:"script_key"`
+	DecimalDisplay uint8            `json:"decimal_display"`
 }
 
 // JsonAssetChanInfo is a struct that represents the channel information of a

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -4407,7 +4407,7 @@ func (r *rpcServer) FetchAssetMeta(ctx context.Context,
 		var assetID asset.ID
 		copy(assetID[:], req.GetAssetId())
 
-		assetMeta, err = r.cfg.AssetStore.FetchAssetMetaForAsset(
+		assetMeta, err = r.cfg.AddrBook.FetchAssetMetaForAsset(
 			ctx, assetID,
 		)
 
@@ -4426,7 +4426,7 @@ func (r *rpcServer) FetchAssetMeta(ctx context.Context,
 		var assetID asset.ID
 		copy(assetID[:], assetIDBytes)
 
-		assetMeta, err = r.cfg.AssetStore.FetchAssetMetaForAsset(
+		assetMeta, err = r.cfg.AddrBook.FetchAssetMetaForAsset(
 			ctx, assetID,
 		)
 
@@ -4438,7 +4438,7 @@ func (r *rpcServer) FetchAssetMeta(ctx context.Context,
 		var metaHash [asset.MetaHashLen]byte
 		copy(metaHash[:], req.GetMetaHash())
 
-		assetMeta, err = r.cfg.AssetStore.FetchAssetMetaByHash(
+		assetMeta, err = r.cfg.AddrBook.FetchAssetMetaByHash(
 			ctx, metaHash,
 		)
 
@@ -4457,7 +4457,7 @@ func (r *rpcServer) FetchAssetMeta(ctx context.Context,
 		var metaHash [asset.MetaHashLen]byte
 		copy(metaHash[:], metaHashBytes)
 
-		assetMeta, err = r.cfg.AssetStore.FetchAssetMetaByHash(
+		assetMeta, err = r.cfg.AddrBook.FetchAssetMetaByHash(
 			ctx, metaHash,
 		)
 
@@ -7603,7 +7603,7 @@ func encodeVirtualPackets(packets []*tappsbt.VPacket) ([][]byte, error) {
 func (r *rpcServer) DecDisplayForAssetID(ctx context.Context,
 	id asset.ID) (fn.Option[uint32], error) {
 
-	meta, err := r.cfg.AssetStore.FetchAssetMetaForAsset(ctx, id)
+	meta, err := r.cfg.AddrBook.FetchAssetMetaForAsset(ctx, id)
 	if err != nil {
 		return fn.None[uint32](), fmt.Errorf("unable to fetch asset "+
 			"meta for asset_id=%v :%v", id, err)

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -1461,7 +1461,7 @@ func (r *rpcServer) NewAddr(ctx context.Context,
 		return nil, err
 	}
 
-	addrVersion, err := taprpc.UnmarshalAddressVersion(req.AddressVersion)
+	addrVersion, err := address.UnmarshalVersion(req.AddressVersion)
 	if err != nil {
 		return nil, err
 	}
@@ -3027,7 +3027,7 @@ func marshalAddr(addr *address.Tap,
 		return nil, err
 	}
 
-	addrVersion, err := taprpc.MarshalAddressVersion(addr.Version)
+	addrVersion, err := address.MarshalVersion(addr.Version)
 	if err != nil {
 		return nil, err
 	}

--- a/tapchannel/aux_funding_controller.go
+++ b/tapchannel/aux_funding_controller.go
@@ -541,7 +541,7 @@ func (p *pendingAssetFunding) toAuxFundingDesc(req *bindFundingReq,
 
 	// With all the outputs assembled, we'll now map that to the open
 	// channel wrapper that'll go in the set of TLV blobs.
-	openChanDesc := cmsg.NewOpenChannel(assetOutputs)
+	openChanDesc := cmsg.NewOpenChannel(assetOutputs, decimalDisplay)
 
 	// Now we'll encode the 3 TLV blobs that lnd will store: the main one
 	// for the funding details, and then the blobs for the local and remote

--- a/tapchannel/aux_funding_controller.go
+++ b/tapchannel/aux_funding_controller.go
@@ -183,6 +183,11 @@ type AssetSyncer interface {
 	// for issuance proofs.
 	QueryAssetInfo(ctx context.Context,
 		id asset.ID) (*asset.AssetGroup, error)
+
+	// FetchAssetMetaForAsset attempts to fetch an asset meta based on an
+	// asset ID.
+	FetchAssetMetaForAsset(ctx context.Context,
+		assetID asset.ID) (*proof.MetaReveal, error)
 }
 
 // FundingControllerCfg is a configuration struct that houses the necessary

--- a/tapchannelmsg/custom_channel_data.go
+++ b/tapchannelmsg/custom_channel_data.go
@@ -81,6 +81,7 @@ func (c *ChannelCustomData) AsJson() ([]byte, error) {
 			ScriptKey: hex.EncodeToString(
 				a.ScriptKey.PubKey.SerializeCompressed(),
 			),
+			DecimalDisplay: c.OpenChan.DecimalDisplay.Val,
 		}
 		resp.Assets = append(resp.Assets, rfqmsg.JsonAssetChanInfo{
 			AssetInfo:     utxo,

--- a/tapchannelmsg/records.go
+++ b/tapchannelmsg/records.go
@@ -86,15 +86,27 @@ type OpenChannel struct {
 	// FundedAssets is a list of asset outputs that was committed to the
 	// funding output of a commitment.
 	FundedAssets tlv.RecordT[tlv.TlvType0, AssetOutputListRecord]
+
+	// DecimalDisplay is the asset's unit precision. We place this value on
+	// the channel directly and not into each funding asset balance struct
+	// since even for a channel with multiple tranches of fungible assets,
+	// this value needs to be the same for all assets. Otherwise, they would
+	// not be fungible.
+	DecimalDisplay tlv.RecordT[tlv.TlvType1, uint8]
 }
 
 // NewOpenChannel creates a new OpenChannel record with the given funded assets.
-func NewOpenChannel(fundedAssets []*AssetOutput) *OpenChannel {
+func NewOpenChannel(fundedAssets []*AssetOutput,
+	decimalDisplay uint8) *OpenChannel {
+
 	return &OpenChannel{
 		FundedAssets: tlv.NewRecordT[tlv.TlvType0](
 			AssetOutputListRecord{
 				Outputs: fundedAssets,
 			},
+		),
+		DecimalDisplay: tlv.NewPrimitiveRecord[tlv.TlvType1](
+			decimalDisplay,
 		),
 	}
 }
@@ -109,6 +121,7 @@ func (o *OpenChannel) Assets() []*AssetOutput {
 func (o *OpenChannel) records() []tlv.Record {
 	return []tlv.Record{
 		o.FundedAssets.Record(),
+		o.DecimalDisplay.Record(),
 	}
 }
 

--- a/tapchannelmsg/records_test.go
+++ b/tapchannelmsg/records_test.go
@@ -76,14 +76,14 @@ func TestOpenChannel(t *testing.T) {
 			name: "channel with funded asset",
 			channel: NewOpenChannel([]*AssetOutput{
 				NewAssetOutput([32]byte{1}, 1000, *randProof),
-			}),
+			}, 0),
 		},
 		{
 			name: "channel with multiple funded assets",
 			channel: NewOpenChannel([]*AssetOutput{
 				NewAssetOutput([32]byte{1}, 1000, *randProof),
 				NewAssetOutput([32]byte{2}, 2000, *randProof),
-			}),
+			}, 11),
 		},
 	}
 

--- a/tapfreighter/parcel.go
+++ b/tapfreighter/parcel.go
@@ -529,6 +529,11 @@ func ConvertToTransfer(currentHeight uint32, activeTransfers []*tappsbt.VPacket,
 		PassiveAssetsAnchor: passiveAssetAnchor,
 	}
 
+	allPackets := append(activeTransfers, passiveAssets...)
+	if err := tapsend.AssertInputsUnique(allPackets); err != nil {
+		return nil, fmt.Errorf("unable to convert to transfer: %w", err)
+	}
+
 	for pIdx := range activeTransfers {
 		vPkt := activeTransfers[pIdx]
 

--- a/taprpc/marshal.go
+++ b/taprpc/marshal.go
@@ -11,7 +11,6 @@ import (
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
-	"github.com/lightninglabs/taproot-assets/address"
 	"github.com/lightninglabs/taproot-assets/asset"
 	"github.com/lightninglabs/taproot-assets/commitment"
 	"github.com/lightninglabs/taproot-assets/fn"
@@ -162,44 +161,6 @@ func MarshalAssetVersion(version asset.Version) (AssetVersion, error) {
 
 	default:
 		return 0, fmt.Errorf("unknown asset version: %v", version)
-	}
-}
-
-// UnmarshalAddressVerion parses an address version from the RPC variant.
-func UnmarshalAddressVersion(version AddrVersion) (address.Version, error) {
-	// For now we'll only support two address versions. The ones in the
-	// future should be reserved for future use, so we disallow unknown
-	// versions.
-	switch version {
-	case AddrVersion_ADDR_VERSION_UNSPECIFIED:
-		return address.V1, nil
-
-	case AddrVersion_ADDR_VERSION_V0:
-		return address.V0, nil
-
-	case AddrVersion_ADDR_VERSION_V1:
-		return address.V1, nil
-
-	default:
-		return 0, fmt.Errorf("unknown address version: %v", version)
-	}
-}
-
-// MarshalAddressVerion marshals the native address version into the RPC
-// variant.
-func MarshalAddressVersion(version address.Version) (AddrVersion, error) {
-	// For now we'll only support two address versions. The ones in the
-	// future should be reserved for future use, so we disallow unknown
-	// versions.
-	switch version {
-	case address.V0:
-		return AddrVersion_ADDR_VERSION_V0, nil
-
-	case address.V1:
-		return AddrVersion_ADDR_VERSION_V1, nil
-
-	default:
-		return 0, fmt.Errorf("unknown address version: %v", version)
 	}
 }
 


### PR DESCRIPTION
Fixes https://github.com/lightninglabs/taproot-assets/issues/1067.

Adds the decimal display value to the channel funding blob, so it can be rendered for `lncli listchannels` and `lncli pendingchannels`.
To make the code in the funding manager as nice as possible, we first do some refactor.