### PR TITLE
universe: sync "missing universe id" when syncing unknown asset ID

### DIFF
--- a/itest/universe_test.go
+++ b/itest/universe_test.go
@@ -688,6 +688,57 @@ func testUniverseFederation(t *harnessTest) {
 	)
 	require.NoError(t.t, err)
 	require.Equal(t.t, 0, len(fedNodes.Servers))
+
+	// When querying for a universe root that doesn't exist, we currently
+	// get an empty response. In a future version, this should be a
+	// universe.ErrNoUniverseRoot error.
+	dummyAssetIDBytes := fn.ByteSlice([32]byte{0x01})
+	rootResp, err := bob.QueryAssetRoots(ctxt, &unirpc.AssetRootQuery{
+		Id: &unirpc.ID{
+			Id: &unirpc.ID_AssetId{
+				AssetId: dummyAssetIDBytes,
+			},
+		},
+	})
+	require.NoError(t.t, err)
+
+	// The following checks show the problem: The actual roots are not nil
+	// but all the fields are empty. So they're basically useless. To not
+	// break the sync for older clients, we can't just change this right
+	// away. But we're going to change this in the future.
+	require.NotNil(t.t, rootResp.IssuanceRoot)
+	require.Nil(t.t, rootResp.IssuanceRoot.Id)
+	require.Nil(t.t, rootResp.IssuanceRoot.MssmtRoot)
+	require.Empty(t.t, rootResp.IssuanceRoot.AssetName)
+	require.Empty(t.t, rootResp.IssuanceRoot.AmountsByAssetId)
+	require.NotNil(t.t, rootResp.TransferRoot)
+	require.Nil(t.t, rootResp.TransferRoot.Id)
+	require.Nil(t.t, rootResp.TransferRoot.MssmtRoot)
+	require.Empty(t.t, rootResp.TransferRoot.AssetName)
+	require.Empty(t.t, rootResp.TransferRoot.AmountsByAssetId)
+
+	// Because the above QueryAssetRoots doesn't return an error, this
+	// currently leads to an error further down in the sync logic, which can
+	// be shown by syncing an invalid asset ID.
+	dummyID := &unirpc.ID{
+		Id: &unirpc.ID_AssetId{
+			AssetId: dummyAssetIDBytes,
+		},
+		ProofType: unirpc.ProofType_PROOF_TYPE_ISSUANCE,
+	}
+	_, err = bob.SyncUniverse(ctxt, &unirpc.SyncRequest{
+		UniverseHost: t.tapd.rpcHost(),
+		SyncMode:     unirpc.UniverseSyncMode_SYNC_ISSUANCE_ONLY,
+		SyncTargets: []*unirpc.SyncTarget{
+			{
+				Id: dummyID,
+			},
+		},
+	})
+	require.ErrorContains(
+		t.t, err, "unable to sync universe: unable to fetch roots for "+
+			"universe sync: missing universe id",
+	)
 }
 
 // testFederationSyncConfig tests that we can properly set and query the

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -4946,8 +4946,7 @@ func (r *rpcServer) QueryAssetRoots(ctx context.Context,
 		return assetRoots, nil
 
 	case err != nil:
-		return nil, fmt.Errorf("asset group lookup failed: %w",
-			err)
+		return nil, fmt.Errorf("asset group lookup failed: %w", err)
 
 	// We found the correct group for this asset; fetch the universe
 	// roots for the group.
@@ -4979,10 +4978,12 @@ func (r *rpcServer) QueryAssetRoots(ctx context.Context,
 // specific asset, for both proof types. The asset can be identified by its
 // asset ID or group key.
 func (r *rpcServer) queryAssetProofRoots(ctx context.Context,
-	id universe.Identifier) (*unirpc.QueryRootResponse, error) {
+	uniID universe.Identifier) (*unirpc.QueryRootResponse, error) {
 
-	var issuanceRootRPC, transferRootRPC *unirpc.UniverseRoot
-	uniID := id
+	var (
+		resp unirpc.QueryRootResponse
+		err  error
+	)
 
 	issuanceRoot, issuanceErr := r.cfg.UniverseArchive.RootNode(ctx, uniID)
 	if issuanceErr != nil {
@@ -4994,7 +4995,7 @@ func (r *rpcServer) queryAssetProofRoots(ctx context.Context,
 		}
 	}
 
-	issuanceRootRPC, err := marshalUniverseRoot(issuanceRoot)
+	resp.IssuanceRoot, err = marshalUniverseRoot(issuanceRoot)
 	if err != nil {
 		return nil, err
 	}
@@ -5015,15 +5016,12 @@ func (r *rpcServer) queryAssetProofRoots(ctx context.Context,
 		}
 	}
 
-	transferRootRPC, err = marshalUniverseRoot(transferRoot)
+	resp.TransferRoot, err = marshalUniverseRoot(transferRoot)
 	if err != nil {
 		return nil, err
 	}
 
-	return &unirpc.QueryRootResponse{
-		IssuanceRoot: issuanceRootRPC,
-		TransferRoot: transferRootRPC,
-	}, nil
+	return &resp, nil
 }
 
 // DeleteAssetRoot attempts to locate the current Universe root for a specific

--- a/universe_rpc_diff.go
+++ b/universe_rpc_diff.go
@@ -120,6 +120,14 @@ func (r *RpcUniverseDiff) RootNode(ctx context.Context,
 		return universe.Root{}, err
 	}
 
+	// Old universe servers will return an empty response instead of the
+	// above error. But our sync engine now understands the error, so we can
+	// transform the empty response to the error. Future servers will return
+	// the error directly, which can be handled by newer clients.
+	if universe.IsEmptyRootResponse(universeRoot) {
+		return universe.Root{}, universe.ErrNoUniverseRoot
+	}
+
 	if id.ProofType == universe.ProofTypeIssuance {
 		return unmarshalUniverseRoot(universeRoot.IssuanceRoot)
 	}

--- a/universe_rpc_diff.go
+++ b/universe_rpc_diff.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/lightninglabs/taproot-assets/fn"
 	"github.com/lightninglabs/taproot-assets/mssmt"
 	"github.com/lightninglabs/taproot-assets/taprpc/universerpc"
 	unirpc "github.com/lightninglabs/taproot-assets/taprpc/universerpc"
@@ -109,7 +110,13 @@ func (r *RpcUniverseDiff) RootNode(ctx context.Context,
 	}
 
 	universeRoot, err := r.conn.QueryAssetRoots(ctx, rootReq)
-	if err != nil {
+	switch {
+	// We're calling using the RPC endpoint, so the error cannot be mapped
+	// directly using errors.Is.
+	case fn.IsRpcErr(err, universe.ErrNoUniverseRoot):
+		return universe.Root{}, universe.ErrNoUniverseRoot
+
+	case err != nil:
 		return universe.Root{}, err
 	}
 


### PR DESCRIPTION
Fixes https://github.com/lightninglabs/taproot-assets/issues/990, at least partially.

We'll need another fix in future versions and actually return an error properly (https://github.com/lightninglabs/taproot-assets/issues/1315).
But to not break older clients, we'll only do that after a full version (e.g. we ship this fix in 0.5.1, then with 0.6 or 0.7 we return an actual error, knowing that enough clients will understand to not interrupt the whole sync process).

