### PR TITLE
make+itest: don't use locally installed chantools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,13 +92,13 @@ build:
 	$(GOBUILD) -tags="$(DEV_TAGS)" -o tapcli-debug $(DEV_GCFLAGS) $(DEV_LDFLAGS) $(PKG)/cmd/tapcli
 
 build-itest:
-	@if ! command -v chantools > /dev/null; then \
+	@if [ ! -f itest/chantools/chantools ]; then \
 		$(call print, "Building itest chantools."); \
 		rm -rf itest/chantools; \
 		git clone --depth 1 --branch v0.13.5 https://github.com/lightninglabs/chantools.git itest/chantools; \
-		cd itest/chantools && make install; \
+		cd itest/chantools && go build ./cmd/chantools; \
 	else \
-		$(call print, "Chantools is already installed and available in PATH."); \
+		$(call print, "Chantools is already installed and available in itest/chantools."); \
 	fi
 
 	@$(call print, "Building itest btcd.")

--- a/itest/chantools_harness.go
+++ b/itest/chantools_harness.go
@@ -2,6 +2,7 @@ package itest
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -48,8 +49,9 @@ type ChantoolsHarness struct {
 
 // NewChantoolsHarness creates a new instance of the ChantoolsHarness struct.
 func NewChantoolsHarness(t *testing.T) ChantoolsHarness {
-	path, err := exec.LookPath("chantools")
-	require.NoError(t, err, "chantools is not installed or not in PATH")
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+	path := fmt.Sprintf("%s/chantools/chantools", wd)
 
 	t.Logf("Using chantools binary at: %v", path)
 


### PR DESCRIPTION
A new version of chantools is available. But we want to use a specific version, so we make sure to always build it for the itest to not interfere with any other version that might already be installed on the system.