### PR TITLE
RFQ accept price qualify bug

### DIFF
--- a/rfq/mock.go
+++ b/rfq/mock.go
@@ -1,0 +1,80 @@
+package rfq
+
+import (
+	"context"
+	"time"
+
+	"github.com/lightninglabs/taproot-assets/asset"
+	"github.com/lightninglabs/taproot-assets/fn"
+	"github.com/lightninglabs/taproot-assets/rfqmath"
+	"github.com/lightninglabs/taproot-assets/rfqmsg"
+	"github.com/lightningnetwork/lnd/lnwire"
+)
+
+// MockPriceOracle is a mock implementation of the PriceOracle interface.
+// It returns the suggested rate as the exchange rate.
+type MockPriceOracle struct {
+	// expiryDelay is the lifetime of a quote in seconds.
+	expiryDelay    uint64
+	assetToBtcRate rfqmath.BigIntFixedPoint
+}
+
+// NewMockPriceOracle creates a new mock price oracle.
+func NewMockPriceOracle(expiryDelay,
+	assetRateCoefficient uint64) *MockPriceOracle {
+
+	return &MockPriceOracle{
+		expiryDelay: expiryDelay,
+		assetToBtcRate: rfqmath.NewBigIntFixedPoint(
+			assetRateCoefficient, 0,
+		),
+	}
+}
+
+// NewMockPriceOracleSatPerAsset creates a new mock price oracle with a
+// specified satoshis per asset rate.
+func NewMockPriceOracleSatPerAsset(expiryDelay uint64,
+	satsPerAsset uint64) *MockPriceOracle {
+
+	return &MockPriceOracle{
+		expiryDelay: expiryDelay,
+
+		// TODO(ffranr): This is incorrect, we should convert
+		//  satoshis per asset to assets per BTC.
+		assetToBtcRate: rfqmath.NewBigIntFixedPoint(
+			satsPerAsset, 0,
+		),
+	}
+}
+
+// QueryAskPrice returns the ask price for the given asset amount.
+func (m *MockPriceOracle) QueryAskPrice(_ context.Context,
+	_ asset.Specifier, _ fn.Option[uint64],
+	_ fn.Option[lnwire.MilliSatoshi],
+	_ fn.Option[rfqmsg.AssetRate]) (*OracleResponse, error) {
+
+	// Calculate the rate expiry timestamp.
+	lifetime := time.Duration(m.expiryDelay) * time.Second
+	expiry := time.Now().Add(lifetime).UTC()
+
+	return &OracleResponse{
+		AssetRate: rfqmsg.NewAssetRate(m.assetToBtcRate, expiry),
+	}, nil
+}
+
+// QueryBidPrice returns a bid price for the given asset amount.
+func (m *MockPriceOracle) QueryBidPrice(_ context.Context, _ asset.Specifier,
+	_ fn.Option[uint64], _ fn.Option[lnwire.MilliSatoshi],
+	_ fn.Option[rfqmsg.AssetRate]) (*OracleResponse, error) {
+
+	// Calculate the rate expiry timestamp.
+	lifetime := time.Duration(m.expiryDelay) * time.Second
+	expiry := time.Now().Add(lifetime).UTC()
+
+	return &OracleResponse{
+		AssetRate: rfqmsg.NewAssetRate(m.assetToBtcRate, expiry),
+	}, nil
+}
+
+// Ensure that MockPriceOracle implements the PriceOracle interface.
+var _ PriceOracle = (*MockPriceOracle)(nil)

--- a/rfq/negotiator.go
+++ b/rfq/negotiator.go
@@ -641,8 +641,14 @@ func (n *Negotiator) HandleIncomingBuyAccept(msg rfqmsg.BuyAccept,
 			return
 		}
 
-		// Ensure that the peer provided price is reasonable given the
-		// price provided by the price oracle service.
+		// The price returned by the oracle may not always align with
+		// our specific interests, depending on the oracle's pricing
+		// methodology. In other words, it may provide a general market
+		// price rather than one optimized for our needs.
+		//
+		// To account for this, we allow some tolerance in price
+		// deviation, ensuring that we can accept a reasonable range of
+		// prices while maintaining flexibility.
 		tolerance := rfqmath.NewBigIntFromUint64(
 			n.cfg.AcceptPriceDeviationPpm,
 		)
@@ -774,8 +780,14 @@ func (n *Negotiator) HandleIncomingSellAccept(msg rfqmsg.SellAccept,
 			return
 		}
 
-		// Ensure that the peer provided price is reasonable given the
-		// price provided by the price oracle service.
+		// The price returned by the oracle may not always align with
+		// our specific interests, depending on the oracle's pricing
+		// methodology. In other words, it may provide a general market
+		// price rather than one optimized for our needs.
+		//
+		// To account for this, we allow some tolerance in price
+		// deviation, ensuring that we can accept a reasonable range of
+		// prices while maintaining flexibility.
 		tolerance := rfqmath.NewBigIntFromUint64(
 			n.cfg.AcceptPriceDeviationPpm,
 		)

--- a/rfq/negotiator.go
+++ b/rfq/negotiator.go
@@ -600,14 +600,19 @@ func (n *Negotiator) HandleIncomingBuyAccept(msg rfqmsg.BuyAccept,
 	go func() {
 		defer n.Wg.Done()
 
-		// The buy accept message contains an ask price. This price
-		// is the price that the peer is willing to accept in order to
-		// sell the asset that we are buying.
+		// The buy accept message includes an ask price, which
+		// represents the amount the peer is willing to accept for the
+		// asset we are purchasing.
 		//
-		// We will sanity check that price by querying our price oracle
-		// for an ask price. We will then compare the ask price returned
-		// by the price oracle with the ask price provided by the peer.
-		assetRate, err := n.queryAskFromPriceOracle(
+		// To validate this ask, we will query our price oracle for a
+		// bid price and compare it with the peer's asking price. If the
+		// two prices fall within an acceptable tolerance, we will
+		// approve the quote.
+		//
+		// When querying the price oracle, we will provide the peer's
+		// ask price as a hint. The oracle may factor this into its
+		// calculations to generate a more relevant bid price.
+		assetRate, err := n.queryBidFromPriceOracle(
 			msg.Request.AssetSpecifier,
 			fn.Some(msg.Request.AssetMaxAmt),
 			fn.None[lnwire.MilliSatoshi](), fn.Some(msg.AssetRate),

--- a/rfq/negotiator_test.go
+++ b/rfq/negotiator_test.go
@@ -1,0 +1,385 @@
+package rfq
+
+import (
+	"testing"
+	"time"
+
+	"github.com/lightninglabs/taproot-assets/asset"
+	"github.com/lightninglabs/taproot-assets/fn"
+	"github.com/lightninglabs/taproot-assets/rfqmath"
+	"github.com/lightninglabs/taproot-assets/rfqmsg"
+	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/lightningnetwork/lnd/routing/route"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// testCaseIncomingSellAccept is a test case for the handling of an incoming
+// sell accept message.
+type testCaseIncomingSellAccept struct {
+	// name is the name of the test case.
+	name string
+
+	// incomingSellAcceptRate is the rate in the incoming sell accept
+	// message.
+	incomingSellAcceptRate rfqmsg.AssetRate
+
+	// priceOracleAskPrice is the rate returned by the price oracle.
+	priceOracleAskPrice rfqmsg.AssetRate
+
+	// acceptPriceDeviationPpm is the acceptable price deviation in ppm.
+	acceptPriceDeviationPpm uint64
+
+	// quoteRespStatus is the expected status of the quote check.
+	quoteRespStatus fn.Option[QuoteRespStatus]
+}
+
+// assertIncomingSellAcceptTestCase asserts the handling of an incoming sell
+// accept message for a test case.
+func assertIncomingSellAcceptTestCase(
+	t *testing.T, tc testCaseIncomingSellAccept) {
+
+	// Create a mock price oracle.
+	mockPriceOracle := &MockPriceOracle{}
+
+	// Register an expected call and response for price oracle method
+	// QueryAskPrice.
+	mockPriceOracle.On(
+		"QueryAskPrice", mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything,
+	).Return(
+		&OracleResponse{
+			AssetRate: tc.priceOracleAskPrice,
+		}, nil,
+	)
+
+	// Define sell request and sell accept messages.
+	var (
+		assetSpecifier = asset.NewSpecifierFromId(asset.ID{1, 2, 3})
+		peerID         = route.Vertex{1, 2, 3}
+		msgID          = rfqmsg.ID{1, 2, 3}
+	)
+
+	sellRequest := rfqmsg.SellRequest{
+		Peer:           peerID,
+		ID:             msgID,
+		AssetSpecifier: assetSpecifier,
+		PaymentMaxAmt:  lnwire.MilliSatoshi(1000),
+		AssetRateHint:  fn.None[rfqmsg.AssetRate](),
+	}
+
+	sellAccept := rfqmsg.SellAccept{
+		Request:   sellRequest,
+		AssetRate: tc.incomingSellAcceptRate,
+	}
+
+	// Create the negotiator.
+	errChan := make(chan error, 1)
+	negotiator, err := NewNegotiator(NegotiatorCfg{
+		PriceOracle:             mockPriceOracle,
+		OutgoingMessages:        make(chan rfqmsg.OutgoingMsg, 1),
+		AcceptPriceDeviationPpm: tc.acceptPriceDeviationPpm,
+		ErrChan:                 errChan,
+	})
+	require.NoError(t, err)
+
+	// Define the finalise callback function.
+	finalise := func(msg rfqmsg.SellAccept,
+		event fn.Option[InvalidQuoteRespEvent]) {
+
+		// If the actual event is none and the expected status is none,
+		// then we don't need to check anything.
+		if event.IsNone() && tc.quoteRespStatus.IsNone() {
+			return
+		}
+
+		require.Equal(t, tc.quoteRespStatus.IsSome(), event.IsSome())
+
+		// Extract the actual event status.
+		var actualEventStatus QuoteRespStatus
+		event.WhenSome(func(e InvalidQuoteRespEvent) {
+			actualEventStatus = e.Status
+		})
+
+		// Extract the expected event status.
+		var expectedStatus QuoteRespStatus
+		tc.quoteRespStatus.WhenSome(func(e QuoteRespStatus) {
+			expectedStatus = e
+		})
+
+		// Ensure that the actual and expected event statuses are equal.
+		require.Equal(t, expectedStatus, actualEventStatus)
+	}
+
+	// Handle the incoming sell accept message.
+	negotiator.HandleIncomingSellAccept(sellAccept, finalise)
+
+	// Check that there are no errors.
+	select {
+	case err := <-errChan:
+		t.Fatalf("unexpected error: %v", err)
+	default:
+	}
+
+	// Wait for the negotiator to finish.
+	negotiator.Wg.Wait()
+}
+
+// TestHandleIncomingSellAccept tests the handling of an incoming sell accept
+// message.
+func TestHandleIncomingSellAccept(t *testing.T) {
+	defaultQuoteExpiry := time.Now().Add(time.Hour)
+
+	testCases := []testCaseIncomingSellAccept{
+		{
+			name: "accept price just within bounds 1",
+			incomingSellAcceptRate: rfqmsg.AssetRate{
+				Rate:   rfqmath.NewBigIntFixedPoint(1000, 0),
+				Expiry: defaultQuoteExpiry,
+			},
+			priceOracleAskPrice: rfqmsg.AssetRate{
+				Rate:   rfqmath.NewBigIntFixedPoint(1052, 0),
+				Expiry: defaultQuoteExpiry,
+			},
+			acceptPriceDeviationPpm: DefaultAcceptPriceDeviationPpm,
+		},
+		{
+			name: "accept price just within bounds 2",
+			incomingSellAcceptRate: rfqmsg.AssetRate{
+				Rate:   rfqmath.NewBigIntFixedPoint(1000, 0),
+				Expiry: defaultQuoteExpiry,
+			},
+			priceOracleAskPrice: rfqmsg.AssetRate{
+				Rate:   rfqmath.NewBigIntFixedPoint(950, 0),
+				Expiry: defaultQuoteExpiry,
+			},
+			acceptPriceDeviationPpm: DefaultAcceptPriceDeviationPpm,
+		},
+		{
+			name: "accept price outside bounds, higher than oracle",
+			incomingSellAcceptRate: rfqmsg.AssetRate{
+				Rate:   rfqmath.NewBigIntFixedPoint(8000, 0),
+				Expiry: defaultQuoteExpiry,
+			},
+			priceOracleAskPrice: rfqmsg.AssetRate{
+				Rate:   rfqmath.NewBigIntFixedPoint(1000, 0),
+				Expiry: defaultQuoteExpiry,
+			},
+			acceptPriceDeviationPpm: DefaultAcceptPriceDeviationPpm,
+			quoteRespStatus: fn.Some[QuoteRespStatus](
+				InvalidAssetRatesQuoteRespStatus,
+			),
+		},
+		{
+			name: "accept price outside bounds, lower than oracle",
+			incomingSellAcceptRate: rfqmsg.AssetRate{
+				Rate:   rfqmath.NewBigIntFixedPoint(1000, 0),
+				Expiry: defaultQuoteExpiry,
+			},
+			priceOracleAskPrice: rfqmsg.AssetRate{
+				Rate:   rfqmath.NewBigIntFixedPoint(8000, 0),
+				Expiry: defaultQuoteExpiry,
+			},
+			acceptPriceDeviationPpm: DefaultAcceptPriceDeviationPpm,
+			quoteRespStatus: fn.Some[QuoteRespStatus](
+				InvalidAssetRatesQuoteRespStatus,
+			),
+		},
+	}
+
+	for idx := range testCases {
+		tc := testCases[idx]
+
+		success := t.Run(tc.name, func(t *testing.T) {
+			assertIncomingSellAcceptTestCase(t, tc)
+		})
+		if !success {
+			break
+		}
+	}
+}
+
+// testCaseIncomingBuyAccept is a test case for the handling of an incoming
+// buy accept message.
+type testCaseIncomingBuyAccept struct {
+	// name is the name of the test case.
+	name string
+
+	// incomingBuyAcceptRate is the rate in the incoming buy accept
+	// message.
+	incomingBuyAcceptRate rfqmsg.AssetRate
+
+	// priceOracleBidPrice is the rate returned by the price oracle.
+	priceOracleBidPrice rfqmsg.AssetRate
+
+	// acceptPriceDeviationPpm is the acceptable price deviation in ppm.
+	acceptPriceDeviationPpm uint64
+
+	// quoteRespStatus is the expected status of the quote check.
+	quoteRespStatus fn.Option[QuoteRespStatus]
+}
+
+// assertIncomingBuyAcceptTestCase asserts the handling of an incoming buy
+// accept message for a test case.
+func assertIncomingBuyAcceptTestCase(
+	t *testing.T, tc testCaseIncomingBuyAccept) {
+
+	// Create a mock price oracle.
+	mockPriceOracle := &MockPriceOracle{}
+
+	// Register an expected call and response for price oracle method
+	// QueryBidPrice.
+	mockPriceOracle.On(
+		"QueryBidPrice", mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything,
+	).Return(
+		&OracleResponse{
+			AssetRate: tc.priceOracleBidPrice,
+		}, nil,
+	)
+
+	// Define buy request and buy accept messages.
+	var (
+		assetSpecifier = asset.NewSpecifierFromId(asset.ID{1, 2, 3})
+		peerID         = route.Vertex{1, 2, 3}
+		msgID          = rfqmsg.ID{1, 2, 3}
+	)
+
+	buyRequest := rfqmsg.BuyRequest{
+		Peer:           peerID,
+		ID:             msgID,
+		AssetSpecifier: assetSpecifier,
+		AssetMaxAmt:    1000,
+		AssetRateHint:  fn.None[rfqmsg.AssetRate](),
+	}
+
+	buyAccept := rfqmsg.BuyAccept{
+		Request:   buyRequest,
+		AssetRate: tc.incomingBuyAcceptRate,
+	}
+
+	// Create the negotiator.
+	errChan := make(chan error, 1)
+	negotiator, err := NewNegotiator(NegotiatorCfg{
+		PriceOracle:             mockPriceOracle,
+		OutgoingMessages:        make(chan rfqmsg.OutgoingMsg, 1),
+		AcceptPriceDeviationPpm: tc.acceptPriceDeviationPpm,
+		ErrChan:                 errChan,
+	})
+	require.NoError(t, err)
+
+	// Define the finalise callback function.
+	finalise := func(msg rfqmsg.BuyAccept,
+		event fn.Option[InvalidQuoteRespEvent]) {
+
+		// If the actual event is none and the expected status is none,
+		// then we don't need to check anything.
+		if event.IsNone() && tc.quoteRespStatus.IsNone() {
+			return
+		}
+
+		require.Equal(t, tc.quoteRespStatus.IsSome(), event.IsSome())
+
+		// Extract the actual event status.
+		var actualEventStatus QuoteRespStatus
+		event.WhenSome(func(e InvalidQuoteRespEvent) {
+			actualEventStatus = e.Status
+		})
+
+		// Extract the expected event status.
+		var expectedStatus QuoteRespStatus
+		tc.quoteRespStatus.WhenSome(func(e QuoteRespStatus) {
+			expectedStatus = e
+		})
+
+		// Ensure that the actual and expected event statuses are equal.
+		require.Equal(t, expectedStatus, actualEventStatus)
+	}
+
+	// Handle the incoming buy accept message.
+	negotiator.HandleIncomingBuyAccept(buyAccept, finalise)
+
+	// Check that there are no errors.
+	select {
+	case err := <-errChan:
+		t.Fatalf("unexpected error: %v", err)
+	default:
+	}
+
+	// Wait for the negotiator to finish.
+	negotiator.Wg.Wait()
+}
+
+// TestHandleIncomingBuyAccept tests the handling of an incoming buy accept
+// message.
+func TestHandleIncomingBuyAccept(t *testing.T) {
+	defaultQuoteExpiry := time.Now().Add(time.Hour)
+
+	testCases := []testCaseIncomingBuyAccept{
+		{
+			name: "accept price just within bounds 1",
+			incomingBuyAcceptRate: rfqmsg.AssetRate{
+				Rate:   rfqmath.NewBigIntFixedPoint(1000, 0),
+				Expiry: defaultQuoteExpiry,
+			},
+			priceOracleBidPrice: rfqmsg.AssetRate{
+				Rate:   rfqmath.NewBigIntFixedPoint(1052, 0),
+				Expiry: defaultQuoteExpiry,
+			},
+			acceptPriceDeviationPpm: DefaultAcceptPriceDeviationPpm,
+		},
+		{
+			name: "accept price just within bounds 2",
+			incomingBuyAcceptRate: rfqmsg.AssetRate{
+				Rate:   rfqmath.NewBigIntFixedPoint(1000, 0),
+				Expiry: defaultQuoteExpiry,
+			},
+			priceOracleBidPrice: rfqmsg.AssetRate{
+				Rate:   rfqmath.NewBigIntFixedPoint(950, 0),
+				Expiry: defaultQuoteExpiry,
+			},
+			acceptPriceDeviationPpm: DefaultAcceptPriceDeviationPpm,
+		},
+		{
+			name: "accept price outside bounds, higher than oracle",
+			incomingBuyAcceptRate: rfqmsg.AssetRate{
+				Rate:   rfqmath.NewBigIntFixedPoint(8000, 0),
+				Expiry: defaultQuoteExpiry,
+			},
+			priceOracleBidPrice: rfqmsg.AssetRate{
+				Rate:   rfqmath.NewBigIntFixedPoint(1000, 0),
+				Expiry: defaultQuoteExpiry,
+			},
+			acceptPriceDeviationPpm: DefaultAcceptPriceDeviationPpm,
+			quoteRespStatus: fn.Some[QuoteRespStatus](
+				InvalidAssetRatesQuoteRespStatus,
+			),
+		},
+		{
+			name: "accept price outside bounds, lower than oracle",
+			incomingBuyAcceptRate: rfqmsg.AssetRate{
+				Rate:   rfqmath.NewBigIntFixedPoint(1000, 0),
+				Expiry: defaultQuoteExpiry,
+			},
+			priceOracleBidPrice: rfqmsg.AssetRate{
+				Rate:   rfqmath.NewBigIntFixedPoint(8000, 0),
+				Expiry: defaultQuoteExpiry,
+			},
+			acceptPriceDeviationPpm: DefaultAcceptPriceDeviationPpm,
+			quoteRespStatus: fn.Some[QuoteRespStatus](
+				InvalidAssetRatesQuoteRespStatus,
+			),
+		},
+	}
+
+	for idx := range testCases {
+		tc := testCases[idx]
+
+		success := t.Run(tc.name, func(t *testing.T) {
+			assertIncomingBuyAcceptTestCase(t, tc)
+		})
+		if !success {
+			break
+		}
+	}
+}

--- a/rfq/oracle.go
+++ b/rfq/oracle.go
@@ -430,15 +430,16 @@ func NewMockPriceOracle(expiryDelay,
 
 // NewMockPriceOracleSatPerAsset creates a new mock price oracle with a
 // specified satoshis per asset rate.
-//
-// TODO(ffranr): Remove in favour of NewMockPriceOracle.
 func NewMockPriceOracleSatPerAsset(expiryDelay uint64,
-	assetRateCoefficient uint64) *MockPriceOracle {
+	satsPerAsset uint64) *MockPriceOracle {
 
 	return &MockPriceOracle{
 		expiryDelay: expiryDelay,
+
+		// TODO(ffranr): This is incorrect, we should convert
+		//  satoshis per asset to assets per BTC.
 		assetToBtcRate: rfqmath.NewBigIntFixedPoint(
-			assetRateCoefficient, 0,
+			satsPerAsset, 0,
 		),
 	}
 }

--- a/rfq/oracle.go
+++ b/rfq/oracle.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/lightninglabs/taproot-assets/asset"
 	"github.com/lightninglabs/taproot-assets/fn"
-	"github.com/lightninglabs/taproot-assets/rfqmath"
 	"github.com/lightninglabs/taproot-assets/rfqmsg"
 	oraclerpc "github.com/lightninglabs/taproot-assets/taprpc/priceoraclerpc"
 	"github.com/lightningnetwork/lnd/lnwire"
@@ -407,71 +406,3 @@ func (r *RpcPriceOracle) QueryBidPrice(ctx context.Context,
 
 // Ensure that RpcPriceOracle implements the PriceOracle interface.
 var _ PriceOracle = (*RpcPriceOracle)(nil)
-
-// MockPriceOracle is a mock implementation of the PriceOracle interface.
-// It returns the suggested rate as the exchange rate.
-type MockPriceOracle struct {
-	// expiryDelay is the lifetime of a quote in seconds.
-	expiryDelay    uint64
-	assetToBtcRate rfqmath.BigIntFixedPoint
-}
-
-// NewMockPriceOracle creates a new mock price oracle.
-func NewMockPriceOracle(expiryDelay,
-	assetRateCoefficient uint64) *MockPriceOracle {
-
-	return &MockPriceOracle{
-		expiryDelay: expiryDelay,
-		assetToBtcRate: rfqmath.NewBigIntFixedPoint(
-			assetRateCoefficient, 0,
-		),
-	}
-}
-
-// NewMockPriceOracleSatPerAsset creates a new mock price oracle with a
-// specified satoshis per asset rate.
-func NewMockPriceOracleSatPerAsset(expiryDelay uint64,
-	satsPerAsset uint64) *MockPriceOracle {
-
-	return &MockPriceOracle{
-		expiryDelay: expiryDelay,
-
-		// TODO(ffranr): This is incorrect, we should convert
-		//  satoshis per asset to assets per BTC.
-		assetToBtcRate: rfqmath.NewBigIntFixedPoint(
-			satsPerAsset, 0,
-		),
-	}
-}
-
-// QueryAskPrice returns the ask price for the given asset amount.
-func (m *MockPriceOracle) QueryAskPrice(_ context.Context,
-	_ asset.Specifier, _ fn.Option[uint64],
-	_ fn.Option[lnwire.MilliSatoshi],
-	_ fn.Option[rfqmsg.AssetRate]) (*OracleResponse, error) {
-
-	// Calculate the rate expiry timestamp.
-	lifetime := time.Duration(m.expiryDelay) * time.Second
-	expiry := time.Now().Add(lifetime).UTC()
-
-	return &OracleResponse{
-		AssetRate: rfqmsg.NewAssetRate(m.assetToBtcRate, expiry),
-	}, nil
-}
-
-// QueryBidPrice returns a bid price for the given asset amount.
-func (m *MockPriceOracle) QueryBidPrice(_ context.Context, _ asset.Specifier,
-	_ fn.Option[uint64], _ fn.Option[lnwire.MilliSatoshi],
-	_ fn.Option[rfqmsg.AssetRate]) (*OracleResponse, error) {
-
-	// Calculate the rate expiry timestamp.
-	lifetime := time.Duration(m.expiryDelay) * time.Second
-	expiry := time.Now().Add(lifetime).UTC()
-
-	return &OracleResponse{
-		AssetRate: rfqmsg.NewAssetRate(m.assetToBtcRate, expiry),
-	}, nil
-}
-
-// Ensure that MockPriceOracle implements the PriceOracle interface.
-var _ PriceOracle = (*MockPriceOracle)(nil)


### PR DESCRIPTION
Fixes https://github.com/lightninglabs/taproot-assets/issues/1361  

This PR corrects a bug where we called the wrong price oracle endpoints when evaluating the price from a quote accept message sent in response to a quote request message.  

Additionally, we enhance the mock price oracle to allow method call hooking.  

See the commit messages for details on the original issue and the correct approach.