### PR TITLE
Cleanup Asset Minting Code in Preparation for Universe Commitments

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -600,7 +600,7 @@ func (r *rpcServer) MintAsset(ctx context.Context,
 	}
 
 	rpcsLog.Infof("[MintAsset]: version=%v, type=%v, name=%v, amt=%v, "+
-		"issuance=%v", seedling.AssetVersion, seedling.AssetType,
+		"enable_emission=%v", seedling.AssetVersion, seedling.AssetType,
 		seedling.AssetName, seedling.Amount, seedling.EnableEmission)
 
 	if scriptKey != nil {

--- a/tapgarden/batch.go
+++ b/tapgarden/batch.go
@@ -131,6 +131,10 @@ func (m *MintingBatch) Copy() *MintingBatch {
 // validateGroupAnchor checks if the group anchor for a seedling is valid.
 // A valid anchor must already be part of the batch and have emission enabled.
 func (m *MintingBatch) validateGroupAnchor(s *Seedling) error {
+	if s.GroupAnchor == nil {
+		return fmt.Errorf("group anchor unspecified")
+	}
+
 	anchor, ok := m.Seedlings[*s.GroupAnchor]
 
 	if anchor == nil || !ok {

--- a/tapgarden/caretaker.go
+++ b/tapgarden/caretaker.go
@@ -59,10 +59,10 @@ const (
 // BatchCaretakerConfig houses all the items that the BatchCaretaker needs to
 // carry out its duties.
 type BatchCaretakerConfig struct {
-	// Batch is the minting batch that this caretaker is responsible for?
+	// Batch is the minting batch that this caretaker is responsible for.
 	Batch *MintingBatch
 
-	// BatchFeeRate is an optional manually-set feerate specified when
+	// BatchFeeRate is an optional manually-set fee rate specified when
 	// finalizing a batch.
 	BatchFeeRate *chainfee.SatPerKWeight
 

--- a/tapgarden/planter.go
+++ b/tapgarden/planter.go
@@ -2140,8 +2140,8 @@ func (c *ChainPlanter) finalizeBatch(params FinalizeParams) (*BatchCaretaker,
 	return caretaker, nil
 }
 
-// PendingBatch returns the current pending batch. If there's no pending batch,
-// then an error is returned.
+// PendingBatch returns the current pending batch, or nil if no batch is
+// pending.
 func (c *ChainPlanter) PendingBatch() (*MintingBatch, error) {
 	req := newStateReq[*MintingBatch](reqTypePendingBatch)
 

--- a/tapgarden/planter.go
+++ b/tapgarden/planter.go
@@ -1032,7 +1032,11 @@ func fetchFinalizedBatch(ctx context.Context, batchStore MintingStore,
 
 	// Collect genesis TX information from the batch to build the proof
 	// locators.
-	anchorOutputIndex := extractAnchorOutputIndex(batch.GenesisPacket)
+	anchorOutputIndex, err := extractAnchorOutputIndex(batch.GenesisPacket)
+	if err != nil {
+		return nil, err
+	}
+
 	signedTx, err := psbt.Extract(batch.GenesisPacket.Pkt)
 	if err != nil {
 		return nil, err
@@ -1268,9 +1272,13 @@ func newVerboseBatch(currentBatch *MintingBatch,
 
 	// Before we can build the group key requests for each seedling, we must
 	// fetch the genesis point and anchor index for the batch.
-	anchorOutputIndex := extractAnchorOutputIndex(
+	anchorOutputIndex, err := extractAnchorOutputIndex(
 		currentBatch.GenesisPacket,
 	)
+	if err != nil {
+		return nil, err
+	}
+
 	genesisPoint := extractGenesisOutpoint(
 		currentBatch.GenesisPacket.Pkt.UnsignedTx,
 	)
@@ -1847,9 +1855,13 @@ func (c *ChainPlanter) sealBatch(ctx context.Context, params SealParams,
 
 	// Before we can build the group key requests for each seedling, we must
 	// fetch the genesis point and anchor index for the batch.
-	anchorOutputIndex := extractAnchorOutputIndex(
+	anchorOutputIndex, err := extractAnchorOutputIndex(
 		workingBatch.GenesisPacket,
 	)
+	if err != nil {
+		return nil, err
+	}
+
 	genesisPoint := extractGenesisOutpoint(
 		workingBatch.GenesisPacket.Pkt.UnsignedTx,
 	)

--- a/tapgarden/planter.go
+++ b/tapgarden/planter.go
@@ -1437,6 +1437,10 @@ func (c *ChainPlanter) gardener() {
 			// After some basic validation, prepare the asset
 			// seedling (soon to be a sprout) by committing it to
 			// disk as part of the latest batch.
+			//
+			// This method will also include the seedling in any
+			// existing pending batch or create a new pending batch
+			// if necessary.
 			ctx, cancel := c.WithCtxQuit()
 			err := c.prepAssetSeedling(ctx, req)
 			cancel()
@@ -2223,8 +2227,7 @@ func (c *ChainPlanter) CancelBatch() (*btcec.PublicKey, error) {
 }
 
 // prepAssetSeedling performs some basic validation for the Seedling, then
-// either adds it to an existing pending batch or creates a new batch for it. A
-// bool indicating if a new batch should immediately be created is returned.
+// either adds it to an existing pending batch or creates a new batch for it.
 func (c *ChainPlanter) prepAssetSeedling(ctx context.Context,
 	req *Seedling) error {
 

--- a/tapgarden/planter_test.go
+++ b/tapgarden/planter_test.go
@@ -1658,6 +1658,12 @@ func testFundSealBeforeFinalize(t *mintingTestHarness) {
 	// harness.
 	t.refreshChainPlanter()
 
+	// A pending batch should not exist yet. Therefore, `PendingBatch`
+	// should return nil and no error.
+	batch, err := t.planter.PendingBatch()
+	require.Nil(t, batch)
+	require.NoError(t, err)
+
 	var (
 		wg               sync.WaitGroup
 		respChan         = make(chan *FundBatchResp, 1)


### PR DESCRIPTION
Changes are non-functional but should improve code clarity and robustness.

- enforce output count validation in `extractAnchorOutputIndex`  
- add nil check for group anchor validation  
- improve documentation for `PendingBatch` and `prepAssetSeedling`  
- refine rpc log messages for clarity