### PR TITLE
monitoring: export collector timeout as prometheus config

### DIFF
--- a/monitoring/asset_balances_collector.go
+++ b/monitoring/asset_balances_collector.go
@@ -72,7 +72,7 @@ func (a *assetBalancesCollector) Collect(ch chan<- prometheus.Metric) {
 	a.collectMx.Lock()
 	defer a.collectMx.Unlock()
 
-	ctxdb, cancel := context.WithTimeout(context.Background(), dbTimeout)
+	ctxdb, cancel := context.WithTimeout(context.Background(), promTimeout)
 	defer cancel()
 
 	assets, err := a.cfg.AssetStore.FetchAllAssets(ctxdb, false, false, nil)

--- a/monitoring/asset_collector.go
+++ b/monitoring/asset_collector.go
@@ -97,7 +97,7 @@ func (a *universeStatsCollector) Collect(ch chan<- prometheus.Metric) {
 	a.collectMx.Lock()
 	defer a.collectMx.Unlock()
 
-	ctx, cancel := context.WithTimeout(context.Background(), dbTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), promTimeout)
 	defer cancel()
 
 	universeStats, err := a.cfg.UniverseStats.AggregateSyncStats(ctx)

--- a/monitoring/config.go
+++ b/monitoring/config.go
@@ -1,6 +1,8 @@
 package monitoring
 
 import (
+	"time"
+
 	"github.com/lightninglabs/taproot-assets/tapdb"
 	"github.com/lightninglabs/taproot-assets/tapgarden"
 	"github.com/lightninglabs/taproot-assets/universe"
@@ -10,6 +12,8 @@ import (
 // PrometheusConfig is the set of configuration data that specifies if
 // Prometheus metric exporting is activated, and if so the listening address of
 // the Prometheus server.
+//
+// nolint: lll
 type PrometheusConfig struct {
 	// Active, if true, then Prometheus metrics will be exported.
 	Active bool `long:"active" description:"if true prometheus metrics will be exported"`
@@ -17,6 +21,11 @@ type PrometheusConfig struct {
 	// ListenAddr is the listening address that we should use to allow the
 	// main Prometheus server to scrape our metrics.
 	ListenAddr string `long:"listenaddr" description:"the interface we should listen on for prometheus"`
+
+	// CollectorRPCTimeout is the context timeout to be used by the RPC
+	// calls performed during metrics collection. This should not be greater
+	// than the scrape interval of prometheus.
+	CollectorRPCTimeout time.Duration `long:"collector-rpc-timeout" description:"the default timeout to be used in the RPC calls performed during metric collection"`
 
 	// RPCServer is a pointer to the main RPC server. We use this to export
 	// generic RPC metrics to monitor the health of the service.
@@ -45,7 +54,8 @@ type PrometheusConfig struct {
 // metrics exporter.
 func DefaultPrometheusConfig() PrometheusConfig {
 	return PrometheusConfig{
-		ListenAddr: "127.0.0.1:8989",
-		Active:     false,
+		ListenAddr:          "127.0.0.1:8989",
+		Active:              false,
+		CollectorRPCTimeout: defaultTimeout,
 	}
 }

--- a/monitoring/db_collector.go
+++ b/monitoring/db_collector.go
@@ -84,7 +84,7 @@ func (a *dbCollector) Collect(ch chan<- prometheus.Metric) {
 	a.collectMx.Lock()
 	defer a.collectMx.Unlock()
 
-	ctxdb, cancel := context.WithTimeout(context.Background(), dbTimeout)
+	ctxdb, cancel := context.WithTimeout(context.Background(), promTimeout)
 	defer cancel()
 
 	// Fetch the db size.

--- a/monitoring/prometheus.go
+++ b/monitoring/prometheus.go
@@ -12,15 +12,18 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
+const (
+	// defaultTimeout is the default timeout.
+	defaultTimeout = 25 * time.Second
+)
+
 var (
 	// serverMetrics is a global variable that holds the Prometheus metrics
 	// for the gRPC server.
 	serverMetrics *grpc_prometheus.ServerMetrics
-)
 
-const (
-	// dbTimeout is the default database timeout.
-	dbTimeout = 20 * time.Second
+	// promTimeout is the timeout used by the prometheus collectors.
+	promTimeout time.Duration
 )
 
 // PrometheusExporter is a metric exporter that uses Prometheus directly. The
@@ -44,6 +47,11 @@ func (p *PrometheusExporter) Start() error {
 	// Make sure that the server metrics has been created.
 	if serverMetrics == nil {
 		return fmt.Errorf("server metrics not set")
+	}
+
+	promTimeout = defaultTimeout
+	if p.config.CollectorRPCTimeout.Seconds() != 0 {
+		promTimeout = p.config.CollectorRPCTimeout
 	}
 
 	// Create a custom Prometheus registry.

--- a/sample-tapd.conf
+++ b/sample-tapd.conf
@@ -346,6 +346,9 @@
 ; The interface we should listen on for prometheus
 ; prometheus.listenaddr=127.0.0.1:8989
 
+; The default timeout used in prometheus collectors.
+; prometheus.collector-rpc-timeout=25s
+
 ; Enable additional histogram to track gRPC call processing performance
 ; (latency, etc)
 ; prometheus.perfhistograms=false


### PR DESCRIPTION
This PR exports the prometheus collector timeout as a prometheus config parameter.

With this timeout we will be able to observe values on our loadtest tapds for longer periods, as the timeout will be harder to reach.