### PR TITLE
Add unit test for method ExternalKey.PubKey

### DIFF
--- a/asset/asset_test.go
+++ b/asset/asset_test.go
@@ -1312,11 +1312,21 @@ func TestExternalKeyPubKey(t *testing.T) {
 		return *xpub
 	}
 
+	dummyXPubTestnet := func() hdkeychain.ExtendedKey {
+		xpubStr := "tpubDDfTBtwwqxXuCej7pKYfbXeCW3inAtv1cw4knmvYTTHk" +
+			"w3NoKaeCNH5XdY6n6fnBPc1gWEgeurfmBVzJLfBB1hGU64LsHFz" +
+			"Jv4ASqaHyALH"
+		xpub, err := hdkeychain.NewKeyFromString(xpubStr)
+		require.NoError(t, err, "failed to create xpub from string")
+		return *xpub
+	}
+
 	testCases := []struct {
-		name          string
-		externalKey   ExternalKey
-		expectError   bool
-		expectedError string
+		name           string
+		externalKey    ExternalKey
+		expectedPubKey string
+		expectError    bool
+		expectedError  string
 	}{
 		{
 			name: "valid BIP-86 external key",
@@ -1330,6 +1340,11 @@ func TestExternalKeyPubKey(t *testing.T) {
 				},
 			},
 			expectError: false,
+
+			// The pubkey was generated with "chantools derivekey
+			// --rootkey xpub... --path "m/0/0" --neuter" command.
+			expectedPubKey: "02c0ca6c5d4dc4899de975f17f1023e424a" +
+				"93a7ba6339cbaf514689f75d51787cc",
 		},
 		{
 			name: "invalid derivation path length",
@@ -1361,9 +1376,114 @@ func TestExternalKeyPubKey(t *testing.T) {
 			expectedError: "xpub must be derived from BIP-0086 " +
 				"(Taproot) derivation path",
 		},
+		{
+			name: "valid BIP-86 external key, custom coin_type",
+			externalKey: ExternalKey{
+				XPub:              dummyXPub(),
+				MasterFingerprint: 0x12345678,
+				DerivationPath: []uint32{
+					86 + hdkeychain.HardenedKeyStart,
+					42 + hdkeychain.HardenedKeyStart,
+					0 + hdkeychain.HardenedKeyStart, 0, 0,
+				},
+			},
+			expectError: false,
 
-		// TODO(ffranr): Add test(s) for positive case: valid xpub and
-		//  valid known correct corresponding public key.
+			// The pubkey was generated with "chantools derivekey
+			// --rootkey xpub... --path m/0/0 --neuter" command.
+			expectedPubKey: "02c0ca6c5d4dc4899de975f17f1023e424a" +
+				"93a7ba6339cbaf514689f75d51787cc",
+		},
+		{
+			name: "valid BIP-86 external key, custom account",
+			externalKey: ExternalKey{
+				XPub:              dummyXPub(),
+				MasterFingerprint: 0x12345678,
+				DerivationPath: []uint32{
+					86 + hdkeychain.HardenedKeyStart,
+					0 + hdkeychain.HardenedKeyStart,
+					42 + hdkeychain.HardenedKeyStart, 0, 0,
+				},
+			},
+			expectError: false,
+
+			// The pubkey was generated with "chantools derivekey
+			// --rootkey xpub... --path m/0/0 --neuter" command.
+			expectedPubKey: "02c0ca6c5d4dc4899de975f17f1023e424a" +
+				"93a7ba6339cbaf514689f75d51787cc",
+		},
+		{
+			name: "valid BIP-86 external key, change output",
+			externalKey: ExternalKey{
+				XPub:              dummyXPub(),
+				MasterFingerprint: 0x12345678,
+				DerivationPath: []uint32{
+					86 + hdkeychain.HardenedKeyStart,
+					0 + hdkeychain.HardenedKeyStart,
+					0 + hdkeychain.HardenedKeyStart, 1, 0,
+				},
+			},
+			expectError: false,
+
+			// The pubkey was generated with "chantools derivekey
+			// --rootkey xpub... --path m/1/0 --neuter" command.
+			expectedPubKey: "02ce0e73519634aaf1a34cc17afb517a697" +
+				"95c063386030f1b1b724410a84aa709",
+		},
+		{
+			name: "valid BIP-86 external key, change=2",
+			externalKey: ExternalKey{
+				XPub:              dummyXPub(),
+				MasterFingerprint: 0x12345678,
+				DerivationPath: []uint32{
+					86 + hdkeychain.HardenedKeyStart,
+					0 + hdkeychain.HardenedKeyStart,
+					0 + hdkeychain.HardenedKeyStart, 2, 0,
+				},
+			},
+			expectError: false,
+
+			// The pubkey was generated with "chantools derivekey
+			// --rootkey xpub... --path m/2/0 --neuter" command.
+			expectedPubKey: "0278b9669141d21f0598cc44a427c5d03a3" +
+				"5d6aaed5555931a99a1659dfea4ebcf",
+		},
+		{
+			name: "valid BIP-86 external key, index=2",
+			externalKey: ExternalKey{
+				XPub:              dummyXPub(),
+				MasterFingerprint: 0x12345678,
+				DerivationPath: []uint32{
+					86 + hdkeychain.HardenedKeyStart,
+					0 + hdkeychain.HardenedKeyStart,
+					0 + hdkeychain.HardenedKeyStart, 0, 2,
+				},
+			},
+			expectError: false,
+
+			// The pubkey was generated with "chantools derivekey
+			// --rootkey xpub... --path "m/0/2" --neuter" command.
+			expectedPubKey: "0375e49d472c25d1138a5526b9b7a0198e1" +
+				"d692cc3fd0133f260aca446e1244ff9",
+		},
+		{
+			name: "valid BIP-86 external key, testnet",
+			externalKey: ExternalKey{
+				XPub:              dummyXPubTestnet(),
+				MasterFingerprint: 0x12345678,
+				DerivationPath: []uint32{
+					86 + hdkeychain.HardenedKeyStart,
+					1 + hdkeychain.HardenedKeyStart,
+					0 + hdkeychain.HardenedKeyStart, 0, 0,
+				},
+			},
+			expectError: false,
+
+			// The pubkey was generated with "chantools derivekey
+			// --testnet --rootkey xpub... --path "m/0/0" --neuter".
+			expectedPubKey: "0280a3fcbeb7f770af6dd45cb0f4d02e104" +
+				"4eafe0d8b05bcaec79dc0478c7fa0da",
+		},
 	}
 
 	for _, tc := range testCases {
@@ -1378,10 +1498,16 @@ func TestExternalKeyPubKey(t *testing.T) {
 						tc.expectedError,
 					)
 				}
-			} else {
-				require.NoError(tt, err)
-				require.IsType(tt, btcec.PublicKey{}, pubKey)
+
+				return
 			}
+
+			require.NoError(tt, err)
+			require.IsType(tt, btcec.PublicKey{}, pubKey)
+			pubKeyHex := hex.EncodeToString(
+				pubKey.SerializeCompressed(),
+			)
+			require.Equal(tt, tc.expectedPubKey, pubKeyHex)
 		})
 	}
 }

--- a/asset/asset_test.go
+++ b/asset/asset_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/btcsuite/btcd/blockchain"
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/btcsuite/btcd/btcutil/hdkeychain"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
@@ -1295,4 +1296,92 @@ func TestCopySpendTemplate(t *testing.T) {
 	newAsset.LockTime = 0
 
 	require.True(t, newAsset.DeepEqual(spendTemplate))
+}
+
+// TestExternalKeyPubKey tests that the public key can be derived from an
+// external key.
+func TestExternalKeyPubKey(t *testing.T) {
+	t.Parallel()
+
+	dummyXPub := func() hdkeychain.ExtendedKey {
+		xpubStr := "xpub6BynCcnXLYNnnMUZARkHxbP9pG6h5rES8Zb8aHtGwmFX" +
+			"9DdjJiyT9PNwkSMZfS3CvGRpvV21SkLRM6xhtshvA3DnJbQsvjD" +
+			"yySWGArynQNf"
+		xpub, err := hdkeychain.NewKeyFromString(xpubStr)
+		require.NoError(t, err, "failed to create xpub from string")
+		return *xpub
+	}
+
+	testCases := []struct {
+		name          string
+		externalKey   ExternalKey
+		expectError   bool
+		expectedError string
+	}{
+		{
+			name: "valid BIP-86 external key",
+			externalKey: ExternalKey{
+				XPub:              dummyXPub(),
+				MasterFingerprint: 0x12345678,
+				DerivationPath: []uint32{
+					86 + hdkeychain.HardenedKeyStart,
+					0 + hdkeychain.HardenedKeyStart,
+					0 + hdkeychain.HardenedKeyStart, 0, 0,
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "invalid derivation path length",
+			externalKey: ExternalKey{
+				XPub:              dummyXPub(),
+				MasterFingerprint: 0x12345678,
+				DerivationPath: []uint32{
+					86 + hdkeychain.HardenedKeyStart,
+					0 + hdkeychain.HardenedKeyStart,
+					0 + hdkeychain.HardenedKeyStart,
+				},
+			},
+			expectError: true,
+			expectedError: "derivation path must have exactly 5 " +
+				"components",
+		},
+		{
+			name: "invalid BIP-86 derivation path",
+			externalKey: ExternalKey{
+				XPub:              dummyXPub(),
+				MasterFingerprint: 0x12345678,
+				DerivationPath: []uint32{
+					44 + hdkeychain.HardenedKeyStart,
+					0 + hdkeychain.HardenedKeyStart,
+					0 + hdkeychain.HardenedKeyStart, 0, 0,
+				},
+			},
+			expectError: true,
+			expectedError: "xpub must be derived from BIP-0086 " +
+				"(Taproot) derivation path",
+		},
+
+		// TODO(ffranr): Add test(s) for positive case: valid xpub and
+		//  valid known correct corresponding public key.
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(tt *testing.T) {
+			pubKey, err := tc.externalKey.PubKey()
+
+			if tc.expectError {
+				require.Error(tt, err, tc.name)
+				if tc.expectedError != "" {
+					require.Contains(
+						tt, err.Error(),
+						tc.expectedError,
+					)
+				}
+			} else {
+				require.NoError(tt, err)
+				require.IsType(tt, btcec.PublicKey{}, pubKey)
+			}
+		})
+	}
 }


### PR DESCRIPTION
This PR introduces a comprehensive unit test for the `PubKey` method of the `ExternalKey` struct. The test covers various scenarios, including valid and invalid derivation paths, ensuring the method's correctness and error handling.

---

### Notes for Reviewers

This PR depends on https://github.com/lightninglabs/taproot-assets/pull/1272 . This PR should be merged after https://github.com/lightninglabs/taproot-assets/pull/1272 has been merged. I will keep in draft until https://github.com/lightninglabs/taproot-assets/pull/1272 is merged.