### PR TITLE
Add `mintV2` loadtest

### DIFF
--- a/itest/assets_test.go
+++ b/itest/assets_test.go
@@ -183,7 +183,7 @@ func testMintBatchResume(t *harnessTest) {
 	require.NoError(t.t, t.tapd.stop(false))
 	require.NoError(t.t, t.tapd.start(false))
 
-	hashes, err := waitForNTxsInMempool(
+	hashes, err := WaitForNTxsInMempool(
 		t.lndHarness.Miner().Client, 1, defaultWaitTimeout,
 	)
 	require.NoError(t.t, err)

--- a/itest/loadtest/config.go
+++ b/itest/loadtest/config.go
@@ -93,6 +93,16 @@ type Config struct {
 	// only relevant for the mint test.
 	BatchSize int `long:"mint-test-batch-size" description:"the number of assets to mint in a single batch; only relevant for the mint test"`
 
+	// TotalNumGroups is the total number of groups that the minted assets
+	// belong to.
+	TotalNumGroups int `long:"mint-test-total-groups" description:"the total number of groups the minted assets belong to"`
+
+	// MintSupplyMin is the minimum supply to mint per asset.
+	MintSupplyMin int `long:"mint-test-supply-min" description:"the max supply to mint per asset"`
+
+	// MintSupplyMax is the max suipply to mint per asset.
+	MintSupplyMax int `long:"mint-test-supply-max" description:"the min supply to mint per asset"`
+
 	// NumSends is the number of asset sends to perform. This is only
 	// relevant for the send test.
 	NumSends int `long:"send-test-num-sends" description:"the number of send operations to perform; only relevant for the send test"`

--- a/itest/loadtest/load_test.go
+++ b/itest/loadtest/load_test.go
@@ -40,6 +40,10 @@ var loadTestCases = []testCase{
 		fn:   mintTest,
 	},
 	{
+		name: "mintV2",
+		fn:   mintTestV2,
+	},
+	{
 		name: "send",
 		fn:   sendTest,
 	},

--- a/itest/loadtest/loadtest-sample.conf
+++ b/itest/loadtest/loadtest-sample.conf
@@ -2,10 +2,19 @@
 network=regtest
 
 # The name of the test case to run. Example "send" or "mint"
-test-case="mint"
+test-case="mintV2"
 
 # Batch size for mint test
 mint-test-batch-size=5
+
+# Total number of groups that assets belong to.
+mint-test-total-groups=20
+
+# Max supply per asset mint.
+mint-test-supply-max=500000
+
+# Min supply per asset mint.
+mint-test-supply-min=100000
 
 # Number of send operations to perform for send test
 send-test-num-sends=5

--- a/itest/loadtest/mint_batch_test.go
+++ b/itest/loadtest/mint_batch_test.go
@@ -9,12 +9,15 @@ import (
 	"math/rand"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/btcsuite/btcd/rpcclient"
 	"github.com/lightninglabs/taproot-assets/fn"
 	"github.com/lightninglabs/taproot-assets/itest"
 	"github.com/lightninglabs/taproot-assets/taprpc"
 	"github.com/lightninglabs/taproot-assets/taprpc/mintrpc"
 	unirpc "github.com/lightninglabs/taproot-assets/taprpc/universerpc"
+	"github.com/lightningnetwork/lnd/lntest/wait"
 	"github.com/stretchr/testify/require"
 )
 
@@ -165,4 +168,201 @@ func mintTest(t *testing.T, ctx context.Context, cfg *Config) {
 	require.True(t, correctOp)
 
 	itest.SyncUniverses(ctx, t, bob, alice, aliceHost, cfg.TestTimeout)
+}
+
+// mintTestV2 checks that we can mint a batch of assets. It is a more
+// performant version of the existing mintTest, as it uses less assertions and
+// RPC calls.
+func mintTestV2(t *testing.T, ctx context.Context, cfg *Config) {
+	// Start by initializing all our client connections.
+	alice, bob, bitcoinClient := initClients(t, ctx, cfg)
+
+	// We query the assets of each node once on this step. Every function
+	// that needs to take a node's assets into account will be passed these
+	// values instead of calling the RPC again. This is done to minimize
+	// collateral RPC impact of the loadtest.
+	resAlice, err := alice.ListAssets(ctx, &taprpc.ListAssetRequest{})
+	require.NoError(t, err)
+
+	resBob, err := bob.ListAssets(ctx, &taprpc.ListAssetRequest{})
+	require.NoError(t, err)
+
+	assetsAlice := resAlice.Assets
+	assetsBob := resBob.Assets
+
+	totalAssets := make([]*taprpc.Asset, len(assetsAlice)+len(assetsBob))
+	copy(totalAssets, assetsAlice)
+	copy(totalAssets[len(assetsAlice):], assetsBob)
+
+	// Alice serves as the minter.
+	//
+	// TODO(george): Currently we use only 1 fixed minter, but this could
+	// change in the future to emulate a more realistic environment where
+	// multiple nodes continuously mint assets into their own groups.
+	minter := alice
+
+	// First we make sure group initialization is completed. We check if
+	// there's any more groups left
+	existingGroups := getTotalAssetGroups(totalAssets)
+	groupKeys := make(map[string][]byte, 0)
+
+	for _, v := range existingGroups {
+		tweakedKey, err := hex.DecodeString(v)
+		require.NoError(t, err)
+
+		groupKeys[v] = tweakedKey
+	}
+
+	var remainingGroups int
+	if cfg.TotalNumGroups > len(existingGroups) {
+		remainingGroups = cfg.TotalNumGroups - len(existingGroups)
+	}
+
+	t.Logf("Existing groups=%v, minting %v new groups",
+		len(existingGroups), remainingGroups)
+	for range remainingGroups {
+		mintNewGroup(t, ctx, bitcoinClient, minter, cfg)
+	}
+
+	// If there aren't any existing groups we skip the rest of the steps, we
+	// will mint into those groups in another run.
+	if len(existingGroups) == 0 {
+		return
+	}
+
+	groupIndex := rand.Intn(len(existingGroups))
+	groupKey := groupKeys[existingGroups[groupIndex]]
+
+	mintIntoGroup(t, ctx, bitcoinClient, minter, groupKey, cfg)
+}
+
+// mintNewGroup mints an asset that creates a new group.
+func mintNewGroup(t *testing.T, ctx context.Context, miner *rpcclient.Client,
+	minter *rpcClient, cfg *Config) []*taprpc.Asset {
+
+	mintAmt := rand.Uint64() % uint64(cfg.MintSupplyMax)
+	if mintAmt < uint64(cfg.MintSupplyMin) {
+		mintAmt = uint64(cfg.MintSupplyMin)
+	}
+
+	assetRequests := []*mintrpc.MintAssetRequest{{
+		Asset: &mintrpc.MintAsset{
+			AssetType: taprpc.AssetType_NORMAL,
+			Name: fmt.Sprintf(
+				"tapcoin-%d", time.Now().UnixNano(),
+			),
+			AssetMeta: &taprpc.AssetMeta{
+				Data: []byte("{}"),
+				Type: taprpc.AssetMetaType_META_TYPE_JSON,
+			},
+			Amount:          mintAmt,
+			NewGroupedAsset: true,
+			DecimalDisplay:  4,
+		},
+	}}
+
+	return finishMint(t, ctx, miner, minter, assetRequests)
+}
+
+// mintIntoGroup mints as many assets as the batch size and puts them in the
+// existing group that is provided by the corresponding argument.
+func mintIntoGroup(t *testing.T, ctx context.Context, miner *rpcclient.Client,
+	minter *rpcClient, tweakedKey []byte, cfg *Config) []*taprpc.Asset {
+
+	mintAmt := rand.Uint64() % uint64(cfg.MintSupplyMax)
+	if mintAmt < uint64(cfg.MintSupplyMin) {
+		mintAmt = uint64(cfg.MintSupplyMin)
+	}
+
+	var assetRequests []*mintrpc.MintAssetRequest
+
+	t.Logf("Minting %v assets into group %x", cfg.BatchSize, tweakedKey)
+
+	for range cfg.BatchSize {
+		ts := time.Now().UnixNano()
+
+		// nolint:lll
+		req := &mintrpc.MintAssetRequest{
+			Asset: &mintrpc.MintAsset{
+				AssetType: taprpc.AssetType_NORMAL,
+				Name:      fmt.Sprintf("tapcoin-%d", ts),
+				AssetMeta: &taprpc.AssetMeta{
+					Data: []byte("{}"),
+					Type: taprpc.AssetMetaType_META_TYPE_JSON,
+				},
+				Amount:         mintAmt,
+				GroupedAsset:   true,
+				GroupKey:       tweakedKey,
+				DecimalDisplay: 4,
+			},
+		}
+
+		assetRequests = append(assetRequests, req)
+	}
+
+	return finishMint(t, ctx, miner, minter, assetRequests)
+}
+
+// finishMint accepts a list of asset requests and performs the necessary RPC
+// calls to create and finalize a minting batch.
+func finishMint(t *testing.T, ctx context.Context, miner *rpcclient.Client,
+	minter *rpcClient,
+	assetRequests []*mintrpc.MintAssetRequest) []*taprpc.Asset {
+
+	ctxc, streamCancel := context.WithCancel(ctx)
+	stream, err := minter.SubscribeMintEvents(
+		ctxc, &mintrpc.SubscribeMintEventsRequest{},
+	)
+	require.NoError(t, err)
+	sub := &itest.EventSubscription[*mintrpc.MintEvent]{
+		ClientEventStream: stream,
+		Cancel:            streamCancel,
+	}
+
+	itest.BuildMintingBatch(t, minter, assetRequests)
+
+	ctxb := context.Background()
+	ctxt, cancel := context.WithTimeout(ctxb, wait.DefaultTimeout)
+	defer cancel()
+
+	finalizeReq := &mintrpc.FinalizeBatchRequest{}
+
+	// Instruct the daemon to finalize the batch.
+	batchResp, err := minter.FinalizeBatch(ctxt, finalizeReq)
+	require.NoError(t, err)
+	require.NotEmpty(t, batchResp.Batch)
+	require.Len(t, batchResp.Batch.Assets, len(assetRequests))
+	require.Equal(
+		t, mintrpc.BatchState_BATCH_STATE_BROADCAST,
+		batchResp.Batch.State,
+	)
+
+	itest.WaitForBatchState(
+		t, ctxt, minter, wait.DefaultTimeout,
+		batchResp.Batch.BatchKey,
+		mintrpc.BatchState_BATCH_STATE_BROADCAST,
+	)
+	hashes, err := itest.WaitForNTxsInMempool(
+		miner, 1, wait.DefaultTimeout,
+	)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(hashes), 1)
+
+	return itest.ConfirmBatch(
+		t, miner, minter, assetRequests, sub, *hashes[0],
+		batchResp.Batch.BatchKey,
+	)
+}
+
+// getTotalAssetGroups returns the total number of asset groups found in the
+// passed array of assets.
+func getTotalAssetGroups(assets []*taprpc.Asset) []string {
+	groups := fn.NewSet[string]()
+
+	for _, v := range assets {
+		groupKeyStr := fmt.Sprintf("%x", v.AssetGroup.TweakedGroupKey)
+		groups.Add(groupKeyStr)
+	}
+
+	return groups.ToSlice()
 }

--- a/itest/test_harness.go
+++ b/itest/test_harness.go
@@ -476,10 +476,10 @@ func isMempoolEmpty(miner *rpcclient.Client, timeout time.Duration) (bool,
 	}
 }
 
-// waitForNTxsInMempool polls until finding the desired number of transactions
+// WaitForNTxsInMempool polls until finding the desired number of transactions
 // in the provided miner's mempool. An error is returned if this number is not
 // met after the given timeout.
-func waitForNTxsInMempool(miner *rpcclient.Client, n int,
+func WaitForNTxsInMempool(miner *rpcclient.Client, n int,
 	timeout time.Duration) ([]*chainhash.Hash, error) {
 
 	breakTimeout := time.After(timeout)

--- a/itest/utils.go
+++ b/itest/utils.go
@@ -142,7 +142,7 @@ func MineBlocks(t *testing.T, client *rpcclient.Client,
 	var txids []*chainhash.Hash
 	var err error
 	if numTxs > 0 {
-		txids, err = waitForNTxsInMempool(
+		txids, err = WaitForNTxsInMempool(
 			client, numTxs, minerMempoolTimeout,
 		)
 		if err != nil {
@@ -386,7 +386,7 @@ func FinalizeBatchUnconfirmed(t *testing.T, minerClient *rpcclient.Client,
 		batchResp.Batch.BatchKey,
 		mintrpc.BatchState_BATCH_STATE_BROADCAST,
 	)
-	hashes, err := waitForNTxsInMempool(
+	hashes, err := WaitForNTxsInMempool(
 		minerClient, 1, options.mintingTimeout,
 	)
 	require.NoError(t, err)


### PR DESCRIPTION
## Description

This is a lighter version of the mintTest, which also uses a few more configuration parameters to control how minting occurs. We now mint normal assets into a fixed total number of groups.

This was originally intended as a rewrite of the existing mint test, but it is introduced as a totally separate function. We could keep both functions and even try to run them in parallel at some point.

The minter is fixed to Alice node, as Bob could not mint into a group that is controlled by Alice. So fixing this role to Alice makes things much simpler.