### PR TITLE
Proof of Concept: Simplifying Concurrency with `ContextGuard.Goroutine`

### DIFF
--- a/fn/context_guard.go
+++ b/fn/context_guard.go
@@ -99,3 +99,29 @@ func (g *ContextGuard) WithCtxQuitNoTimeout() (context.Context, func()) {
 
 	return ctx, cancel
 }
+
+// Goroutine runs the given function in a separate goroutine and ensures proper
+// error handling. If the object function returns an error, the provided error
+// handler is called.
+//
+// This method also manages the context guard wait group when spawning the
+// goroutine.
+func (g *ContextGuard) Goroutine(f func() error, errHandler func(error)) {
+	if f == nil {
+		panic("no function provided")
+	}
+
+	if errHandler == nil {
+		panic("no error handler provided")
+	}
+
+	g.Wg.Add(1)
+	go func() {
+		defer g.Wg.Done()
+
+		err := f()
+		if err != nil {
+			errHandler(err)
+		}
+	}()
+}


### PR DESCRIPTION
This PR introduces a **proof of concept** for `ContextGuard.Goroutine`, a method designed to simplify goroutine management within `ContextGuard`. It ensures consistent error handling via a dedicated error handler and manages the wait group automatically.  

To demonstrate its potential usefulness, this PR applies `ContextGuard.Goroutine` in to one spot in our RFQ code, showcasing how it can standardise error handling. This is an early iteration to explore whether this approach is handy for broader use.