### PR TITLE
proof: add new universe commitment TLV fields to asset meta reveal

### DIFF
--- a/itest/assertions.go
+++ b/itest/assertions.go
@@ -1852,22 +1852,19 @@ func AssertAssetsMinted(t *testing.T, tapClient commands.RpcClientsBundle,
 	confirmedAssets := GroupAssetsByName(listRespConfirmed.Assets)
 
 	for _, assetRequest := range assetRequests {
-		metaReveal := &proof.MetaReveal{
-			Data: assetRequest.Asset.AssetMeta.Data,
-		}
-
 		validMetaType, err := proof.IsValidMetaType(
 			assetRequest.Asset.AssetMeta.Type,
 		)
 		require.NoError(t, err)
 
-		metaReveal.Type = validMetaType
-		if metaReveal.Type == proof.MetaJson {
-			err := metaReveal.SetDecDisplay(
-				assetRequest.Asset.DecimalDisplay,
-			)
-			require.NoError(t, err)
+		metaReveal := &proof.MetaReveal{
+			Data: assetRequest.Asset.AssetMeta.Data,
+			Type: validMetaType,
 		}
+		err = metaReveal.SetDecDisplay(
+			assetRequest.Asset.DecimalDisplay,
+		)
+		require.NoError(t, err)
 
 		metaHash := metaReveal.MetaHash()
 
@@ -2077,10 +2074,15 @@ func assertGroups(t *testing.T, client taprpc.TaprootAssetsClient,
 	equalityCheck := func(a *mintrpc.MintAsset,
 		b *taprpc.AssetHumanReadable) {
 
-		metaHash := (&proof.MetaReveal{
+		assetMeta := &proof.MetaReveal{
 			Type: proof.MetaOpaque,
 			Data: a.AssetMeta.Data,
-		}).MetaHash()
+		}
+
+		err = assetMeta.SetDecDisplay(a.DecimalDisplay)
+		require.NoError(t, err)
+
+		metaHash := assetMeta.MetaHash()
 
 		require.Equal(t, a.AssetType, b.Type)
 		require.Equal(t, a.Name, b.Tag)

--- a/itest/asset_meta_test.go
+++ b/itest/asset_meta_test.go
@@ -167,31 +167,83 @@ func testMintAssetWithDecimalDisplayMetaField(t *harnessTest) {
 	secondAssetReq.Asset.GroupKey = groupKey
 	secondAssetReq.Asset.DecimalDisplay = 0
 
-	// Reissuance should fail if the decimal display does not match the
+	// Re-issuance should fail if the decimal display does not match the
 	// group anchor.
 	_, err = t.tapd.MintAsset(ctxt, secondAssetReq)
 	require.ErrorContains(t.t, err, "decimal display does not match")
 
-	// Requesting a decimal display without specifying the metadata type as
-	// JSON should fail.
+	// Requesting a decimal display without specifying the metadata field
+	// with at least the type should fail.
 	secondAssetReq.Asset.DecimalDisplay = firstAsset.DecimalDisplay
 	secondAssetReq.Asset.AssetMeta = nil
 
 	_, err = t.tapd.MintAsset(ctxt, secondAssetReq)
-	require.ErrorContains(t.t, err, "decimal display requires JSON")
+	require.ErrorContains(
+		t.t, err, "decimal display requires asset metadata",
+	)
 
-	// If we update the decimal display to match the group anchor, minting
-	// should succeed. We also unset the metadata to ensure that the decimal
-	// display is set as the sole JSON object if needed.
+	// Attempting to set a different decimal display in the JSON meta data
+	// as in the new RPC request field should give us an error as well.
 	secondAssetReq.Asset.AssetMeta = &taprpc.AssetMeta{
 		Type: taprpc.AssetMetaType_META_TYPE_JSON,
+		Data: []byte(`{"foo": "bar", "decimal_display": 3}`),
 	}
-	MintAssetsConfirmBatch(
+	_, err = t.tapd.MintAsset(ctxt, secondAssetReq)
+	require.ErrorContains(
+		t.t, err, "decimal display in JSON asset meta does not match",
+	)
+
+	// If we set a valid asset meta again, minting should succeed, using the
+	// same decimal display as the group anchor.
+	secondAssetReq.Asset.AssetMeta.Data = []byte(`{"foo": "bar"}`)
+	secondAssets := MintAssetsConfirmBatch(
 		t.t, t.lndHarness.Miner().Client, t.tapd,
 		[]*mintrpc.MintAssetRequest{secondAssetReq},
 	)
+	require.Len(t.t, secondAssets, 1)
+	require.NotNil(t.t, secondAssets[0].DecimalDisplay)
+	require.EqualValues(
+		t.t, 2, secondAssets[0].DecimalDisplay.DecimalDisplay,
+	)
+
+	// For an asset with a JSON meta data type, we also expect the decimal
+	// display to be encoded in the meta data JSON.
+	metaResp, err := t.tapd.FetchAssetMeta(
+		ctxt, &taprpc.FetchAssetMetaRequest{
+			Asset: &taprpc.FetchAssetMetaRequest_AssetId{
+				AssetId: secondAssets[0].AssetGenesis.AssetId,
+			},
+		},
+	)
+	require.NoError(t.t, err)
+	require.Contains(t.t, string(metaResp.Data), `"foo":"bar"`)
+	require.Contains(t.t, string(metaResp.Data), `"decimal_display":2`)
 
 	AssertGroupSizes(
 		t.t, t.tapd, []string{hex.EncodeToString(groupKey)}, []int{2},
+	)
+
+	// Now we also test minting an asset that uses the opaque meta data type
+	// and check that the decimal display is correctly encoded as well.
+	thirdAsset := &mintrpc.MintAsset{
+		AssetType: taprpc.AssetType_NORMAL,
+		Name:      "test-asset-opaque-decimal-display",
+		AssetMeta: &taprpc.AssetMeta{
+			Type: taprpc.AssetMetaType_META_TYPE_OPAQUE,
+			Data: []byte("some opaque data"),
+		},
+		Amount:         123,
+		DecimalDisplay: 7,
+	}
+	thirdAssetReq := &mintrpc.MintAssetRequest{Asset: thirdAsset}
+	thirdAssets := MintAssetsConfirmBatch(
+		t.t, t.lndHarness.Miner().Client, t.tapd,
+		[]*mintrpc.MintAssetRequest{thirdAssetReq},
+	)
+
+	require.Len(t.t, thirdAssets, 1)
+	require.NotNil(t.t, thirdAssets[0].DecimalDisplay)
+	require.EqualValues(
+		t.t, 7, thirdAssets[0].DecimalDisplay.DecimalDisplay,
 	)
 }

--- a/itest/utils.go
+++ b/itest/utils.go
@@ -427,12 +427,10 @@ func FinalizeBatchUnconfirmed(t *testing.T, minerClient *rpcclient.Client,
 		require.NoError(t, err)
 
 		metaReveal.Type = validMetaType
-		if metaReveal.Type == proof.MetaJson {
-			err := metaReveal.SetDecDisplay(
-				assetRequest.Asset.DecimalDisplay,
-			)
-			require.NoError(t, err)
-		}
+		err = metaReveal.SetDecDisplay(
+			assetRequest.Asset.DecimalDisplay,
+		)
+		require.NoError(t, err)
 
 		metaHash := metaReveal.MetaHash()
 
@@ -604,6 +602,9 @@ func ManualMintSimpleAsset(t *harnessTest, lndNode *node.HarnessNode,
 		Type: proof.MetaOpaque,
 		Data: req.AssetMeta.Data,
 	}
+	err = assetMeta.SetDecDisplay(req.DecimalDisplay)
+	require.NoError(t.t, err)
+
 	metaHash := assetMeta.MetaHash()
 	metaReveals := tapgarden.AssetMetas{
 		asset.ToSerialized(assetScriptKey.PubKey): &assetMeta,

--- a/proof/meta.go
+++ b/proof/meta.go
@@ -100,6 +100,16 @@ type MetaReveal struct {
 	// Data is the committed data being revealed.
 	Data []byte
 
+	// DecimalDisplay is the decimal display value of the asset. This is
+	// used to determine the number of decimal places to display when
+	// presenting the asset amount to the user. If this field is not
+	// explicitly encoded in the TLV, this is an older asset that didn't
+	// have this field. New assets will always set an explicit value, even
+	// if that is the default value of zero. If the meta type is JSON and
+	// this value is not zero, then the decimal display is also added as a
+	// field to the JSON object for backward compatibility.
+	DecimalDisplay fn.Option[uint32]
+
 	// UnknownOddTypes is a map of unknown odd types that were encountered
 	// during decoding. This map is used to preserve unknown types that we
 	// don't know of yet, so we can still encode them back when serializing.
@@ -141,7 +151,8 @@ func (m *MetaReveal) Validate() error {
 		}
 	}
 
-	return nil
+	// If the decimal display is set, it must be valid.
+	return fn.MapOptionZ(m.DecimalDisplay, IsValidDecDisplay)
 }
 
 // IsValidMetaType checks if the passed value is a valid meta type.
@@ -232,6 +243,12 @@ func (m *MetaReveal) GetDecDisplay() (map[string]interface{}, uint32, error) {
 		return nil, 0, nil
 	}
 
+	// If the decimal display is set as the new TLV value, we can use that
+	// directly.
+	if m.DecimalDisplay.IsSome() {
+		return nil, m.DecimalDisplay.UnwrapOr(0), nil
+	}
+
 	if m.Type != MetaJson {
 		return nil, 0, ErrNotJSON
 	}
@@ -311,9 +328,18 @@ func (m *MetaReveal) SetDecDisplay(decDisplay uint32) error {
 		return err
 	}
 
-	// If the meta type is not JSON, we can't set the decimal display value.
+	m.DecimalDisplay = fn.Some(decDisplay)
+
+	// We only set the decimal display value in the JSON if it isn't the
+	// default value of 0.
+	if decDisplay == 0 {
+		return nil
+	}
+
+	// If the meta type is not JSON, we're done already, as the decimal
+	// display will only be encoded in the TLV.
 	if m.Type != MetaJson {
-		return ErrNotJSON
+		return nil
 	}
 
 	// If the meta type is JSON, we'll also want to set the decimal display
@@ -359,6 +385,15 @@ func (m *MetaReveal) EncodeRecords() []tlv.Record {
 		MetaRevealDataRecord(&m.Data),
 	}
 
+	// To make sure we don't re-encode old assets that don't have a decimal
+	// display value as a TLV field with a different value, we only encode
+	// the decimal display value if it is explicitly set.
+	if m.DecimalDisplay.IsSome() {
+		records = append(records, MetaRevealDecimalDisplayRecord(
+			&m.DecimalDisplay,
+		))
+	}
+
 	// Add any unknown odd types that were encountered during decoding.
 	return asset.CombineRecords(records, m.UnknownOddTypes)
 }
@@ -368,6 +403,7 @@ func (m *MetaReveal) DecodeRecords() []tlv.Record {
 	return []tlv.Record{
 		MetaRevealTypeRecord(&m.Type),
 		MetaRevealDataRecord(&m.Data),
+		MetaRevealDecimalDisplayRecord(&m.DecimalDisplay),
 	}
 }
 

--- a/proof/meta_test.go
+++ b/proof/meta_test.go
@@ -3,12 +3,15 @@ package proof
 import (
 	"bytes"
 	"encoding/hex"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/lightninglabs/taproot-assets/asset"
+	"github.com/lightninglabs/taproot-assets/fn"
 	"github.com/lightninglabs/taproot-assets/internal/test"
 	"github.com/lightningnetwork/lnd/tlv"
 	"github.com/stretchr/testify/require"
@@ -23,8 +26,26 @@ var (
 	)
 )
 
+// TestValidateMetaReveal tests the validation of a MetaReveal.
 func TestValidateMetaReveal(t *testing.T) {
 	t.Parallel()
+
+	dummyURL, err := url.Parse("universerpc://localhost:1234")
+	require.NoError(t, err)
+
+	dummyURL2, err := url.Parse("universerpc://another-host:765")
+	require.NoError(t, err)
+
+	tooLongURL, err := url.Parse(
+		"universerpc://localhost:1234/" + strings.Repeat("a", 255),
+	)
+	require.NoError(t, err)
+
+	oneURL := fn.Some[[]url.URL]([]url.URL{*dummyURL})
+	twoURL := fn.Some[[]url.URL]([]url.URL{*dummyURL, *dummyURL2})
+	twoURLTooLong := fn.Some[[]url.URL]([]url.URL{*dummyURL, *tooLongURL})
+
+	dummyKey := test.RandPubKey(t)
 
 	testCases := []struct {
 		name        string
@@ -75,6 +96,73 @@ func TestValidateMetaReveal(t *testing.T) {
 				Data: []byte(`{"key": "value"}`),
 			},
 			expectedErr: nil,
+		},
+		{
+			name: "invalid decimal display",
+			reveal: &MetaReveal{
+				Type:           MetaJson,
+				Data:           []byte(`{"key": "value"}`),
+				DecimalDisplay: fn.Some[uint32](999),
+			},
+			expectedErr: ErrDecDisplayTooLarge,
+		},
+		{
+			name: "correct decimal display",
+			reveal: &MetaReveal{
+				Type:           MetaJson,
+				Data:           []byte(`{"key": "value"}`),
+				DecimalDisplay: fn.Some[uint32](8),
+			},
+			expectedErr: nil,
+		},
+		{
+			name: "new asset meta reveal with explicit zero " +
+				"decimal display and uni fields",
+			reveal: &MetaReveal{
+				Type:                MetaOpaque,
+				Data:                []byte(`not JSON`),
+				DecimalDisplay:      fn.Some[uint32](0),
+				UniverseCommitments: true,
+				CanonicalUniverses:  oneURL,
+				DelegationKey:       fn.MaybeSome(dummyKey),
+			},
+			expectedErr: nil,
+		},
+		{
+			name: "new asset meta reveal with two URLs",
+			reveal: &MetaReveal{
+				Type:               MetaOpaque,
+				Data:               []byte(`not JSON`),
+				CanonicalUniverses: twoURL,
+			},
+			expectedErr: nil,
+		},
+		{
+			name: "universe URL too long",
+			reveal: &MetaReveal{
+				Type:               MetaOpaque,
+				Data:               []byte(`not JSON`),
+				CanonicalUniverses: twoURLTooLong,
+			},
+			expectedErr: ErrCanonicalUniverseURLTooLong,
+		},
+		{
+			name: "empty universe URL slice",
+			reveal: &MetaReveal{
+				Type:               MetaOpaque,
+				Data:               []byte(`not JSON`),
+				CanonicalUniverses: fn.Some[[]url.URL](nil),
+			},
+			expectedErr: ErrCanonicalUniverseInvalid,
+		},
+		{
+			name: "empty delegation key",
+			reveal: &MetaReveal{
+				Type:          MetaOpaque,
+				Data:          []byte(`not JSON`),
+				DelegationKey: fn.Some(emptyKey),
+			},
+			expectedErr: ErrDelegationKeyEmpty,
 		},
 	}
 
@@ -153,4 +241,228 @@ func TestMetaRevealUnknownOddType(t *testing.T) {
 			require.Equal(t, knownMeta, parsedMeta)
 		},
 	)
+}
+
+// TestMetaDataRevealEncoding tests the encoding and decoding of valid meta
+// reveal structs.
+func TestMetaDataRevealEncoding(t *testing.T) {
+	t.Parallel()
+
+	dummyURL, err := url.Parse("universerpc://localhost:1234")
+	require.NoError(t, err)
+
+	dummyURL2, err := url.Parse("universerpc://another-host:765")
+	require.NoError(t, err)
+
+	oneURL := fn.Some[[]url.URL]([]url.URL{*dummyURL})
+	twoURL := fn.Some[[]url.URL]([]url.URL{*dummyURL, *dummyURL2})
+
+	testCases := []struct {
+		name     string
+		reveal   *MetaReveal
+		expected []byte
+	}{
+		{
+			name: "valid reveal",
+			reveal: &MetaReveal{
+				Type: MetaOpaque,
+				Data: []byte("data"),
+			},
+			expected: []byte{
+				0x00, 0x01, 0x00, // Type
+				0x02, 0x04, 0x64, 0x61, 0x74, 0x61, // Data
+			},
+		},
+		{
+			name: "valid JSON reveal",
+			reveal: &MetaReveal{
+				Type: MetaJson,
+				Data: []byte(`{"key": "value"}`),
+			},
+			expected: append([]byte{
+				0x00, 0x01, 0x01, // Type
+				0x02, 0x10, // Data
+			}, []byte(`{"key": "value"}`)...),
+		},
+		{
+			name: "valid custom reveal",
+			reveal: &MetaReveal{
+				Type: MetaType(99),
+				Data: []byte("custom stuff"),
+			},
+			expected: []byte{
+				0x00, 0x01, 0x63, // Type
+				0x02, 0x0c, 0x63, 0x75, 0x73, 0x74, 0x6f, 0x6d,
+				0x20, 0x73, 0x74, 0x75, 0x66, 0x66, // Data
+			},
+		},
+		{
+			name: "correct decimal display",
+			reveal: &MetaReveal{
+				Type:           MetaJson,
+				Data:           []byte(`{"key": "value"}`),
+				DecimalDisplay: fn.Some[uint32](8),
+			},
+			expected: []byte{
+				0x00, 0x01, 0x01, // Type
+				0x02, 0x10, 0x7b, 0x22, 0x6b, 0x65, 0x79, 0x22,
+				0x3a, 0x20, 0x22, 0x76, 0x61, 0x6c, 0x75, 0x65,
+				0x22, 0x7d, // Data
+				0x05, 0x04, 0x00, 0x00, 0x00, 0x8, // DecDisplay
+			},
+		},
+		{
+			name: "correct non-JSON, all fields",
+			reveal: &MetaReveal{
+				Type:                MetaOpaque,
+				Data:                []byte(`not JSON`),
+				DecimalDisplay:      fn.Some[uint32](8),
+				UniverseCommitments: true,
+				CanonicalUniverses:  oneURL,
+				DelegationKey: fn.MaybeSome(
+					asset.NUMSPubKey,
+				),
+			},
+			expected: []byte{
+				0x00, 0x01, 0x00, // Type
+				// Data:
+				0x02, 0x08, 0x6e, 0x6f, 0x74, 0x20, 0x4a, 0x53,
+				0x4f, 0x4e,
+				// DecDisplay:
+				0x05, 0x04, 0x00, 0x00, 0x00, 0x08,
+				// UniverseCommitments:
+				0x07, 0x01, 0x01,
+				// CanonicalUniverses:
+				0x09, 0x1e, 0x01, 0x1c, 0x75, 0x6e, 0x69, 0x76,
+				0x65, 0x72, 0x73, 0x65, 0x72, 0x70, 0x63, 0x3a,
+				0x2f, 0x2f, 0x6c, 0x6f, 0x63, 0x61, 0x6c, 0x68,
+				0x6f, 0x73, 0x74, 0x3a, 0x31, 0x32, 0x33, 0x34,
+				// DelegationKey:
+				0x0b, 0x21, 0x02, 0x7c, 0x79, 0xb9, 0xb2, 0x6e,
+				0x46, 0x38, 0x95, 0xee, 0xf5, 0x67, 0x9d, 0x85,
+				0x58, 0x94, 0x2c, 0x86, 0xc4, 0xad, 0x22, 0x33,
+				0xad, 0xef, 0x01, 0xbc, 0x3e, 0x6d, 0x54, 0x0b,
+				0x36, 0x53, 0xfe,
+			},
+		},
+		{
+			name: "correct non-JSON, just URLs",
+			reveal: &MetaReveal{
+				Type:               MetaOpaque,
+				Data:               []byte(`not JSON`),
+				CanonicalUniverses: twoURL,
+			},
+			expected: []byte{
+				0x00, 0x01, 0x00, // Type
+				// Data:
+				0x02, 0x08, 0x6e, 0x6f, 0x74, 0x20, 0x4a, 0x53,
+				0x4f, 0x4e,
+				// CanonicalUniverses:
+				0x09, 0x3d, 0x02,
+				0x1c, 0x75, 0x6e, 0x69, 0x76, 0x65, 0x72, 0x73,
+				0x65, 0x72, 0x70, 0x63, 0x3a, 0x2f, 0x2f, 0x6c,
+				0x6f, 0x63, 0x61, 0x6c, 0x68, 0x6f, 0x73, 0x74,
+				0x3a, 0x31, 0x32, 0x33, 0x34,
+				0x1e, 0x75, 0x6e, 0x69, 0x76, 0x65, 0x72, 0x73,
+				0x65, 0x72, 0x70, 0x63, 0x3a, 0x2f, 0x2f, 0x61,
+				0x6e, 0x6f, 0x74, 0x68, 0x65, 0x72, 0x2d, 0x68,
+				0x6f, 0x73, 0x74, 0x3a, 0x37, 0x36, 0x35,
+			},
+		},
+		{
+			name: "new asset meta reveal with explicit zero " +
+				"decimal display",
+			reveal: &MetaReveal{
+				Type:           MetaOpaque,
+				Data:           []byte(`not JSON`),
+				DecimalDisplay: fn.Some[uint32](0),
+			},
+			expected: []byte{
+				0x00, 0x01, 0x00, // Type
+				// Data:
+				0x02, 0x08, 0x6e, 0x6f, 0x74, 0x20, 0x4a, 0x53,
+				0x4f, 0x4e,
+				// DecDisplay:
+				0x05, 0x04, 0x00, 0x00, 0x00, 0x00,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+
+		t.Run(tc.name, func(tt *testing.T) {
+			tt.Parallel()
+
+			var buf bytes.Buffer
+			err := tc.reveal.Encode(&buf)
+			require.NoError(tt, err)
+
+			rawBytes := buf.Bytes()
+			require.Equal(tt, tc.expected, rawBytes)
+
+			decoded := &MetaReveal{}
+			err = decoded.Decode(&buf)
+			require.NoError(tt, err)
+
+			require.Equal(tt, tc.reveal, decoded)
+		})
+	}
+}
+
+// TestDecodeOldMetaReveal tests decoding an old MetaReveal encoding that does
+// not include the decimal display.
+func TestDecodeOldMetaReveal(t *testing.T) {
+	metaWithoutDecimalDisplay := []byte{
+		0x00,                   // Type (0, MetaRevealEncodingType)
+		0x01,                   // Length (1)
+		0x00,                   // Value (0, MetaOpaque)
+		0x02,                   // Type (1, MetaRevealDataType)
+		0x04,                   // Length (4)
+		0x64, 0x61, 0x74, 0x61, // Value ("data")
+	}
+
+	var decoded MetaReveal
+	err := decoded.Decode(bytes.NewReader(metaWithoutDecimalDisplay))
+	require.NoError(t, err)
+
+	require.Equal(t, MetaOpaque, decoded.Type)
+	require.Equal(t, []byte("data"), decoded.Data)
+	require.Equal(t, fn.None[uint32](), decoded.DecimalDisplay)
+	require.Equal(t, false, decoded.UniverseCommitments)
+	require.Equal(t, fn.None[[]url.URL](), decoded.CanonicalUniverses)
+	require.Equal(t, fn.None[btcec.PublicKey](), decoded.DelegationKey)
+}
+
+// TestDecodeNewMetaReveal tests that an old client with the old MetaReveal
+// decoding fields does not fail when presented with a new MetaReveal encoding
+// that includes the decimal display.
+func TestDecodeNewMetaReveal(t *testing.T) {
+	metaWithDecimalDisplay := []byte{
+		0x00, 0x01, 0x01, // Type
+		0x02, 0x10, 0x7b, 0x22, 0x6b, 0x65, 0x79, 0x22,
+		0x3a, 0x20, 0x22, 0x76, 0x61, 0x6c, 0x75, 0x65,
+		0x22, 0x7d, // Data
+		0x05, 0x04, 0x00, 0x00, 0x00, 0x8, // DecDisplay
+	}
+
+	var decoded MetaReveal
+
+	oldDecodeRecords := []tlv.Record{
+		MetaRevealTypeRecord(&decoded.Type),
+		MetaRevealDataRecord(&decoded.Data),
+	}
+
+	stream, err := tlv.NewStream(oldDecodeRecords...)
+	require.NoError(t, err)
+
+	err = stream.Decode(bytes.NewReader(metaWithDecimalDisplay))
+	require.NoError(t, err)
+
+	require.Equal(t, MetaJson, decoded.Type)
+	require.Equal(t, []byte(`{"key": "value"}`), decoded.Data)
+	require.Equal(t, fn.None[uint32](), decoded.DecimalDisplay)
+	require.Equal(t, false, decoded.UniverseCommitments)
+	require.Equal(t, fn.None[[]url.URL](), decoded.CanonicalUniverses)
+	require.Equal(t, fn.None[btcec.PublicKey](), decoded.DelegationKey)
 }

--- a/proof/records.go
+++ b/proof/records.go
@@ -2,6 +2,7 @@ package proof
 
 import (
 	"bytes"
+	"net/url"
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/wire"
@@ -43,9 +44,12 @@ const (
 	TapscriptProofTapPreimage2 tlv.Type = 3
 	TapscriptProofBip86        tlv.Type = 4
 
-	MetaRevealEncodingType   tlv.Type = 0
-	MetaRevealDataType       tlv.Type = 2
-	MetaRevealDecimalDisplay tlv.Type = 5
+	MetaRevealEncodingType           tlv.Type = 0
+	MetaRevealDataType               tlv.Type = 2
+	MetaRevealDecimalDisplay         tlv.Type = 5
+	MetaRevealUniverseCommitments    tlv.Type = 7
+	MetaRevealCanonicalUniversesType tlv.Type = 9
+	MetaRevealDelegationKeyType      tlv.Type = 11
 )
 
 // KnownProofTypes is a set of all known proof TLV types. This set is asserted
@@ -85,6 +89,8 @@ var KnownTapscriptProofTypes = fn.NewSet(
 // asserted to be complete by a check in the BIP test vector unit tests.
 var KnownMetaRevealTypes = fn.NewSet(
 	MetaRevealEncodingType, MetaRevealDataType, MetaRevealDecimalDisplay,
+	MetaRevealUniverseCommitments, MetaRevealCanonicalUniversesType,
+	MetaRevealDelegationKeyType,
 )
 
 func VersionRecord(version *TransitionVersion) tlv.Record {
@@ -378,6 +384,52 @@ func MetaRevealDecimalDisplayRecord(
 	return tlv.MakeStaticRecord(
 		MetaRevealDecimalDisplay, decimalDisplay, size,
 		EUint32Option, DUint32Option,
+	)
+}
+
+func MetaRevealUniverseCommitmentsRecord(useCommitments *bool) tlv.Record {
+	return tlv.MakeStaticRecord(
+		MetaRevealUniverseCommitments, useCommitments, 1,
+		BoolEncoder, BoolDecoder,
+	)
+}
+
+func MetaRevealCanonicalUniversesRecord(
+	addrs *fn.Option[[]url.URL]) tlv.Record {
+
+	// If the option is not set, or it's an empty slice, we'll encode it as
+	// a zero-length record. But because we'll not include the record at all
+	// if it's not set at the call site when encoding, this will not be the
+	// case for this specific record.
+	recordSize := func() uint64 {
+		var (
+			b   bytes.Buffer
+			buf [8]byte
+		)
+		if err := UrlSliceOptionEncoder(&b, addrs, &buf); err != nil {
+			panic(err)
+		}
+		return uint64(len(b.Bytes()))
+	}
+	return tlv.MakeDynamicRecord(
+		MetaRevealCanonicalUniversesType, addrs, recordSize,
+		UrlSliceOptionEncoder, UrlSliceOptionDecoder,
+	)
+}
+
+func MetaRevealDelegationKeyRecord(key *fn.Option[btcec.PublicKey]) tlv.Record {
+	// If the option is not set, we'll encode it as a zero-length record.
+	// But because we'll not include the record at all if it's not set at
+	// the call site when encoding, this will not be the case for this
+	// specific record.
+	var size uint64
+	if key != nil && key.IsSome() {
+		size = btcec.PubKeyBytesLenCompressed
+	}
+
+	return tlv.MakeStaticRecord(
+		MetaRevealDelegationKeyType, key, size,
+		PublicKeyOptionEncoder, PublicKeyOptionDecoder,
 	)
 }
 

--- a/proof/records.go
+++ b/proof/records.go
@@ -43,8 +43,9 @@ const (
 	TapscriptProofTapPreimage2 tlv.Type = 3
 	TapscriptProofBip86        tlv.Type = 4
 
-	MetaRevealEncodingType tlv.Type = 0
-	MetaRevealDataType     tlv.Type = 2
+	MetaRevealEncodingType   tlv.Type = 0
+	MetaRevealDataType       tlv.Type = 2
+	MetaRevealDecimalDisplay tlv.Type = 5
 )
 
 // KnownProofTypes is a set of all known proof TLV types. This set is asserted
@@ -83,7 +84,7 @@ var KnownTapscriptProofTypes = fn.NewSet(
 // KnownMetaRevealTypes is a set of all known meta reveal TLV types. This set is
 // asserted to be complete by a check in the BIP test vector unit tests.
 var KnownMetaRevealTypes = fn.NewSet(
-	MetaRevealEncodingType, MetaRevealDataType,
+	MetaRevealEncodingType, MetaRevealDataType, MetaRevealDecimalDisplay,
 )
 
 func VersionRecord(version *TransitionVersion) tlv.Record {
@@ -359,6 +360,24 @@ func MetaRevealDataRecord(data *[]byte) tlv.Record {
 	return tlv.MakeDynamicRecord(
 		MetaRevealDataType, data, sizeFunc, tlv.EVarBytes,
 		asset.DVarBytesWithLimit(MetaDataMaxSizeBytes),
+	)
+}
+
+func MetaRevealDecimalDisplayRecord(
+	decimalDisplay *fn.Option[uint32]) tlv.Record {
+
+	// If the option is not set, we'll encode it as a zero-length record.
+	// But because we'll not include the record at all if it's not set at
+	// the call site when encoding, this will not be the case for this
+	// specific record.
+	var size uint64
+	if decimalDisplay != nil && decimalDisplay.IsSome() {
+		size = 4
+	}
+
+	return tlv.MakeStaticRecord(
+		MetaRevealDecimalDisplay, decimalDisplay, size,
+		EUint32Option, DUint32Option,
 	)
 }
 

--- a/proof/testdata/proof_tlv_encoding_generated.json
+++ b/proof/testdata/proof_tlv_encoding_generated.json
@@ -1197,6 +1197,10 @@
         "meta_reveal": {
           "type": 0,
           "data": "6d65616e7420696e2063726f6b696e67206e657665726d6f7265",
+          "decimal_display": null,
+          "universe_commitments": null,
+          "canonical_universes": null,
+          "delegation_key": null,
           "unknown_odd_types": null
         },
         "additional_inputs": null,
@@ -1347,6 +1351,10 @@
         "meta_reveal": {
           "type": 0,
           "data": "7368616c6c206265206c6966746564206e657665726d6f7265",
+          "decimal_display": null,
+          "universe_commitments": null,
+          "canonical_universes": null,
+          "delegation_key": null,
           "unknown_odd_types": null
         },
         "additional_inputs": null,
@@ -1445,6 +1453,10 @@
         "meta_reveal": {
           "type": 1,
           "data": "7b22666f6f223a2022626172227d",
+          "decimal_display": null,
+          "universe_commitments": null,
+          "canonical_universes": null,
+          "delegation_key": null,
           "unknown_odd_types": {
             "31337": "ZGVjaW1hbERpc3BsYXk/"
           }
@@ -1467,6 +1479,370 @@
       },
       "expected": "544150500004000000000224e700164e518b243f424c46f9ea63db1c2c34b512c403c128ee19030a6226517b96ba92e20450000000006fe28c0ab6f1b372c1a6a246ae63f74f931e8365e15a089c68d61900000000000eb76d7cef2bc52fbde22a56b2cb5750c64a5f9b5b75ae8d1ed943876896824d1f2247e70000000000000000065e0200000001e700164e518b243f424c46f9ea63db1c2c34b512c403c128ee19030a6226517be292ba960000000000014a0100000000000022512087c5895738b41cf39358c72acd68045bcde8caa83e30b6c8b5fc4bcc0ace35b2000000000801000afd018e000100028ae700164e518b243f424c46f9ea63db1c2c34b512c403c128ee19030a6226517b96ba92e24038363162393663613635653334643331663234643666353665653835303932333134613464373635363230356331353332326631633937363133633037396561bd4c1872ae986883d0e8efaccc2cebfb2141bcdf5fd99a51950ee10e461c018500000000010401010601010bad01ab016500000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000342014053708a81ea99bb907ea297021dadc6f43c57bfdac91c578cb6df4d5b11b9f6d48c4e931ae3edf7944894c480291ddfbccc52df7bb72301a042e41408bf53e9150e0200001021021fee70480d0e1993490293bb7a747b01602ab5ed55d3dc88f2178853f448e1b5112103dd2340c51f4b7e90984731e96af24a45eccdfc854c2b45f21ad8aada65c4dd880c9f0004000000000221022681983a9b0ebfe74d02e665cf2409061b0038078230ef3d1c706880ce8814c903740149000100022001df08d7a8685881c98ac9d9f045aa953570726c8ff5a6b7ede1c948ee6f4ebb04220000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff022700010202220000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff1126000101020e7b22666f6f223a2022626172227dfd7a690f646563696d616c446973706c61793f160400000001178ae700164e518b243f424c46f9ea63db1c2c34b512c403c128ee19030a6226517b96ba92e24038363162393663613635653334643331663234643666353665653835303932333134613464373635363230356331353332326631633937363133633037396561bd4c1872ae986883d0e8efaccc2cebfb2141bcdf5fd99a51950ee10e461c01850000000001192102076fa1bc3fa96db45917cf9532e73362f9588c7e834b70ee455188737dab7fa0",
       "comment": "meta reveal with unknown odd type"
+    },
+    {
+      "proof": {
+        "prev_out": "b525865f44fa13d1180663d178adeb89dc7a74866ea38039cb4455c5f648c1cb:112541181",
+        "block_header": {
+          "version": 0,
+          "prev_block": "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f",
+          "merkle_root": "e1334f6ae7423751d310180a818e84afc7d3683dca08d7b55ee616cdad954be6",
+          "timestamp": 3747137179,
+          "bits": 0,
+          "nonce": 0
+        },
+        "block_height": 1,
+        "anchor_tx": "0200000001cbc148f6c55544cb3980a36e86747adc89ebad78d1630618d113fa445f8625b5fd3db5060000000000014a01000000000000225120ead4a22567590cd1a87e61a5875e18947bd5d30d8a4890a5ee6d17b92ef3f2e100000000",
+        "tx_merkle_proof": {
+          "nodes": [],
+          "bits": []
+        },
+        "asset": {
+          "version": 0,
+          "genesis_first_prev_out": "b525865f44fa13d1180663d178adeb89dc7a74866ea38039cb4455c5f648c1cb:112541181",
+          "genesis_tag": "d7ad323c50a5b11703374174a9977026c20cd52c10b72f14e0569a684a3dcf2c",
+          "genesis_meta_hash": "f7f383557db65a613e7f07b2ed4dc6aca69b9c487ee7656f0500f7ad3b15353b",
+          "genesis_output_index": 0,
+          "genesis_type": 0,
+          "amount": 5000,
+          "lock_time": 0,
+          "relative_lock_time": 0,
+          "prev_witnesses": [
+            {
+              "prev_id": {
+                "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
+                "asset_id": "0000000000000000000000000000000000000000000000000000000000000000",
+                "script_key": "000000000000000000000000000000000000000000000000000000000000000000"
+              },
+              "tx_witness": [
+                "bfeeb9a3637491d42e3a8459fc587c08be3a031c1a41fde3314ad68867678f104348b01643f00e3a84922ef441e3baa2be2dfad3818b938bf24ec35373da8da4"
+              ],
+              "split_commitment": null
+            }
+          ],
+          "split_commitment_root": null,
+          "script_version": 0,
+          "script_key": "02a8fbf44877a3f6d05f47f3e3a53a80f9896fce987b99df90b399af033878c318",
+          "group_key": {
+            "group_key": "032b38f1ac407583a49a517fba228e1a028c6089c9380d8fa105abff7a5eae64e4"
+          },
+          "unknown_odd_types": null
+        },
+        "inclusion_proof": {
+          "output_index": 0,
+          "internal_key": "0210004ee6b0a1f59afb7c045cc9eb9d3fdb8c5de1beef7fc65cf441c322ca1613",
+          "commitment_proof": {
+            "proof": {
+              "asset_proof": {
+                "proof": "0000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+                "version": 0,
+                "tap_key": "dadc2d3b175457cbb536ca1b7c2443f8073806eacd4e456bde8bcbc91ba5ba7d",
+                "unknown_odd_types": null
+              },
+              "taproot_asset_proof": {
+                "proof": "0000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+                "version": 2,
+                "unknown_odd_types": null
+              },
+              "unknown_odd_types": null
+            },
+            "tapscript_sibling": "",
+            "unknown_odd_types": null
+          },
+          "tapscript_proof": null,
+          "unknown_odd_types": null
+        },
+        "exclusion_proofs": null,
+        "split_root_proof": null,
+        "meta_reveal": {
+          "type": 0,
+          "data": "6d65616e7420696e2063726f6f6b696e67206e657665726d6f7265",
+          "decimal_display": 8,
+          "universe_commitments": null,
+          "canonical_universes": [
+            "universerpc://some-host:1234"
+          ],
+          "delegation_key": null,
+          "unknown_odd_types": null
+        },
+        "additional_inputs": null,
+        "challenge_witness": null,
+        "genesis_reveal": {
+          "first_prev_out": "b525865f44fa13d1180663d178adeb89dc7a74866ea38039cb4455c5f648c1cb:112541181",
+          "tag": "d7ad323c50a5b11703374174a9977026c20cd52c10b72f14e0569a684a3dcf2c",
+          "meta_hash": "f7f383557db65a613e7f07b2ed4dc6aca69b9c487ee7656f0500f7ad3b15353b",
+          "output_index": 0,
+          "type": 0
+        },
+        "group_key_reveal": {
+          "raw_key": "02b3545fd507b4a79726561e2c736bc6a31ac742bd9bc215dc397f3fd5d5c1c372",
+          "tapscript_root": ""
+        },
+        "alt_leaves": null,
+        "unknown_odd_types": null
+      },
+      "expected": "544150500004000000000224cbc148f6c55544cb3980a36e86747adc89ebad78d1630618d113fa445f8625b506b53dfd0450000000006fe28c0ab6f1b372c1a6a246ae63f74f931e8365e15a089c68d6190000000000e64b95adcd16e65eb5d708ca3d68d3c7af848e810a1810d3513742e76a4f33e19bc658df0000000000000000065e0200000001cbc148f6c55544cb3980a36e86747adc89ebad78d1630618d113fa445f8625b5fd3db5060000000000014a01000000000000225120ead4a22567590cd1a87e61a5875e18947bd5d30d8a4890a5ee6d17b92ef3f2e1000000000801000afd0190000100028acbc148f6c55544cb3980a36e86747adc89ebad78d1630618d113fa445f8625b506b53dfd4064376164333233633530613562313137303333373431373461393937373032366332306364353263313062373266313465303536396136383461336463663263f7f383557db65a613e7f07b2ed4dc6aca69b9c487ee7656f0500f7ad3b15353b00000000000401000603fd13880bad01ab0165000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000003420140bfeeb9a3637491d42e3a8459fc587c08be3a031c1a41fde3314ad68867678f104348b01643f00e3a84922ef441e3baa2be2dfad3818b938bf24ec35373da8da40e020000102102a8fbf44877a3f6d05f47f3e3a53a80f9896fce987b99df90b399af033878c3181121032b38f1ac407583a49a517fba228e1a028c6089c9380d8fa105abff7a5eae64e40c9f00040000000002210210004ee6b0a1f59afb7c045cc9eb9d3fdb8c5de1beef7fc65cf441c322ca1613037401490001000220dadc2d3b175457cbb536ca1b7c2443f8073806eacd4e456bde8bcbc91ba5ba7d04220000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff022700010202220000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff1146000100021b6d65616e7420696e2063726f6f6b696e67206e657665726d6f7265050400000008091e011c756e6976657273657270633a2f2f736f6d652d686f73743a31323334160400000001178acbc148f6c55544cb3980a36e86747adc89ebad78d1630618d113fa445f8625b506b53dfd4064376164333233633530613562313137303333373431373461393937373032366332306364353263313062373266313465303536396136383461336463663263f7f383557db65a613e7f07b2ed4dc6aca69b9c487ee7656f0500f7ad3b15353b0000000000192102b3545fd507b4a79726561e2c736bc6a31ac742bd9bc215dc397f3fd5d5c1c372",
+      "comment": "normal asset with a meta reveal and decimal display and canonical universe URL"
+    },
+    {
+      "proof": {
+        "prev_out": "fe9960a9175e67a980c31ab1911b06963e340f9f30d433d9705eefdfe762e9c9:2020055348",
+        "block_header": {
+          "version": 0,
+          "prev_block": "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f",
+          "merkle_root": "ee10a15ce35bee17e4eb151e64b76426ae25326d8ca082036ad0f4be311b6b0d",
+          "timestamp": 2824388468,
+          "bits": 0,
+          "nonce": 0
+        },
+        "block_height": 1,
+        "anchor_tx": "0200000001c9e962e7dfef5e70d933d4309f0f343e96061b91b11ac380a9675e17a96099fe349967780000000000014a010000000000002251204519ee4b32cc6bb7289f5d434dead85ec709d33b2a534840bcd8f454cc5d0ad100000000",
+        "tx_merkle_proof": {
+          "nodes": [],
+          "bits": []
+        },
+        "asset": {
+          "version": 0,
+          "genesis_first_prev_out": "fe9960a9175e67a980c31ab1911b06963e340f9f30d433d9705eefdfe762e9c9:2020055348",
+          "genesis_tag": "264ec9451ec23aaaa367d640faad4af3d44d6d86544ade34c935182843f6b4d1",
+          "genesis_meta_hash": "fe28de4a80a62597f24f1279b41cc4c3488e2037537a9145959cca33389e1b8a",
+          "genesis_output_index": 0,
+          "genesis_type": 1,
+          "amount": 1,
+          "lock_time": 0,
+          "relative_lock_time": 0,
+          "prev_witnesses": [
+            {
+              "prev_id": {
+                "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
+                "asset_id": "0000000000000000000000000000000000000000000000000000000000000000",
+                "script_key": "000000000000000000000000000000000000000000000000000000000000000000"
+              },
+              "tx_witness": [
+                "2411e25e9bb6e7eb2bb8cd56c27022746c3da6120b53e60a206be8476f0f0525b01d0179ad029e0adb75b7569111f0401b55273ece98f4ffc5e042c7f40646e7"
+              ],
+              "split_commitment": null
+            }
+          ],
+          "split_commitment_root": null,
+          "script_version": 0,
+          "script_key": "02aa2a1a5a62ec9177f3c1fec2255dbf881e7b7bb52617998c7a1fe85e515ee3dd",
+          "group_key": {
+            "group_key": "02e6f0423945264476b2254c711956a2827404cc88ab624213fcf5545804c1c7a3"
+          },
+          "unknown_odd_types": null
+        },
+        "inclusion_proof": {
+          "output_index": 0,
+          "internal_key": "02bc34e025fb476662eb9b7b4a912a79d668b0268acc36765977513b09f6e52fb3",
+          "commitment_proof": {
+            "proof": {
+              "asset_proof": {
+                "proof": "0000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+                "version": 0,
+                "tap_key": "4013e71144131c0842870b7710ae5fc875e338f1107ed31443f961df22ab4963",
+                "unknown_odd_types": null
+              },
+              "taproot_asset_proof": {
+                "proof": "0000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+                "version": 2,
+                "unknown_odd_types": null
+              },
+              "unknown_odd_types": null
+            },
+            "tapscript_sibling": "",
+            "unknown_odd_types": null
+          },
+          "tapscript_proof": null,
+          "unknown_odd_types": null
+        },
+        "exclusion_proofs": null,
+        "split_root_proof": null,
+        "meta_reveal": {
+          "type": 0,
+          "data": "7368616c6c206265206c6966746564206e657665726d6f7265",
+          "decimal_display": 3,
+          "universe_commitments": null,
+          "canonical_universes": [
+            "universerpc://some-host:1234"
+          ],
+          "delegation_key": null,
+          "unknown_odd_types": null
+        },
+        "additional_inputs": null,
+        "challenge_witness": null,
+        "genesis_reveal": {
+          "first_prev_out": "fe9960a9175e67a980c31ab1911b06963e340f9f30d433d9705eefdfe762e9c9:2020055348",
+          "tag": "264ec9451ec23aaaa367d640faad4af3d44d6d86544ade34c935182843f6b4d1",
+          "meta_hash": "fe28de4a80a62597f24f1279b41cc4c3488e2037537a9145959cca33389e1b8a",
+          "output_index": 0,
+          "type": 1
+        },
+        "group_key_reveal": {
+          "raw_key": "0361770a58dfcd17906b7f8a0e0425a52337970d06591abc9240d4d8693ec3b57b",
+          "tapscript_root": ""
+        },
+        "alt_leaves": null,
+        "unknown_odd_types": null
+      },
+      "expected": "544150500004000000000224c9e962e7dfef5e70d933d4309f0f343e96061b91b11ac380a9675e17a96099fe786799340450000000006fe28c0ab6f1b372c1a6a246ae63f74f931e8365e15a089c68d61900000000000d6b1b31bef4d06a0382a08c6d3225ae2664b7641e15ebe417ee5be35ca110ee74bf58a80000000000000000065e0200000001c9e962e7dfef5e70d933d4309f0f343e96061b91b11ac380a9675e17a96099fe349967780000000000014a010000000000002251204519ee4b32cc6bb7289f5d434dead85ec709d33b2a534840bcd8f454cc5d0ad1000000000801000afd018e000100028ac9e962e7dfef5e70d933d4309f0f343e96061b91b11ac380a9675e17a96099fe786799344032363465633934353165633233616161613336376436343066616164346166336434346436643836353434616465333463393335313832383433663662346431fe28de4a80a62597f24f1279b41cc4c3488e2037537a9145959cca33389e1b8a00000000010401010601010bad01ab01650000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000034201402411e25e9bb6e7eb2bb8cd56c27022746c3da6120b53e60a206be8476f0f0525b01d0179ad029e0adb75b7569111f0401b55273ece98f4ffc5e042c7f40646e70e020000102102aa2a1a5a62ec9177f3c1fec2255dbf881e7b7bb52617998c7a1fe85e515ee3dd112102e6f0423945264476b2254c711956a2827404cc88ab624213fcf5545804c1c7a30c9f000400000000022102bc34e025fb476662eb9b7b4a912a79d668b0268acc36765977513b09f6e52fb30374014900010002204013e71144131c0842870b7710ae5fc875e338f1107ed31443f961df22ab496304220000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff022700010202220000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff114400010002197368616c6c206265206c6966746564206e657665726d6f7265050400000003091e011c756e6976657273657270633a2f2f736f6d652d686f73743a31323334160400000001178ac9e962e7dfef5e70d933d4309f0f343e96061b91b11ac380a9675e17a96099fe786799344032363465633934353165633233616161613336376436343066616164346166336434346436643836353434616465333463393335313832383433663662346431fe28de4a80a62597f24f1279b41cc4c3488e2037537a9145959cca33389e1b8a000000000119210361770a58dfcd17906b7f8a0e0425a52337970d06591abc9240d4d8693ec3b57b",
+      "comment": "collectible with a meta reveal and decimal display and canonical universe URL"
+    },
+    {
+      "proof": {
+        "prev_out": "19e7358a5f2e2a4b735937f40d3b628bd494710cb199c0d99e9f3420b82dd4fc:1469177755",
+        "block_header": {
+          "version": 0,
+          "prev_block": "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f",
+          "merkle_root": "c38176aa77fb7087f335ec2c11428e48c826151652b6073409b879fd31799618",
+          "timestamp": 2189833511,
+          "bits": 0,
+          "nonce": 0
+        },
+        "block_height": 1,
+        "anchor_tx": "0200000001fcd42db820349f9ed9c099b10c7194d48b623b0df43759734b2a2e5f8a35e7199bdf91570000000000014a0100000000000022512039251f1e865e6286adf1c46680549cc88e03c5c0113612efa25e8a71ee8f24a600000000",
+        "tx_merkle_proof": {
+          "nodes": [],
+          "bits": []
+        },
+        "asset": {
+          "version": 0,
+          "genesis_first_prev_out": "19e7358a5f2e2a4b735937f40d3b628bd494710cb199c0d99e9f3420b82dd4fc:1469177755",
+          "genesis_tag": "a1612aad5d3ea7e8e35f325c9168ac490f22cb713ddb61fbd96011c5849ac8e2",
+          "genesis_meta_hash": "ba94bffcac0cac6f383fadd9782e7d1dfe741fa76bff5723ad78688348edabc5",
+          "genesis_output_index": 0,
+          "genesis_type": 0,
+          "amount": 5000,
+          "lock_time": 0,
+          "relative_lock_time": 0,
+          "prev_witnesses": [
+            {
+              "prev_id": {
+                "out_point": "0000000000000000000000000000000000000000000000000000000000000000:0",
+                "asset_id": "0000000000000000000000000000000000000000000000000000000000000000",
+                "script_key": "000000000000000000000000000000000000000000000000000000000000000000"
+              },
+              "tx_witness": [
+                "85cc79e362b307fca4f2326461c0f15610285aa0356495a3be74336d60f1f2537f729d0ba22ca99a94c15ddeb18b82879895ed61631246022e36ab171fe41148"
+              ],
+              "split_commitment": null
+            }
+          ],
+          "split_commitment_root": null,
+          "script_version": 0,
+          "script_key": "02dd3d9c135f1cc434ede36929ffe262ad5f8211c3ed0dd133eb394f3e4519a818",
+          "group_key": {
+            "group_key": "0248596ab49bde017257e64abea83543ed63079091b2ff734d03ca764e0d0d1a0f"
+          },
+          "unknown_odd_types": null
+        },
+        "inclusion_proof": {
+          "output_index": 0,
+          "internal_key": "02792ffb6abbf3d5bce42afff4638be7343e033e9c7b3d9ac81d6da7ce7176524e",
+          "commitment_proof": {
+            "proof": {
+              "asset_proof": {
+                "proof": "0000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+                "version": 0,
+                "tap_key": "83757d67c9b10ee40badf050079635b903443a9b253d67b204ef4a2a5d625d28",
+                "unknown_odd_types": null
+              },
+              "taproot_asset_proof": {
+                "proof": "00019a0e15afd4bc8fdc393eab668d009ba0f33955b9cca4c4ab6ecc95b1ababa7460000000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7f",
+                "version": 2,
+                "unknown_odd_types": null
+              },
+              "unknown_odd_types": null
+            },
+            "tapscript_sibling": "",
+            "unknown_odd_types": null
+          },
+          "tapscript_proof": null,
+          "unknown_odd_types": null
+        },
+        "exclusion_proofs": null,
+        "split_root_proof": null,
+        "meta_reveal": {
+          "type": 0,
+          "data": "66756c6c79206c6f61646564",
+          "decimal_display": 11,
+          "universe_commitments": true,
+          "canonical_universes": [
+            "universerpc://some-host:1234",
+            "universerpc://another-host:765"
+          ],
+          "delegation_key": "027c79b9b26e463895eef5679d8558942c86c4ad2233adef01bc3e6d540b3653fe",
+          "unknown_odd_types": null
+        },
+        "additional_inputs": null,
+        "challenge_witness": null,
+        "genesis_reveal": {
+          "first_prev_out": "19e7358a5f2e2a4b735937f40d3b628bd494710cb199c0d99e9f3420b82dd4fc:1469177755",
+          "tag": "a1612aad5d3ea7e8e35f325c9168ac490f22cb713ddb61fbd96011c5849ac8e2",
+          "meta_hash": "ba94bffcac0cac6f383fadd9782e7d1dfe741fa76bff5723ad78688348edabc5",
+          "output_index": 0,
+          "type": 0
+        },
+        "group_key_reveal": {
+          "raw_key": "0239d8231e5af9668eb4af2f81e536fb24f46fdbad9a09f69154d1c002a183db06",
+          "tapscript_root": ""
+        },
+        "alt_leaves": [
+          {
+            "version": 0,
+            "genesis_first_prev_out": "0000000000000000000000000000000000000000000000000000000000000000:0",
+            "genesis_tag": "",
+            "genesis_meta_hash": "0000000000000000000000000000000000000000000000000000000000000000",
+            "genesis_output_index": 0,
+            "genesis_type": 0,
+            "amount": 0,
+            "lock_time": 0,
+            "relative_lock_time": 0,
+            "prev_witnesses": [
+              {
+                "prev_id": null,
+                "tx_witness": null,
+                "split_commitment": null
+              }
+            ],
+            "split_commitment_root": null,
+            "script_version": 9561,
+            "script_key": "0293ef7b605bc9769eeb0091b20a5979fda874402f2c0881af561d58032a684361",
+            "group_key": null,
+            "unknown_odd_types": null
+          },
+          {
+            "version": 0,
+            "genesis_first_prev_out": "0000000000000000000000000000000000000000000000000000000000000000:0",
+            "genesis_tag": "",
+            "genesis_meta_hash": "0000000000000000000000000000000000000000000000000000000000000000",
+            "genesis_output_index": 0,
+            "genesis_type": 0,
+            "amount": 0,
+            "lock_time": 0,
+            "relative_lock_time": 0,
+            "prev_witnesses": [
+              {
+                "prev_id": null,
+                "tx_witness": [
+                  "de7b9e8c546035eab7e2",
+                  "da420f32ed5c94bc12a3",
+                  "4dc68eb99257a7ea03b6"
+                ],
+                "split_commitment": null
+              }
+            ],
+            "split_commitment_root": null,
+            "script_version": 7185,
+            "script_key": "02442ef4f15828c4a929123d2639b9868721f0a91ae8a37c2b9bdc79aefa03eb77",
+            "group_key": null,
+            "unknown_odd_types": null
+          }
+        ],
+        "unknown_odd_types": null
+      },
+      "expected": "544150500004000000000224fcd42db820349f9ed9c099b10c7194d48b623b0df43759734b2a2e5f8a35e7195791df9b0450000000006fe28c0ab6f1b372c1a6a246ae63f74f931e8365e15a089c68d619000000000018967931fd79b8093407b652161526c8488e42112cec35f38770fb77aa7681c3273586820000000000000000065e0200000001fcd42db820349f9ed9c099b10c7194d48b623b0df43759734b2a2e5f8a35e7199bdf91570000000000014a0100000000000022512039251f1e865e6286adf1c46680549cc88e03c5c0113612efa25e8a71ee8f24a6000000000801000afd0190000100028afcd42db820349f9ed9c099b10c7194d48b623b0df43759734b2a2e5f8a35e7195791df9b4061313631326161643564336561376538653335663332356339313638616334393066323263623731336464623631666264393630313163353834396163386532ba94bffcac0cac6f383fadd9782e7d1dfe741fa76bff5723ad78688348edabc500000000000401000603fd13880bad01ab016500000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000342014085cc79e362b307fca4f2326461c0f15610285aa0356495a3be74336d60f1f2537f729d0ba22ca99a94c15ddeb18b82879895ed61631246022e36ab171fe411480e020000102102dd3d9c135f1cc434ede36929ffe262ad5f8211c3ed0dd133eb394f3e4519a81811210248596ab49bde017257e64abea83543ed63079091b2ff734d03ca764e0d0d1a0f0cc7000400000000022102792ffb6abbf3d5bce42afff4638be7343e033e9c7b3d9ac81d6da7ce7176524e039c0149000100022083757d67c9b10ee40badf050079635b903443a9b253d67b204ef4a2a5d625d2804220000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff024f000102024a00019a0e15afd4bc8fdc393eab668d009ba0f33955b9cca4c4ab6ecc95b1ababa7460000000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7f117c000100020c66756c6c79206c6f6164656405040000000b070101093d021c756e6976657273657270633a2f2f736f6d652d686f73743a313233341e756e6976657273657270633a2f2f616e6f746865722d686f73743a3736350b21027c79b9b26e463895eef5679d8558942c86c4ad2233adef01bc3e6d540b3653fe160400000001178afcd42db820349f9ed9c099b10c7194d48b623b0df43759734b2a2e5f8a35e7195791df9b4061313631326161643564336561376538653335663332356339313638616334393066323263623731336464623631666264393630313163353834396163386532ba94bffcac0cac6f383fadd9782e7d1dfe741fa76bff5723ad78688348edabc5000000000019210239d8231e5af9668eb4af2f81e536fb24f46fdbad9a09f69154d1c002a183db061b7d022b0b0201000e02255910210293ef7b605bc9769eeb0091b20a5979fda874402f2c0881af561d58032a6843614f0b2601240322030ade7b9e8c546035eab7e20ada420f32ed5c94bc12a30a4dc68eb99257a7ea03b60e021c11102102442ef4f15828c4a929123d2639b9868721f0a91ae8a37c2b9bdc79aefa03eb77",
+      "comment": "normal asset with all meta reveal fields"
     }
   ],
   "error_test_cases": null

--- a/tapdb/addrs.go
+++ b/tapdb/addrs.go
@@ -1131,11 +1131,14 @@ func (t *TapAddressBook) FetchAssetMetaByHash(ctx context.Context,
 
 		// If no record is present, we should get a sql.ErrNoRows error
 		// above.
-		parseAssetMetaReveal(dbMeta.AssetsMetum).WhenSome(
-			func(meta proof.MetaReveal) {
-				assetMeta = &meta
-			},
-		)
+		metaOpt, err := parseAssetMetaReveal(dbMeta.AssetsMetum)
+		if err != nil {
+			return fmt.Errorf("unable to parse asset meta: %w", err)
+		}
+
+		metaOpt.WhenSome(func(meta proof.MetaReveal) {
+			assetMeta = &meta
+		})
 
 		return nil
 	})
@@ -1164,11 +1167,14 @@ func (t *TapAddressBook) FetchAssetMetaForAsset(ctx context.Context,
 
 		// If no record is present, we should get a sql.ErrNoRows error
 		// above.
-		parseAssetMetaReveal(dbMeta.AssetsMetum).WhenSome(
-			func(meta proof.MetaReveal) {
-				assetMeta = &meta
-			},
-		)
+		metaOpt, err := parseAssetMetaReveal(dbMeta.AssetsMetum)
+		if err != nil {
+			return fmt.Errorf("unable to parse asset meta: %w", err)
+		}
+
+		metaOpt.WhenSome(func(meta proof.MetaReveal) {
+			assetMeta = &meta
+		})
 
 		return nil
 	})

--- a/tapdb/asset_meta.go
+++ b/tapdb/asset_meta.go
@@ -1,6 +1,10 @@
 package tapdb
 
 import (
+	"net/url"
+	"strings"
+
+	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/lightninglabs/taproot-assets/fn"
 	"github.com/lightninglabs/taproot-assets/proof"
 	"github.com/lightninglabs/taproot-assets/tapdb/sqlc"
@@ -11,13 +15,48 @@ import (
 // the case if there is no database entry for the asset meta and there was a
 // LEFT JOIN in a query. Non-existence of a standalone asset metadata record
 // should be decided by the sql.ErrNoRows instead.
-func parseAssetMetaReveal(meta sqlc.AssetsMetum) fn.Option[proof.MetaReveal] {
+func parseAssetMetaReveal(
+	meta sqlc.AssetsMetum) (fn.Option[proof.MetaReveal], error) {
+
 	if len(meta.MetaDataHash) == 0 {
-		return fn.None[proof.MetaReveal]()
+		return fn.None[proof.MetaReveal](), nil
+	}
+
+	var canonicalUniverse fn.Option[[]url.URL]
+	if len(meta.MetaCanonicalUniverses) > 0 {
+		urls := strings.Split(
+			string(meta.MetaCanonicalUniverses), "\x00",
+		)
+		canonicalUniverseURLs := make([]url.URL, len(urls))
+		for i, u := range urls {
+			canonicalUniverseURL, err := url.ParseRequestURI(u)
+			if err != nil {
+				return fn.None[proof.MetaReveal](), err
+			}
+			canonicalUniverseURLs[i] = *canonicalUniverseURL
+		}
+
+		canonicalUniverse = fn.Some(canonicalUniverseURLs)
+	}
+
+	var delegationKey fn.Option[btcec.PublicKey]
+	if len(meta.MetaDelegationKey) > 0 {
+		key, err := btcec.ParsePubKey(meta.MetaDelegationKey)
+		if err != nil {
+			return fn.None[proof.MetaReveal](), err
+		}
+
+		delegationKey = fn.Some(*key)
 	}
 
 	return fn.Some(proof.MetaReveal{
 		Data: meta.MetaDataBlob,
 		Type: proof.MetaType(meta.MetaDataType.Int16),
-	})
+		DecimalDisplay: extractOptSqlInt32[uint32](
+			meta.MetaDecimalDisplay,
+		),
+		UniverseCommitments: extractBool(meta.MetaUniverseCommitments),
+		CanonicalUniverses:  canonicalUniverse,
+		DelegationKey:       delegationKey,
+	}), nil
 }

--- a/tapdb/migrations.go
+++ b/tapdb/migrations.go
@@ -22,7 +22,7 @@ const (
 	// daemon.
 	//
 	// NOTE: This MUST be updated when a new migration is added.
-	LatestMigrationVersion = 27
+	LatestMigrationVersion = 28
 )
 
 // MigrationTarget is a functional option that can be passed to applyMigrations

--- a/tapdb/sqlc/migrations/000028_asset_meta_tlv_fields.down.sql
+++ b/tapdb/sqlc/migrations/000028_asset_meta_tlv_fields.down.sql
@@ -1,0 +1,4 @@
+ALTER TABLE assets_meta DROP COLUMN meta_decimal_display;
+ALTER TABLE assets_meta DROP COLUMN meta_universe_commitments;
+ALTER TABLE assets_meta DROP COLUMN meta_canonical_universes;
+ALTER TABLE assets_meta DROP COLUMN meta_delegation_key;

--- a/tapdb/sqlc/migrations/000028_asset_meta_tlv_fields.up.sql
+++ b/tapdb/sqlc/migrations/000028_asset_meta_tlv_fields.up.sql
@@ -1,0 +1,22 @@
+-- We add a set of new minting/universe related columns. Those will all be
+-- added to the meta record as odd (optional) TLV fields. Therefore, they will
+-- not be set on older assets, which is why we need to make them nullable here.
+ALTER TABLE assets_meta ADD COLUMN meta_decimal_display INTEGER;
+
+-- This boolean indicates if the asset is going to produce universe commitments.
+ALTER TABLE assets_meta ADD COLUMN meta_universe_commitments BOOL;
+
+-- If there's more than one URL, we're going to join them using the 0x00 control
+-- character (which is invalid in a URL itself). The size restriction is based
+-- on the number of allowed URLs (16) and the maximum size per URL (255). We
+-- need to allow for the control character in between, so we just assume 256
+-- characters per URL.
+ALTER TABLE assets_meta ADD COLUMN meta_canonical_universes BLOB
+    CHECK(LENGTH(meta_canonical_universes) <= 4096);
+
+-- We don't want to decide on the SQL level if this key is a 33-byte compressed
+-- or 32-byte x-only one, so we just use the <= operator in case we ever need
+-- to change the semantics on this field (on the SQL level we just care about
+-- there being a size restriction in the first place).
+ALTER TABLE assets_meta ADD COLUMN meta_delegation_key BLOB
+    CHECK(LENGTH(meta_delegation_key) <= 33);

--- a/tapdb/sqlc/models.go
+++ b/tapdb/sqlc/models.go
@@ -162,10 +162,14 @@ type AssetWitness struct {
 }
 
 type AssetsMetum struct {
-	MetaID       int64
-	MetaDataHash []byte
-	MetaDataBlob []byte
-	MetaDataType sql.NullInt16
+	MetaID                  int64
+	MetaDataHash            []byte
+	MetaDataBlob            []byte
+	MetaDataType            sql.NullInt16
+	MetaDecimalDisplay      sql.NullInt32
+	MetaUniverseCommitments sql.NullBool
+	MetaCanonicalUniverses  []byte
+	MetaDelegationKey       []byte
 }
 
 type ChainTxn struct {

--- a/tapdb/sqlc/queries/assets.sql
+++ b/tapdb/sqlc/queries/assets.sql
@@ -982,15 +982,20 @@ WHERE asset_id = $1;
 
 -- name: UpsertAssetMeta :one
 INSERT INTO assets_meta (
-    meta_data_hash, meta_data_blob, meta_data_type
+    meta_data_hash, meta_data_blob, meta_data_type, meta_decimal_display,
+    meta_universe_commitments, meta_canonical_universes, meta_delegation_key
 ) VALUES (
-    $1, $2, $3 
+    $1, $2, $3, $4, $5, $6, $7
 ) ON CONFLICT (meta_data_hash)
     -- In this case, we may be inserting the data+type for an existing blob. So
-    -- we'll set both of those values. At this layer we assume the meta hash
+    -- we'll set all of those values. At this layer we assume the meta hash
     -- has been validated elsewhere.
-    DO UPDATE SET meta_data_blob = COALESCE(EXCLUDED.meta_data_blob, assets_meta.meta_data_blob), 
-                  meta_data_type = COALESCE(EXCLUDED.meta_data_type, assets_meta.meta_data_type)
+    DO UPDATE SET meta_data_blob = COALESCE(EXCLUDED.meta_data_blob, assets_meta.meta_data_blob),
+                  meta_data_type = COALESCE(EXCLUDED.meta_data_type, assets_meta.meta_data_type),
+                  meta_decimal_display = COALESCE(EXCLUDED.meta_decimal_display, assets_meta.meta_decimal_display),
+                  meta_universe_commitments = COALESCE(EXCLUDED.meta_universe_commitments, assets_meta.meta_universe_commitments),
+                  meta_canonical_universes = COALESCE(EXCLUDED.meta_canonical_universes, assets_meta.meta_canonical_universes),
+                  meta_delegation_key = COALESCE(EXCLUDED.meta_delegation_key, assets_meta.meta_delegation_key)
         
 RETURNING meta_id;
 

--- a/tapgarden/batch.go
+++ b/tapgarden/batch.go
@@ -146,19 +146,7 @@ func (m *MintingBatch) validateGroupAnchor(s *Seedling) error {
 			*s.GroupAnchor)
 	}
 
-	// The decimal display of the seedling must match that of the group
-	// anchor. We already validated the seedling metadata, so we don't care
-	// if the value is explicit or if the metadata is JSON, but we must
-	// compute the same value for both assets.
-	_, seedlingDecDisplay, _ := s.Meta.GetDecDisplay()
-	_, anchorDecDisplay, _ := anchor.Meta.GetDecDisplay()
-	if seedlingDecDisplay != anchorDecDisplay {
-		return fmt.Errorf("seedling decimal display does not match "+
-			"group anchor: %d, %d", seedlingDecDisplay,
-			anchorDecDisplay)
-	}
-
-	return nil
+	return validateAnchorMeta(s.Meta, anchor.Meta)
 }
 
 // MintingOutputKey derives the output key that once mined, will commit to the

--- a/tappsbt/testdata/psbt_encoding_generated.json
+++ b/tappsbt/testdata/psbt_encoding_generated.json
@@ -367,6 +367,10 @@
               "meta_reveal": {
                 "type": 0,
                 "data": "71756f74682074686520726176656e206e657665726d6f7265",
+                "decimal_display": null,
+                "universe_commitments": null,
+                "canonical_universes": null,
+                "delegation_key": null,
                 "unknown_odd_types": null
               },
               "additional_inputs": null,
@@ -757,6 +761,10 @@
               "meta_reveal": {
                 "type": 0,
                 "data": "71756f74682074686520726176656e206e657665726d6f7265",
+                "decimal_display": null,
+                "universe_commitments": null,
+                "canonical_universes": null,
+                "delegation_key": null,
                 "unknown_odd_types": null
               },
               "additional_inputs": null,
@@ -1208,6 +1216,10 @@
               "meta_reveal": {
                 "type": 0,
                 "data": "71756f74682074686520726176656e206e657665726d6f7265",
+                "decimal_display": null,
+                "universe_commitments": null,
+                "canonical_universes": null,
+                "delegation_key": null,
                 "unknown_odd_types": null
               },
               "additional_inputs": null,
@@ -1627,6 +1639,10 @@
               "meta_reveal": {
                 "type": 0,
                 "data": "71756f74682074686520726176656e206e657665726d6f7265",
+                "decimal_display": null,
+                "universe_commitments": null,
+                "canonical_universes": null,
+                "delegation_key": null,
                 "unknown_odd_types": null
               },
               "additional_inputs": null,


### PR DESCRIPTION
~Depends on https://github.com/lightninglabs/taproot-assets/pull/1337.~

Fixes https://github.com/lightninglabs/taproot-assets/issues/956.

Adds two new fields to the TLV record of the asset's meta reveal:
 - Decimal display: Allows minting of assets with non-JSON meta data as we don't need to rely on writing the field there)
 - Canonical universe URL: Define the "home" universe for an asset that universe commitments will be synced to

**Important for reviewers**:
 - This PR does not add the RPC or CLI level flags for the two new entries. Those only really make sense with https://github.com/lightninglabs/taproot-assets/pull/1325 merged as well, so we'll add those later.
 - ~While writing this PR a bug was found in the backward compatible way we use odd TLV records. See e9286f0d245b09cfda79d9e00d5acd0508e6dbf7. Unfortunately that means these new fields will only be backward compatible to `v0.5.1` (this PR) and not all the way back to `v0.5.0`.~
 - ~We prepare for future backward compatibility tests with 293c60f22cddce014e4f5a6e6bccbeda3a5eba28. The idea is to be able to have a CI step that check out an older version (e.g. `v0.5.1`) in the future and run that test with updated test vectors of the future version, to make sure they can still be parsed and validated by that older version.~