### PR TITLE
Unlock Coins on Anchor TX Broadcast Failure  

### DIFF
--- a/itest/assertions.go
+++ b/itest/assertions.go
@@ -963,7 +963,7 @@ func AssertSendEventsComplete(t *testing.T, scriptKey []byte,
 	stream *EventSubscription[*taprpc.SendEvent]) {
 
 	AssertSendEvents(
-		t, scriptKey, stream, tapfreighter.SendStateWaitTxConf,
+		t, scriptKey, stream, tapfreighter.SendStateBroadcastComplete,
 		tapfreighter.SendStateComplete,
 	)
 }

--- a/itest/psbt_test.go
+++ b/itest/psbt_test.go
@@ -1388,7 +1388,7 @@ func testPsbtMultiSend(t *harnessTest) {
 
 	AssertSendEvents(
 		t.t, scriptKey1Bytes, sendEvents,
-		tapfreighter.SendStateWaitTxConf,
+		tapfreighter.SendStateBroadcastComplete,
 		tapfreighter.SendStateComplete,
 	)
 

--- a/tapfreighter/chain_porter.go
+++ b/tapfreighter/chain_porter.go
@@ -1491,6 +1491,9 @@ func (p *ChainPorter) unlockInputs(ctx context.Context, pkg *sendPackage) {
 		return
 	}
 
+	// TODO(ffranr): Make use of CheckMempoolAccept to ensure we don't
+	//  unlock inputs for transactions that are in the mempool.
+
 	// If we haven't even attempted to broadcast yet, we're still in a state
 	// where we give feedback to the user synchronously, as we haven't
 	// created an on-chain transaction that we need to await confirmation.
@@ -1530,6 +1533,9 @@ func (p *ChainPorter) unlockInputs(ctx context.Context, pkg *sendPackage) {
 			log.Warnf("Unable to unlock input %v: %v", op, err)
 		}
 	}
+
+	// TODO(ffranr): Remove pending asset transfer and chain tx from the
+	//  database.
 }
 
 // logPacket logs the virtual packet to the debug log.

--- a/tapfreighter/chain_porter.go
+++ b/tapfreighter/chain_porter.go
@@ -1178,6 +1178,9 @@ func (p *ChainPorter) stateStep(currentPkg sendPackage) (*sendPackage, error) {
 				"minimum relay fee: %w", err)
 		}
 
+		log.Infof("Min relay fee: %v",
+			minRelayFee.FeePerKVByte().String())
+
 		// If the fee rate is below the minimum relay fee, we'll
 		// bump it up.
 		if feeRate < minRelayFee {

--- a/tapfreighter/chain_porter.go
+++ b/tapfreighter/chain_porter.go
@@ -1487,7 +1487,7 @@ func (p *ChainPorter) unlockInputs(ctx context.Context, pkg *sendPackage) {
 	// sanity-check that we have known input commitments to unlock, since
 	// that might not always be the case (for example if another party
 	// contributes inputs).
-	if pkg.SendState < SendStateStorePreBroadcast &&
+	if pkg.SendState < SendStateBroadcastComplete &&
 		len(pkg.InputCommitments) > 0 {
 
 		for prevID := range pkg.InputCommitments {

--- a/tapfreighter/chain_porter.go
+++ b/tapfreighter/chain_porter.go
@@ -1395,6 +1395,16 @@ func (p *ChainPorter) stateStep(currentPkg sendPackage) (*sendPackage, error) {
 				"transaction %v: %w", txHash, err)
 		}
 
+		// Set send state to the next state to evaluate.
+		currentPkg.SendState = SendStateBroadcastComplete
+		return &currentPkg, nil
+
+	// At this stage, the transaction has been broadcast to the network.
+	// From this point forward, the transfer cancellation methodology
+	// changes.
+	case SendStateBroadcastComplete:
+		log.Infof("Transfer tx broadcast complete")
+
 		// With the transaction broadcast, we'll deliver a
 		// notification via the transaction broadcast response channel.
 		currentPkg.deliverTxBroadcastResp()

--- a/tapfreighter/parcel.go
+++ b/tapfreighter/parcel.go
@@ -47,6 +47,12 @@ const (
 	// ensure it properly tracks the coins allocated to the anchor output.
 	SendStateBroadcast
 
+	// SendStateBroadcastComplete represents the state where the transfer
+	// transaction has been broadcast and is either in the mempool or
+	// confirmed on-chain. At this stage, cancellation cannot rely solely
+	// on naive coin unlocking.
+	SendStateBroadcastComplete
+
 	// SendStateWaitTxConf is a state in which we will wait for the transfer
 	// transaction to confirm on-chain.
 	SendStateWaitTxConf
@@ -84,6 +90,9 @@ func (s SendState) String() string {
 
 	case SendStateBroadcast:
 		return "SendStateBroadcast"
+
+	case SendStateBroadcastComplete:
+		return "SendStateBroadcastComplete"
 
 	case SendStateWaitTxConf:
 		return "SendStateWaitTxConf"

--- a/tapfreighter/wallet.go
+++ b/tapfreighter/wallet.go
@@ -12,6 +12,7 @@ import (
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/btcutil/psbt"
+	"github.com/btcsuite/btcd/mempool"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/davecgh/go-spew/spew"
@@ -1438,10 +1439,20 @@ func (f *AssetWallet) AnchorVirtualTransactions(ctx context.Context,
 	}
 
 	// Final TX sanity check.
-	err = blockchain.CheckTransactionSanity(btcutil.NewTx(finalTx))
+	finalBtcUtilTx := btcutil.NewTx(finalTx)
+	err = blockchain.CheckTransactionSanity(finalBtcUtilTx)
 	if err != nil {
 		return nil, fmt.Errorf("anchor TX failed final checks: %w", err)
 	}
+
+	// Report the actual fee rate that will be paid.
+	//
+	// Compute the virtual size of the transaction in bytes.
+	size := mempool.GetTxVirtualSize(finalBtcUtilTx)
+
+	// Compute the fee rate in sat/kvb.
+	actualFeeRate := int64(chainFees) * 1000 / size
+	log.Infof("Anchor TX final fee rate: %d sat/kvb", actualFeeRate)
 
 	anchorTx := &tapsend.AnchorTransaction{
 		FundedPsbt:    anchorPkt,


### PR DESCRIPTION
This PR ensures that asset coins are properly unlocked if an error occurs during the anchor transaction broadcast process. Previously, failed broadcasts could leave coins locked, causing send attempts to be stuck.  

Key changes:  
- Unlock asset coins before returning an error when publishing an anchor transaction.  
- Ensure inputs are unlocked if an error occurs before reaching the broadcast complete state.  
- Introduce `SendStateBroadcastComplete` to better define when a transfer can be canceled.  
- Improve logging by reporting the final fee rate of the anchoring transaction and logging the wallet's minimum relay fee for better debugging.