### PR TITLE
rfqmath: Improve WithinTolerance doc and handle zero coefficient edge case

### DIFF
--- a/rfqmath/fixed_point.go
+++ b/rfqmath/fixed_point.go
@@ -121,7 +121,14 @@ func (f FixedPoint[T]) Equals(other FixedPoint[T]) bool {
 // WithinTolerance returns true if the two FixedPoint values are within the
 // given tolerance (in parts per million (PPM)).
 func (f FixedPoint[T]) WithinTolerance(
-	other FixedPoint[T], tolerancePpm T) bool {
+	other FixedPoint[T], tolerancePpm T) (bool, error) {
+
+	// If either of the coefficients are zero, we cannot check tolerance.
+	zero := NewInt[T]().FromUint64(0)
+	if f.Coefficient.Equals(zero) || other.Coefficient.Equals(zero) {
+		return false, fmt.Errorf("cannot check tolerance with zero " +
+			"value")
+	}
 
 	// Determine the larger scale between the two fixed-point numbers.
 	// Both values will be scaled to this larger scale to ensure a
@@ -162,7 +169,8 @@ func (f FixedPoint[T]) WithinTolerance(
 	// Compare the scaled delta to the product of the maximum coefficient
 	// and the tolerance.
 	toleranceCoefficient := maxCoefficient.Mul(tolerancePpm)
-	return toleranceCoefficient.Gte(scaledDelta)
+	result := toleranceCoefficient.Gte(scaledDelta)
+	return result, nil
 }
 
 // FixedPointFromUint64 creates a new FixedPoint from the given integer and

--- a/rfqmath/fixed_point.go
+++ b/rfqmath/fixed_point.go
@@ -119,7 +119,20 @@ func (f FixedPoint[T]) Equals(other FixedPoint[T]) bool {
 }
 
 // WithinTolerance returns true if the two FixedPoint values are within the
-// given tolerance (in parts per million (PPM)).
+// given tolerance, specified in parts per million (PPM).
+//
+// The tolerance is applied relative to the larger of the two values to ensure
+// that a 100% tolerance (1,000,000 PPM) always results in a match for any two
+// nonzero values.
+//
+// This max-based approach (e.g. ask) is more lenient than using the smaller
+// value (e.g., bid) as the reference. For example, if the two values are 100
+// and 105, a 5% tolerance (50,000 PPM) allows a maximum difference of:
+// - Bid-based: 100 × 0.05 = 5 (so 105 is the limit)
+// - Max-based: 105 × 0.05 = 5.25 (so 105 is still within tolerance)
+//
+// This means max-based tolerance accepts slightly wider spreads, making it
+// less strict in bid-ask scenarios.
 func (f FixedPoint[T]) WithinTolerance(
 	other FixedPoint[T], tolerancePpm T) (bool, error) {
 


### PR DESCRIPTION
This PR enhances the documentation for `FixedPoint.WithinTolerance` to clarify that the tolerance check is max-based, meaning it is applied relative to the larger of the two values. This ensures that a 100% tolerance (1,000,000 PPM) always results in a match for any two nonzero values.  

Additionally, the function now returns an error if either value is zero, as tolerance is undefined in such cases.  

#### Alternative Tolerance Strategies For Consideration
These are alternative strategies that we don't use in our code.
  
- **Bid-based (stricter):** Uses the smaller value as the reference. This enforces a tighter threshold but does not guarantee a match at 100% tolerance. It may also be more intuitive in some bid-ask spread scenarios, so it is something to keep in mind.  
- **Midpoint-based (balanced):** Uses the average of both values. This smooths out variations but is less intuitive for bid-ask spread comparisons.  

The max-based approach was chosen for its predictability and leniency in bid-ask scenarios, ensuring a 100% tolerance always results in a match while still maintaining a meaningful spread constraint at lower tolerances.  