### PR TITLE
Invoice Acceptor: ensure asset ID match between RFQ and HTLC 

### DIFF
--- a/asset/asset.go
+++ b/asset/asset.go
@@ -431,6 +431,11 @@ func (s *Specifier) WhenId(f func(ID)) {
 	s.id.WhenSome(f)
 }
 
+// ID returns the underlying asset ID option of the specifier.
+func (s *Specifier) ID() fn.Option[ID] {
+	return s.id
+}
+
 // WhenGroupPubKey executes the given function if asset group public key field
 // is specified.
 func (s *Specifier) WhenGroupPubKey(f func(btcec.PublicKey)) {


### PR DESCRIPTION
## Description

This PR adds an extra strictness check which requires the asset ID of the RFQ quote and HTLC records to match. This is done as an extra strict check to guard against HTLC and RFQ asset ID mismatch, which can lead to malicious behavior where a quote for a different asset is being accounted for when accepting an asset HTLC.

Closes https://github.com/lightninglabs/taproot-assets/issues/1255