### PR TITLE
GitHub: update tapd's CI litd branch to testing target

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -21,7 +21,7 @@ env:
 
   GO_VERSION: '1.22.6'
   
-  LITD_ITEST_BRANCH: 'update-to-lnd-18-4'
+  LITD_ITEST_BRANCH: 'master'
 
 jobs:
   #######################


### PR DESCRIPTION
tapd's CI tests using litd tests has failed to run.  CI failed to run due to the `LITD_ITEST_BRANCH:` CI environment variable not being updated after the merge of litd's `update-to-lnd-18-4` branch.

This CI gap was observed during review of another review:
https://github.com/lightninglabs/taproot-assets/actions/runs/12690734269/job/35454398525?pr=1283#step:4:63
<details>
<summary>CI details</summary>
<br>
Run actions/checkout@v3
Syncing repository: lightninglabs/lightning-terminal
Getting Git version info
Temporarily overriding HOME='/home/runner/work/_temp/54a16043-e669-4360-a3d6-f41d903bdcc8' before making global git config changes
Adding repository directory to the temporary git global config as a safe directory
/usr/bin/git config --global --add safe.directory /home/runner/work/taproot-assets/taproot-assets/lightning-terminal
Initializing the repository
Disabling automatic garbage collection
Setting up auth
Fetching the repository
  /usr/bin/git -c protocol.version=2 fetch --no-tags --prune --progress --no-recurse-submodules --depth=1 origin +refs/heads/update-to-lnd-18-4*:refs/remotes/origin/update-to-lnd-18-4* +refs/tags/update-to-lnd-18-4*:refs/tags/update-to-lnd-18-4*
</details>

Unless other compelling reasons exist:
Fixing CI should take priority before more merges occur to ensure testing remains sound.