### PR TITLE
tapdb: thread through enabled flag correctly

### DIFF
--- a/tapdb/multiverse_cache.go
+++ b/tapdb/multiverse_cache.go
@@ -294,6 +294,7 @@ func newSyncerRootNodeCache(enabled bool,
 		preAllocSize:  preAllocSize,
 		universeRoots: rootsMap,
 		cacheLogger:   newCacheLogger("syncer_universe_roots"),
+		enabled:       enabled,
 	}
 }
 


### PR DESCRIPTION
Flag was forgotten to be threaded through, so cache never turned on outside of unit tests.