### PR TITLE
server+tapchannel: move IsCustomHTLC method

### DIFF
--- a/server.go
+++ b/server.go
@@ -19,6 +19,7 @@ import (
 	"github.com/lightninglabs/taproot-assets/fn"
 	"github.com/lightninglabs/taproot-assets/monitoring"
 	"github.com/lightninglabs/taproot-assets/perms"
+	"github.com/lightninglabs/taproot-assets/rfqmsg"
 	"github.com/lightninglabs/taproot-assets/rpcperms"
 	"github.com/lightninglabs/taproot-assets/tapchannel"
 	cmsg "github.com/lightninglabs/taproot-assets/tapchannelmsg"
@@ -1050,6 +1051,17 @@ func (s *Server) ProduceHtlcExtraData(totalAmount lnwire.MilliSatoshi,
 	return s.cfg.AuxTrafficShaper.ProduceHtlcExtraData(
 		totalAmount, htlcCustomRecords,
 	)
+}
+
+// IsCustomHTLC returns true if the HTLC carries the set of relevant custom
+// records to put it under the purview of the traffic shaper, meaning that it's
+// from a custom channel.
+//
+// NOTE: This method is part of the routing.TlvTrafficShaper interface.
+func (s *Server) IsCustomHTLC(htlcRecords lnwire.CustomRecords) bool {
+	// We don't need to wait for server ready here since this operation can
+	// be done completely stateless.
+	return rfqmsg.HasAssetHTLCCustomRecords(htlcRecords)
 }
 
 // AuxCloseOutputs returns the set of close outputs to use for this co-op close

--- a/tapchannel/aux_traffic_shaper.go
+++ b/tapchannel/aux_traffic_shaper.go
@@ -12,7 +12,6 @@ import (
 	"github.com/lightninglabs/taproot-assets/rfqmsg"
 	cmsg "github.com/lightninglabs/taproot-assets/tapchannelmsg"
 	lfn "github.com/lightningnetwork/lnd/fn"
-	"github.com/lightningnetwork/lnd/htlcswitch"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/tlv"
 )
@@ -71,10 +70,6 @@ func (s *AuxTrafficShaper) Stop() error {
 
 	return stopErr
 }
-
-// A compile-time check to ensure that AuxTrafficShaper fully implements the
-// htlcswitch.AuxTrafficShaper interface.
-var _ htlcswitch.AuxTrafficShaper = (*AuxTrafficShaper)(nil)
 
 // ShouldHandleTraffic is called in order to check if the channel identified by
 // the provided channel ID is handled by the traffic shaper implementation. If
@@ -325,11 +320,4 @@ func (s *AuxTrafficShaper) ProduceHtlcExtraData(totalAmount lnwire.MilliSatoshi,
 	}
 
 	return htlcAmountMSat, updatedRecords, nil
-}
-
-// IsCustomHTLC returns true if the HTLC carries the set of relevant custom
-// records to put it under the purview of the traffic shaper, meaning that it's
-// from a custom channel.
-func (s *AuxTrafficShaper) IsCustomHTLC(htlcRecords lnwire.CustomRecords) bool {
-	return rfqmsg.HasAssetHTLCCustomRecords(htlcRecords)
 }


### PR DESCRIPTION
Follow-up for https://github.com/lightninglabs/taproot-assets/pull/1334.

The Server struct needs to implement all the interfaces for litd.