### PR TITLE
Aggregate Universe Stats: always store result of querySyncStats

### DIFF
--- a/tapdb/universe_stats_test.go
+++ b/tapdb/universe_stats_test.go
@@ -255,6 +255,60 @@ func TestUniverseStatsEvents(t *testing.T) {
 	})
 }
 
+// TestUniverseStatsAsyncCache tests that the cache of the universe aggregate
+// stats is asynchronously populated regardless of what the outcome of the
+// RPC call is.
+func TestUniverseStatsAsyncCache(t *testing.T) {
+	t.Parallel()
+
+	db := NewTestDB(t)
+
+	yesterday := time.Now().UTC().Add(-24 * time.Hour)
+	testClock := clock.NewTestClock(yesterday)
+	statsDB, _ := newUniverseStatsWithDB(db.BaseDB, testClock)
+
+	const numTranches = 3
+
+	sh := newUniStatsHarness(t, numTranches, db.BaseDB, statsDB)
+
+	// Record the number of groups in this asset.
+	var numGroups uint64
+	for i := 0; i < numTranches; i++ {
+		if sh.universeLeaves[i].Leaf.GroupKey != nil {
+			numGroups++
+		}
+	}
+
+	// First let's make sure the cache is empty. This should be the case as
+	// no calls have been made so far.
+	val := sh.db.statsSnapshot.Load()
+	require.Nil(t, val)
+
+	const (
+		quickTimeoutDuration = time.Microsecond * 1
+		defaultTick          = time.Millisecond * 250
+	)
+
+	// We now create a client context with a very quick timeout. This is
+	// meant to quickly fail the RPC call.
+	ctx, cancel := context.WithTimeout(
+		context.Background(), quickTimeoutDuration,
+	)
+	defer cancel()
+
+	// The tiny timeout duration should make the following call result in a
+	// context deadline related error.
+	_, err := sh.db.AggregateSyncStats(ctx)
+	require.ErrorContains(t, err, "context deadline exceeded")
+
+	// Regardless of the above call failing, the cache should asynchronously
+	// get updated in the background, so let's wait until a value is loaded.
+	require.Eventually(t, func() bool {
+		val := sh.db.statsSnapshot.Load()
+		return val != nil
+	}, DefaultStoreTimeout, defaultTick)
+}
+
 // TestUniverseQuerySyncStatsSorting tests that we're able to properly sort the
 // response using any of the available params.
 func TestUniverseQuerySyncStatsSorting(t *testing.T) {


### PR DESCRIPTION
Our universe stats could run into a case where if in an un-cached state (like on system start-up) the db query takes longer than the default client timeout (usually 30s) then we'd fail the query and return early. This would cause the next client to also receive an error instead of the cached result, making this codepath stuck in an endless failing query. With this change we parallelize the db query and we always wait for the result in order to store it in cache. We may fail the function earlier, but the result will always be retrieved & persisted. This way, even if the 1st client retrieves an error, the next one will receive the cached (late) result of the previous run.

Closes https://github.com/lightninglabs/taproot-assets/issues/1304