### PR TITLE
tapdb: fixes another issue with the syncer cache

### DIFF
--- a/itest/tapd_harness.go
+++ b/itest/tapd_harness.go
@@ -126,6 +126,10 @@ type harnessOpts struct {
 	// sqliteDatabaseFilePath is the path to the SQLite database file to
 	// use.
 	sqliteDatabaseFilePath *string
+
+	// disableSyncCache is a flag that can be set to true to disable the
+	// universe syncer cache.
+	disableSyncCache bool
 }
 
 type harnessOption func(*harnessOpts)
@@ -281,6 +285,10 @@ func newTapdHarness(t *testing.T, ht *harnessTest, cfg tapdConfig,
 
 	if opts.fedSyncTickerInterval != nil {
 		finalCfg.Universe.SyncInterval = *opts.fedSyncTickerInterval
+	}
+
+	if !opts.disableSyncCache {
+		finalCfg.Universe.MultiverseCaches.SyncerCacheEnabled = true
 	}
 
 	return &tapdHarness{

--- a/itest/test_harness.go
+++ b/itest/test_harness.go
@@ -378,6 +378,9 @@ type tapdHarnessParams struct {
 	// sqliteDatabaseFilePath is the path to the SQLite database file to
 	// use.
 	sqliteDatabaseFilePath *string
+
+	// disableSyncCache indicates whether the sync cache should be disabled.
+	disableSyncCache bool
 }
 
 type Option func(*tapdHarnessParams)
@@ -413,6 +416,7 @@ func setupTapdHarness(t *testing.T, ht *harnessTest,
 		ho.addrAssetSyncerDisable = params.addrAssetSyncerDisable
 		ho.fedSyncTickerInterval = params.fedSyncTickerInterval
 		ho.sqliteDatabaseFilePath = params.sqliteDatabaseFilePath
+		ho.disableSyncCache = params.disableSyncCache
 	}
 
 	tapdCfg := tapdConfig{

--- a/tapdb/multiverse.go
+++ b/tapdb/multiverse.go
@@ -786,7 +786,7 @@ func (b *MultiverseStore) UpsertProofLeaf(ctx context.Context,
 	b.syncerCache.addOrReplace(universe.Root{
 		ID:        id,
 		AssetName: leaf.Asset.Tag,
-		Node:      issuanceProof.MultiverseRoot,
+		Node:      issuanceProof.UniverseRoot,
 	})
 
 	// Notify subscribers about the new proof leaf, now that we're sure we


### PR DESCRIPTION
This time we activate the syncer cache by default in the integration tests to avoid further issues.

The actual bug fix is quite trivial, the wrong root node was inserted into the cache.