### PR TITLE
gitignore: add rule to ignore btcd-itest log files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ cmd/tapd/tapd
 /itest/chantools
 /itest/regtest/*
 /itest/*.log
+/itest/*.log.*
 /itest/.backendlogs/*
 /itest/.minerlogs/*
 /itest/tapd-itest


### PR DESCRIPTION
Update `.gitignore` to exclude `itest` directory log files matching the pattern `.log.<num>.gz`.