### PR TITLE
github-ci: bump upload-artifact@v3 to @v4

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -258,7 +258,7 @@ jobs:
         run: 7z a logs-itest.zip itest/**/*.log
 
       - name: Upload log files on failure
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ failure() }}
         with:
           name: logs-itest
@@ -286,7 +286,7 @@ jobs:
         run: 7z a logs-itest-postgres.zip itest/**/*.log
 
       - name: Upload log files on failure
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ failure() }}
         with:
           name: logs-itest-postgres


### PR DESCRIPTION
## Description

Bumps the github workflow action `upload-artifact` from v3 to v4
([Migration Doc](https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md))