### PR TITLE
Add `sync` loadtest

### DIFF
--- a/itest/loadtest/config.go
+++ b/itest/loadtest/config.go
@@ -27,10 +27,13 @@ type User struct {
 
 // TapConfig are the main parameters needed for identifying and creating a grpc
 // client to a tapd subsystem.
+//
+// nolint:lll
 type TapConfig struct {
-	Name string `long:"name" description:"the name of the tapd instance"`
-	Host string `long:"host" description:"the host to connect to"`
-	Port int    `long:"port" description:"the port to connect to"`
+	Name     string `long:"name" description:"the name of the tapd instance"`
+	Host     string `long:"host" description:"the host to connect to"`
+	Port     int    `long:"port" description:"the port to connect to"`
+	RestPort int    `long:"restport" description:"the rest port to connect to"`
 
 	TLSPath string `long:"tlspath" description:"Path to tapd's TLS certificate, leave empty if TLS is disabled"`
 	MacPath string `long:"macpath" description:"Path to tapd's macaroon file"`
@@ -114,6 +117,20 @@ type Config struct {
 	// relevant for the send test. Acceptable values are "normal" and
 	// "collectible".
 	SendAssetType string `long:"send-asset-type" description:"the type of asset to attempt to send; only relevant for the send test"`
+
+	// SyncType is the type of sync to execute in the sync test. Acceptable
+	// values include:
+	//     "simplesyncer": re-uses simple syncer to perform a full sync
+	//     "rest": syncs the roots over rest requests
+	SyncType string `long:"sync-type" description:"the type of sync to execute"`
+
+	// SyncPageSize is the page size to use in the sync test for calls made
+	// to the universe server.
+	SyncPageSize int `long:"sync-page-size" description:"the page size to use in the sync test when fetching data from the universe server"`
+
+	// SyncNumClients is the number of clients to use in the sync test. This
+	// many clients will try to sync in parallel.
+	SyncNumClients int `long:"sync-num-clients" description:"the number of sync clients to use for the sync test"`
 
 	// TestSuiteTimeout is the timeout for the entire test suite.
 	TestSuiteTimeout time.Duration `long:"test-suite-timeout" description:"the timeout for the entire test suite"`

--- a/itest/loadtest/load_test.go
+++ b/itest/loadtest/load_test.go
@@ -55,6 +55,10 @@ var loadTestCases = []testCase{
 		name: "multisig",
 		fn:   multisigTest,
 	},
+	{
+		name: "sync",
+		fn:   syncTest,
+	},
 }
 
 // TestPerformance executes the configured performance tests.

--- a/itest/loadtest/loadtest-sample.conf
+++ b/itest/loadtest/loadtest-sample.conf
@@ -26,6 +26,18 @@ send-test-num-assets=1
 # required.
 send-asset-type="normal"
 
+# SyncType is the type of sync to execute in the sync test. Acceptable
+# values include:
+#     "simplesyncer": re-uses simple syncer to perform a full sync
+#     "rest": syncs the roots over rest requests
+sync-type="simplesyncer"
+
+# Number of clients to perform a sync in sync test.
+sync-num-clients=16
+
+# Page size to be used when requesting data from universe in sync test.
+sync-page-size=128
+
 # Timeout for the entire test suite
 test-suite-timeout=120m
 
@@ -43,6 +55,7 @@ bitcoin.password=lightning
 alice.tapd.name=alice
 alice.tapd.host="localhost"
 alice.tapd.port=XXX
+alice.tapd.restport=XXX
 alice.tapd.tlspath=/path/to/tls.cert
 alice.tapd.macpath=/path/to/admin.macaroon
 alice.lnd.name=alice_lnd
@@ -55,6 +68,7 @@ alice.lnd.macpath=/path/to/admin.macaroon
 bob.tapd.name=bob
 bob.tapd.host="localhost"
 bob.tapd.port=XXX
+bob.tapd.restport=XXX
 bob.tapd.tlspath=/path/to/tls.cert
 bob.tapd.macpath=/path/to/admin.macaroon
 bob.lnd.name=bob_lnd

--- a/itest/loadtest/sync_test.go
+++ b/itest/loadtest/sync_test.go
@@ -1,0 +1,157 @@
+package loadtest
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+
+	tap "github.com/lightninglabs/taproot-assets"
+	"github.com/lightninglabs/taproot-assets/taprpc/universerpc"
+	"github.com/lightninglabs/taproot-assets/universe"
+	"github.com/stretchr/testify/require"
+)
+
+// syncTest checks that the universe server can handle multiple requests to its
+// public universe endpoints. The number of clients is configurable.
+func syncTest(t *testing.T, ctx context.Context, cfg *Config) {
+	alice := initAlice(t, ctx, cfg)
+
+	// Let's start by logging the aggregate universe stats.
+	res, err := alice.UniverseStats(ctx, &universerpc.StatsRequest{})
+	require.NoError(t, err)
+
+	t.Logf("Universe Aggregate Stats: %+v", res)
+
+	// We'll use this wait group to block until all clients are done.
+	var wg sync.WaitGroup
+
+	// We dispatch a client sync for the configured number of clients.
+	for i := range cfg.SyncNumClients {
+		switch cfg.SyncType {
+		case "simplesyncer":
+			wg.Add(1)
+			go simpleSyncer(t, ctx, cfg, i, &wg)
+
+		case "rest":
+			wg.Add(1)
+			go syncAssetRootsREST(t, ctx, cfg, i, &wg)
+		}
+	}
+
+	wg.Wait()
+}
+
+// simpleSyncer creates a simple syncer instance and uses Alice as the remote
+// diff engine. It always triggers a full sync as the local diff engine returns
+// an empty leaf node.
+func simpleSyncer(t *testing.T, ctx context.Context, cfg *Config, id int,
+	wg *sync.WaitGroup) {
+
+	defer wg.Done()
+
+	// Alice is always serving as the universe server.
+	uniURL := fmt.Sprintf("%s:%v", cfg.Alice.Tapd.Host, cfg.Alice.Tapd.Port)
+
+	syncer := universe.NewSimpleSyncer(
+		universe.SimpleSyncCfg{
+			LocalDiffEngine:     noopBaseUni{},
+			NewRemoteDiffEngine: tap.NewRpcUniverseDiff,
+			LocalRegistrar:      noopBaseUni{},
+			SyncBatchSize:       512,
+		},
+	)
+
+	t.Logf("SimpleSyncer-%02d: Starting full universe sync", id)
+
+	// We don't care about the diff, so we only check if an error occurred,
+	// otherwise the sync completed.
+	_, err := syncer.SyncUniverse(
+		ctx, universe.NewServerAddrFromStr(uniURL),
+		universe.SyncFull, universe.SyncConfigs{
+			GlobalSyncConfigs: []*universe.FedGlobalSyncConfig{
+				{
+					// nolint:lll
+					ProofType:       universe.ProofTypeIssuance,
+					AllowSyncInsert: true,
+				},
+			},
+		},
+	)
+	require.NoError(t, err)
+
+	t.Logf("SimpleSyncer-%02d: Completed full universe sync", id)
+}
+
+// syncAssetRootsREST performs a series of requests to the AssetRoots endpoint
+// of the universe server. It automatically progresses the requested page until
+// the whole data is read.
+func syncAssetRootsREST(t *testing.T, ctx context.Context, cfg *Config,
+	id int, wg *sync.WaitGroup) {
+
+	defer wg.Done()
+	var (
+		limit  = cfg.SyncPageSize
+		offset = 0
+	)
+
+	for {
+		// This is the URL of the universe server, in our case that's
+		// always Alice.
+		baseURL := fmt.Sprintf(
+			"https://%s:%v/v1/taproot-assets/universe/roots",
+			cfg.Alice.Tapd.Host, cfg.Alice.Tapd.RestPort,
+		)
+
+		// We inject the pagination GET params.
+		fullURL := fmt.Sprintf(
+			"%s?offset=%v&limit=%v", baseURL, offset, limit,
+		)
+
+		t.Logf("Syncer%02d: Fetching AssetRoots offset=%v, limit=%v",
+			id, offset, limit)
+
+		res := getAssetRoots(t, ctx, fullURL)
+
+		// In order to count the length of the response without doing
+		// JSON parsing, we simply count the occurences of a top-level
+		// field name that repeats for all entries in the array.
+		len := strings.Count(res, "mssmt_root")
+
+		// Break if we reached the end. This is signalled by retrieving
+		// less entities than what was defined as the max limit,
+		// meaning that there's nothing left to consume.
+		if len < limit {
+			break
+		}
+
+		offset += limit
+	}
+}
+
+// getAssetRoots performs a GET request to the AssetRoots REST endpoint of the
+// universe server. We don't care about handling the response, we just hit the
+// endpoint and return the text of the body.
+func getAssetRoots(t *testing.T, ctx context.Context, fullURL string) string {
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}
+
+	client := &http.Client{Transport: tr}
+
+	req, err := http.NewRequestWithContext(ctx, "GET", fullURL, nil)
+	require.NoError(t, err)
+
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	return string(body)
+}

--- a/itest/loadtest/utils.go
+++ b/itest/loadtest/utils.go
@@ -100,6 +100,16 @@ func (r *rpcClient) listTransfersSince(t *testing.T, ctx context.Context,
 	return resp.Transfers[newIndex:]
 }
 
+// initAlice is similar to initClients, but only returns the Alice client.
+func initAlice(t *testing.T, ctx context.Context, cfg *Config) *rpcClient {
+	alice := getTapClient(t, ctx, cfg.Alice.Tapd, cfg.Alice.Lnd)
+
+	_, err := alice.GetInfo(ctx, &taprpc.GetInfoRequest{})
+	require.NoError(t, err)
+
+	return alice
+}
+
 func initClients(t *testing.T, ctx context.Context,
 	cfg *Config) (*rpcClient, *rpcClient, *rpcclient.Client) {
 


### PR DESCRIPTION
## Description

This PR adds a new type of loadtest, which is focused around the syncing endpoints.

We add a new test that emulates a full `AssetRoots` sync by a configurable number of clients. The page size may also be configured (although I believe we better use the max).

Since the dummy syncers don't care about the actual data and all we're trying to do is stress the universe server, we don't even use a tap related client. We hit the public REST endpoint for simplicity and ignore the response's details.

Also added a TODO for future expansions and configurations for this test. For now, this test is only restricted to performing an AssetRoots sync from multiple clients (from the PoV of the server).

Closes #1313 