### PR TITLE
rfq+rfqmath: fix sats-per-asset conversion in mock price oracle

### DIFF
--- a/rfq/mock.go
+++ b/rfq/mock.go
@@ -45,13 +45,8 @@ func NewMockPriceOracleSatPerAsset(expiryDelay uint64,
 	satsPerAsset uint64) *MockPriceOracle {
 
 	return &MockPriceOracle{
-		expiryDelay: expiryDelay,
-
-		// TODO(ffranr): This is incorrect, we should convert
-		//  satoshis per asset to assets per BTC.
-		assetToBtcRate: rfqmath.NewBigIntFixedPoint(
-			satsPerAsset, 0,
-		),
+		expiryDelay:    expiryDelay,
+		assetToBtcRate: rfqmath.SatsPerAssetToAssetRate(satsPerAsset),
 	}
 }
 

--- a/rfqmath/convert.go
+++ b/rfqmath/convert.go
@@ -172,3 +172,16 @@ func MinTransportableMSat(dustLimit lnwire.MilliSatoshi,
 	oneAssetUnit := NewBigIntFixedPoint(1, 0)
 	return dustLimit + UnitsToMilliSatoshi(oneAssetUnit, rate)
 }
+
+// SatsPerAssetToAssetRate converts a satoshis per asset rate to an asset to
+// BTC rate.
+func SatsPerAssetToAssetRate(satsPerAsset uint64) BigIntFixedPoint {
+	if satsPerAsset == 0 {
+		return NewBigIntFixedPoint(0, 0)
+	}
+
+	satsPerAssetFp := NewBigIntFixedPoint(satsPerAsset, 0)
+	satsPerBTC := NewBigIntFixedPoint(100_000_000, 0)
+
+	return satsPerBTC.Div(satsPerAssetFp)
+}

--- a/rfqmath/convert_test.go
+++ b/rfqmath/convert_test.go
@@ -828,3 +828,59 @@ func TestConversionMsat(t *testing.T) {
 		rapid.MakeCheck(testRoundTripConversion[BigInt]),
 	)
 }
+
+// TestConversionSatsPerAsset tests the conversion of satoshis per asset to an
+// asset per BTC rate.
+func TestConversionSatsPerAsset(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		satsPerAsset  uint64
+		expectedValue uint64
+	}{
+		{
+			satsPerAsset:  5,
+			expectedValue: 20_000_000,
+		},
+		{
+			satsPerAsset:  10,
+			expectedValue: 10_000_000,
+		},
+		{
+			satsPerAsset:  20,
+			expectedValue: 5_000_000,
+		},
+		{
+			satsPerAsset:  1,
+			expectedValue: 100_000_000,
+		},
+		{
+			satsPerAsset:  50,
+			expectedValue: 2_000_000,
+		},
+		{
+			satsPerAsset:  100,
+			expectedValue: 1_000_000,
+		},
+		{
+			satsPerAsset:  0,
+			expectedValue: 0,
+		},
+	}
+
+	for idx := range testCases {
+		testCase := testCases[idx]
+
+		t.Run(fmt.Sprintf("SatsPerAsset=%d", testCase.satsPerAsset),
+			func(t *testing.T) {
+				actual := SatsPerAssetToAssetRate(
+					testCase.satsPerAsset,
+				)
+				expected := NewBigIntFixedPoint(
+					testCase.expectedValue, 0,
+				)
+				require.Equal(t, expected, actual)
+			},
+		)
+	}
+}


### PR DESCRIPTION
* Add a fixed-point conversion function for converting sats per asset to asset units per BTC.
* Add a unit test.
* Use the new function to fix the conversion in `NewMockPriceOracleSatPerAsset`.