### PR TITLE
.github: update upload-artifact action to v4

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -258,7 +258,7 @@ jobs:
         run: 7z a logs-itest.zip itest/**/*.log
 
       - name: Upload log files on failure
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ failure() }}
         with:
           name: logs-itest


### PR DESCRIPTION
PR to update github actions

context: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
migration notes: https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md

TY to @ellemouton for researching the necessary update steps

TODO
- [ ] Consider what logging artifact exists to prevent name-spacing collisions