### PR TITLE
Add price oracle proxy

### DIFF
--- a/config.go
+++ b/config.go
@@ -15,6 +15,7 @@ import (
 	"github.com/lightninglabs/taproot-assets/tapdb"
 	"github.com/lightninglabs/taproot-assets/tapfreighter"
 	"github.com/lightninglabs/taproot-assets/tapgarden"
+	"github.com/lightninglabs/taproot-assets/taprpc/priceoraclerpc"
 	"github.com/lightninglabs/taproot-assets/universe"
 	"github.com/lightningnetwork/lnd"
 	"github.com/lightningnetwork/lnd/build"
@@ -196,6 +197,10 @@ type Config struct {
 	RfqManager *rfq.Manager
 
 	PriceOracle rfq.PriceOracle
+
+	// ProxyPriceOracle is an optional price oracle that can be used to
+	// proxy price requests to another price oracle.
+	ProxyPriceOracle priceoraclerpc.PriceOracleClient
 
 	UniverseStats universe.Telemetry
 

--- a/config.go
+++ b/config.go
@@ -53,6 +53,8 @@ type RPCConfig struct {
 
 	AllowPublicStats bool
 
+	AllowPublicPriceOracle bool
+
 	LetsEncryptDir string
 
 	LetsEncryptListen string

--- a/itest/integration_test.go
+++ b/itest/integration_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/lightninglabs/taproot-assets/taprpc"
+	"github.com/lightninglabs/taproot-assets/taprpc/priceoraclerpc"
 	"github.com/lightningnetwork/lnd/lntest"
 	"github.com/stretchr/testify/require"
 )
@@ -128,4 +129,24 @@ func testGetInfo(t *harnessTest) {
 
 	// Ensure the response matches the expected response.
 	require.Equal(t.t, resp, respCli)
+}
+
+// testPriceOracleProxy tests the price oracle proxy.
+func testPriceOracleProxy(t *harnessTest) {
+	ctxb := context.Background()
+	ctxt, cancel := context.WithTimeout(ctxb, defaultWaitTimeout)
+	defer cancel()
+
+	resp, err := t.tapd.PriceOracleClient.QueryAssetRates(
+		ctxt, &priceoraclerpc.QueryAssetRatesRequest{},
+	)
+	require.NoError(t.t, err)
+
+	okResp := resp.GetOk()
+	require.NotNil(t.t, okResp)
+
+	require.Equal(
+		t.t, fmt.Sprintf("%v", mockPriceOracleCoef),
+		okResp.AssetRates.SubjectAssetRate.Coefficient,
+	)
 }

--- a/itest/tapd_harness.go
+++ b/itest/tapd_harness.go
@@ -23,6 +23,7 @@ import (
 	"github.com/lightninglabs/taproot-assets/taprpc"
 	"github.com/lightninglabs/taproot-assets/taprpc/assetwalletrpc"
 	"github.com/lightninglabs/taproot-assets/taprpc/mintrpc"
+	"github.com/lightninglabs/taproot-assets/taprpc/priceoraclerpc"
 	"github.com/lightninglabs/taproot-assets/taprpc/rfqrpc"
 	tchrpc "github.com/lightninglabs/taproot-assets/taprpc/tapchannelrpc"
 	"github.com/lightninglabs/taproot-assets/taprpc/tapdevrpc"
@@ -83,6 +84,10 @@ const (
 	// timeout we'll use for waiting for a receiver to acknowledge a proof
 	// transfer.
 	defaultProofTransferReceiverAckTimeout = 500 * time.Millisecond
+
+	// mockPriceOracleCoef is the coefficient used in the mock price oracle
+	// to calculate the asset rate.
+	mockPriceOracleCoef = 5_820_600
 )
 
 // tapdHarness is a test harness that holds everything that is needed to
@@ -102,6 +107,7 @@ type tapdHarness struct {
 	tchrpc.TaprootAssetChannelsClient
 	universerpc.UniverseClient
 	tapdevrpc.TapDevClient
+	priceoraclerpc.PriceOracleClient
 }
 
 // tapdConfig holds all configuration items that are required to start a tapd
@@ -223,7 +229,7 @@ func newTapdHarness(t *testing.T, ht *harnessTest, cfg tapdConfig,
 		Rfq: rfq.CliConfig{
 			//nolint:lll
 			PriceOracleAddress:     rfq.MockPriceOracleServiceAddress,
-			MockOracleAssetsPerBTC: 5_820_600,
+			MockOracleAssetsPerBTC: mockPriceOracleCoef,
 		},
 	}
 
@@ -425,6 +431,7 @@ func (hs *tapdHarness) start(expectErrExit bool) error {
 	)
 	hs.UniverseClient = universerpc.NewUniverseClient(rpcConn)
 	hs.TapDevClient = tapdevrpc.NewTapDevClient(rpcConn)
+	hs.PriceOracleClient = priceoraclerpc.NewPriceOracleClient(rpcConn)
 
 	return nil
 }

--- a/itest/test_list_on_test.go
+++ b/itest/test_list_on_test.go
@@ -336,6 +336,10 @@ var testCases = []*testCase{
 		name: "asset signing after lnd restore from seed",
 		test: testRestoreLndFromSeed,
 	},
+	{
+		name: "price oracle proxy",
+		test: testPriceOracleProxy,
+	},
 }
 
 var optionalTestCases = []*testCase{

--- a/perms/perms.go
+++ b/perms/perms.go
@@ -336,7 +336,8 @@ var (
 // macaroon authentication.
 func MacaroonWhitelist(allowUniPublicAccessRead bool,
 	allowUniPublicAccessWrite bool, allowPublicUniProofCourier bool,
-	allowPublicStats bool) map[string]struct{} {
+	allowPublicStats bool, allowPublicPriceOracle bool,
+) map[string]struct{} {
 
 	// Make a copy of the default whitelist.
 	whitelist := make(map[string]struct{})
@@ -359,6 +360,11 @@ func MacaroonWhitelist(allowUniPublicAccessRead bool,
 		whitelist["/universerpc.Universe/QueryAssetStats"] = struct{}{}
 		whitelist["/universerpc.Universe/UniverseStats"] = struct{}{}
 		whitelist["/universerpc.Universe/QueryEvents"] = struct{}{}
+	}
+
+	// Conditionally add public price oracle RPC endpoints to the whitelist.
+	if allowPublicPriceOracle {
+		whitelist["/priceoraclerpc.PriceOracle/QueryAssetRates"] = struct{}{} // nolint: lll
 	}
 
 	return whitelist

--- a/perms/perms.go
+++ b/perms/perms.go
@@ -311,6 +311,10 @@ var (
 			Entity: "assets",
 			Action: "write",
 		}},
+		"/priceoraclerpc.PriceOracle/QueryAssetRates": {{
+			Entity: "priceoracle",
+			Action: "read",
+		}},
 	}
 
 	// defaultMacaroonWhitelist defines a default set of RPC endpoints that

--- a/rfq/oracle.go
+++ b/rfq/oracle.go
@@ -107,6 +107,9 @@ type PriceOracle interface {
 		paymentMaxAmt fn.Option[lnwire.MilliSatoshi],
 		assetRateHint fn.Option[rfqmsg.AssetRate]) (
 		*OracleResponse, error)
+
+	// RawClient returns the underlying RPC client.
+	Client() oraclerpc.PriceOracleClient
 }
 
 // RpcPriceOracle is a price oracle that uses an external RPC server to get
@@ -402,6 +405,11 @@ func (r *RpcPriceOracle) QueryBidPrice(ctx context.Context,
 	default:
 		return nil, fmt.Errorf("unexpected response type: %T", result)
 	}
+}
+
+// Client returns the underlying RPC client.
+func (r *RpcPriceOracle) Client() oraclerpc.PriceOracleClient {
+	return r.client
 }
 
 // Ensure that RpcPriceOracle implements the PriceOracle interface.

--- a/sample-tapd.conf
+++ b/sample-tapd.conf
@@ -128,6 +128,9 @@
 ; Disable macaroon authentication for stats RPC endpoints
 ; allow-public-stats=false
 
+; Disble macaroon authentication for price oracle proxy RPC endpoints
+; allow-public-price-oracle=false
+
 ; Add an ip:port/hostname to allow cross origin access from
 ; To allow all origins, set as "*"
 ; restcors=

--- a/server.go
+++ b/server.go
@@ -315,6 +315,7 @@ func (s *Server) RunUntilShutdown(mainErrChan <-chan error) error {
 		s.cfg.UniversePublicAccess.IsWriteAccessGranted(),
 		s.cfg.RPCConfig.AllowPublicUniProofCourier,
 		s.cfg.RPCConfig.AllowPublicStats,
+		s.cfg.RPCConfig.AllowPublicPriceOracle,
 	)
 
 	// Create a new RPC interceptor that we'll add to the GRPC server. This

--- a/tapcfg/config.go
+++ b/tapcfg/config.go
@@ -238,6 +238,7 @@ type RpcConfig struct {
 
 	AllowPublicUniProofCourier bool `long:"allow-public-uni-proof-courier" description:"Disable macaroon authentication for universe proof courier RPC endpoints."`
 	AllowPublicStats           bool `long:"allow-public-stats" description:"Disable macaroon authentication for stats RPC endpoints."`
+	AllowPublicPriceOracle     bool `long:"allow-public-price-oracle" description:"Disable macaroon authentication for price oracle RPC endpoints."`
 
 	RestCORS []string `long:"restcors" description:"Add an ip:port/hostname to allow cross origin access from. To allow all origins, set as \"*\"."`
 

--- a/tapcfg/server.go
+++ b/tapcfg/server.go
@@ -20,6 +20,7 @@ import (
 	"github.com/lightninglabs/taproot-assets/tapdb/sqlc"
 	"github.com/lightninglabs/taproot-assets/tapfreighter"
 	"github.com/lightninglabs/taproot-assets/tapgarden"
+	"github.com/lightninglabs/taproot-assets/taprpc/priceoraclerpc"
 	"github.com/lightninglabs/taproot-assets/tapscript"
 	"github.com/lightninglabs/taproot-assets/universe"
 	"github.com/lightningnetwork/lnd"
@@ -366,6 +367,7 @@ func genServerConfig(cfg *Config, cfgLogger btclog.Logger,
 	// Determine whether we should use the mock price oracle service or a
 	// real price oracle service.
 	var priceOracle rfq.PriceOracle
+	var rpcPriceOracleClient priceoraclerpc.PriceOracleClient
 
 	rfqCfg := cfg.Experimental.Rfq
 	switch rfqCfg.PriceOracleAddress {
@@ -381,6 +383,7 @@ func genServerConfig(cfg *Config, cfgLogger btclog.Logger,
 				3600, rfqCfg.MockOracleSatsPerAsset,
 			)
 		}
+		rpcPriceOracleClient = priceOracle.Client()
 
 	case "":
 		// Leave the price oracle as nil, which will cause the RFQ
@@ -395,6 +398,7 @@ func genServerConfig(cfg *Config, cfgLogger btclog.Logger,
 			return nil, fmt.Errorf("unable to create price "+
 				"oracle: %w", err)
 		}
+		rpcPriceOracleClient = priceOracle.Client()
 	}
 
 	// Construct the RFQ manager.
@@ -590,6 +594,7 @@ func genServerConfig(cfg *Config, cfgLogger btclog.Logger,
 		UniverseQueriesBurst:     cfg.Universe.UniverseQueriesBurst,
 		RfqManager:               rfqManager,
 		PriceOracle:              priceOracle,
+		ProxyPriceOracle:         rpcPriceOracleClient,
 		AuxLeafSigner:            auxLeafSigner,
 		AuxFundingController:     auxFundingController,
 		AuxChanCloser:            auxChanCloser,


### PR DESCRIPTION
This PR adds a price oracle proxy to the rpcserver. The motivation behind is that an application dev might want to reuse the price oracle that is used with the connected tap daemon. Currently this would then mean that the application needs seperate connections for tapd and the price oracle. This simplyfies this.

Closes #https://github.com/lightninglabs/taproot-assets/issues/1356


## AI generated summary 

This pull request introduces a price oracle proxy feature to the system, along with necessary configurations and tests. The changes include adding new imports, configuration options, and implementing the price oracle proxy functionality in various parts of the codebase.

Key changes include:

### Configuration and Imports:
* Added `priceoraclerpc` import in multiple files to support the price oracle proxy feature. (`config.go`, `itest/integration_test.go`, `itest/tapd_harness.go`, `perms/perms.go`, `rfq/mock.go`, `rfq/oracle.go`, `rpcserver.go`, `server.go`) [[1]](diffhunk://#diff-0e426a43248661127a0c0ee115aef7a1093b635f8993b3f7ebb1dd9f05b8f249R18) [[2]](diffhunk://#diff-fbe1bd50dbbe60c56ddd824f32474e2d0a553406dc9ca134bde0a83a580d48efR13) [[3]](diffhunk://#diff-9b361b0f4dda3ff2d30d486ad25db0739960c2e25505ec98ae15469902d29cdeR26) [[4]](diffhunk://#diff-d42acaa1f99428a4826c815792c3ec66f7336d07228eb0273a460d0897b60f0fR314-R317) [[5]](diffhunk://#diff-9198190036883530706cd6bd01dc1dd21e4cb6a6b153289123bb748df361bedeR12-R16) [[6]](diffhunk://#diff-d52cb635c26130928444581337c372815805612cc7209cceff4a970766eb0ff4R110-R112) [[7]](diffhunk://#diff-674c79ba02b6e9c45a994388392689814f3538800351b2fd43fb3ade21e1effbR49) [[8]](diffhunk://#diff-2944bf2087f1fd686d35ff850be326aff768b77d65a5eba6a91b3bf8e8948213R23)

### Configuration Options:
* Added `AllowPublicPriceOracle` to `RPCConfig` to control public access to the price oracle RPC endpoints. (`config.go`) [[1]](diffhunk://#diff-0e426a43248661127a0c0ee115aef7a1093b635f8993b3f7ebb1dd9f05b8f249R56-R57) [[2]](diffhunk://#diff-d42acaa1f99428a4826c815792c3ec66f7336d07228eb0273a460d0897b60f0fL335-R340) [[3]](diffhunk://#diff-717ec15a0a0110b455e398b08b21a0a3b67e934b51aceccb8c49022d529986e3R241)
* Introduced `ProxyPriceOracle` in `Config` to proxy price requests to another price oracle. (`config.go`) [[1]](diffhunk://#diff-0e426a43248661127a0c0ee115aef7a1093b635f8993b3f7ebb1dd9f05b8f249R203-R206) [[2]](diffhunk://#diff-2944bf2087f1fd686d35ff850be326aff768b77d65a5eba6a91b3bf8e8948213R597)

### Implementation:
* Implemented `QueryAssetRates` method in `rpcServer` to handle price oracle proxy requests. (`rpcserver.go`)
* Registered the `PriceOracleServer` with the gRPC server. (`rpcserver.go`)

### Testing:
* Added `testPriceOracleProxy` to verify the functionality of the price oracle proxy. (`itest/integration_test.go`)
* Included the new test in the test cases list. (`itest/test_list_on_test.go`)
* Defined a mock implementation for `QueryAssetRates` in `MockPriceOracle`. (`rfq/mock.go`)

### Miscellaneous:
* Added `ErrPriceOracleUnimplemented` to handle cases where the price oracle service is not implemented. (`rpcserver.go`)

These changes collectively introduce and test the price oracle proxy feature, ensuring it integrates seamlessly with the existing system.