### PR TITLE
rfq: reduce min expiry to 10 seconds

### DIFF
--- a/docs/rfq-and-decimal-display.md
+++ b/docs/rfq-and-decimal-display.md
@@ -369,6 +369,9 @@ use a price oracle, but its role is different for those parties:
   tasked with validating exchange rates offered to them by the edge node, to
   make sure they aren't proposing absurd rates (by accident or on purpose).
 
+**NOTE**: By default, the _minimum_ quote expiry at tapd node will accept is _10
+seconds_.
+
 Due to the fundamentally different roles of the price oracle for both parties,
 it is expected that the actual implementation for the price oracle is also
 different among the parties.

--- a/rfq/negotiator.go
+++ b/rfq/negotiator.go
@@ -17,7 +17,7 @@ import (
 const (
 	// minAssetRatesExpiryLifetime is the minimum asset rates expiry
 	// lifetime in seconds.
-	minAssetRatesExpiryLifetime = 60
+	minAssetRatesExpiryLifetime = 10
 
 	// DefaultAcceptPriceDeviationPpm is the default price deviation in
 	// parts per million that is accepted by the RFQ negotiator.


### PR DESCRIPTION
This permits a wider range of RFQ quote expires, as a shorter quote expiry serves to limit optionally.

Fixes: https://github.com/lightninglabs/taproot-assets/issues/1342