### PR TITLE
tapdb: fix performance of aggregate stats

### DIFF
--- a/sqlc.yaml
+++ b/sqlc.yaml
@@ -8,3 +8,4 @@ sql:
         out: tapdb/sqlc
         package: sqlc
         emit_interface: true
+        emit_exported_queries: true

--- a/tapdb/migrations.go
+++ b/tapdb/migrations.go
@@ -22,7 +22,7 @@ const (
 	// daemon.
 	//
 	// NOTE: This MUST be updated when a new migration is added.
-	LatestMigrationVersion = 26
+	LatestMigrationVersion = 27
 )
 
 // MigrationTarget is a functional option that can be passed to applyMigrations

--- a/tapdb/sqlc/addrs.sql.go
+++ b/tapdb/sqlc/addrs.sql.go
@@ -11,7 +11,7 @@ import (
 	"time"
 )
 
-const fetchAddrByTaprootOutputKey = `-- name: FetchAddrByTaprootOutputKey :one
+const FetchAddrByTaprootOutputKey = `-- name: FetchAddrByTaprootOutputKey :one
 SELECT
     version, asset_version, genesis_asset_id, group_key, tapscript_sibling,
     taproot_output_key, amount, asset_type, creation_time, managed_from,
@@ -59,7 +59,7 @@ type FetchAddrByTaprootOutputKeyRow struct {
 }
 
 func (q *Queries) FetchAddrByTaprootOutputKey(ctx context.Context, taprootOutputKey []byte) (FetchAddrByTaprootOutputKeyRow, error) {
-	row := q.db.QueryRowContext(ctx, fetchAddrByTaprootOutputKey, taprootOutputKey)
+	row := q.db.QueryRowContext(ctx, FetchAddrByTaprootOutputKey, taprootOutputKey)
 	var i FetchAddrByTaprootOutputKeyRow
 	err := row.Scan(
 		&i.Version,
@@ -86,7 +86,7 @@ func (q *Queries) FetchAddrByTaprootOutputKey(ctx context.Context, taprootOutput
 	return i, err
 }
 
-const fetchAddrEvent = `-- name: FetchAddrEvent :one
+const FetchAddrEvent = `-- name: FetchAddrEvent :one
 SELECT
     creation_time, status, asset_proof_id, asset_id,
     chain_txns.txid as txid,
@@ -119,7 +119,7 @@ type FetchAddrEventRow struct {
 }
 
 func (q *Queries) FetchAddrEvent(ctx context.Context, id int64) (FetchAddrEventRow, error) {
-	row := q.db.QueryRowContext(ctx, fetchAddrEvent, id)
+	row := q.db.QueryRowContext(ctx, FetchAddrEvent, id)
 	var i FetchAddrEventRow
 	err := row.Scan(
 		&i.CreationTime,
@@ -136,7 +136,7 @@ func (q *Queries) FetchAddrEvent(ctx context.Context, id int64) (FetchAddrEventR
 	return i, err
 }
 
-const fetchAddrEventByAddrKeyAndOutpoint = `-- name: FetchAddrEventByAddrKeyAndOutpoint :one
+const FetchAddrEventByAddrKeyAndOutpoint = `-- name: FetchAddrEventByAddrKeyAndOutpoint :one
 WITH target_addr(addr_id) AS (
     SELECT id
     FROM addrs
@@ -184,7 +184,7 @@ type FetchAddrEventByAddrKeyAndOutpointRow struct {
 }
 
 func (q *Queries) FetchAddrEventByAddrKeyAndOutpoint(ctx context.Context, arg FetchAddrEventByAddrKeyAndOutpointParams) (FetchAddrEventByAddrKeyAndOutpointRow, error) {
-	row := q.db.QueryRowContext(ctx, fetchAddrEventByAddrKeyAndOutpoint, arg.TaprootOutputKey, arg.Txid, arg.ChainTxnOutputIndex)
+	row := q.db.QueryRowContext(ctx, FetchAddrEventByAddrKeyAndOutpoint, arg.TaprootOutputKey, arg.Txid, arg.ChainTxnOutputIndex)
 	var i FetchAddrEventByAddrKeyAndOutpointRow
 	err := row.Scan(
 		&i.ID,
@@ -202,7 +202,7 @@ func (q *Queries) FetchAddrEventByAddrKeyAndOutpoint(ctx context.Context, arg Fe
 	return i, err
 }
 
-const fetchAddrs = `-- name: FetchAddrs :many
+const FetchAddrs = `-- name: FetchAddrs :many
 SELECT 
     version, asset_version, genesis_asset_id, group_key, tapscript_sibling,
     taproot_output_key, amount, asset_type, creation_time, managed_from,
@@ -263,7 +263,7 @@ type FetchAddrsRow struct {
 }
 
 func (q *Queries) FetchAddrs(ctx context.Context, arg FetchAddrsParams) ([]FetchAddrsRow, error) {
-	rows, err := q.db.QueryContext(ctx, fetchAddrs,
+	rows, err := q.db.QueryContext(ctx, FetchAddrs,
 		arg.CreatedAfter,
 		arg.CreatedBefore,
 		arg.UnmanagedOnly,
@@ -312,7 +312,7 @@ func (q *Queries) FetchAddrs(ctx context.Context, arg FetchAddrsParams) ([]Fetch
 	return items, nil
 }
 
-const insertAddr = `-- name: InsertAddr :one
+const InsertAddr = `-- name: InsertAddr :one
 INSERT INTO addrs (
     version, asset_version, genesis_asset_id, group_key, script_key_id,
     taproot_key_id, tapscript_sibling, taproot_output_key, amount, asset_type,
@@ -336,7 +336,7 @@ type InsertAddrParams struct {
 }
 
 func (q *Queries) InsertAddr(ctx context.Context, arg InsertAddrParams) (int64, error) {
-	row := q.db.QueryRowContext(ctx, insertAddr,
+	row := q.db.QueryRowContext(ctx, InsertAddr,
 		arg.Version,
 		arg.AssetVersion,
 		arg.GenesisAssetID,
@@ -355,7 +355,7 @@ func (q *Queries) InsertAddr(ctx context.Context, arg InsertAddrParams) (int64, 
 	return id, err
 }
 
-const queryEventIDs = `-- name: QueryEventIDs :many
+const QueryEventIDs = `-- name: QueryEventIDs :many
 SELECT
     addr_events.id as event_id, addrs.taproot_output_key as taproot_output_key
 FROM addr_events
@@ -381,7 +381,7 @@ type QueryEventIDsRow struct {
 }
 
 func (q *Queries) QueryEventIDs(ctx context.Context, arg QueryEventIDsParams) ([]QueryEventIDsRow, error) {
-	rows, err := q.db.QueryContext(ctx, queryEventIDs,
+	rows, err := q.db.QueryContext(ctx, QueryEventIDs,
 		arg.StatusFrom,
 		arg.StatusTo,
 		arg.AddrTaprootKey,
@@ -408,7 +408,7 @@ func (q *Queries) QueryEventIDs(ctx context.Context, arg QueryEventIDsParams) ([
 	return items, nil
 }
 
-const setAddrManaged = `-- name: SetAddrManaged :exec
+const SetAddrManaged = `-- name: SetAddrManaged :exec
 WITH target_addr(addr_id) AS (
     SELECT id
     FROM addrs
@@ -425,11 +425,11 @@ type SetAddrManagedParams struct {
 }
 
 func (q *Queries) SetAddrManaged(ctx context.Context, arg SetAddrManagedParams) error {
-	_, err := q.db.ExecContext(ctx, setAddrManaged, arg.TaprootOutputKey, arg.ManagedFrom)
+	_, err := q.db.ExecContext(ctx, SetAddrManaged, arg.TaprootOutputKey, arg.ManagedFrom)
 	return err
 }
 
-const upsertAddrEvent = `-- name: UpsertAddrEvent :one
+const UpsertAddrEvent = `-- name: UpsertAddrEvent :one
 WITH target_addr(addr_id) AS (
     SELECT id
     FROM addrs
@@ -465,7 +465,7 @@ type UpsertAddrEventParams struct {
 }
 
 func (q *Queries) UpsertAddrEvent(ctx context.Context, arg UpsertAddrEventParams) (int64, error) {
-	row := q.db.QueryRowContext(ctx, upsertAddrEvent,
+	row := q.db.QueryRowContext(ctx, UpsertAddrEvent,
 		arg.TaprootOutputKey,
 		arg.Txid,
 		arg.CreationTime,

--- a/tapdb/sqlc/assets.sql.go
+++ b/tapdb/sqlc/assets.sql.go
@@ -11,13 +11,13 @@ import (
 	"time"
 )
 
-const allAssets = `-- name: AllAssets :many
+const AllAssets = `-- name: AllAssets :many
 SELECT asset_id, genesis_id, version, script_key_id, asset_group_witness_id, script_version, amount, lock_time, relative_lock_time, split_commitment_root_hash, split_commitment_root_value, anchor_utxo_id, spent 
 FROM assets
 `
 
 func (q *Queries) AllAssets(ctx context.Context) ([]Asset, error) {
-	rows, err := q.db.QueryContext(ctx, allAssets)
+	rows, err := q.db.QueryContext(ctx, AllAssets)
 	if err != nil {
 		return nil, err
 	}
@@ -53,13 +53,13 @@ func (q *Queries) AllAssets(ctx context.Context) ([]Asset, error) {
 	return items, nil
 }
 
-const allInternalKeys = `-- name: AllInternalKeys :many
+const AllInternalKeys = `-- name: AllInternalKeys :many
 SELECT key_id, raw_key, key_family, key_index 
 FROM internal_keys
 `
 
 func (q *Queries) AllInternalKeys(ctx context.Context) ([]InternalKey, error) {
-	rows, err := q.db.QueryContext(ctx, allInternalKeys)
+	rows, err := q.db.QueryContext(ctx, AllInternalKeys)
 	if err != nil {
 		return nil, err
 	}
@@ -86,7 +86,7 @@ func (q *Queries) AllInternalKeys(ctx context.Context) ([]InternalKey, error) {
 	return items, nil
 }
 
-const allMintingBatches = `-- name: AllMintingBatches :many
+const AllMintingBatches = `-- name: AllMintingBatches :many
 SELECT batch_id, batch_state, minting_tx_psbt, change_output_index, genesis_id, height_hint, creation_time_unix, tapscript_sibling, key_id, raw_key, key_family, key_index 
 FROM asset_minting_batches
 JOIN internal_keys 
@@ -109,7 +109,7 @@ type AllMintingBatchesRow struct {
 }
 
 func (q *Queries) AllMintingBatches(ctx context.Context) ([]AllMintingBatchesRow, error) {
-	rows, err := q.db.QueryContext(ctx, allMintingBatches)
+	rows, err := q.db.QueryContext(ctx, AllMintingBatches)
 	if err != nil {
 		return nil, err
 	}
@@ -144,7 +144,7 @@ func (q *Queries) AllMintingBatches(ctx context.Context) ([]AllMintingBatchesRow
 	return items, nil
 }
 
-const anchorGenesisPoint = `-- name: AnchorGenesisPoint :exec
+const AnchorGenesisPoint = `-- name: AnchorGenesisPoint :exec
 WITH target_point(genesis_id) AS (
     SELECT genesis_id
     FROM genesis_points
@@ -161,11 +161,11 @@ type AnchorGenesisPointParams struct {
 }
 
 func (q *Queries) AnchorGenesisPoint(ctx context.Context, arg AnchorGenesisPointParams) error {
-	_, err := q.db.ExecContext(ctx, anchorGenesisPoint, arg.PrevOut, arg.AnchorTxID)
+	_, err := q.db.ExecContext(ctx, AnchorGenesisPoint, arg.PrevOut, arg.AnchorTxID)
 	return err
 }
 
-const anchorPendingAssets = `-- name: AnchorPendingAssets :exec
+const AnchorPendingAssets = `-- name: AnchorPendingAssets :exec
 WITH assets_to_update AS (
     SELECT script_key_id
     FROM assets 
@@ -186,11 +186,11 @@ type AnchorPendingAssetsParams struct {
 }
 
 func (q *Queries) AnchorPendingAssets(ctx context.Context, arg AnchorPendingAssetsParams) error {
-	_, err := q.db.ExecContext(ctx, anchorPendingAssets, arg.PrevOut, arg.AnchorUtxoID)
+	_, err := q.db.ExecContext(ctx, AnchorPendingAssets, arg.PrevOut, arg.AnchorUtxoID)
 	return err
 }
 
-const assetsByGenesisPoint = `-- name: AssetsByGenesisPoint :many
+const AssetsByGenesisPoint = `-- name: AssetsByGenesisPoint :many
 SELECT assets.asset_id, assets.genesis_id, version, script_key_id, asset_group_witness_id, script_version, amount, lock_time, relative_lock_time, split_commitment_root_hash, split_commitment_root_value, anchor_utxo_id, spent, gen_asset_id, genesis_assets.asset_id, asset_tag, meta_data_id, output_index, asset_type, genesis_point_id, genesis_points.genesis_id, prev_out, anchor_tx_id
 FROM assets 
 JOIN genesis_assets 
@@ -227,7 +227,7 @@ type AssetsByGenesisPointRow struct {
 }
 
 func (q *Queries) AssetsByGenesisPoint(ctx context.Context, prevOut []byte) ([]AssetsByGenesisPointRow, error) {
-	rows, err := q.db.QueryContext(ctx, assetsByGenesisPoint, prevOut)
+	rows, err := q.db.QueryContext(ctx, AssetsByGenesisPoint, prevOut)
 	if err != nil {
 		return nil, err
 	}
@@ -273,7 +273,7 @@ func (q *Queries) AssetsByGenesisPoint(ctx context.Context, prevOut []byte) ([]A
 	return items, nil
 }
 
-const assetsInBatch = `-- name: AssetsInBatch :many
+const AssetsInBatch = `-- name: AssetsInBatch :many
 SELECT
     gen_asset_id, asset_id, asset_tag, assets_meta.meta_data_hash, 
     output_index, asset_type, genesis_points.prev_out prev_out
@@ -300,7 +300,7 @@ type AssetsInBatchRow struct {
 }
 
 func (q *Queries) AssetsInBatch(ctx context.Context, rawKey []byte) ([]AssetsInBatchRow, error) {
-	rows, err := q.db.QueryContext(ctx, assetsInBatch, rawKey)
+	rows, err := q.db.QueryContext(ctx, AssetsInBatch, rawKey)
 	if err != nil {
 		return nil, err
 	}
@@ -330,7 +330,7 @@ func (q *Queries) AssetsInBatch(ctx context.Context, rawKey []byte) ([]AssetsInB
 	return items, nil
 }
 
-const bindMintingBatchWithTapSibling = `-- name: BindMintingBatchWithTapSibling :exec
+const BindMintingBatchWithTapSibling = `-- name: BindMintingBatchWithTapSibling :exec
 WITH target_batch AS (
     SELECT batch_id
     FROM asset_minting_batches batches
@@ -349,11 +349,11 @@ type BindMintingBatchWithTapSiblingParams struct {
 }
 
 func (q *Queries) BindMintingBatchWithTapSibling(ctx context.Context, arg BindMintingBatchWithTapSiblingParams) error {
-	_, err := q.db.ExecContext(ctx, bindMintingBatchWithTapSibling, arg.RawKey, arg.TapscriptSibling)
+	_, err := q.db.ExecContext(ctx, BindMintingBatchWithTapSibling, arg.RawKey, arg.TapscriptSibling)
 	return err
 }
 
-const bindMintingBatchWithTx = `-- name: BindMintingBatchWithTx :exec
+const BindMintingBatchWithTx = `-- name: BindMintingBatchWithTx :exec
 WITH target_batch AS (
     SELECT batch_id
     FROM asset_minting_batches batches
@@ -374,7 +374,7 @@ type BindMintingBatchWithTxParams struct {
 }
 
 func (q *Queries) BindMintingBatchWithTx(ctx context.Context, arg BindMintingBatchWithTxParams) error {
-	_, err := q.db.ExecContext(ctx, bindMintingBatchWithTx,
+	_, err := q.db.ExecContext(ctx, BindMintingBatchWithTx,
 		arg.RawKey,
 		arg.MintingTxPsbt,
 		arg.ChangeOutputIndex,
@@ -383,7 +383,7 @@ func (q *Queries) BindMintingBatchWithTx(ctx context.Context, arg BindMintingBat
 	return err
 }
 
-const confirmChainAnchorTx = `-- name: ConfirmChainAnchorTx :exec
+const ConfirmChainAnchorTx = `-- name: ConfirmChainAnchorTx :exec
 UPDATE chain_txns
 SET block_height = $2, block_hash = $3, tx_index = $4
 WHERE txid = $1
@@ -397,7 +397,7 @@ type ConfirmChainAnchorTxParams struct {
 }
 
 func (q *Queries) ConfirmChainAnchorTx(ctx context.Context, arg ConfirmChainAnchorTxParams) error {
-	_, err := q.db.ExecContext(ctx, confirmChainAnchorTx,
+	_, err := q.db.ExecContext(ctx, ConfirmChainAnchorTx,
 		arg.Txid,
 		arg.BlockHeight,
 		arg.BlockHash,
@@ -406,7 +406,7 @@ func (q *Queries) ConfirmChainAnchorTx(ctx context.Context, arg ConfirmChainAnch
 	return err
 }
 
-const confirmChainTx = `-- name: ConfirmChainTx :exec
+const ConfirmChainTx = `-- name: ConfirmChainTx :exec
 WITH target_txn(txn_id) AS (
     SELECT anchor_tx_id
     FROM genesis_points points
@@ -429,7 +429,7 @@ type ConfirmChainTxParams struct {
 }
 
 func (q *Queries) ConfirmChainTx(ctx context.Context, arg ConfirmChainTxParams) error {
-	_, err := q.db.ExecContext(ctx, confirmChainTx,
+	_, err := q.db.ExecContext(ctx, ConfirmChainTx,
 		arg.RawKey,
 		arg.BlockHeight,
 		arg.BlockHash,
@@ -438,7 +438,7 @@ func (q *Queries) ConfirmChainTx(ctx context.Context, arg ConfirmChainTxParams) 
 	return err
 }
 
-const deleteExpiredUTXOLeases = `-- name: DeleteExpiredUTXOLeases :exec
+const DeleteExpiredUTXOLeases = `-- name: DeleteExpiredUTXOLeases :exec
 UPDATE managed_utxos
 SET lease_owner = NULL, lease_expiry = NULL
 WHERE lease_owner IS NOT NULL AND
@@ -447,21 +447,21 @@ WHERE lease_owner IS NOT NULL AND
 `
 
 func (q *Queries) DeleteExpiredUTXOLeases(ctx context.Context, now sql.NullTime) error {
-	_, err := q.db.ExecContext(ctx, deleteExpiredUTXOLeases, now)
+	_, err := q.db.ExecContext(ctx, DeleteExpiredUTXOLeases, now)
 	return err
 }
 
-const deleteManagedUTXO = `-- name: DeleteManagedUTXO :exec
+const DeleteManagedUTXO = `-- name: DeleteManagedUTXO :exec
 DELETE FROM managed_utxos
 WHERE outpoint = $1
 `
 
 func (q *Queries) DeleteManagedUTXO(ctx context.Context, outpoint []byte) error {
-	_, err := q.db.ExecContext(ctx, deleteManagedUTXO, outpoint)
+	_, err := q.db.ExecContext(ctx, DeleteManagedUTXO, outpoint)
 	return err
 }
 
-const deleteTapscriptTreeEdges = `-- name: DeleteTapscriptTreeEdges :exec
+const DeleteTapscriptTreeEdges = `-- name: DeleteTapscriptTreeEdges :exec
 WITH tree_info AS (
     -- This CTE is used to fetch all edges that link the given tapscript tree
     -- root hash to child nodes.
@@ -476,11 +476,11 @@ WHERE edge_id IN (SELECT edge_id FROM tree_info)
 `
 
 func (q *Queries) DeleteTapscriptTreeEdges(ctx context.Context, rootHash []byte) error {
-	_, err := q.db.ExecContext(ctx, deleteTapscriptTreeEdges, rootHash)
+	_, err := q.db.ExecContext(ctx, DeleteTapscriptTreeEdges, rootHash)
 	return err
 }
 
-const deleteTapscriptTreeNodes = `-- name: DeleteTapscriptTreeNodes :exec
+const DeleteTapscriptTreeNodes = `-- name: DeleteTapscriptTreeNodes :exec
 DELETE FROM tapscript_nodes
 WHERE NOT EXISTS (
     SELECT 1
@@ -491,32 +491,32 @@ WHERE NOT EXISTS (
 `
 
 func (q *Queries) DeleteTapscriptTreeNodes(ctx context.Context) error {
-	_, err := q.db.ExecContext(ctx, deleteTapscriptTreeNodes)
+	_, err := q.db.ExecContext(ctx, DeleteTapscriptTreeNodes)
 	return err
 }
 
-const deleteTapscriptTreeRoot = `-- name: DeleteTapscriptTreeRoot :exec
+const DeleteTapscriptTreeRoot = `-- name: DeleteTapscriptTreeRoot :exec
 DELETE FROM tapscript_roots
 WHERE root_hash = $1
 `
 
 func (q *Queries) DeleteTapscriptTreeRoot(ctx context.Context, rootHash []byte) error {
-	_, err := q.db.ExecContext(ctx, deleteTapscriptTreeRoot, rootHash)
+	_, err := q.db.ExecContext(ctx, DeleteTapscriptTreeRoot, rootHash)
 	return err
 }
 
-const deleteUTXOLease = `-- name: DeleteUTXOLease :exec
+const DeleteUTXOLease = `-- name: DeleteUTXOLease :exec
 UPDATE managed_utxos
 SET lease_owner = NULL, lease_expiry = NULL
 WHERE outpoint = $1
 `
 
 func (q *Queries) DeleteUTXOLease(ctx context.Context, outpoint []byte) error {
-	_, err := q.db.ExecContext(ctx, deleteUTXOLease, outpoint)
+	_, err := q.db.ExecContext(ctx, DeleteUTXOLease, outpoint)
 	return err
 }
 
-const fetchAssetID = `-- name: FetchAssetID :many
+const FetchAssetID = `-- name: FetchAssetID :many
 SELECT asset_id
     FROM assets
     JOIN script_keys 
@@ -536,7 +536,7 @@ type FetchAssetIDParams struct {
 }
 
 func (q *Queries) FetchAssetID(ctx context.Context, arg FetchAssetIDParams) ([]int64, error) {
-	rows, err := q.db.QueryContext(ctx, fetchAssetID, arg.TweakedScriptKey, arg.Outpoint)
+	rows, err := q.db.QueryContext(ctx, FetchAssetID, arg.TweakedScriptKey, arg.Outpoint)
 	if err != nil {
 		return nil, err
 	}
@@ -558,7 +558,7 @@ func (q *Queries) FetchAssetID(ctx context.Context, arg FetchAssetIDParams) ([]i
 	return items, nil
 }
 
-const fetchAssetMeta = `-- name: FetchAssetMeta :one
+const FetchAssetMeta = `-- name: FetchAssetMeta :one
 SELECT meta_data_hash, meta_data_blob, meta_data_type
 FROM assets_meta
 WHERE meta_id = $1
@@ -571,13 +571,13 @@ type FetchAssetMetaRow struct {
 }
 
 func (q *Queries) FetchAssetMeta(ctx context.Context, metaID int64) (FetchAssetMetaRow, error) {
-	row := q.db.QueryRowContext(ctx, fetchAssetMeta, metaID)
+	row := q.db.QueryRowContext(ctx, FetchAssetMeta, metaID)
 	var i FetchAssetMetaRow
 	err := row.Scan(&i.MetaDataHash, &i.MetaDataBlob, &i.MetaDataType)
 	return i, err
 }
 
-const fetchAssetMetaByHash = `-- name: FetchAssetMetaByHash :one
+const FetchAssetMetaByHash = `-- name: FetchAssetMetaByHash :one
 SELECT meta_data_hash, meta_data_blob, meta_data_type
 FROM assets_meta
 WHERE meta_data_hash = $1
@@ -590,13 +590,13 @@ type FetchAssetMetaByHashRow struct {
 }
 
 func (q *Queries) FetchAssetMetaByHash(ctx context.Context, metaDataHash []byte) (FetchAssetMetaByHashRow, error) {
-	row := q.db.QueryRowContext(ctx, fetchAssetMetaByHash, metaDataHash)
+	row := q.db.QueryRowContext(ctx, FetchAssetMetaByHash, metaDataHash)
 	var i FetchAssetMetaByHashRow
 	err := row.Scan(&i.MetaDataHash, &i.MetaDataBlob, &i.MetaDataType)
 	return i, err
 }
 
-const fetchAssetMetaForAsset = `-- name: FetchAssetMetaForAsset :one
+const FetchAssetMetaForAsset = `-- name: FetchAssetMetaForAsset :one
 SELECT meta_data_hash, meta_data_blob, meta_data_type
 FROM genesis_assets assets
 JOIN assets_meta
@@ -611,13 +611,13 @@ type FetchAssetMetaForAssetRow struct {
 }
 
 func (q *Queries) FetchAssetMetaForAsset(ctx context.Context, assetID []byte) (FetchAssetMetaForAssetRow, error) {
-	row := q.db.QueryRowContext(ctx, fetchAssetMetaForAsset, assetID)
+	row := q.db.QueryRowContext(ctx, FetchAssetMetaForAsset, assetID)
 	var i FetchAssetMetaForAssetRow
 	err := row.Scan(&i.MetaDataHash, &i.MetaDataBlob, &i.MetaDataType)
 	return i, err
 }
 
-const fetchAssetProof = `-- name: FetchAssetProof :many
+const FetchAssetProof = `-- name: FetchAssetProof :many
 WITH asset_info AS (
     SELECT assets.asset_id, script_keys.tweaked_script_key, utxos.outpoint
     FROM assets
@@ -650,7 +650,7 @@ type FetchAssetProofRow struct {
 }
 
 func (q *Queries) FetchAssetProof(ctx context.Context, arg FetchAssetProofParams) ([]FetchAssetProofRow, error) {
-	rows, err := q.db.QueryContext(ctx, fetchAssetProof, arg.TweakedScriptKey, arg.Outpoint)
+	rows, err := q.db.QueryContext(ctx, FetchAssetProof, arg.TweakedScriptKey, arg.Outpoint)
 	if err != nil {
 		return nil, err
 	}
@@ -678,7 +678,7 @@ func (q *Queries) FetchAssetProof(ctx context.Context, arg FetchAssetProofParams
 	return items, nil
 }
 
-const fetchAssetProofs = `-- name: FetchAssetProofs :many
+const FetchAssetProofs = `-- name: FetchAssetProofs :many
 WITH asset_info AS (
     SELECT assets.asset_id, script_keys.tweaked_script_key
     FROM assets
@@ -697,7 +697,7 @@ type FetchAssetProofsRow struct {
 }
 
 func (q *Queries) FetchAssetProofs(ctx context.Context) ([]FetchAssetProofsRow, error) {
-	rows, err := q.db.QueryContext(ctx, fetchAssetProofs)
+	rows, err := q.db.QueryContext(ctx, FetchAssetProofs)
 	if err != nil {
 		return nil, err
 	}
@@ -719,7 +719,7 @@ func (q *Queries) FetchAssetProofs(ctx context.Context) ([]FetchAssetProofsRow, 
 	return items, nil
 }
 
-const fetchAssetProofsByAssetID = `-- name: FetchAssetProofsByAssetID :many
+const FetchAssetProofsByAssetID = `-- name: FetchAssetProofsByAssetID :many
 WITH asset_info AS (
     SELECT assets.asset_id, script_keys.tweaked_script_key
     FROM assets
@@ -741,7 +741,7 @@ type FetchAssetProofsByAssetIDRow struct {
 }
 
 func (q *Queries) FetchAssetProofsByAssetID(ctx context.Context, assetID []byte) ([]FetchAssetProofsByAssetIDRow, error) {
-	rows, err := q.db.QueryContext(ctx, fetchAssetProofsByAssetID, assetID)
+	rows, err := q.db.QueryContext(ctx, FetchAssetProofsByAssetID, assetID)
 	if err != nil {
 		return nil, err
 	}
@@ -763,7 +763,7 @@ func (q *Queries) FetchAssetProofsByAssetID(ctx context.Context, assetID []byte)
 	return items, nil
 }
 
-const fetchAssetProofsSizes = `-- name: FetchAssetProofsSizes :many
+const FetchAssetProofsSizes = `-- name: FetchAssetProofsSizes :many
 SELECT script_keys.tweaked_script_key AS script_key, 
        LENGTH(asset_proofs.proof_file) AS proof_file_length
 FROM asset_proofs
@@ -779,7 +779,7 @@ type FetchAssetProofsSizesRow struct {
 }
 
 func (q *Queries) FetchAssetProofsSizes(ctx context.Context) ([]FetchAssetProofsSizesRow, error) {
-	rows, err := q.db.QueryContext(ctx, fetchAssetProofsSizes)
+	rows, err := q.db.QueryContext(ctx, FetchAssetProofsSizes)
 	if err != nil {
 		return nil, err
 	}
@@ -801,7 +801,7 @@ func (q *Queries) FetchAssetProofsSizes(ctx context.Context) ([]FetchAssetProofs
 	return items, nil
 }
 
-const fetchAssetWitnesses = `-- name: FetchAssetWitnesses :many
+const FetchAssetWitnesses = `-- name: FetchAssetWitnesses :many
 SELECT 
     assets.asset_id, prev_out_point, prev_asset_id, prev_script_key, 
     witness_stack, split_commitment_proof
@@ -824,7 +824,7 @@ type FetchAssetWitnessesRow struct {
 }
 
 func (q *Queries) FetchAssetWitnesses(ctx context.Context, assetID sql.NullInt64) ([]FetchAssetWitnessesRow, error) {
-	rows, err := q.db.QueryContext(ctx, fetchAssetWitnesses, assetID)
+	rows, err := q.db.QueryContext(ctx, FetchAssetWitnesses, assetID)
 	if err != nil {
 		return nil, err
 	}
@@ -853,14 +853,14 @@ func (q *Queries) FetchAssetWitnesses(ctx context.Context, assetID sql.NullInt64
 	return items, nil
 }
 
-const fetchAssetsByAnchorTx = `-- name: FetchAssetsByAnchorTx :many
+const FetchAssetsByAnchorTx = `-- name: FetchAssetsByAnchorTx :many
 SELECT asset_id, genesis_id, version, script_key_id, asset_group_witness_id, script_version, amount, lock_time, relative_lock_time, split_commitment_root_hash, split_commitment_root_value, anchor_utxo_id, spent
 FROM assets
 WHERE anchor_utxo_id = $1
 `
 
 func (q *Queries) FetchAssetsByAnchorTx(ctx context.Context, anchorUtxoID sql.NullInt64) ([]Asset, error) {
-	rows, err := q.db.QueryContext(ctx, fetchAssetsByAnchorTx, anchorUtxoID)
+	rows, err := q.db.QueryContext(ctx, FetchAssetsByAnchorTx, anchorUtxoID)
 	if err != nil {
 		return nil, err
 	}
@@ -896,7 +896,7 @@ func (q *Queries) FetchAssetsByAnchorTx(ctx context.Context, anchorUtxoID sql.Nu
 	return items, nil
 }
 
-const fetchAssetsForBatch = `-- name: FetchAssetsForBatch :many
+const FetchAssetsForBatch = `-- name: FetchAssetsForBatch :many
 WITH genesis_info AS (
     -- This CTE is used to fetch the base asset information from disk based on
     -- the raw key of the batch that will ultimately create this set of assets.
@@ -997,7 +997,7 @@ type FetchAssetsForBatchRow struct {
 // doesn't have a group key. See the comment in fetchAssetSprouts for a work
 // around that needs to be used with this query until a sqlc bug is fixed.
 func (q *Queries) FetchAssetsForBatch(ctx context.Context, rawKey []byte) ([]FetchAssetsForBatchRow, error) {
-	rows, err := q.db.QueryContext(ctx, fetchAssetsForBatch, rawKey)
+	rows, err := q.db.QueryContext(ctx, FetchAssetsForBatch, rawKey)
 	if err != nil {
 		return nil, err
 	}
@@ -1046,14 +1046,14 @@ func (q *Queries) FetchAssetsForBatch(ctx context.Context, rawKey []byte) ([]Fet
 	return items, nil
 }
 
-const fetchChainTx = `-- name: FetchChainTx :one
+const FetchChainTx = `-- name: FetchChainTx :one
 SELECT txn_id, txid, chain_fees, raw_tx, block_height, block_hash, tx_index
 FROM chain_txns
 WHERE txid = $1
 `
 
 func (q *Queries) FetchChainTx(ctx context.Context, txid []byte) (ChainTxn, error) {
-	row := q.db.QueryRowContext(ctx, fetchChainTx, txid)
+	row := q.db.QueryRowContext(ctx, FetchChainTx, txid)
 	var i ChainTxn
 	err := row.Scan(
 		&i.TxnID,
@@ -1067,14 +1067,14 @@ func (q *Queries) FetchChainTx(ctx context.Context, txid []byte) (ChainTxn, erro
 	return i, err
 }
 
-const fetchGenesisByAssetID = `-- name: FetchGenesisByAssetID :one
+const FetchGenesisByAssetID = `-- name: FetchGenesisByAssetID :one
 SELECT gen_asset_id, asset_id, asset_tag, meta_hash, output_index, asset_type, prev_out, anchor_txid, block_height 
 FROM genesis_info_view
 WHERE asset_id = $1
 `
 
 func (q *Queries) FetchGenesisByAssetID(ctx context.Context, assetID []byte) (GenesisInfoView, error) {
-	row := q.db.QueryRowContext(ctx, fetchGenesisByAssetID, assetID)
+	row := q.db.QueryRowContext(ctx, FetchGenesisByAssetID, assetID)
 	var i GenesisInfoView
 	err := row.Scan(
 		&i.GenAssetID,
@@ -1090,7 +1090,7 @@ func (q *Queries) FetchGenesisByAssetID(ctx context.Context, assetID []byte) (Ge
 	return i, err
 }
 
-const fetchGenesisByID = `-- name: FetchGenesisByID :one
+const FetchGenesisByID = `-- name: FetchGenesisByID :one
 SELECT
     asset_id, asset_tag, assets_meta.meta_data_hash, output_index, asset_type,
     genesis_points.prev_out prev_out
@@ -1112,7 +1112,7 @@ type FetchGenesisByIDRow struct {
 }
 
 func (q *Queries) FetchGenesisByID(ctx context.Context, genAssetID int64) (FetchGenesisByIDRow, error) {
-	row := q.db.QueryRowContext(ctx, fetchGenesisByID, genAssetID)
+	row := q.db.QueryRowContext(ctx, FetchGenesisByID, genAssetID)
 	var i FetchGenesisByIDRow
 	err := row.Scan(
 		&i.AssetID,
@@ -1125,7 +1125,7 @@ func (q *Queries) FetchGenesisByID(ctx context.Context, genAssetID int64) (Fetch
 	return i, err
 }
 
-const fetchGenesisID = `-- name: FetchGenesisID :one
+const FetchGenesisID = `-- name: FetchGenesisID :one
 WITH target_point(genesis_id) AS (
     SELECT genesis_id
     FROM genesis_points
@@ -1155,7 +1155,7 @@ type FetchGenesisIDParams struct {
 }
 
 func (q *Queries) FetchGenesisID(ctx context.Context, arg FetchGenesisIDParams) (int64, error) {
-	row := q.db.QueryRowContext(ctx, fetchGenesisID,
+	row := q.db.QueryRowContext(ctx, FetchGenesisID,
 		arg.AssetID,
 		arg.AssetTag,
 		arg.MetaHash,
@@ -1168,20 +1168,20 @@ func (q *Queries) FetchGenesisID(ctx context.Context, arg FetchGenesisIDParams) 
 	return gen_asset_id, err
 }
 
-const fetchGenesisPointByAnchorTx = `-- name: FetchGenesisPointByAnchorTx :one
+const FetchGenesisPointByAnchorTx = `-- name: FetchGenesisPointByAnchorTx :one
 SELECT genesis_id, prev_out, anchor_tx_id 
 FROM genesis_points
 WHERE anchor_tx_id = $1
 `
 
 func (q *Queries) FetchGenesisPointByAnchorTx(ctx context.Context, anchorTxID sql.NullInt64) (GenesisPoint, error) {
-	row := q.db.QueryRowContext(ctx, fetchGenesisPointByAnchorTx, anchorTxID)
+	row := q.db.QueryRowContext(ctx, FetchGenesisPointByAnchorTx, anchorTxID)
 	var i GenesisPoint
 	err := row.Scan(&i.GenesisID, &i.PrevOut, &i.AnchorTxID)
 	return i, err
 }
 
-const fetchGroupByGenesis = `-- name: FetchGroupByGenesis :one
+const FetchGroupByGenesis = `-- name: FetchGroupByGenesis :one
 SELECT
     key_group_info_view.version AS version,
     key_group_info_view.tweaked_group_key AS tweaked_group_key,
@@ -1209,7 +1209,7 @@ type FetchGroupByGenesisRow struct {
 }
 
 func (q *Queries) FetchGroupByGenesis(ctx context.Context, genesisID int64) (FetchGroupByGenesisRow, error) {
-	row := q.db.QueryRowContext(ctx, fetchGroupByGenesis, genesisID)
+	row := q.db.QueryRowContext(ctx, FetchGroupByGenesis, genesisID)
 	var i FetchGroupByGenesisRow
 	err := row.Scan(
 		&i.Version,
@@ -1224,7 +1224,7 @@ func (q *Queries) FetchGroupByGenesis(ctx context.Context, genesisID int64) (Fet
 	return i, err
 }
 
-const fetchGroupByGroupKey = `-- name: FetchGroupByGroupKey :one
+const FetchGroupByGroupKey = `-- name: FetchGroupByGroupKey :one
 SELECT
     key_group_info_view.version AS version,
     key_group_info_view.gen_asset_id AS gen_asset_id,
@@ -1255,7 +1255,7 @@ type FetchGroupByGroupKeyRow struct {
 
 // Sort and limit to return the genesis ID for initial genesis of the group.
 func (q *Queries) FetchGroupByGroupKey(ctx context.Context, groupKey []byte) (FetchGroupByGroupKeyRow, error) {
-	row := q.db.QueryRowContext(ctx, fetchGroupByGroupKey, groupKey)
+	row := q.db.QueryRowContext(ctx, FetchGroupByGroupKey, groupKey)
 	var i FetchGroupByGroupKeyRow
 	err := row.Scan(
 		&i.Version,
@@ -1270,7 +1270,7 @@ func (q *Queries) FetchGroupByGroupKey(ctx context.Context, groupKey []byte) (Fe
 	return i, err
 }
 
-const fetchGroupedAssets = `-- name: FetchGroupedAssets :many
+const FetchGroupedAssets = `-- name: FetchGroupedAssets :many
 SELECT
     assets.asset_id AS asset_primary_key,
     amount, lock_time, relative_lock_time, spent, 
@@ -1303,7 +1303,7 @@ type FetchGroupedAssetsRow struct {
 }
 
 func (q *Queries) FetchGroupedAssets(ctx context.Context) ([]FetchGroupedAssetsRow, error) {
-	rows, err := q.db.QueryContext(ctx, fetchGroupedAssets)
+	rows, err := q.db.QueryContext(ctx, FetchGroupedAssets)
 	if err != nil {
 		return nil, err
 	}
@@ -1337,7 +1337,7 @@ func (q *Queries) FetchGroupedAssets(ctx context.Context) ([]FetchGroupedAssetsR
 	return items, nil
 }
 
-const fetchInternalKeyLocator = `-- name: FetchInternalKeyLocator :one
+const FetchInternalKeyLocator = `-- name: FetchInternalKeyLocator :one
 SELECT key_family, key_index
 FROM internal_keys
 WHERE raw_key = $1
@@ -1349,13 +1349,13 @@ type FetchInternalKeyLocatorRow struct {
 }
 
 func (q *Queries) FetchInternalKeyLocator(ctx context.Context, rawKey []byte) (FetchInternalKeyLocatorRow, error) {
-	row := q.db.QueryRowContext(ctx, fetchInternalKeyLocator, rawKey)
+	row := q.db.QueryRowContext(ctx, FetchInternalKeyLocator, rawKey)
 	var i FetchInternalKeyLocatorRow
 	err := row.Scan(&i.KeyFamily, &i.KeyIndex)
 	return i, err
 }
 
-const fetchManagedUTXO = `-- name: FetchManagedUTXO :one
+const FetchManagedUTXO = `-- name: FetchManagedUTXO :one
 SELECT utxo_id, outpoint, amt_sats, internal_key_id, taproot_asset_root, tapscript_sibling, merkle_root, txn_id, lease_owner, lease_expiry, root_version, key_id, raw_key, key_family, key_index
 FROM managed_utxos utxos
 JOIN internal_keys keys
@@ -1390,7 +1390,7 @@ type FetchManagedUTXORow struct {
 }
 
 func (q *Queries) FetchManagedUTXO(ctx context.Context, arg FetchManagedUTXOParams) (FetchManagedUTXORow, error) {
-	row := q.db.QueryRowContext(ctx, fetchManagedUTXO, arg.TxnID, arg.Outpoint)
+	row := q.db.QueryRowContext(ctx, FetchManagedUTXO, arg.TxnID, arg.Outpoint)
 	var i FetchManagedUTXORow
 	err := row.Scan(
 		&i.UtxoID,
@@ -1412,7 +1412,7 @@ func (q *Queries) FetchManagedUTXO(ctx context.Context, arg FetchManagedUTXOPara
 	return i, err
 }
 
-const fetchManagedUTXOs = `-- name: FetchManagedUTXOs :many
+const FetchManagedUTXOs = `-- name: FetchManagedUTXOs :many
 SELECT utxo_id, outpoint, amt_sats, internal_key_id, taproot_asset_root, tapscript_sibling, merkle_root, txn_id, lease_owner, lease_expiry, root_version, key_id, raw_key, key_family, key_index
 FROM managed_utxos utxos
 JOIN internal_keys keys
@@ -1438,7 +1438,7 @@ type FetchManagedUTXOsRow struct {
 }
 
 func (q *Queries) FetchManagedUTXOs(ctx context.Context) ([]FetchManagedUTXOsRow, error) {
-	rows, err := q.db.QueryContext(ctx, fetchManagedUTXOs)
+	rows, err := q.db.QueryContext(ctx, FetchManagedUTXOs)
 	if err != nil {
 		return nil, err
 	}
@@ -1476,7 +1476,7 @@ func (q *Queries) FetchManagedUTXOs(ctx context.Context) ([]FetchManagedUTXOsRow
 	return items, nil
 }
 
-const fetchMintingBatch = `-- name: FetchMintingBatch :one
+const FetchMintingBatch = `-- name: FetchMintingBatch :one
 WITH target_batch AS (
     -- This CTE is used to fetch the ID of a batch, based on the serialized
     -- internal key associated with the batch. This internal key is used as the
@@ -1511,7 +1511,7 @@ type FetchMintingBatchRow struct {
 }
 
 func (q *Queries) FetchMintingBatch(ctx context.Context, rawKey []byte) (FetchMintingBatchRow, error) {
-	row := q.db.QueryRowContext(ctx, fetchMintingBatch, rawKey)
+	row := q.db.QueryRowContext(ctx, FetchMintingBatch, rawKey)
 	var i FetchMintingBatchRow
 	err := row.Scan(
 		&i.BatchID,
@@ -1530,7 +1530,7 @@ func (q *Queries) FetchMintingBatch(ctx context.Context, rawKey []byte) (FetchMi
 	return i, err
 }
 
-const fetchMintingBatchesByInverseState = `-- name: FetchMintingBatchesByInverseState :many
+const FetchMintingBatchesByInverseState = `-- name: FetchMintingBatchesByInverseState :many
 SELECT batch_id, batch_state, minting_tx_psbt, change_output_index, genesis_id, height_hint, creation_time_unix, tapscript_sibling, key_id, raw_key, key_family, key_index
 FROM asset_minting_batches batches
 JOIN internal_keys keys
@@ -1554,7 +1554,7 @@ type FetchMintingBatchesByInverseStateRow struct {
 }
 
 func (q *Queries) FetchMintingBatchesByInverseState(ctx context.Context, batchState int16) ([]FetchMintingBatchesByInverseStateRow, error) {
-	rows, err := q.db.QueryContext(ctx, fetchMintingBatchesByInverseState, batchState)
+	rows, err := q.db.QueryContext(ctx, FetchMintingBatchesByInverseState, batchState)
 	if err != nil {
 		return nil, err
 	}
@@ -1589,7 +1589,7 @@ func (q *Queries) FetchMintingBatchesByInverseState(ctx context.Context, batchSt
 	return items, nil
 }
 
-const fetchScriptKeyByTweakedKey = `-- name: FetchScriptKeyByTweakedKey :one
+const FetchScriptKeyByTweakedKey = `-- name: FetchScriptKeyByTweakedKey :one
 SELECT tweak, raw_key, key_family, key_index, declared_known
 FROM script_keys
 JOIN internal_keys
@@ -1606,7 +1606,7 @@ type FetchScriptKeyByTweakedKeyRow struct {
 }
 
 func (q *Queries) FetchScriptKeyByTweakedKey(ctx context.Context, tweakedScriptKey []byte) (FetchScriptKeyByTweakedKeyRow, error) {
-	row := q.db.QueryRowContext(ctx, fetchScriptKeyByTweakedKey, tweakedScriptKey)
+	row := q.db.QueryRowContext(ctx, FetchScriptKeyByTweakedKey, tweakedScriptKey)
 	var i FetchScriptKeyByTweakedKeyRow
 	err := row.Scan(
 		&i.Tweak,
@@ -1618,27 +1618,27 @@ func (q *Queries) FetchScriptKeyByTweakedKey(ctx context.Context, tweakedScriptK
 	return i, err
 }
 
-const fetchScriptKeyIDByTweakedKey = `-- name: FetchScriptKeyIDByTweakedKey :one
+const FetchScriptKeyIDByTweakedKey = `-- name: FetchScriptKeyIDByTweakedKey :one
 SELECT script_key_id
 FROM script_keys
 WHERE tweaked_script_key = $1
 `
 
 func (q *Queries) FetchScriptKeyIDByTweakedKey(ctx context.Context, tweakedScriptKey []byte) (int64, error) {
-	row := q.db.QueryRowContext(ctx, fetchScriptKeyIDByTweakedKey, tweakedScriptKey)
+	row := q.db.QueryRowContext(ctx, FetchScriptKeyIDByTweakedKey, tweakedScriptKey)
 	var script_key_id int64
 	err := row.Scan(&script_key_id)
 	return script_key_id, err
 }
 
-const fetchSeedlingByID = `-- name: FetchSeedlingByID :one
+const FetchSeedlingByID = `-- name: FetchSeedlingByID :one
 SELECT seedling_id, asset_name, asset_version, asset_type, asset_supply, asset_meta_id, emission_enabled, batch_id, group_genesis_id, group_anchor_id, script_key_id, group_internal_key_id, group_tapscript_root
 FROM asset_seedlings
 WHERE seedling_id = $1
 `
 
 func (q *Queries) FetchSeedlingByID(ctx context.Context, seedlingID int64) (AssetSeedling, error) {
-	row := q.db.QueryRowContext(ctx, fetchSeedlingByID, seedlingID)
+	row := q.db.QueryRowContext(ctx, FetchSeedlingByID, seedlingID)
 	var i AssetSeedling
 	err := row.Scan(
 		&i.SeedlingID,
@@ -1658,7 +1658,7 @@ func (q *Queries) FetchSeedlingByID(ctx context.Context, seedlingID int64) (Asse
 	return i, err
 }
 
-const fetchSeedlingID = `-- name: FetchSeedlingID :one
+const FetchSeedlingID = `-- name: FetchSeedlingID :one
 WITH target_key_id AS (
     -- We use this CTE to fetch the key_id of the internal key that's
     -- associated with a given batch. This can only return one value in
@@ -1682,13 +1682,13 @@ type FetchSeedlingIDParams struct {
 }
 
 func (q *Queries) FetchSeedlingID(ctx context.Context, arg FetchSeedlingIDParams) (int64, error) {
-	row := q.db.QueryRowContext(ctx, fetchSeedlingID, arg.SeedlingName, arg.BatchKey)
+	row := q.db.QueryRowContext(ctx, FetchSeedlingID, arg.SeedlingName, arg.BatchKey)
 	var seedling_id int64
 	err := row.Scan(&seedling_id)
 	return seedling_id, err
 }
 
-const fetchSeedlingsForBatch = `-- name: FetchSeedlingsForBatch :many
+const FetchSeedlingsForBatch = `-- name: FetchSeedlingsForBatch :many
 WITH target_batch(batch_id) AS (
     SELECT batch_id
     FROM asset_minting_batches batches
@@ -1747,7 +1747,7 @@ type FetchSeedlingsForBatchRow struct {
 }
 
 func (q *Queries) FetchSeedlingsForBatch(ctx context.Context, rawKey []byte) ([]FetchSeedlingsForBatchRow, error) {
-	rows, err := q.db.QueryContext(ctx, fetchSeedlingsForBatch, rawKey)
+	rows, err := q.db.QueryContext(ctx, FetchSeedlingsForBatch, rawKey)
 	if err != nil {
 		return nil, err
 	}
@@ -1792,7 +1792,7 @@ func (q *Queries) FetchSeedlingsForBatch(ctx context.Context, rawKey []byte) ([]
 	return items, nil
 }
 
-const fetchTapscriptTree = `-- name: FetchTapscriptTree :many
+const FetchTapscriptTree = `-- name: FetchTapscriptTree :many
 WITH tree_info AS (
     -- This CTE is used to fetch all edges that link the given tapscript tree
     -- root hash to child nodes. Each edge also contains the index of the child
@@ -1818,7 +1818,7 @@ type FetchTapscriptTreeRow struct {
 
 // Sort the nodes by node_index here instead of returning the indices.
 func (q *Queries) FetchTapscriptTree(ctx context.Context, rootHash []byte) ([]FetchTapscriptTreeRow, error) {
-	rows, err := q.db.QueryContext(ctx, fetchTapscriptTree, rootHash)
+	rows, err := q.db.QueryContext(ctx, FetchTapscriptTree, rootHash)
 	if err != nil {
 		return nil, err
 	}
@@ -1840,13 +1840,13 @@ func (q *Queries) FetchTapscriptTree(ctx context.Context, rootHash []byte) ([]Fe
 	return items, nil
 }
 
-const genesisAssets = `-- name: GenesisAssets :many
+const GenesisAssets = `-- name: GenesisAssets :many
 SELECT gen_asset_id, asset_id, asset_tag, meta_data_id, output_index, asset_type, genesis_point_id 
 FROM genesis_assets
 `
 
 func (q *Queries) GenesisAssets(ctx context.Context) ([]GenesisAsset, error) {
-	rows, err := q.db.QueryContext(ctx, genesisAssets)
+	rows, err := q.db.QueryContext(ctx, GenesisAssets)
 	if err != nil {
 		return nil, err
 	}
@@ -1876,13 +1876,13 @@ func (q *Queries) GenesisAssets(ctx context.Context) ([]GenesisAsset, error) {
 	return items, nil
 }
 
-const genesisPoints = `-- name: GenesisPoints :many
+const GenesisPoints = `-- name: GenesisPoints :many
 SELECT genesis_id, prev_out, anchor_tx_id
 FROM genesis_points
 `
 
 func (q *Queries) GenesisPoints(ctx context.Context) ([]GenesisPoint, error) {
-	rows, err := q.db.QueryContext(ctx, genesisPoints)
+	rows, err := q.db.QueryContext(ctx, GenesisPoints)
 	if err != nil {
 		return nil, err
 	}
@@ -1904,7 +1904,7 @@ func (q *Queries) GenesisPoints(ctx context.Context) ([]GenesisPoint, error) {
 	return items, nil
 }
 
-const hasAssetProof = `-- name: HasAssetProof :one
+const HasAssetProof = `-- name: HasAssetProof :one
 WITH asset_info AS (
     SELECT assets.asset_id
     FROM assets
@@ -1919,13 +1919,13 @@ JOIN asset_info
 `
 
 func (q *Queries) HasAssetProof(ctx context.Context, tweakedScriptKey []byte) (bool, error) {
-	row := q.db.QueryRowContext(ctx, hasAssetProof, tweakedScriptKey)
+	row := q.db.QueryRowContext(ctx, HasAssetProof, tweakedScriptKey)
 	var has_proof bool
 	err := row.Scan(&has_proof)
 	return has_proof, err
 }
 
-const insertAssetSeedling = `-- name: InsertAssetSeedling :exec
+const InsertAssetSeedling = `-- name: InsertAssetSeedling :exec
 INSERT INTO asset_seedlings (
     asset_name, asset_type, asset_version, asset_supply, asset_meta_id,
     emission_enabled, batch_id, group_genesis_id, group_anchor_id,
@@ -1955,7 +1955,7 @@ type InsertAssetSeedlingParams struct {
 }
 
 func (q *Queries) InsertAssetSeedling(ctx context.Context, arg InsertAssetSeedlingParams) error {
-	_, err := q.db.ExecContext(ctx, insertAssetSeedling,
+	_, err := q.db.ExecContext(ctx, InsertAssetSeedling,
 		arg.AssetName,
 		arg.AssetType,
 		arg.AssetVersion,
@@ -1972,7 +1972,7 @@ func (q *Queries) InsertAssetSeedling(ctx context.Context, arg InsertAssetSeedli
 	return err
 }
 
-const insertAssetSeedlingIntoBatch = `-- name: InsertAssetSeedlingIntoBatch :exec
+const InsertAssetSeedlingIntoBatch = `-- name: InsertAssetSeedlingIntoBatch :exec
 WITH target_key_id AS (
     -- We use this CTE to fetch the key_id of the internal key that's
     -- associated with a given batch. This can only return one value in
@@ -2013,7 +2013,7 @@ type InsertAssetSeedlingIntoBatchParams struct {
 }
 
 func (q *Queries) InsertAssetSeedlingIntoBatch(ctx context.Context, arg InsertAssetSeedlingIntoBatchParams) error {
-	_, err := q.db.ExecContext(ctx, insertAssetSeedlingIntoBatch,
+	_, err := q.db.ExecContext(ctx, InsertAssetSeedlingIntoBatch,
 		arg.RawKey,
 		arg.AssetName,
 		arg.AssetType,
@@ -2030,7 +2030,7 @@ func (q *Queries) InsertAssetSeedlingIntoBatch(ctx context.Context, arg InsertAs
 	return err
 }
 
-const newMintingBatch = `-- name: NewMintingBatch :exec
+const NewMintingBatch = `-- name: NewMintingBatch :exec
 INSERT INTO asset_minting_batches (
     batch_state, batch_id, height_hint, creation_time_unix
 ) VALUES (0, $1, $2, $3)
@@ -2043,11 +2043,11 @@ type NewMintingBatchParams struct {
 }
 
 func (q *Queries) NewMintingBatch(ctx context.Context, arg NewMintingBatchParams) error {
-	_, err := q.db.ExecContext(ctx, newMintingBatch, arg.BatchID, arg.HeightHint, arg.CreationTimeUnix)
+	_, err := q.db.ExecContext(ctx, NewMintingBatch, arg.BatchID, arg.HeightHint, arg.CreationTimeUnix)
 	return err
 }
 
-const queryAssetBalancesByAsset = `-- name: QueryAssetBalancesByAsset :many
+const QueryAssetBalancesByAsset = `-- name: QueryAssetBalancesByAsset :many
 SELECT
     genesis_info_view.asset_id, SUM(amount) balance,
     genesis_info_view.asset_tag, genesis_info_view.meta_hash,
@@ -2104,7 +2104,7 @@ type QueryAssetBalancesByAssetRow struct {
 // doesn't have a group key. See the comment in fetchAssetSprouts for a work
 // around that needs to be used with this query until a sqlc bug is fixed.
 func (q *Queries) QueryAssetBalancesByAsset(ctx context.Context, arg QueryAssetBalancesByAssetParams) ([]QueryAssetBalancesByAssetRow, error) {
-	rows, err := q.db.QueryContext(ctx, queryAssetBalancesByAsset,
+	rows, err := q.db.QueryContext(ctx, QueryAssetBalancesByAsset,
 		arg.AssetIDFilter,
 		arg.Leased,
 		arg.Now,
@@ -2139,7 +2139,7 @@ func (q *Queries) QueryAssetBalancesByAsset(ctx context.Context, arg QueryAssetB
 	return items, nil
 }
 
-const queryAssetBalancesByGroup = `-- name: QueryAssetBalancesByGroup :many
+const QueryAssetBalancesByGroup = `-- name: QueryAssetBalancesByGroup :many
 SELECT
     key_group_info_view.tweaked_group_key, SUM(amount) balance
 FROM assets
@@ -2179,7 +2179,7 @@ type QueryAssetBalancesByGroupRow struct {
 }
 
 func (q *Queries) QueryAssetBalancesByGroup(ctx context.Context, arg QueryAssetBalancesByGroupParams) ([]QueryAssetBalancesByGroupRow, error) {
-	rows, err := q.db.QueryContext(ctx, queryAssetBalancesByGroup,
+	rows, err := q.db.QueryContext(ctx, QueryAssetBalancesByGroup,
 		arg.KeyGroupFilter,
 		arg.Leased,
 		arg.Now,
@@ -2206,7 +2206,7 @@ func (q *Queries) QueryAssetBalancesByGroup(ctx context.Context, arg QueryAssetB
 	return items, nil
 }
 
-const queryAssets = `-- name: QueryAssets :many
+const QueryAssets = `-- name: QueryAssets :many
 SELECT
     assets.asset_id AS asset_primary_key,
     assets.genesis_id, assets.version, spent,
@@ -2357,7 +2357,7 @@ type QueryAssetsRow struct {
 // make the entire statement evaluate to true, if none of these extra args are
 // specified.
 func (q *Queries) QueryAssets(ctx context.Context, arg QueryAssetsParams) ([]QueryAssetsRow, error) {
-	rows, err := q.db.QueryContext(ctx, queryAssets,
+	rows, err := q.db.QueryContext(ctx, QueryAssets,
 		arg.AssetIDFilter,
 		arg.TweakedScriptKey,
 		arg.AnchorPoint,
@@ -2434,7 +2434,7 @@ func (q *Queries) QueryAssets(ctx context.Context, arg QueryAssetsParams) ([]Que
 	return items, nil
 }
 
-const setAssetSpent = `-- name: SetAssetSpent :one
+const SetAssetSpent = `-- name: SetAssetSpent :one
 WITH target_asset(asset_id) AS (
     SELECT assets.asset_id
     FROM assets
@@ -2462,13 +2462,13 @@ type SetAssetSpentParams struct {
 }
 
 func (q *Queries) SetAssetSpent(ctx context.Context, arg SetAssetSpentParams) (int64, error) {
-	row := q.db.QueryRowContext(ctx, setAssetSpent, arg.AnchorPoint, arg.ScriptKey, arg.GenAssetID)
+	row := q.db.QueryRowContext(ctx, SetAssetSpent, arg.AnchorPoint, arg.ScriptKey, arg.GenAssetID)
 	var asset_id int64
 	err := row.Scan(&asset_id)
 	return asset_id, err
 }
 
-const updateBatchGenesisTx = `-- name: UpdateBatchGenesisTx :exec
+const UpdateBatchGenesisTx = `-- name: UpdateBatchGenesisTx :exec
 WITH target_batch AS (
     SELECT batch_id
     FROM asset_minting_batches batches
@@ -2487,11 +2487,11 @@ type UpdateBatchGenesisTxParams struct {
 }
 
 func (q *Queries) UpdateBatchGenesisTx(ctx context.Context, arg UpdateBatchGenesisTxParams) error {
-	_, err := q.db.ExecContext(ctx, updateBatchGenesisTx, arg.RawKey, arg.MintingTxPsbt)
+	_, err := q.db.ExecContext(ctx, UpdateBatchGenesisTx, arg.RawKey, arg.MintingTxPsbt)
 	return err
 }
 
-const updateMintingBatchState = `-- name: UpdateMintingBatchState :exec
+const UpdateMintingBatchState = `-- name: UpdateMintingBatchState :exec
 WITH target_batch AS (
     -- This CTE is used to fetch the ID of a batch, based on the serialized
     -- internal key associated with the batch. This internal key is used as the
@@ -2514,11 +2514,11 @@ type UpdateMintingBatchStateParams struct {
 }
 
 func (q *Queries) UpdateMintingBatchState(ctx context.Context, arg UpdateMintingBatchStateParams) error {
-	_, err := q.db.ExecContext(ctx, updateMintingBatchState, arg.RawKey, arg.BatchState)
+	_, err := q.db.ExecContext(ctx, UpdateMintingBatchState, arg.RawKey, arg.BatchState)
 	return err
 }
 
-const updateUTXOLease = `-- name: UpdateUTXOLease :exec
+const UpdateUTXOLease = `-- name: UpdateUTXOLease :exec
 UPDATE managed_utxos
 SET lease_owner = $1, lease_expiry = $2
 WHERE outpoint = $3
@@ -2531,11 +2531,11 @@ type UpdateUTXOLeaseParams struct {
 }
 
 func (q *Queries) UpdateUTXOLease(ctx context.Context, arg UpdateUTXOLeaseParams) error {
-	_, err := q.db.ExecContext(ctx, updateUTXOLease, arg.LeaseOwner, arg.LeaseExpiry, arg.Outpoint)
+	_, err := q.db.ExecContext(ctx, UpdateUTXOLease, arg.LeaseOwner, arg.LeaseExpiry, arg.Outpoint)
 	return err
 }
 
-const upsertAsset = `-- name: UpsertAsset :one
+const UpsertAsset = `-- name: UpsertAsset :one
 INSERT INTO assets (
     genesis_id, version, script_key_id, asset_group_witness_id, script_version, 
     amount, lock_time, relative_lock_time, anchor_utxo_id, spent
@@ -2563,7 +2563,7 @@ type UpsertAssetParams struct {
 }
 
 func (q *Queries) UpsertAsset(ctx context.Context, arg UpsertAssetParams) (int64, error) {
-	row := q.db.QueryRowContext(ctx, upsertAsset,
+	row := q.db.QueryRowContext(ctx, UpsertAsset,
 		arg.GenesisID,
 		arg.Version,
 		arg.ScriptKeyID,
@@ -2580,7 +2580,7 @@ func (q *Queries) UpsertAsset(ctx context.Context, arg UpsertAssetParams) (int64
 	return asset_id, err
 }
 
-const upsertAssetGroupKey = `-- name: UpsertAssetGroupKey :one
+const UpsertAssetGroupKey = `-- name: UpsertAssetGroupKey :one
 INSERT INTO asset_groups (
     version, tweaked_group_key, tapscript_root, internal_key_id,
     genesis_point_id, custom_subtree_root_id
@@ -2603,7 +2603,7 @@ type UpsertAssetGroupKeyParams struct {
 }
 
 func (q *Queries) UpsertAssetGroupKey(ctx context.Context, arg UpsertAssetGroupKeyParams) (int64, error) {
-	row := q.db.QueryRowContext(ctx, upsertAssetGroupKey,
+	row := q.db.QueryRowContext(ctx, UpsertAssetGroupKey,
 		arg.Version,
 		arg.TweakedGroupKey,
 		arg.TapscriptRoot,
@@ -2616,7 +2616,7 @@ func (q *Queries) UpsertAssetGroupKey(ctx context.Context, arg UpsertAssetGroupK
 	return group_id, err
 }
 
-const upsertAssetGroupWitness = `-- name: UpsertAssetGroupWitness :one
+const UpsertAssetGroupWitness = `-- name: UpsertAssetGroupWitness :one
 INSERT INTO asset_group_witnesses (
     witness_stack, gen_asset_id, group_key_id
 ) VALUES (
@@ -2634,13 +2634,13 @@ type UpsertAssetGroupWitnessParams struct {
 }
 
 func (q *Queries) UpsertAssetGroupWitness(ctx context.Context, arg UpsertAssetGroupWitnessParams) (int64, error) {
-	row := q.db.QueryRowContext(ctx, upsertAssetGroupWitness, arg.WitnessStack, arg.GenAssetID, arg.GroupKeyID)
+	row := q.db.QueryRowContext(ctx, UpsertAssetGroupWitness, arg.WitnessStack, arg.GenAssetID, arg.GroupKeyID)
 	var witness_id int64
 	err := row.Scan(&witness_id)
 	return witness_id, err
 }
 
-const upsertAssetMeta = `-- name: UpsertAssetMeta :one
+const UpsertAssetMeta = `-- name: UpsertAssetMeta :one
 INSERT INTO assets_meta (
     meta_data_hash, meta_data_blob, meta_data_type
 ) VALUES (
@@ -2662,13 +2662,13 @@ type UpsertAssetMetaParams struct {
 }
 
 func (q *Queries) UpsertAssetMeta(ctx context.Context, arg UpsertAssetMetaParams) (int64, error) {
-	row := q.db.QueryRowContext(ctx, upsertAssetMeta, arg.MetaDataHash, arg.MetaDataBlob, arg.MetaDataType)
+	row := q.db.QueryRowContext(ctx, UpsertAssetMeta, arg.MetaDataHash, arg.MetaDataBlob, arg.MetaDataType)
 	var meta_id int64
 	err := row.Scan(&meta_id)
 	return meta_id, err
 }
 
-const upsertAssetProofByID = `-- name: UpsertAssetProofByID :exec
+const UpsertAssetProofByID = `-- name: UpsertAssetProofByID :exec
 INSERT INTO asset_proofs (
     asset_id, proof_file
 ) VALUES (
@@ -2684,11 +2684,11 @@ type UpsertAssetProofByIDParams struct {
 }
 
 func (q *Queries) UpsertAssetProofByID(ctx context.Context, arg UpsertAssetProofByIDParams) error {
-	_, err := q.db.ExecContext(ctx, upsertAssetProofByID, arg.AssetID, arg.ProofFile)
+	_, err := q.db.ExecContext(ctx, UpsertAssetProofByID, arg.AssetID, arg.ProofFile)
 	return err
 }
 
-const upsertAssetWitness = `-- name: UpsertAssetWitness :exec
+const UpsertAssetWitness = `-- name: UpsertAssetWitness :exec
 INSERT INTO asset_witnesses (
     asset_id, prev_out_point, prev_asset_id, prev_script_key, witness_stack,
     split_commitment_proof, witness_index
@@ -2714,7 +2714,7 @@ type UpsertAssetWitnessParams struct {
 }
 
 func (q *Queries) UpsertAssetWitness(ctx context.Context, arg UpsertAssetWitnessParams) error {
-	_, err := q.db.ExecContext(ctx, upsertAssetWitness,
+	_, err := q.db.ExecContext(ctx, UpsertAssetWitness,
 		arg.AssetID,
 		arg.PrevOutPoint,
 		arg.PrevAssetID,
@@ -2726,7 +2726,7 @@ func (q *Queries) UpsertAssetWitness(ctx context.Context, arg UpsertAssetWitness
 	return err
 }
 
-const upsertChainTx = `-- name: UpsertChainTx :one
+const UpsertChainTx = `-- name: UpsertChainTx :one
 INSERT INTO chain_txns (
     txid, raw_tx, chain_fees, block_height, block_hash, tx_index
 ) VALUES (
@@ -2751,7 +2751,7 @@ type UpsertChainTxParams struct {
 }
 
 func (q *Queries) UpsertChainTx(ctx context.Context, arg UpsertChainTxParams) (int64, error) {
-	row := q.db.QueryRowContext(ctx, upsertChainTx,
+	row := q.db.QueryRowContext(ctx, UpsertChainTx,
 		arg.Txid,
 		arg.RawTx,
 		arg.ChainFees,
@@ -2764,7 +2764,7 @@ func (q *Queries) UpsertChainTx(ctx context.Context, arg UpsertChainTxParams) (i
 	return txn_id, err
 }
 
-const upsertGenesisAsset = `-- name: UpsertGenesisAsset :one
+const UpsertGenesisAsset = `-- name: UpsertGenesisAsset :one
 WITH target_meta_id AS (
     SELECT meta_id
     FROM assets_meta
@@ -2790,7 +2790,7 @@ type UpsertGenesisAssetParams struct {
 }
 
 func (q *Queries) UpsertGenesisAsset(ctx context.Context, arg UpsertGenesisAssetParams) (int64, error) {
-	row := q.db.QueryRowContext(ctx, upsertGenesisAsset,
+	row := q.db.QueryRowContext(ctx, UpsertGenesisAsset,
 		arg.MetaDataHash,
 		arg.AssetID,
 		arg.AssetTag,
@@ -2803,7 +2803,7 @@ func (q *Queries) UpsertGenesisAsset(ctx context.Context, arg UpsertGenesisAsset
 	return gen_asset_id, err
 }
 
-const upsertGenesisPoint = `-- name: UpsertGenesisPoint :one
+const UpsertGenesisPoint = `-- name: UpsertGenesisPoint :one
 INSERT INTO genesis_points(
     prev_out
 ) VALUES (
@@ -2815,13 +2815,13 @@ RETURNING genesis_id
 `
 
 func (q *Queries) UpsertGenesisPoint(ctx context.Context, prevOut []byte) (int64, error) {
-	row := q.db.QueryRowContext(ctx, upsertGenesisPoint, prevOut)
+	row := q.db.QueryRowContext(ctx, UpsertGenesisPoint, prevOut)
 	var genesis_id int64
 	err := row.Scan(&genesis_id)
 	return genesis_id, err
 }
 
-const upsertInternalKey = `-- name: UpsertInternalKey :one
+const UpsertInternalKey = `-- name: UpsertInternalKey :one
 INSERT INTO internal_keys (
     raw_key,  key_family, key_index
 ) VALUES (
@@ -2839,13 +2839,13 @@ type UpsertInternalKeyParams struct {
 }
 
 func (q *Queries) UpsertInternalKey(ctx context.Context, arg UpsertInternalKeyParams) (int64, error) {
-	row := q.db.QueryRowContext(ctx, upsertInternalKey, arg.RawKey, arg.KeyFamily, arg.KeyIndex)
+	row := q.db.QueryRowContext(ctx, UpsertInternalKey, arg.RawKey, arg.KeyFamily, arg.KeyIndex)
 	var key_id int64
 	err := row.Scan(&key_id)
 	return key_id, err
 }
 
-const upsertManagedUTXO = `-- name: UpsertManagedUTXO :one
+const UpsertManagedUTXO = `-- name: UpsertManagedUTXO :one
 WITH target_key(key_id) AS (
     SELECT key_id
     FROM internal_keys
@@ -2875,7 +2875,7 @@ type UpsertManagedUTXOParams struct {
 }
 
 func (q *Queries) UpsertManagedUTXO(ctx context.Context, arg UpsertManagedUTXOParams) (int64, error) {
-	row := q.db.QueryRowContext(ctx, upsertManagedUTXO,
+	row := q.db.QueryRowContext(ctx, UpsertManagedUTXO,
 		arg.RawKey,
 		arg.Outpoint,
 		arg.AmtSats,
@@ -2890,7 +2890,7 @@ func (q *Queries) UpsertManagedUTXO(ctx context.Context, arg UpsertManagedUTXOPa
 	return utxo_id, err
 }
 
-const upsertScriptKey = `-- name: UpsertScriptKey :one
+const UpsertScriptKey = `-- name: UpsertScriptKey :one
 INSERT INTO script_keys (
     internal_key_id, tweaked_script_key, tweak, declared_known
 ) VALUES (
@@ -2924,7 +2924,7 @@ type UpsertScriptKeyParams struct {
 }
 
 func (q *Queries) UpsertScriptKey(ctx context.Context, arg UpsertScriptKeyParams) (int64, error) {
-	row := q.db.QueryRowContext(ctx, upsertScriptKey,
+	row := q.db.QueryRowContext(ctx, UpsertScriptKey,
 		arg.InternalKeyID,
 		arg.TweakedScriptKey,
 		arg.Tweak,
@@ -2935,7 +2935,7 @@ func (q *Queries) UpsertScriptKey(ctx context.Context, arg UpsertScriptKeyParams
 	return script_key_id, err
 }
 
-const upsertTapscriptTreeEdge = `-- name: UpsertTapscriptTreeEdge :one
+const UpsertTapscriptTreeEdge = `-- name: UpsertTapscriptTreeEdge :one
 INSERT INTO tapscript_edges (
     root_hash_id, node_index, raw_node_id
 ) VALUES (
@@ -2955,13 +2955,13 @@ type UpsertTapscriptTreeEdgeParams struct {
 }
 
 func (q *Queries) UpsertTapscriptTreeEdge(ctx context.Context, arg UpsertTapscriptTreeEdgeParams) (int64, error) {
-	row := q.db.QueryRowContext(ctx, upsertTapscriptTreeEdge, arg.RootHashID, arg.NodeIndex, arg.RawNodeID)
+	row := q.db.QueryRowContext(ctx, UpsertTapscriptTreeEdge, arg.RootHashID, arg.NodeIndex, arg.RawNodeID)
 	var edge_id int64
 	err := row.Scan(&edge_id)
 	return edge_id, err
 }
 
-const upsertTapscriptTreeNode = `-- name: UpsertTapscriptTreeNode :one
+const UpsertTapscriptTreeNode = `-- name: UpsertTapscriptTreeNode :one
 INSERT INTO tapscript_nodes (
     raw_node
 ) VALUES (
@@ -2973,13 +2973,13 @@ RETURNING node_id
 `
 
 func (q *Queries) UpsertTapscriptTreeNode(ctx context.Context, rawNode []byte) (int64, error) {
-	row := q.db.QueryRowContext(ctx, upsertTapscriptTreeNode, rawNode)
+	row := q.db.QueryRowContext(ctx, UpsertTapscriptTreeNode, rawNode)
 	var node_id int64
 	err := row.Scan(&node_id)
 	return node_id, err
 }
 
-const upsertTapscriptTreeRootHash = `-- name: UpsertTapscriptTreeRootHash :one
+const UpsertTapscriptTreeRootHash = `-- name: UpsertTapscriptTreeRootHash :one
 INSERT INTO tapscript_roots (
     root_hash, branch_only
 ) VALUES (
@@ -2998,7 +2998,7 @@ type UpsertTapscriptTreeRootHashParams struct {
 }
 
 func (q *Queries) UpsertTapscriptTreeRootHash(ctx context.Context, arg UpsertTapscriptTreeRootHashParams) (int64, error) {
-	row := q.db.QueryRowContext(ctx, upsertTapscriptTreeRootHash, arg.RootHash, arg.BranchOnly)
+	row := q.db.QueryRowContext(ctx, UpsertTapscriptTreeRootHash, arg.RootHash, arg.BranchOnly)
 	var root_id int64
 	err := row.Scan(&root_id)
 	return root_id, err

--- a/tapdb/sqlc/macaroons.sql.go
+++ b/tapdb/sqlc/macaroons.sql.go
@@ -9,19 +9,19 @@ import (
 	"context"
 )
 
-const getRootKey = `-- name: GetRootKey :one
+const GetRootKey = `-- name: GetRootKey :one
 SELECT id, root_key FROM macaroons 
 WHERE id = $1
 `
 
 func (q *Queries) GetRootKey(ctx context.Context, id []byte) (Macaroon, error) {
-	row := q.db.QueryRowContext(ctx, getRootKey, id)
+	row := q.db.QueryRowContext(ctx, GetRootKey, id)
 	var i Macaroon
 	err := row.Scan(&i.ID, &i.RootKey)
 	return i, err
 }
 
-const insertRootKey = `-- name: InsertRootKey :exec
+const InsertRootKey = `-- name: InsertRootKey :exec
 INSERT INTO macaroons (id, root_key) VALUES ($1, $2)
 `
 
@@ -31,6 +31,6 @@ type InsertRootKeyParams struct {
 }
 
 func (q *Queries) InsertRootKey(ctx context.Context, arg InsertRootKeyParams) error {
-	_, err := q.db.ExecContext(ctx, insertRootKey, arg.ID, arg.RootKey)
+	_, err := q.db.ExecContext(ctx, InsertRootKey, arg.ID, arg.RootKey)
 	return err
 }

--- a/tapdb/sqlc/metadata.sql.go
+++ b/tapdb/sqlc/metadata.sql.go
@@ -9,24 +9,24 @@ import (
 	"context"
 )
 
-const assetsDBSizePostgres = `-- name: AssetsDBSizePostgres :one
+const AssetsDBSizePostgres = `-- name: AssetsDBSizePostgres :one
 SELECT pg_catalog.pg_database_size(current_database()) AS size
 `
 
 func (q *Queries) AssetsDBSizePostgres(ctx context.Context) (int64, error) {
-	row := q.db.QueryRowContext(ctx, assetsDBSizePostgres)
+	row := q.db.QueryRowContext(ctx, AssetsDBSizePostgres)
 	var size int64
 	err := row.Scan(&size)
 	return size, err
 }
 
-const assetsDBSizeSqlite = `-- name: AssetsDBSizeSqlite :one
+const AssetsDBSizeSqlite = `-- name: AssetsDBSizeSqlite :one
 SELECT page_count * page_size AS size_in_bytes 
 FROM pragma_page_count(), pragma_page_size()
 `
 
 func (q *Queries) AssetsDBSizeSqlite(ctx context.Context) (int32, error) {
-	row := q.db.QueryRowContext(ctx, assetsDBSizeSqlite)
+	row := q.db.QueryRowContext(ctx, AssetsDBSizeSqlite)
 	var size_in_bytes int32
 	err := row.Scan(&size_in_bytes)
 	return size_in_bytes, err

--- a/tapdb/sqlc/migrations/000027_better_universe_stats.down.sql
+++ b/tapdb/sqlc/migrations/000027_better_universe_stats.down.sql
@@ -1,0 +1,16 @@
+-- We restore the previous version of the universe_stats view, as it was created
+-- in the 000010_universe_stats.up.sql migration file.
+
+DROP VIEW universe_stats;
+
+CREATE VIEW universe_stats AS
+SELECT
+    COUNT(CASE WHEN u.event_type = 'SYNC' THEN 1 ELSE NULL END) AS total_asset_syncs,
+    COUNT(CASE WHEN u.event_type = 'NEW_PROOF' THEN 1 ELSE NULL END) AS total_asset_proofs,
+    roots.asset_id,
+    roots.group_key,
+    roots.proof_type
+FROM universe_events u
+JOIN universe_roots roots
+  ON u.universe_root_id = roots.id
+GROUP BY roots.asset_id, roots.group_key, roots.proof_type;

--- a/tapdb/sqlc/migrations/000027_better_universe_stats.up.sql
+++ b/tapdb/sqlc/migrations/000027_better_universe_stats.up.sql
@@ -1,0 +1,37 @@
+DROP VIEW universe_stats;
+
+CREATE VIEW universe_stats AS
+WITH sync_counts AS (
+    SELECT universe_root_id, COUNT(*) AS count
+    FROM universe_events
+    WHERE event_type = 'SYNC'
+    GROUP BY universe_root_id
+), proof_counts AS (
+    SELECT universe_root_id, event_type, COUNT(*) AS count
+    FROM universe_events
+    WHERE event_type = 'NEW_PROOF'
+    GROUP BY universe_root_id, event_type
+), aggregated AS (
+    SELECT COALESCE(SUM(count), 0) as total_asset_syncs,
+           0 AS total_asset_proofs,
+           universe_root_id
+    FROM sync_counts
+    GROUP BY universe_root_id
+    UNION ALL
+    SELECT 0 AS total_asset_syncs,
+           COALESCE(SUM(count), 0) as total_asset_proofs,
+           universe_root_id
+    FROM proof_counts
+    GROUP BY universe_root_id
+)
+SELECT
+    SUM(ag.total_asset_syncs) AS total_asset_syncs,
+    SUM(ag.total_asset_proofs) AS total_asset_proofs,
+    roots.asset_id,
+    roots.group_key,
+    roots.proof_type
+FROM aggregated ag
+JOIN universe_roots roots
+    ON ag.universe_root_id = roots.id
+GROUP BY roots.asset_id, roots.group_key, roots.proof_type
+ORDER BY roots.asset_id, roots.group_key, roots.proof_type;

--- a/tapdb/sqlc/mssmt.sql.go
+++ b/tapdb/sqlc/mssmt.sql.go
@@ -9,19 +9,19 @@ import (
 	"context"
 )
 
-const deleteAllNodes = `-- name: DeleteAllNodes :execrows
+const DeleteAllNodes = `-- name: DeleteAllNodes :execrows
 DELETE FROM mssmt_nodes WHERE namespace = $1
 `
 
 func (q *Queries) DeleteAllNodes(ctx context.Context, namespace string) (int64, error) {
-	result, err := q.db.ExecContext(ctx, deleteAllNodes, namespace)
+	result, err := q.db.ExecContext(ctx, DeleteAllNodes, namespace)
 	if err != nil {
 		return 0, err
 	}
 	return result.RowsAffected()
 }
 
-const deleteNode = `-- name: DeleteNode :execrows
+const DeleteNode = `-- name: DeleteNode :execrows
 DELETE FROM mssmt_nodes WHERE hash_key = $1 AND namespace = $2
 `
 
@@ -31,31 +31,31 @@ type DeleteNodeParams struct {
 }
 
 func (q *Queries) DeleteNode(ctx context.Context, arg DeleteNodeParams) (int64, error) {
-	result, err := q.db.ExecContext(ctx, deleteNode, arg.HashKey, arg.Namespace)
+	result, err := q.db.ExecContext(ctx, DeleteNode, arg.HashKey, arg.Namespace)
 	if err != nil {
 		return 0, err
 	}
 	return result.RowsAffected()
 }
 
-const deleteRoot = `-- name: DeleteRoot :execrows
+const DeleteRoot = `-- name: DeleteRoot :execrows
 DELETE FROM mssmt_roots WHERE namespace = $1
 `
 
 func (q *Queries) DeleteRoot(ctx context.Context, namespace string) (int64, error) {
-	result, err := q.db.ExecContext(ctx, deleteRoot, namespace)
+	result, err := q.db.ExecContext(ctx, DeleteRoot, namespace)
 	if err != nil {
 		return 0, err
 	}
 	return result.RowsAffected()
 }
 
-const fetchAllNodes = `-- name: FetchAllNodes :many
+const FetchAllNodes = `-- name: FetchAllNodes :many
 SELECT hash_key, l_hash_key, r_hash_key, key, value, sum, namespace FROM mssmt_nodes
 `
 
 func (q *Queries) FetchAllNodes(ctx context.Context) ([]MssmtNode, error) {
-	rows, err := q.db.QueryContext(ctx, fetchAllNodes)
+	rows, err := q.db.QueryContext(ctx, FetchAllNodes)
 	if err != nil {
 		return nil, err
 	}
@@ -85,7 +85,7 @@ func (q *Queries) FetchAllNodes(ctx context.Context) ([]MssmtNode, error) {
 	return items, nil
 }
 
-const fetchChildren = `-- name: FetchChildren :many
+const FetchChildren = `-- name: FetchChildren :many
 WITH RECURSIVE mssmt_branches_cte (
     hash_key, l_hash_key, r_hash_key, key, value, sum, namespace, depth
 )
@@ -124,7 +124,7 @@ type FetchChildrenRow struct {
 }
 
 func (q *Queries) FetchChildren(ctx context.Context, arg FetchChildrenParams) ([]FetchChildrenRow, error) {
-	rows, err := q.db.QueryContext(ctx, fetchChildren, arg.HashKey, arg.Namespace)
+	rows, err := q.db.QueryContext(ctx, FetchChildren, arg.HashKey, arg.Namespace)
 	if err != nil {
 		return nil, err
 	}
@@ -155,7 +155,7 @@ func (q *Queries) FetchChildren(ctx context.Context, arg FetchChildrenParams) ([
 	return items, nil
 }
 
-const fetchChildrenSelfJoin = `-- name: FetchChildrenSelfJoin :many
+const FetchChildrenSelfJoin = `-- name: FetchChildrenSelfJoin :many
 WITH subtree_cte (
     hash_key, l_hash_key, r_hash_key, key, value, sum, namespace, depth
 ) AS (
@@ -186,7 +186,7 @@ type FetchChildrenSelfJoinRow struct {
 }
 
 func (q *Queries) FetchChildrenSelfJoin(ctx context.Context, arg FetchChildrenSelfJoinParams) ([]FetchChildrenSelfJoinRow, error) {
-	rows, err := q.db.QueryContext(ctx, fetchChildrenSelfJoin, arg.HashKey, arg.Namespace)
+	rows, err := q.db.QueryContext(ctx, FetchChildrenSelfJoin, arg.HashKey, arg.Namespace)
 	if err != nil {
 		return nil, err
 	}
@@ -217,7 +217,7 @@ func (q *Queries) FetchChildrenSelfJoin(ctx context.Context, arg FetchChildrenSe
 	return items, nil
 }
 
-const fetchRootNode = `-- name: FetchRootNode :one
+const FetchRootNode = `-- name: FetchRootNode :one
 SELECT nodes.hash_key, nodes.l_hash_key, nodes.r_hash_key, nodes.key, nodes.value, nodes.sum, nodes.namespace
 FROM mssmt_nodes nodes
 JOIN mssmt_roots roots
@@ -226,7 +226,7 @@ JOIN mssmt_roots roots
 `
 
 func (q *Queries) FetchRootNode(ctx context.Context, namespace string) (MssmtNode, error) {
-	row := q.db.QueryRowContext(ctx, fetchRootNode, namespace)
+	row := q.db.QueryRowContext(ctx, FetchRootNode, namespace)
 	var i MssmtNode
 	err := row.Scan(
 		&i.HashKey,
@@ -240,7 +240,7 @@ func (q *Queries) FetchRootNode(ctx context.Context, namespace string) (MssmtNod
 	return i, err
 }
 
-const insertBranch = `-- name: InsertBranch :exec
+const InsertBranch = `-- name: InsertBranch :exec
 INSERT INTO mssmt_nodes (
     hash_key, l_hash_key, r_hash_key, key, value, sum, namespace
 ) VALUES ($1, $2, $3, NULL, NULL, $4, $5)
@@ -255,7 +255,7 @@ type InsertBranchParams struct {
 }
 
 func (q *Queries) InsertBranch(ctx context.Context, arg InsertBranchParams) error {
-	_, err := q.db.ExecContext(ctx, insertBranch,
+	_, err := q.db.ExecContext(ctx, InsertBranch,
 		arg.HashKey,
 		arg.LHashKey,
 		arg.RHashKey,
@@ -265,7 +265,7 @@ func (q *Queries) InsertBranch(ctx context.Context, arg InsertBranchParams) erro
 	return err
 }
 
-const insertCompactedLeaf = `-- name: InsertCompactedLeaf :exec
+const InsertCompactedLeaf = `-- name: InsertCompactedLeaf :exec
 INSERT INTO mssmt_nodes (
     hash_key, l_hash_key, r_hash_key, key, value, sum, namespace
 ) VALUES ($1, NULL, NULL, $2, $3, $4, $5)
@@ -280,7 +280,7 @@ type InsertCompactedLeafParams struct {
 }
 
 func (q *Queries) InsertCompactedLeaf(ctx context.Context, arg InsertCompactedLeafParams) error {
-	_, err := q.db.ExecContext(ctx, insertCompactedLeaf,
+	_, err := q.db.ExecContext(ctx, InsertCompactedLeaf,
 		arg.HashKey,
 		arg.Key,
 		arg.Value,
@@ -290,7 +290,7 @@ func (q *Queries) InsertCompactedLeaf(ctx context.Context, arg InsertCompactedLe
 	return err
 }
 
-const insertLeaf = `-- name: InsertLeaf :exec
+const InsertLeaf = `-- name: InsertLeaf :exec
 INSERT INTO mssmt_nodes (
     hash_key, l_hash_key, r_hash_key, key, value, sum, namespace
 ) VALUES ($1, NULL, NULL, NULL, $2, $3, $4)
@@ -304,7 +304,7 @@ type InsertLeafParams struct {
 }
 
 func (q *Queries) InsertLeaf(ctx context.Context, arg InsertLeafParams) error {
-	_, err := q.db.ExecContext(ctx, insertLeaf,
+	_, err := q.db.ExecContext(ctx, InsertLeaf,
 		arg.HashKey,
 		arg.Value,
 		arg.Sum,
@@ -313,7 +313,7 @@ func (q *Queries) InsertLeaf(ctx context.Context, arg InsertLeafParams) error {
 	return err
 }
 
-const upsertRootNode = `-- name: UpsertRootNode :exec
+const UpsertRootNode = `-- name: UpsertRootNode :exec
 INSERT INTO mssmt_roots (
     root_hash, namespace
 ) VALUES (
@@ -329,6 +329,6 @@ type UpsertRootNodeParams struct {
 }
 
 func (q *Queries) UpsertRootNode(ctx context.Context, arg UpsertRootNodeParams) error {
-	_, err := q.db.ExecContext(ctx, upsertRootNode, arg.RootHash, arg.Namespace)
+	_, err := q.db.ExecContext(ctx, UpsertRootNode, arg.RootHash, arg.Namespace)
 	return err
 }

--- a/tapdb/sqlc/transfers.sql.go
+++ b/tapdb/sqlc/transfers.sql.go
@@ -11,7 +11,7 @@ import (
 	"time"
 )
 
-const applyPendingOutput = `-- name: ApplyPendingOutput :one
+const ApplyPendingOutput = `-- name: ApplyPendingOutput :one
 WITH spent_asset AS (
     SELECT genesis_id, asset_group_witness_id, script_version
     FROM assets
@@ -50,7 +50,7 @@ type ApplyPendingOutputParams struct {
 }
 
 func (q *Queries) ApplyPendingOutput(ctx context.Context, arg ApplyPendingOutputParams) (int64, error) {
-	row := q.db.QueryRowContext(ctx, applyPendingOutput,
+	row := q.db.QueryRowContext(ctx, ApplyPendingOutput,
 		arg.AssetVersion,
 		arg.LockTime,
 		arg.RelativeLockTime,
@@ -67,17 +67,17 @@ func (q *Queries) ApplyPendingOutput(ctx context.Context, arg ApplyPendingOutput
 	return asset_id, err
 }
 
-const deleteAssetWitnesses = `-- name: DeleteAssetWitnesses :exec
+const DeleteAssetWitnesses = `-- name: DeleteAssetWitnesses :exec
 DELETE FROM asset_witnesses
 WHERE asset_id = $1
 `
 
 func (q *Queries) DeleteAssetWitnesses(ctx context.Context, assetID int64) error {
-	_, err := q.db.ExecContext(ctx, deleteAssetWitnesses, assetID)
+	_, err := q.db.ExecContext(ctx, DeleteAssetWitnesses, assetID)
 	return err
 }
 
-const fetchTransferInputs = `-- name: FetchTransferInputs :many
+const FetchTransferInputs = `-- name: FetchTransferInputs :many
 SELECT input_id, anchor_point, asset_id, script_key, amount
 FROM asset_transfer_inputs inputs
 WHERE transfer_id = $1
@@ -93,7 +93,7 @@ type FetchTransferInputsRow struct {
 }
 
 func (q *Queries) FetchTransferInputs(ctx context.Context, transferID int64) ([]FetchTransferInputsRow, error) {
-	rows, err := q.db.QueryContext(ctx, fetchTransferInputs, transferID)
+	rows, err := q.db.QueryContext(ctx, FetchTransferInputs, transferID)
 	if err != nil {
 		return nil, err
 	}
@@ -121,7 +121,7 @@ func (q *Queries) FetchTransferInputs(ctx context.Context, transferID int64) ([]
 	return items, nil
 }
 
-const fetchTransferOutputs = `-- name: FetchTransferOutputs :many
+const FetchTransferOutputs = `-- name: FetchTransferOutputs :many
 SELECT
     output_id, proof_suffix, amount, serialized_witnesses, script_key_local,
     split_commitment_root_hash, split_commitment_root_value, num_passive_assets,
@@ -193,7 +193,7 @@ type FetchTransferOutputsRow struct {
 }
 
 func (q *Queries) FetchTransferOutputs(ctx context.Context, transferID int64) ([]FetchTransferOutputsRow, error) {
-	rows, err := q.db.QueryContext(ctx, fetchTransferOutputs, transferID)
+	rows, err := q.db.QueryContext(ctx, FetchTransferOutputs, transferID)
 	if err != nil {
 		return nil, err
 	}
@@ -248,7 +248,7 @@ func (q *Queries) FetchTransferOutputs(ctx context.Context, transferID int64) ([
 	return items, nil
 }
 
-const insertAssetTransfer = `-- name: InsertAssetTransfer :one
+const InsertAssetTransfer = `-- name: InsertAssetTransfer :one
 WITH target_txn(txn_id) AS (
     SELECT txn_id
     FROM chain_txns
@@ -268,13 +268,13 @@ type InsertAssetTransferParams struct {
 }
 
 func (q *Queries) InsertAssetTransfer(ctx context.Context, arg InsertAssetTransferParams) (int64, error) {
-	row := q.db.QueryRowContext(ctx, insertAssetTransfer, arg.HeightHint, arg.TransferTimeUnix, arg.AnchorTxid)
+	row := q.db.QueryRowContext(ctx, InsertAssetTransfer, arg.HeightHint, arg.TransferTimeUnix, arg.AnchorTxid)
 	var id int64
 	err := row.Scan(&id)
 	return id, err
 }
 
-const insertAssetTransferInput = `-- name: InsertAssetTransferInput :exec
+const InsertAssetTransferInput = `-- name: InsertAssetTransferInput :exec
 INSERT INTO asset_transfer_inputs (
     transfer_id, anchor_point, asset_id, script_key, amount
 ) VALUES (
@@ -291,7 +291,7 @@ type InsertAssetTransferInputParams struct {
 }
 
 func (q *Queries) InsertAssetTransferInput(ctx context.Context, arg InsertAssetTransferInputParams) error {
-	_, err := q.db.ExecContext(ctx, insertAssetTransferInput,
+	_, err := q.db.ExecContext(ctx, InsertAssetTransferInput,
 		arg.TransferID,
 		arg.AnchorPoint,
 		arg.AssetID,
@@ -301,7 +301,7 @@ func (q *Queries) InsertAssetTransferInput(ctx context.Context, arg InsertAssetT
 	return err
 }
 
-const insertAssetTransferOutput = `-- name: InsertAssetTransferOutput :exec
+const InsertAssetTransferOutput = `-- name: InsertAssetTransferOutput :exec
 INSERT INTO asset_transfer_outputs (
     transfer_id, anchor_utxo, script_key, script_key_local,
     amount, serialized_witnesses, split_commitment_root_hash,
@@ -334,7 +334,7 @@ type InsertAssetTransferOutputParams struct {
 }
 
 func (q *Queries) InsertAssetTransferOutput(ctx context.Context, arg InsertAssetTransferOutputParams) error {
-	_, err := q.db.ExecContext(ctx, insertAssetTransferOutput,
+	_, err := q.db.ExecContext(ctx, InsertAssetTransferOutput,
 		arg.TransferID,
 		arg.AnchorUtxo,
 		arg.ScriptKey,
@@ -356,7 +356,7 @@ func (q *Queries) InsertAssetTransferOutput(ctx context.Context, arg InsertAsset
 	return err
 }
 
-const insertBurn = `-- name: InsertBurn :one
+const InsertBurn = `-- name: InsertBurn :one
 INSERT INTO asset_burn_transfers (
     transfer_id, note, asset_id, group_key, amount
 )
@@ -375,7 +375,7 @@ type InsertBurnParams struct {
 }
 
 func (q *Queries) InsertBurn(ctx context.Context, arg InsertBurnParams) (int64, error) {
-	row := q.db.QueryRowContext(ctx, insertBurn,
+	row := q.db.QueryRowContext(ctx, InsertBurn,
 		arg.TransferID,
 		arg.Note,
 		arg.AssetID,
@@ -387,7 +387,7 @@ func (q *Queries) InsertBurn(ctx context.Context, arg InsertBurnParams) (int64, 
 	return burn_id, err
 }
 
-const insertPassiveAsset = `-- name: InsertPassiveAsset :exec
+const InsertPassiveAsset = `-- name: InsertPassiveAsset :exec
 WITH target_asset(asset_id) AS (
     SELECT assets.asset_id
     FROM assets
@@ -422,7 +422,7 @@ type InsertPassiveAssetParams struct {
 }
 
 func (q *Queries) InsertPassiveAsset(ctx context.Context, arg InsertPassiveAssetParams) error {
-	_, err := q.db.ExecContext(ctx, insertPassiveAsset,
+	_, err := q.db.ExecContext(ctx, InsertPassiveAsset,
 		arg.TransferID,
 		arg.NewAnchorUtxo,
 		arg.ScriptKey,
@@ -435,7 +435,7 @@ func (q *Queries) InsertPassiveAsset(ctx context.Context, arg InsertPassiveAsset
 	return err
 }
 
-const logProofTransferAttempt = `-- name: LogProofTransferAttempt :exec
+const LogProofTransferAttempt = `-- name: LogProofTransferAttempt :exec
 INSERT INTO proof_transfer_log (
     transfer_type, proof_locator_hash, time_unix
 ) VALUES (
@@ -450,11 +450,11 @@ type LogProofTransferAttemptParams struct {
 }
 
 func (q *Queries) LogProofTransferAttempt(ctx context.Context, arg LogProofTransferAttemptParams) error {
-	_, err := q.db.ExecContext(ctx, logProofTransferAttempt, arg.TransferType, arg.ProofLocatorHash, arg.TimeUnix)
+	_, err := q.db.ExecContext(ctx, LogProofTransferAttempt, arg.TransferType, arg.ProofLocatorHash, arg.TimeUnix)
 	return err
 }
 
-const queryAssetTransfers = `-- name: QueryAssetTransfers :many
+const QueryAssetTransfers = `-- name: QueryAssetTransfers :many
 SELECT
     id, height_hint, txns.txid, txns.block_hash AS anchor_tx_block_hash,
     transfer_time_unix
@@ -497,7 +497,7 @@ type QueryAssetTransfersRow struct {
 }
 
 func (q *Queries) QueryAssetTransfers(ctx context.Context, arg QueryAssetTransfersParams) ([]QueryAssetTransfersRow, error) {
-	rows, err := q.db.QueryContext(ctx, queryAssetTransfers, arg.AnchorTxHash, arg.PendingTransfersOnly)
+	rows, err := q.db.QueryContext(ctx, QueryAssetTransfers, arg.AnchorTxHash, arg.PendingTransfersOnly)
 	if err != nil {
 		return nil, err
 	}
@@ -525,7 +525,7 @@ func (q *Queries) QueryAssetTransfers(ctx context.Context, arg QueryAssetTransfe
 	return items, nil
 }
 
-const queryBurns = `-- name: QueryBurns :many
+const QueryBurns = `-- name: QueryBurns :many
 SELECT
     abt.note,
     abt.asset_id,
@@ -562,7 +562,7 @@ type QueryBurnsRow struct {
 }
 
 func (q *Queries) QueryBurns(ctx context.Context, arg QueryBurnsParams) ([]QueryBurnsRow, error) {
-	rows, err := q.db.QueryContext(ctx, queryBurns, arg.AssetID, arg.GroupKey, arg.AnchorTxid)
+	rows, err := q.db.QueryContext(ctx, QueryBurns, arg.AssetID, arg.GroupKey, arg.AnchorTxid)
 	if err != nil {
 		return nil, err
 	}
@@ -590,7 +590,7 @@ func (q *Queries) QueryBurns(ctx context.Context, arg QueryBurnsParams) ([]Query
 	return items, nil
 }
 
-const queryPassiveAssets = `-- name: QueryPassiveAssets :many
+const QueryPassiveAssets = `-- name: QueryPassiveAssets :many
 SELECT passive.asset_id, passive.new_anchor_utxo, passive.script_key,
        passive.new_witness_stack, passive.new_proof,
        genesis_assets.asset_id AS genesis_id, passive.asset_version,
@@ -617,7 +617,7 @@ type QueryPassiveAssetsRow struct {
 }
 
 func (q *Queries) QueryPassiveAssets(ctx context.Context, transferID int64) ([]QueryPassiveAssetsRow, error) {
-	rows, err := q.db.QueryContext(ctx, queryPassiveAssets, transferID)
+	rows, err := q.db.QueryContext(ctx, QueryPassiveAssets, transferID)
 	if err != nil {
 		return nil, err
 	}
@@ -648,7 +648,7 @@ func (q *Queries) QueryPassiveAssets(ctx context.Context, transferID int64) ([]Q
 	return items, nil
 }
 
-const queryProofTransferAttempts = `-- name: QueryProofTransferAttempts :many
+const QueryProofTransferAttempts = `-- name: QueryProofTransferAttempts :many
 SELECT time_unix
 FROM proof_transfer_log
 WHERE proof_locator_hash = $1
@@ -662,7 +662,7 @@ type QueryProofTransferAttemptsParams struct {
 }
 
 func (q *Queries) QueryProofTransferAttempts(ctx context.Context, arg QueryProofTransferAttemptsParams) ([]time.Time, error) {
-	rows, err := q.db.QueryContext(ctx, queryProofTransferAttempts, arg.ProofLocatorHash, arg.TransferType)
+	rows, err := q.db.QueryContext(ctx, QueryProofTransferAttempts, arg.ProofLocatorHash, arg.TransferType)
 	if err != nil {
 		return nil, err
 	}
@@ -684,7 +684,7 @@ func (q *Queries) QueryProofTransferAttempts(ctx context.Context, arg QueryProof
 	return items, nil
 }
 
-const reAnchorPassiveAssets = `-- name: ReAnchorPassiveAssets :exec
+const ReAnchorPassiveAssets = `-- name: ReAnchorPassiveAssets :exec
 UPDATE assets
 SET anchor_utxo_id = $1,
     split_commitment_root_hash = NULL,
@@ -698,11 +698,11 @@ type ReAnchorPassiveAssetsParams struct {
 }
 
 func (q *Queries) ReAnchorPassiveAssets(ctx context.Context, arg ReAnchorPassiveAssetsParams) error {
-	_, err := q.db.ExecContext(ctx, reAnchorPassiveAssets, arg.NewAnchorUtxoID, arg.AssetID)
+	_, err := q.db.ExecContext(ctx, ReAnchorPassiveAssets, arg.NewAnchorUtxoID, arg.AssetID)
 	return err
 }
 
-const setTransferOutputProofDeliveryStatus = `-- name: SetTransferOutputProofDeliveryStatus :exec
+const SetTransferOutputProofDeliveryStatus = `-- name: SetTransferOutputProofDeliveryStatus :exec
 WITH target(output_id) AS (
     SELECT output_id
     FROM asset_transfer_outputs output
@@ -723,6 +723,6 @@ type SetTransferOutputProofDeliveryStatusParams struct {
 }
 
 func (q *Queries) SetTransferOutputProofDeliveryStatus(ctx context.Context, arg SetTransferOutputProofDeliveryStatusParams) error {
-	_, err := q.db.ExecContext(ctx, setTransferOutputProofDeliveryStatus, arg.DeliveryComplete, arg.SerializedAnchorOutpoint, arg.Position)
+	_, err := q.db.ExecContext(ctx, SetTransferOutputProofDeliveryStatus, arg.DeliveryComplete, arg.SerializedAnchorOutpoint, arg.Position)
 	return err
 }

--- a/tapdb/sqlc/universe.sql.go
+++ b/tapdb/sqlc/universe.sql.go
@@ -11,7 +11,7 @@ import (
 	"time"
 )
 
-const deleteFederationProofSyncLog = `-- name: DeleteFederationProofSyncLog :exec
+const DeleteFederationProofSyncLog = `-- name: DeleteFederationProofSyncLog :exec
 WITH selected_server_id AS (
     -- Select the server ids from the universe_servers table for the specified
     -- hosts.
@@ -40,7 +40,7 @@ type DeleteFederationProofSyncLogParams struct {
 }
 
 func (q *Queries) DeleteFederationProofSyncLog(ctx context.Context, arg DeleteFederationProofSyncLogParams) error {
-	_, err := q.db.ExecContext(ctx, deleteFederationProofSyncLog,
+	_, err := q.db.ExecContext(ctx, DeleteFederationProofSyncLog,
 		arg.Status,
 		arg.MinTimestamp,
 		arg.MinAttemptCounter,
@@ -49,7 +49,7 @@ func (q *Queries) DeleteFederationProofSyncLog(ctx context.Context, arg DeleteFe
 	return err
 }
 
-const deleteMultiverseLeaf = `-- name: DeleteMultiverseLeaf :exec
+const DeleteMultiverseLeaf = `-- name: DeleteMultiverseLeaf :exec
 DELETE FROM multiverse_leaves
 WHERE leaf_node_namespace = $1 AND leaf_node_key = $2
 `
@@ -60,11 +60,11 @@ type DeleteMultiverseLeafParams struct {
 }
 
 func (q *Queries) DeleteMultiverseLeaf(ctx context.Context, arg DeleteMultiverseLeafParams) error {
-	_, err := q.db.ExecContext(ctx, deleteMultiverseLeaf, arg.Namespace, arg.LeafNodeKey)
+	_, err := q.db.ExecContext(ctx, DeleteMultiverseLeaf, arg.Namespace, arg.LeafNodeKey)
 	return err
 }
 
-const deleteUniverseEvents = `-- name: DeleteUniverseEvents :exec
+const DeleteUniverseEvents = `-- name: DeleteUniverseEvents :exec
 WITH root_id AS (
     SELECT id
     FROM universe_roots
@@ -75,31 +75,31 @@ WHERE universe_root_id = (SELECT id FROM root_id)
 `
 
 func (q *Queries) DeleteUniverseEvents(ctx context.Context, namespaceRoot string) error {
-	_, err := q.db.ExecContext(ctx, deleteUniverseEvents, namespaceRoot)
+	_, err := q.db.ExecContext(ctx, DeleteUniverseEvents, namespaceRoot)
 	return err
 }
 
-const deleteUniverseLeaves = `-- name: DeleteUniverseLeaves :exec
+const DeleteUniverseLeaves = `-- name: DeleteUniverseLeaves :exec
 DELETE FROM universe_leaves
 WHERE leaf_node_namespace = $1
 `
 
 func (q *Queries) DeleteUniverseLeaves(ctx context.Context, namespace string) error {
-	_, err := q.db.ExecContext(ctx, deleteUniverseLeaves, namespace)
+	_, err := q.db.ExecContext(ctx, DeleteUniverseLeaves, namespace)
 	return err
 }
 
-const deleteUniverseRoot = `-- name: DeleteUniverseRoot :exec
+const DeleteUniverseRoot = `-- name: DeleteUniverseRoot :exec
 DELETE FROM universe_roots
 WHERE namespace_root = $1
 `
 
 func (q *Queries) DeleteUniverseRoot(ctx context.Context, namespaceRoot string) error {
-	_, err := q.db.ExecContext(ctx, deleteUniverseRoot, namespaceRoot)
+	_, err := q.db.ExecContext(ctx, DeleteUniverseRoot, namespaceRoot)
 	return err
 }
 
-const deleteUniverseServer = `-- name: DeleteUniverseServer :exec
+const DeleteUniverseServer = `-- name: DeleteUniverseServer :exec
 DELETE FROM universe_servers
 WHERE server_host = $1 OR id = $2
 `
@@ -110,11 +110,11 @@ type DeleteUniverseServerParams struct {
 }
 
 func (q *Queries) DeleteUniverseServer(ctx context.Context, arg DeleteUniverseServerParams) error {
-	_, err := q.db.ExecContext(ctx, deleteUniverseServer, arg.TargetServer, arg.TargetID)
+	_, err := q.db.ExecContext(ctx, DeleteUniverseServer, arg.TargetServer, arg.TargetID)
 	return err
 }
 
-const fetchMultiverseRoot = `-- name: FetchMultiverseRoot :one
+const FetchMultiverseRoot = `-- name: FetchMultiverseRoot :one
 SELECT proof_type, n.hash_key as multiverse_root_hash, n.sum as multiverse_root_sum
 FROM multiverse_roots r
 JOIN mssmt_roots m
@@ -132,13 +132,13 @@ type FetchMultiverseRootRow struct {
 }
 
 func (q *Queries) FetchMultiverseRoot(ctx context.Context, namespaceRoot string) (FetchMultiverseRootRow, error) {
-	row := q.db.QueryRowContext(ctx, fetchMultiverseRoot, namespaceRoot)
+	row := q.db.QueryRowContext(ctx, FetchMultiverseRoot, namespaceRoot)
 	var i FetchMultiverseRootRow
 	err := row.Scan(&i.ProofType, &i.MultiverseRootHash, &i.MultiverseRootSum)
 	return i, err
 }
 
-const fetchUniverseKeys = `-- name: FetchUniverseKeys :many
+const FetchUniverseKeys = `-- name: FetchUniverseKeys :many
 SELECT leaves.minting_point, leaves.script_key_bytes
 FROM universe_leaves AS leaves
 WHERE leaves.leaf_node_namespace = $1
@@ -161,7 +161,7 @@ type FetchUniverseKeysRow struct {
 }
 
 func (q *Queries) FetchUniverseKeys(ctx context.Context, arg FetchUniverseKeysParams) ([]FetchUniverseKeysRow, error) {
-	rows, err := q.db.QueryContext(ctx, fetchUniverseKeys,
+	rows, err := q.db.QueryContext(ctx, FetchUniverseKeys,
 		arg.Namespace,
 		arg.SortDirection,
 		arg.NumOffset,
@@ -188,7 +188,7 @@ func (q *Queries) FetchUniverseKeys(ctx context.Context, arg FetchUniverseKeysPa
 	return items, nil
 }
 
-const fetchUniverseRoot = `-- name: FetchUniverseRoot :one
+const FetchUniverseRoot = `-- name: FetchUniverseRoot :one
 SELECT universe_roots.asset_id, group_key, proof_type,
        mssmt_nodes.hash_key root_hash, mssmt_nodes.sum root_sum,
        genesis_assets.asset_tag asset_name
@@ -213,7 +213,7 @@ type FetchUniverseRootRow struct {
 }
 
 func (q *Queries) FetchUniverseRoot(ctx context.Context, namespace string) (FetchUniverseRootRow, error) {
-	row := q.db.QueryRowContext(ctx, fetchUniverseRoot, namespace)
+	row := q.db.QueryRowContext(ctx, FetchUniverseRoot, namespace)
 	var i FetchUniverseRootRow
 	err := row.Scan(
 		&i.AssetID,
@@ -226,7 +226,7 @@ func (q *Queries) FetchUniverseRoot(ctx context.Context, namespace string) (Fetc
 	return i, err
 }
 
-const insertNewProofEvent = `-- name: InsertNewProofEvent :exec
+const InsertNewProofEvent = `-- name: InsertNewProofEvent :exec
 WITH group_key_root_id AS (
     SELECT id
     FROM universe_roots roots
@@ -265,7 +265,7 @@ type InsertNewProofEventParams struct {
 }
 
 func (q *Queries) InsertNewProofEvent(ctx context.Context, arg InsertNewProofEventParams) error {
-	_, err := q.db.ExecContext(ctx, insertNewProofEvent,
+	_, err := q.db.ExecContext(ctx, InsertNewProofEvent,
 		arg.GroupKeyXOnly,
 		arg.EventTime,
 		arg.EventTimestamp,
@@ -275,7 +275,7 @@ func (q *Queries) InsertNewProofEvent(ctx context.Context, arg InsertNewProofEve
 	return err
 }
 
-const insertNewSyncEvent = `-- name: InsertNewSyncEvent :exec
+const InsertNewSyncEvent = `-- name: InsertNewSyncEvent :exec
 WITH group_key_root_id AS (
     SELECT id
     FROM universe_roots roots
@@ -314,7 +314,7 @@ type InsertNewSyncEventParams struct {
 }
 
 func (q *Queries) InsertNewSyncEvent(ctx context.Context, arg InsertNewSyncEventParams) error {
-	_, err := q.db.ExecContext(ctx, insertNewSyncEvent,
+	_, err := q.db.ExecContext(ctx, InsertNewSyncEvent,
 		arg.GroupKeyXOnly,
 		arg.EventTime,
 		arg.EventTimestamp,
@@ -324,7 +324,7 @@ func (q *Queries) InsertNewSyncEvent(ctx context.Context, arg InsertNewSyncEvent
 	return err
 }
 
-const insertUniverseServer = `-- name: InsertUniverseServer :exec
+const InsertUniverseServer = `-- name: InsertUniverseServer :exec
 INSERT INTO universe_servers(
     server_host, last_sync_time
 ) VALUES (
@@ -338,11 +338,11 @@ type InsertUniverseServerParams struct {
 }
 
 func (q *Queries) InsertUniverseServer(ctx context.Context, arg InsertUniverseServerParams) error {
-	_, err := q.db.ExecContext(ctx, insertUniverseServer, arg.ServerHost, arg.LastSyncTime)
+	_, err := q.db.ExecContext(ctx, InsertUniverseServer, arg.ServerHost, arg.LastSyncTime)
 	return err
 }
 
-const logServerSync = `-- name: LogServerSync :exec
+const LogServerSync = `-- name: LogServerSync :exec
 UPDATE universe_servers
 SET last_sync_time = $1
 WHERE server_host = $2
@@ -354,11 +354,11 @@ type LogServerSyncParams struct {
 }
 
 func (q *Queries) LogServerSync(ctx context.Context, arg LogServerSyncParams) error {
-	_, err := q.db.ExecContext(ctx, logServerSync, arg.NewSyncTime, arg.TargetServer)
+	_, err := q.db.ExecContext(ctx, LogServerSync, arg.NewSyncTime, arg.TargetServer)
 	return err
 }
 
-const queryAssetStatsPerDayPostgres = `-- name: QueryAssetStatsPerDayPostgres :many
+const QueryAssetStatsPerDayPostgres = `-- name: QueryAssetStatsPerDayPostgres :many
 SELECT
     to_char(to_timestamp(event_timestamp), 'YYYY-MM-DD') AS day,
     SUM(CASE WHEN event_type = 'SYNC' THEN 1 ELSE 0 END) AS sync_events,
@@ -383,7 +383,7 @@ type QueryAssetStatsPerDayPostgresRow struct {
 
 // BETWEEN is inclusive for both start and end values.
 func (q *Queries) QueryAssetStatsPerDayPostgres(ctx context.Context, arg QueryAssetStatsPerDayPostgresParams) ([]QueryAssetStatsPerDayPostgresRow, error) {
-	rows, err := q.db.QueryContext(ctx, queryAssetStatsPerDayPostgres, arg.StartTime, arg.EndTime)
+	rows, err := q.db.QueryContext(ctx, QueryAssetStatsPerDayPostgres, arg.StartTime, arg.EndTime)
 	if err != nil {
 		return nil, err
 	}
@@ -405,7 +405,7 @@ func (q *Queries) QueryAssetStatsPerDayPostgres(ctx context.Context, arg QueryAs
 	return items, nil
 }
 
-const queryAssetStatsPerDaySqlite = `-- name: QueryAssetStatsPerDaySqlite :many
+const QueryAssetStatsPerDaySqlite = `-- name: QueryAssetStatsPerDaySqlite :many
 SELECT
     cast(strftime('%Y-%m-%d', datetime(event_timestamp, 'unixepoch')) as text) AS day,
     SUM(CASE WHEN event_type = 'SYNC' THEN 1 ELSE 0 END) AS sync_events,
@@ -429,7 +429,7 @@ type QueryAssetStatsPerDaySqliteRow struct {
 }
 
 func (q *Queries) QueryAssetStatsPerDaySqlite(ctx context.Context, arg QueryAssetStatsPerDaySqliteParams) ([]QueryAssetStatsPerDaySqliteRow, error) {
-	rows, err := q.db.QueryContext(ctx, queryAssetStatsPerDaySqlite, arg.StartTime, arg.EndTime)
+	rows, err := q.db.QueryContext(ctx, QueryAssetStatsPerDaySqlite, arg.StartTime, arg.EndTime)
 	if err != nil {
 		return nil, err
 	}
@@ -451,14 +451,14 @@ func (q *Queries) QueryAssetStatsPerDaySqlite(ctx context.Context, arg QueryAsse
 	return items, nil
 }
 
-const queryFederationGlobalSyncConfigs = `-- name: QueryFederationGlobalSyncConfigs :many
+const QueryFederationGlobalSyncConfigs = `-- name: QueryFederationGlobalSyncConfigs :many
 SELECT proof_type, allow_sync_insert, allow_sync_export
 FROM federation_global_sync_config
 ORDER BY proof_type
 `
 
 func (q *Queries) QueryFederationGlobalSyncConfigs(ctx context.Context) ([]FederationGlobalSyncConfig, error) {
-	rows, err := q.db.QueryContext(ctx, queryFederationGlobalSyncConfigs)
+	rows, err := q.db.QueryContext(ctx, QueryFederationGlobalSyncConfigs)
 	if err != nil {
 		return nil, err
 	}
@@ -480,7 +480,7 @@ func (q *Queries) QueryFederationGlobalSyncConfigs(ctx context.Context) ([]Feder
 	return items, nil
 }
 
-const queryFederationProofSyncLog = `-- name: QueryFederationProofSyncLog :many
+const QueryFederationProofSyncLog = `-- name: QueryFederationProofSyncLog :many
 SELECT
     log.id, status, timestamp, sync_direction, attempt_counter,
     -- Select fields from the universe_servers table.
@@ -545,7 +545,7 @@ type QueryFederationProofSyncLogRow struct {
 // Join on mssmt_nodes to get leaf related fields.
 // Join on genesis_info_view to get leaf related fields.
 func (q *Queries) QueryFederationProofSyncLog(ctx context.Context, arg QueryFederationProofSyncLogParams) ([]QueryFederationProofSyncLogRow, error) {
-	rows, err := q.db.QueryContext(ctx, queryFederationProofSyncLog,
+	rows, err := q.db.QueryContext(ctx, QueryFederationProofSyncLog,
 		arg.SyncDirection,
 		arg.Status,
 		arg.LeafNamespace,
@@ -589,14 +589,14 @@ func (q *Queries) QueryFederationProofSyncLog(ctx context.Context, arg QueryFede
 	return items, nil
 }
 
-const queryFederationUniSyncConfigs = `-- name: QueryFederationUniSyncConfigs :many
+const QueryFederationUniSyncConfigs = `-- name: QueryFederationUniSyncConfigs :many
 SELECT namespace, asset_id, group_key, proof_type, allow_sync_insert, allow_sync_export
 FROM federation_uni_sync_config
 ORDER BY group_key NULLS LAST, asset_id NULLS LAST, proof_type
 `
 
 func (q *Queries) QueryFederationUniSyncConfigs(ctx context.Context) ([]FederationUniSyncConfig, error) {
-	rows, err := q.db.QueryContext(ctx, queryFederationUniSyncConfigs)
+	rows, err := q.db.QueryContext(ctx, QueryFederationUniSyncConfigs)
 	if err != nil {
 		return nil, err
 	}
@@ -625,7 +625,7 @@ func (q *Queries) QueryFederationUniSyncConfigs(ctx context.Context) ([]Federati
 	return items, nil
 }
 
-const queryMultiverseLeaves = `-- name: QueryMultiverseLeaves :many
+const QueryMultiverseLeaves = `-- name: QueryMultiverseLeaves :many
 SELECT r.namespace_root, r.proof_type, l.asset_id, l.group_key, 
        smt_nodes.value AS universe_root_hash, smt_nodes.sum AS universe_root_sum
 FROM multiverse_leaves l
@@ -655,7 +655,7 @@ type QueryMultiverseLeavesRow struct {
 }
 
 func (q *Queries) QueryMultiverseLeaves(ctx context.Context, arg QueryMultiverseLeavesParams) ([]QueryMultiverseLeavesRow, error) {
-	rows, err := q.db.QueryContext(ctx, queryMultiverseLeaves, arg.ProofType, arg.AssetID, arg.GroupKey)
+	rows, err := q.db.QueryContext(ctx, QueryMultiverseLeaves, arg.ProofType, arg.AssetID, arg.GroupKey)
 	if err != nil {
 		return nil, err
 	}
@@ -684,7 +684,7 @@ func (q *Queries) QueryMultiverseLeaves(ctx context.Context, arg QueryMultiverse
 	return items, nil
 }
 
-const queryUniverseAssetStats = `-- name: QueryUniverseAssetStats :many
+const QueryUniverseAssetStats = `-- name: QueryUniverseAssetStats :many
 
 WITH asset_supply AS (
     SELECT SUM(nodes.sum) AS supply, gen.asset_id AS asset_id
@@ -803,7 +803,7 @@ type QueryUniverseAssetStatsRow struct {
 // TODO(roasbeef): use the universe id instead for the grouping? so namespace
 // root, simplifies queries
 func (q *Queries) QueryUniverseAssetStats(ctx context.Context, arg QueryUniverseAssetStatsParams) ([]QueryUniverseAssetStatsRow, error) {
-	rows, err := q.db.QueryContext(ctx, queryUniverseAssetStats,
+	rows, err := q.db.QueryContext(ctx, QueryUniverseAssetStats,
 		arg.SortBy,
 		arg.SortDirection,
 		arg.NumOffset,
@@ -846,7 +846,7 @@ func (q *Queries) QueryUniverseAssetStats(ctx context.Context, arg QueryUniverse
 	return items, nil
 }
 
-const queryUniverseLeaves = `-- name: QueryUniverseLeaves :many
+const QueryUniverseLeaves = `-- name: QueryUniverseLeaves :many
 SELECT leaves.script_key_bytes, gen.gen_asset_id, nodes.value AS genesis_proof, 
        nodes.sum AS sum_amt, gen.asset_id
 FROM universe_leaves AS leaves
@@ -877,7 +877,7 @@ type QueryUniverseLeavesRow struct {
 }
 
 func (q *Queries) QueryUniverseLeaves(ctx context.Context, arg QueryUniverseLeavesParams) ([]QueryUniverseLeavesRow, error) {
-	rows, err := q.db.QueryContext(ctx, queryUniverseLeaves, arg.Namespace, arg.MintingPointBytes, arg.ScriptKeyBytes)
+	rows, err := q.db.QueryContext(ctx, QueryUniverseLeaves, arg.Namespace, arg.MintingPointBytes, arg.ScriptKeyBytes)
 	if err != nil {
 		return nil, err
 	}
@@ -905,7 +905,7 @@ func (q *Queries) QueryUniverseLeaves(ctx context.Context, arg QueryUniverseLeav
 	return items, nil
 }
 
-const queryUniverseServers = `-- name: QueryUniverseServers :many
+const QueryUniverseServers = `-- name: QueryUniverseServers :many
 SELECT id, server_host, last_sync_time FROM universe_servers
 WHERE (id = $1 OR $1 IS NULL) AND
       (server_host = $2
@@ -918,7 +918,7 @@ type QueryUniverseServersParams struct {
 }
 
 func (q *Queries) QueryUniverseServers(ctx context.Context, arg QueryUniverseServersParams) ([]UniverseServer, error) {
-	rows, err := q.db.QueryContext(ctx, queryUniverseServers, arg.ID, arg.ServerHost)
+	rows, err := q.db.QueryContext(ctx, QueryUniverseServers, arg.ID, arg.ServerHost)
 	if err != nil {
 		return nil, err
 	}
@@ -940,7 +940,7 @@ func (q *Queries) QueryUniverseServers(ctx context.Context, arg QueryUniverseSer
 	return items, nil
 }
 
-const queryUniverseStats = `-- name: QueryUniverseStats :one
+const QueryUniverseStats = `-- name: QueryUniverseStats :one
 WITH stats AS (
     SELECT total_asset_syncs, total_asset_proofs
     FROM universe_stats
@@ -990,7 +990,7 @@ type QueryUniverseStatsRow struct {
 }
 
 func (q *Queries) QueryUniverseStats(ctx context.Context) (QueryUniverseStatsRow, error) {
-	row := q.db.QueryRowContext(ctx, queryUniverseStats)
+	row := q.db.QueryRowContext(ctx, QueryUniverseStats)
 	var i QueryUniverseStatsRow
 	err := row.Scan(
 		&i.TotalSyncs,
@@ -1001,12 +1001,12 @@ func (q *Queries) QueryUniverseStats(ctx context.Context) (QueryUniverseStatsRow
 	return i, err
 }
 
-const universeLeaves = `-- name: UniverseLeaves :many
+const UniverseLeaves = `-- name: UniverseLeaves :many
 SELECT id, asset_genesis_id, minting_point, script_key_bytes, universe_root_id, leaf_node_key, leaf_node_namespace FROM universe_leaves
 `
 
 func (q *Queries) UniverseLeaves(ctx context.Context) ([]UniverseLeafe, error) {
-	rows, err := q.db.QueryContext(ctx, universeLeaves)
+	rows, err := q.db.QueryContext(ctx, UniverseLeaves)
 	if err != nil {
 		return nil, err
 	}
@@ -1036,7 +1036,7 @@ func (q *Queries) UniverseLeaves(ctx context.Context) ([]UniverseLeafe, error) {
 	return items, nil
 }
 
-const universeRoots = `-- name: UniverseRoots :many
+const UniverseRoots = `-- name: UniverseRoots :many
 SELECT universe_roots.asset_id, group_key, proof_type,
        mssmt_roots.root_hash AS root_hash, mssmt_nodes.sum AS root_sum,
        genesis_assets.asset_tag AS asset_name
@@ -1070,7 +1070,7 @@ type UniverseRootsRow struct {
 }
 
 func (q *Queries) UniverseRoots(ctx context.Context, arg UniverseRootsParams) ([]UniverseRootsRow, error) {
-	rows, err := q.db.QueryContext(ctx, universeRoots, arg.SortDirection, arg.NumOffset, arg.NumLimit)
+	rows, err := q.db.QueryContext(ctx, UniverseRoots, arg.SortDirection, arg.NumOffset, arg.NumLimit)
 	if err != nil {
 		return nil, err
 	}
@@ -1099,7 +1099,7 @@ func (q *Queries) UniverseRoots(ctx context.Context, arg UniverseRootsParams) ([
 	return items, nil
 }
 
-const upsertFederationGlobalSyncConfig = `-- name: UpsertFederationGlobalSyncConfig :exec
+const UpsertFederationGlobalSyncConfig = `-- name: UpsertFederationGlobalSyncConfig :exec
 INSERT INTO federation_global_sync_config (
     proof_type, allow_sync_insert, allow_sync_export
 )
@@ -1117,11 +1117,11 @@ type UpsertFederationGlobalSyncConfigParams struct {
 }
 
 func (q *Queries) UpsertFederationGlobalSyncConfig(ctx context.Context, arg UpsertFederationGlobalSyncConfigParams) error {
-	_, err := q.db.ExecContext(ctx, upsertFederationGlobalSyncConfig, arg.ProofType, arg.AllowSyncInsert, arg.AllowSyncExport)
+	_, err := q.db.ExecContext(ctx, UpsertFederationGlobalSyncConfig, arg.ProofType, arg.AllowSyncInsert, arg.AllowSyncExport)
 	return err
 }
 
-const upsertFederationProofSyncLog = `-- name: UpsertFederationProofSyncLog :one
+const UpsertFederationProofSyncLog = `-- name: UpsertFederationProofSyncLog :one
 INSERT INTO federation_proof_sync_log AS log (
     status, timestamp, sync_direction, proof_leaf_id, universe_root_id,
     servers_id
@@ -1175,7 +1175,7 @@ type UpsertFederationProofSyncLogParams struct {
 }
 
 func (q *Queries) UpsertFederationProofSyncLog(ctx context.Context, arg UpsertFederationProofSyncLogParams) (int64, error) {
-	row := q.db.QueryRowContext(ctx, upsertFederationProofSyncLog,
+	row := q.db.QueryRowContext(ctx, UpsertFederationProofSyncLog,
 		arg.Status,
 		arg.Timestamp,
 		arg.SyncDirection,
@@ -1191,7 +1191,7 @@ func (q *Queries) UpsertFederationProofSyncLog(ctx context.Context, arg UpsertFe
 	return id, err
 }
 
-const upsertFederationUniSyncConfig = `-- name: UpsertFederationUniSyncConfig :exec
+const UpsertFederationUniSyncConfig = `-- name: UpsertFederationUniSyncConfig :exec
 INSERT INTO federation_uni_sync_config  (
     namespace, asset_id, group_key, proof_type, allow_sync_insert, allow_sync_export
 )
@@ -1214,7 +1214,7 @@ type UpsertFederationUniSyncConfigParams struct {
 }
 
 func (q *Queries) UpsertFederationUniSyncConfig(ctx context.Context, arg UpsertFederationUniSyncConfigParams) error {
-	_, err := q.db.ExecContext(ctx, upsertFederationUniSyncConfig,
+	_, err := q.db.ExecContext(ctx, UpsertFederationUniSyncConfig,
 		arg.Namespace,
 		arg.AssetID,
 		arg.GroupKey,
@@ -1225,7 +1225,7 @@ func (q *Queries) UpsertFederationUniSyncConfig(ctx context.Context, arg UpsertF
 	return err
 }
 
-const upsertMultiverseLeaf = `-- name: UpsertMultiverseLeaf :one
+const UpsertMultiverseLeaf = `-- name: UpsertMultiverseLeaf :one
 INSERT INTO multiverse_leaves (
     multiverse_root_id, asset_id, group_key, leaf_node_key, leaf_node_namespace
 ) VALUES (
@@ -1248,7 +1248,7 @@ type UpsertMultiverseLeafParams struct {
 }
 
 func (q *Queries) UpsertMultiverseLeaf(ctx context.Context, arg UpsertMultiverseLeafParams) (int64, error) {
-	row := q.db.QueryRowContext(ctx, upsertMultiverseLeaf,
+	row := q.db.QueryRowContext(ctx, UpsertMultiverseLeaf,
 		arg.MultiverseRootID,
 		arg.AssetID,
 		arg.GroupKey,
@@ -1260,7 +1260,7 @@ func (q *Queries) UpsertMultiverseLeaf(ctx context.Context, arg UpsertMultiverse
 	return id, err
 }
 
-const upsertMultiverseRoot = `-- name: UpsertMultiverseRoot :one
+const UpsertMultiverseRoot = `-- name: UpsertMultiverseRoot :one
 INSERT INTO multiverse_roots (namespace_root, proof_type)
 VALUES ($1, $2)
 ON CONFLICT (namespace_root)
@@ -1275,13 +1275,13 @@ type UpsertMultiverseRootParams struct {
 }
 
 func (q *Queries) UpsertMultiverseRoot(ctx context.Context, arg UpsertMultiverseRootParams) (int64, error) {
-	row := q.db.QueryRowContext(ctx, upsertMultiverseRoot, arg.NamespaceRoot, arg.ProofType)
+	row := q.db.QueryRowContext(ctx, UpsertMultiverseRoot, arg.NamespaceRoot, arg.ProofType)
 	var id int64
 	err := row.Scan(&id)
 	return id, err
 }
 
-const upsertUniverseLeaf = `-- name: UpsertUniverseLeaf :exec
+const UpsertUniverseLeaf = `-- name: UpsertUniverseLeaf :exec
 INSERT INTO universe_leaves (
     asset_genesis_id, script_key_bytes, universe_root_id, leaf_node_key, 
     leaf_node_namespace, minting_point
@@ -1305,7 +1305,7 @@ type UpsertUniverseLeafParams struct {
 }
 
 func (q *Queries) UpsertUniverseLeaf(ctx context.Context, arg UpsertUniverseLeafParams) error {
-	_, err := q.db.ExecContext(ctx, upsertUniverseLeaf,
+	_, err := q.db.ExecContext(ctx, UpsertUniverseLeaf,
 		arg.AssetGenesisID,
 		arg.ScriptKeyBytes,
 		arg.UniverseRootID,
@@ -1316,7 +1316,7 @@ func (q *Queries) UpsertUniverseLeaf(ctx context.Context, arg UpsertUniverseLeaf
 	return err
 }
 
-const upsertUniverseRoot = `-- name: UpsertUniverseRoot :one
+const UpsertUniverseRoot = `-- name: UpsertUniverseRoot :one
 INSERT INTO universe_roots (
     namespace_root, asset_id, group_key, proof_type
 ) VALUES (
@@ -1336,7 +1336,7 @@ type UpsertUniverseRootParams struct {
 }
 
 func (q *Queries) UpsertUniverseRoot(ctx context.Context, arg UpsertUniverseRootParams) (int64, error) {
-	row := q.db.QueryRowContext(ctx, upsertUniverseRoot,
+	row := q.db.QueryRowContext(ctx, UpsertUniverseRoot,
 		arg.NamespaceRoot,
 		arg.AssetID,
 		arg.GroupKey,

--- a/tapdb/universe_perf_long_test.go
+++ b/tapdb/universe_perf_long_test.go
@@ -2,6 +2,8 @@
 
 package tapdb
 
+import "time"
+
 // longTestScale is the scale factor for long tests.
 const longTestScale = 5
 
@@ -9,4 +11,6 @@ var (
 	numAssets        = 100 * longTestScale
 	numLeavesPerTree = 300 * longTestScale
 	numQueries       = 100 * longTestScale
+
+	testTimeout = 5 * time.Minute * longTestScale
 )

--- a/tapdb/universe_perf_long_test.go
+++ b/tapdb/universe_perf_long_test.go
@@ -6,7 +6,7 @@ package tapdb
 const longTestScale = 5
 
 var (
-	numAssets         = 100 * longTestScale
-	numLeavesPerTree  = 300 * longTestScale
-	numQueries        = 100 * longTestScale
+	numAssets        = 100 * longTestScale
+	numLeavesPerTree = 300 * longTestScale
+	numQueries       = 100 * longTestScale
 )

--- a/tapdb/universe_perf_short_test.go
+++ b/tapdb/universe_perf_short_test.go
@@ -2,8 +2,12 @@
 
 package tapdb
 
+import "time"
+
 var (
 	numAssets        = 100
 	numLeavesPerTree = 300
 	numQueries       = 100
+
+	testTimeout = 5 * time.Minute
 )

--- a/tapdb/universe_stats_test.go
+++ b/tapdb/universe_stats_test.go
@@ -125,6 +125,20 @@ func (u *uniStatsHarness) assertUniverseStatsEqual(t *testing.T,
 	require.NoError(t, err)
 }
 
+func (u *uniStatsHarness) addEvents(numAssets int) {
+	// Next, we'll log 2 proof events, and a random amount of syncs for
+	// each asset.
+	for i := 0; i < numAssets; i++ {
+		u.logProofEventByIndex(i)
+		u.logProofEventByIndex(i)
+
+		numSyncs := rand.Int() % 10
+		for j := 0; j < numSyncs; j++ {
+			u.logSyncEventByIndex(i)
+		}
+	}
+}
+
 // TestUniverseStatsEvents tests that we're able to properly insert, and also
 // fetch information related to universe sync related events.
 func TestUniverseStatsEvents(t *testing.T) {
@@ -271,15 +285,7 @@ func TestUniverseQuerySyncStatsSorting(t *testing.T) {
 
 	// Next, we'll log 2 proof events, and a random amount of syncs for
 	// each asset.
-	for i := 0; i < numAssets; i++ {
-		sh.logProofEventByIndex(i)
-		sh.logProofEventByIndex(i)
-
-		numSyncs := rand.Int() % 10
-		for j := 0; j < numSyncs; j++ {
-			sh.logSyncEventByIndex(i)
-		}
-	}
+	sh.addEvents(numAssets)
 
 	// sortCheck is used to generate an IsSorted func bound to the
 	// response, for each sort type below.


### PR DESCRIPTION
Addition to https://github.com/lightninglabs/taproot-assets/pull/1302.

Difference can best be seen when running `make unit-trace pkg=tapdb long-tests=1 case=TestUniverseIndexPerformance/name=query_aggregated`:

```
    universe_perf_test.go:279: No indices exec time: 28.961577804s
    universe_perf_test.go:280: With indices exec time: 11.647093789s
    universe_perf_test.go:289: Improvement: 2.49x
```

I also confirmed on mainnet that the old and new query return the exact same result:
[old-query.txt](https://github.com/user-attachments/files/18479924/old-query.txt)
[new-query.txt](https://github.com/user-attachments/files/18479925/new-query.txt)

The speedup on mainnet is also quite significant. The old query took 2.5 minutes while the new one only took 15 seconds.

Hopefully this should make https://github.com/lightninglabs/taproot-assets/pull/1302 not necessary (but let's keep it anyway, since it's a good idea as well).

Shout out to @jbrill who's performance test setup allowed me to test this quite easily.