### PR TITLE
proof: add new IgnoreChecker proof rejection cache 

### DIFF
--- a/itest/assertions.go
+++ b/itest/assertions.go
@@ -746,10 +746,14 @@ func VerifyProofBlob(t *testing.T, tapClient taprpc.TaprootAssetsClient,
 		return nil
 	}
 
-	snapshot, err := f.Verify(
-		ctxt, headerVerifier, proof.DefaultMerkleVerifier,
-		groupVerifier, proof.MockChainLookup,
-	)
+	vCtx := proof.VerifierCtx{
+		HeaderVerifier: headerVerifier,
+		MerkleVerifier: proof.DefaultMerkleVerifier,
+		GroupVerifier:  groupVerifier,
+		ChainLookupGen: proof.MockChainLookup,
+	}
+
+	snapshot, err := f.Verify(ctxt, vCtx)
 	require.NoError(t, err)
 
 	return f, snapshot

--- a/itest/utils.go
+++ b/itest/utils.go
@@ -712,11 +712,9 @@ func ManualMintSimpleAsset(t *harnessTest, lndNode *node.HarnessNode,
 	)
 	require.NoError(t.t, err)
 
-	chainBridge := tapgarden.NewMockChainBridge()
 	mintingProofs, err := proof.NewMintingBlobs(
-		&baseProof, proof.MockHeaderVerifier, proof.MockMerkleVerifier,
-		proof.MockGroupVerifier, proof.MockGroupAnchorVerifier,
-		chainBridge, proof.WithAssetMetaReveals(metaReveals),
+		&baseProof, proof.MockVerifierCtx,
+		proof.WithAssetMetaReveals(metaReveals),
 	)
 	require.NoError(t.t, err)
 

--- a/proof/append.go
+++ b/proof/append.go
@@ -43,9 +43,7 @@ type TransitionParams struct {
 // the proof for. This method returns both the encoded full provenance (proof
 // chain) and the added latest proof.
 func AppendTransition(blob Blob, params *TransitionParams,
-	headerVerifier HeaderVerifier, merkleVerifier MerkleVerifier,
-	groupVerifier GroupVerifier, chainLookup asset.ChainLookup) (Blob,
-	*Proof, error) {
+	vCtx VerifierCtx) (Blob, *Proof, error) {
 
 	// Decode the proof blob into a proper file structure first.
 	f := NewEmptyFile(V0)
@@ -83,9 +81,8 @@ func AppendTransition(blob Blob, params *TransitionParams,
 	if err := f.AppendProof(*newProof); err != nil {
 		return nil, nil, fmt.Errorf("error appending proof: %w", err)
 	}
-	_, err = f.Verify(
-		ctx, headerVerifier, merkleVerifier, groupVerifier, chainLookup,
-	)
+
+	_, err = f.Verify(ctx, vCtx)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error verifying proof: %w", err)
 	}

--- a/proof/append_test.go
+++ b/proof/append_test.go
@@ -212,8 +212,7 @@ func runAppendTransitionTest(t *testing.T, assetType asset.Type, amt uint64,
 
 	// Append the new transition to the genesis blob.
 	transitionBlob, transitionProof, err := AppendTransition(
-		genesisBlob, transitionParams, MockHeaderVerifier,
-		MockMerkleVerifier, MockGroupVerifier, MockChainLookup,
+		genesisBlob, transitionParams, MockVerifierCtx,
 	)
 	require.NoError(t, err)
 	require.Greater(t, len(transitionBlob), len(genesisBlob))
@@ -421,8 +420,7 @@ func runAppendTransitionTest(t *testing.T, assetType asset.Type, amt uint64,
 	}
 
 	split1Blob, split1Proof, err := AppendTransition(
-		transitionBlob, split1Params, MockHeaderVerifier,
-		MockMerkleVerifier, MockGroupVerifier, MockChainLookup,
+		transitionBlob, split1Params, MockVerifierCtx,
 	)
 	require.NoError(t, err)
 	require.Greater(t, len(split1Blob), len(transitionBlob))
@@ -464,8 +462,7 @@ func runAppendTransitionTest(t *testing.T, assetType asset.Type, amt uint64,
 	}
 
 	split2Blob, split2Proof, err := AppendTransition(
-		transitionBlob, split2Params, MockHeaderVerifier,
-		MockMerkleVerifier, MockGroupVerifier, MockChainLookup,
+		transitionBlob, split2Params, MockVerifierCtx,
 	)
 	require.NoError(t, err)
 	require.Greater(t, len(split2Blob), len(transitionBlob))
@@ -508,8 +505,7 @@ func runAppendTransitionTest(t *testing.T, assetType asset.Type, amt uint64,
 	}
 
 	split3Blob, split3Proof, err := AppendTransition(
-		transitionBlob, split3Params, MockHeaderVerifier,
-		MockMerkleVerifier, MockGroupVerifier, MockChainLookup,
+		transitionBlob, split3Params, MockVerifierCtx,
 	)
 	require.NoError(t, err)
 	require.Greater(t, len(split3Blob), len(transitionBlob))
@@ -569,10 +565,7 @@ func verifyBlob(t testing.TB, blob Blob) *AssetSnapshot {
 	f := NewEmptyFile(V0)
 	require.NoError(t, f.Decode(bytes.NewReader(blob)))
 
-	finalSnapshot, err := f.Verify(
-		context.Background(), MockHeaderVerifier, MockMerkleVerifier,
-		MockGroupVerifier, MockChainLookup,
-	)
+	finalSnapshot, err := f.Verify(context.Background(), MockVerifierCtx)
 	require.NoError(t, err)
 
 	return finalSnapshot

--- a/proof/archive.go
+++ b/proof/archive.go
@@ -167,10 +167,8 @@ type Archiver interface {
 	// the script key itself. If replace is specified, we expect a proof to
 	// already be present, and we just update (replace) it with the new
 	// proof.
-	ImportProofs(ctx context.Context, headerVerifier HeaderVerifier,
-		merkleVerifier MerkleVerifier, groupVerifier GroupVerifier,
-		chainLookupGen ChainLookupGenerator, replace bool,
-		proofs ...*AnnotatedProof) error
+	ImportProofs(ctx context.Context, vCtx VerifierCtx,
+		replace bool, proofs ...*AnnotatedProof) error
 }
 
 // NotifyArchiver is an Archiver that also allows callers to subscribe to
@@ -709,9 +707,8 @@ func (f *FileArchiver) FetchProofs(_ context.Context,
 // update (replace) it with the new proof.
 //
 // NOTE: This implements the Archiver interface.
-func (f *FileArchiver) ImportProofs(_ context.Context,
-	_ HeaderVerifier, _ MerkleVerifier, _ GroupVerifier,
-	_ ChainLookupGenerator, replace bool, proofs ...*AnnotatedProof) error {
+func (f *FileArchiver) ImportProofs(_ context.Context, _ VerifierCtx,
+	replace bool, proofs ...*AnnotatedProof) error {
 
 	for _, proof := range proofs {
 		proofPath, err := genProofFileStoragePath(
@@ -906,9 +903,7 @@ func (m *MultiArchiver) FetchProofs(ctx context.Context,
 // ImportProofs attempts to store fully populated proofs on disk. The previous
 // outpoint of the first state transition will be used as the Genesis point.
 // The final resting place of the asset will be used as the script key itself.
-func (m *MultiArchiver) ImportProofs(ctx context.Context,
-	headerVerifier HeaderVerifier, merkleVerifier MerkleVerifier,
-	groupVerifier GroupVerifier, chainLookupGen ChainLookupGenerator,
+func (m *MultiArchiver) ImportProofs(ctx context.Context, vCtx VerifierCtx,
 	replace bool, proofs ...*AnnotatedProof) error {
 
 	// Before we import the proofs into the archive, we want to make sure
@@ -917,8 +912,7 @@ func (m *MultiArchiver) ImportProofs(ctx context.Context,
 	f := func(c context.Context, proof *AnnotatedProof) error {
 		// First, we'll decode and then also verify the proof.
 		finalStateTransition, err := m.proofVerifier.Verify(
-			c, bytes.NewReader(proof.Blob), headerVerifier,
-			merkleVerifier, groupVerifier, chainLookupGen,
+			c, bytes.NewReader(proof.Blob), vCtx,
 		)
 		if err != nil {
 			return fmt.Errorf("unable to verify proof: %w", err)
@@ -957,10 +951,7 @@ func (m *MultiArchiver) ImportProofs(ctx context.Context,
 	// additional supplementary information into the locator, we'll attempt
 	// to import each proof our archive backends.
 	for _, archive := range m.backends {
-		err := archive.ImportProofs(
-			ctx, headerVerifier, merkleVerifier, groupVerifier,
-			chainLookupGen, replace, proofs...,
-		)
+		err := archive.ImportProofs(ctx, vCtx, replace, proofs...)
 		if err != nil {
 			return err
 		}
@@ -1026,9 +1017,7 @@ var _ NotifyArchiver = (*MultiArchiver)(nil)
 // assets of the same ID. This is useful when we want to update the proof with a
 // new one after a re-org.
 func ReplaceProofInBlob(ctx context.Context, p *Proof, archive Archiver,
-	headerVerifier HeaderVerifier, merkleVerifier MerkleVerifier,
-	groupVerifier GroupVerifier,
-	chainLookupGen ChainLookupGenerator) error {
+	vCtx VerifierCtx) error {
 
 	// This is a bit of a hacky part. If we have a chain of transactions
 	// that were re-organized, we can't verify the whole chain until all of
@@ -1037,7 +1026,7 @@ func ReplaceProofInBlob(ctx context.Context, p *Proof, archive Archiver,
 	// since we don't know if the whole chain has been updated yet (the
 	// confirmations might come in out of order).
 	// TODO(guggero): Find a better way to do this.
-	headerVerifier = func(wire.BlockHeader, uint32) error {
+	vCtx.HeaderVerifier = func(wire.BlockHeader, uint32) error {
 		return nil
 	}
 
@@ -1105,10 +1094,7 @@ func ReplaceProofInBlob(ctx context.Context, p *Proof, archive Archiver,
 			Locator: existingProof.Locator,
 			Blob:    buf.Bytes(),
 		}
-		err = archive.ImportProofs(
-			ctx, headerVerifier, merkleVerifier, groupVerifier,
-			chainLookupGen, true, directProof,
-		)
+		err = archive.ImportProofs(ctx, vCtx, true, directProof)
 		if err != nil {
 			return fmt.Errorf("unable to import updated proof: %w",
 				err)

--- a/proof/archive_test.go
+++ b/proof/archive_test.go
@@ -62,16 +62,14 @@ func TestFileArchiverProofCollision(t *testing.T) {
 		blob2 = []byte("this is the second blob")
 	)
 	err = fileArchive.ImportProofs(
-		ctx, MockHeaderVerifier, MockMerkleVerifier, MockGroupVerifier,
-		MockChainLookup, false, &AnnotatedProof{
+		ctx, MockVerifierCtx, false, &AnnotatedProof{
 			Locator: locator1,
 			Blob:    blob1,
 		},
 	)
 	require.NoError(t, err)
 	err = fileArchive.ImportProofs(
-		ctx, MockHeaderVerifier, MockMerkleVerifier, MockGroupVerifier,
-		MockChainLookup, false, &AnnotatedProof{
+		ctx, MockVerifierCtx, false, &AnnotatedProof{
 			Locator: locator2,
 			Blob:    blob2,
 		},
@@ -189,10 +187,7 @@ func TestFileArchiver(t *testing.T) {
 				}
 
 				err = archive.ImportProofs(
-					ctx, MockHeaderVerifier,
-					MockMerkleVerifier, MockGroupVerifier,
-					MockChainLookup, false,
-					proof,
+					ctx, MockVerifierCtx, false, proof,
 				)
 
 				if testCase.expectedStoreError != nil {
@@ -326,7 +321,7 @@ func TestMigrateOldFileNames(t *testing.T) {
 	// under the new naming scheme.
 	proof6 := RandProof(t, genesis2, scriptKey2, oddTxBlock, 2, 1)
 	err = fileArchive.ImportProofs(
-		nil, nil, nil, nil, MockChainLookup, false, &AnnotatedProof{
+		nil, MockVerifierCtx, false, &AnnotatedProof{
 			Locator: Locator{
 				AssetID:   fn.Ptr(proof6.Asset.ID()),
 				ScriptKey: *proof6.Asset.ScriptKey.PubKey,

--- a/proof/backward_compat_test.go
+++ b/proof/backward_compat_test.go
@@ -68,11 +68,15 @@ func runBIPTestVectorBackwardCompatible(t *testing.T,
 			// full proof chain, as it's the first proof in the
 			// chain.
 			if decoded.GenesisReveal != nil {
+				vCtx := VerifierCtx{
+					HeaderVerifier: MockHeaderVerifier,
+					MerkleVerifier: DefaultMerkleVerifier,
+					GroupVerifier:  MockGroupVerifier,
+					ChainLookupGen: MockChainLookup,
+				}
 				_, err = decoded.Verify(
 					context.Background(), nil,
-					MockHeaderVerifier,
-					DefaultMerkleVerifier,
-					MockGroupVerifier, MockChainLookup,
+					MockChainLookup, vCtx,
 				)
 				require.NoError(tt, err)
 			}

--- a/proof/mint_test.go
+++ b/proof/mint_test.go
@@ -128,9 +128,6 @@ func TestNewMintingBlobs(t *testing.T) {
 			}},
 		},
 		GenesisPoint: genesisTx.TxIn[0].PreviousOutPoint,
-	}, MockHeaderVerifier, MockMerkleVerifier, MockGroupVerifier,
-		MockGroupAnchorVerifier, MockChainLookup,
-		WithAssetMetaReveals(metaReveals),
-	)
+	}, MockVerifierCtx, WithAssetMetaReveals(metaReveals))
 	require.NoError(t, err)
 }

--- a/proof/mock.go
+++ b/proof/mock.go
@@ -27,6 +27,18 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var (
+	// MockVerifierCtx is a verifier context that uses mock implementations
+	// for all the verifier interfaces.
+	MockVerifierCtx = VerifierCtx{
+		HeaderVerifier:      MockHeaderVerifier,
+		MerkleVerifier:      MockMerkleVerifier,
+		GroupVerifier:       MockGroupVerifier,
+		GroupAnchorVerifier: MockGroupAnchorVerifier,
+		ChainLookupGen:      MockChainLookup,
+	}
+)
+
 func RandProof(t testing.TB, genesis asset.Genesis,
 	scriptKey *btcec.PublicKey, block wire.MsgBlock, txIndex int,
 	outputIndex uint32) Proof {
@@ -161,8 +173,7 @@ func NewMockVerifier(t *testing.T) *MockVerifier {
 }
 
 func (m *MockVerifier) Verify(context.Context, io.Reader,
-	HeaderVerifier, MerkleVerifier, GroupVerifier,
-	ChainLookupGenerator) (*AssetSnapshot, error) {
+	VerifierCtx) (*AssetSnapshot, error) {
 
 	return &AssetSnapshot{
 		Asset: &asset.Asset{
@@ -413,9 +424,8 @@ func (m *MockProofArchive) FetchProofs(_ context.Context,
 }
 
 // ImportProofs will store the given proofs, without performing any validation.
-func (m *MockProofArchive) ImportProofs(_ context.Context, _ HeaderVerifier,
-	_ MerkleVerifier, _ GroupVerifier, _ ChainLookupGenerator, _ bool,
-	proofs ...*AnnotatedProof) error {
+func (m *MockProofArchive) ImportProofs(_ context.Context, _ VerifierCtx,
+	_ bool, proofs ...*AnnotatedProof) error {
 
 	for _, proof := range proofs {
 		err := m.storeLocator(proof.Locator)

--- a/proof/mock.go
+++ b/proof/mock.go
@@ -1028,3 +1028,21 @@ func (tmr *TestMetaReveal) ToMetaReveal(t testing.TB) *MetaReveal {
 		UnknownOddTypes:     tmr.UnknownOddTypes,
 	}
 }
+
+type mockIgnoreChecker struct {
+	ignoredAssetPoints fn.Set[AssetPoint]
+	ignoreAll          bool
+}
+
+func newMockIgnoreChecker(ignoreAll bool,
+	ignorePoints ...AssetPoint) *mockIgnoreChecker {
+
+	return &mockIgnoreChecker{
+		ignoredAssetPoints: fn.NewSet(ignorePoints...),
+		ignoreAll:          ignoreAll,
+	}
+}
+
+func (m *mockIgnoreChecker) IsIgnored(assetPoint AssetPoint) bool {
+	return m.ignoreAll || m.ignoredAssetPoints.Contains(assetPoint)
+}

--- a/proof/proof_test.go
+++ b/proof/proof_test.go
@@ -812,10 +812,10 @@ func TestGenesisProofVerification(t *testing.T) {
 				tc.genesisRevealMutator, tc.groupRevealMutator,
 				tc.assetVersion,
 			)
+
 			_, err := genesisProof.Verify(
-				context.Background(), nil, MockHeaderVerifier,
-				MockMerkleVerifier, MockGroupVerifier,
-				MockChainLookup,
+				context.Background(), nil, MockChainLookup,
+				MockVerifierCtx,
 			)
 			require.ErrorIs(t, err, tc.expectedErr)
 
@@ -861,10 +861,14 @@ func TestProofBlockHeaderVerification(t *testing.T) {
 		originalBlockHeight = proof.BlockHeight
 	)
 
+	vCtx := MockVerifierCtx
+
 	// Header verifier compares given header to expected header. Verifier
 	// does not return error.
 	errHeaderVerifier := fmt.Errorf("invalid block header")
-	headerVerifier := func(header wire.BlockHeader, height uint32) error {
+	vCtx.HeaderVerifier = func(header wire.BlockHeader,
+		height uint32) error {
+
 		// Compare given block header against base reference block
 		// header.
 		if header != originalBlockHeader || height != originalBlockHeight {
@@ -875,18 +879,14 @@ func TestProofBlockHeaderVerification(t *testing.T) {
 
 	// Verify that the original proof block header is as expected and
 	// therefore an error is not returned.
-	_, err := proof.Verify(
-		context.Background(), nil, headerVerifier, MockMerkleVerifier,
-		MockGroupVerifier, MockChainLookup,
-	)
+	_, err := proof.Verify(context.Background(), nil, MockChainLookup, vCtx)
 	require.NoError(t, err)
 
 	// Modify proof block header, then check that the verification function
 	// propagates the correct error.
 	proof.BlockHeader.Nonce += 1
 	_, actualErr := proof.Verify(
-		context.Background(), nil, headerVerifier, MockMerkleVerifier,
-		MockGroupVerifier, MockChainLookup,
+		context.Background(), nil, MockChainLookup, vCtx,
 	)
 	require.ErrorIs(t, actualErr, errHeaderVerifier)
 
@@ -897,8 +897,7 @@ func TestProofBlockHeaderVerification(t *testing.T) {
 	// propagates the correct error.
 	proof.BlockHeight += 1
 	_, actualErr = proof.Verify(
-		context.Background(), nil, headerVerifier, MockMerkleVerifier,
-		MockGroupVerifier, MockChainLookup,
+		context.Background(), nil, MockChainLookup, vCtx,
 	)
 	require.ErrorIs(t, actualErr, errHeaderVerifier)
 }
@@ -918,19 +917,13 @@ func TestProofFileVerification(t *testing.T) {
 	err = f.Decode(bytes.NewReader(proofBytes))
 	require.NoError(t, err)
 
-	_, err = f.Verify(
-		context.Background(), MockHeaderVerifier, MockMerkleVerifier,
-		MockGroupVerifier, MockChainLookup,
-	)
+	_, err = f.Verify(context.Background(), MockVerifierCtx)
 	require.NoError(t, err)
 
 	// Ensure that verification of a proof of unknown version fails.
 	f.Version = Version(212)
 
-	lastAsset, err := f.Verify(
-		context.Background(), MockHeaderVerifier, MockMerkleVerifier,
-		MockGroupVerifier, MockChainLookup,
-	)
+	lastAsset, err := f.Verify(context.Background(), MockVerifierCtx)
 	require.Nil(t, lastAsset)
 	require.ErrorIs(t, err, ErrUnknownVersion)
 }
@@ -988,8 +981,8 @@ func TestProofVerification(t *testing.T) {
 	// previous proof.
 	if len(p.ChallengeWitness) > 0 {
 		_, err = p.Verify(
-			context.Background(), nil, MockHeaderVerifier,
-			MockMerkleVerifier, MockGroupVerifier, MockChainLookup,
+			context.Background(), nil, MockChainLookup,
+			MockVerifierCtx,
 		)
 		require.NoError(t, err)
 	}
@@ -1003,8 +996,7 @@ func TestProofVerification(t *testing.T) {
 	p.Version = TransitionVersion(212)
 
 	lastAsset, err := p.Verify(
-		context.Background(), nil, MockHeaderVerifier,
-		MockMerkleVerifier, MockGroupVerifier, MockChainLookup,
+		context.Background(), nil, MockChainLookup, MockVerifierCtx,
 	)
 	require.Nil(t, lastAsset)
 	require.ErrorIs(t, err, ErrUnknownVersion)
@@ -1026,8 +1018,7 @@ func TestOwnershipProofVerification(t *testing.T) {
 	require.NoError(t, err)
 
 	snapshot, err := p.Verify(
-		context.Background(), nil, MockHeaderVerifier,
-		MockMerkleVerifier, MockGroupVerifier, MockChainLookup,
+		context.Background(), nil, MockChainLookup, MockVerifierCtx,
 	)
 	require.NoError(t, err)
 	require.NotNil(t, snapshot)
@@ -1272,11 +1263,15 @@ func runBIPTestVector(t *testing.T, testVectors *TestVectors) {
 			// full proof chain, as it's the first proof in the
 			// chain.
 			if decoded.GenesisReveal != nil {
+				vCtx := VerifierCtx{
+					HeaderVerifier: MockHeaderVerifier,
+					MerkleVerifier: DefaultMerkleVerifier,
+					GroupVerifier:  MockGroupVerifier,
+					ChainLookupGen: MockChainLookup,
+				}
 				_, err = decoded.Verify(
 					context.Background(), nil,
-					MockHeaderVerifier,
-					DefaultMerkleVerifier,
-					MockGroupVerifier, MockChainLookup,
+					MockChainLookup, vCtx,
 				)
 				require.NoError(tt, err)
 			}

--- a/tapchannel/aux_sweeper.go
+++ b/tapchannel/aux_sweeper.go
@@ -1427,11 +1427,16 @@ func importOutputProofs(scid lnwire.ShortChannelID,
 			return fmt.Errorf("unable to encode proof: %w", err)
 		}
 
+		vCtx := proof.VerifierCtx{
+			HeaderVerifier: headerVerifier,
+			MerkleVerifier: proof.DefaultMerkleVerifier,
+			GroupVerifier:  groupVerifier,
+			ChainLookupGen: chainBridge,
+		}
+
 		fundingUTXO := proofToImport.Asset
 		err = proofArchive.ImportProofs(
-			ctxb, headerVerifier, proof.DefaultMerkleVerifier,
-			groupVerifier, chainBridge, false,
-			&proof.AnnotatedProof{
+			ctxb, vCtx, false, &proof.AnnotatedProof{
 				//nolint:lll
 				Locator: proof.Locator{
 					AssetID:   fn.Ptr(fundingUTXO.ID()),

--- a/tapdb/assets_store.go
+++ b/tapdb/assets_store.go
@@ -1835,10 +1835,8 @@ func (a *AssetStore) upsertAssetProof(ctx context.Context,
 // The final resting place of the asset will be used as the script key itself.
 //
 // NOTE: This implements the proof.ArchiveBackend interface.
-func (a *AssetStore) ImportProofs(ctx context.Context, _ proof.HeaderVerifier,
-	_ proof.MerkleVerifier, _ proof.GroupVerifier,
-	_ proof.ChainLookupGenerator, replace bool,
-	proofs ...*proof.AnnotatedProof) error {
+func (a *AssetStore) ImportProofs(ctx context.Context, _ proof.VerifierCtx,
+	replace bool, proofs ...*proof.AnnotatedProof) error {
 
 	var writeTxOpts AssetStoreTxOptions
 

--- a/tapdb/assets_store_test.go
+++ b/tapdb/assets_store_test.go
@@ -336,8 +336,7 @@ func TestImportAssetProof(t *testing.T) {
 	testProof.AnchorTxIndex = 5678
 	testProof.Blob = updatedBlob
 	require.NoError(t, assetStore.ImportProofs(
-		ctxb, proof.MockHeaderVerifier, proof.MockMerkleVerifier,
-		proof.MockGroupVerifier, proof.MockChainLookup, true, testProof,
+		ctxb, proof.MockVerifierCtx, true, testProof,
 	))
 
 	currentBlob, err = assetStore.FetchProof(ctxb, proof.Locator{
@@ -391,9 +390,7 @@ func TestImportAssetProof(t *testing.T) {
 	testProof.Blob = []byte("new proof")
 
 	require.NoError(t, assetStore.ImportProofs(
-		ctxb, proof.MockHeaderVerifier, proof.MockMerkleVerifier,
-		proof.MockGroupVerifier, proof.MockChainLookup, false,
-		testProof,
+		ctxb, proof.MockVerifierCtx, false, testProof,
 	))
 
 	// We should still be able to fetch the old proof.

--- a/tapdb/sqlutils_test.go
+++ b/tapdb/sqlutils_test.go
@@ -171,9 +171,7 @@ func (d *DbHandler) AddRandomAssetProof(t *testing.T) (*asset.Asset,
 	// With all our test data constructed, we'll now attempt to import the
 	// asset into the database.
 	require.NoError(t, assetStore.ImportProofs(
-		ctx, proof.MockHeaderVerifier, proof.MockMerkleVerifier,
-		proof.MockGroupVerifier, proof.MockChainLookup, false,
-		annotatedProof,
+		ctx, proof.MockVerifierCtx, false, annotatedProof,
 	))
 
 	// Now the HasProof should return true.

--- a/tapgarden/custodian_test.go
+++ b/tapgarden/custodian_test.go
@@ -72,9 +72,7 @@ func newMockVerifier(t *testing.T) *mockVerifier {
 }
 
 func (m *mockVerifier) Verify(_ context.Context, r io.Reader,
-	_ proof.HeaderVerifier, _ proof.MerkleVerifier,
-	_ proof.GroupVerifier,
-	_ proof.ChainLookupGenerator) (*proof.AssetSnapshot, error) {
+	_ proof.VerifierCtx) (*proof.AssetSnapshot, error) {
 
 	f := &proof.File{}
 	err := f.Decode(r)

--- a/tapgarden/re-org_watcher.go
+++ b/tapgarden/re-org_watcher.go
@@ -580,12 +580,17 @@ func (w *ReOrgWatcher) DefaultUpdateCallback() proof.UpdateCallback {
 		ctxt, cancel := w.CtxBlocking()
 		defer cancel()
 
-		headerVerifier := GenHeaderVerifier(ctxt, w.cfg.ChainBridge)
+		vCtx := proof.VerifierCtx{
+			HeaderVerifier: GenHeaderVerifier(
+				ctxt, w.cfg.ChainBridge,
+			),
+			MerkleVerifier: proof.DefaultMerkleVerifier,
+			GroupVerifier:  w.cfg.GroupVerifier,
+			ChainLookupGen: w.cfg.ChainBridge,
+		}
 		for idx := range proofs {
 			err := proof.ReplaceProofInBlob(
-				ctxt, proofs[idx], w.cfg.ProofArchive,
-				headerVerifier, proof.DefaultMerkleVerifier,
-				w.cfg.GroupVerifier, w.cfg.ChainBridge,
+				ctxt, proofs[idx], w.cfg.ProofArchive, vCtx,
 			)
 			if err != nil {
 				return fmt.Errorf("unable to update proofs: %w",

--- a/tapsend/proof_test.go
+++ b/tapsend/proof_test.go
@@ -101,9 +101,8 @@ func TestCreateProofSuffix(t *testing.T) {
 			}
 
 			_, err = proofSuffix.Verify(
-				ctx, prev, proof.MockHeaderVerifier,
-				proof.MockMerkleVerifier,
-				proof.MockGroupVerifier, proof.MockChainLookup,
+				ctx, prev, proof.MockChainLookup,
+				proof.MockVerifierCtx,
 			)
 
 			// Checking the transfer witness is the very last step

--- a/tapsend/send_test.go
+++ b/tapsend/send_test.go
@@ -1787,34 +1787,24 @@ func TestProofVerify(t *testing.T) {
 
 	// Create a proof for each receiver and verify it.
 	senderBlob, _, err := proof.AppendTransition(
-		genesisProofBlob, &proofParams[0], proof.MockHeaderVerifier,
-		proof.MockMerkleVerifier, proof.MockGroupVerifier,
-		proof.MockChainLookup,
+		genesisProofBlob, &proofParams[0], proof.MockVerifierCtx,
 	)
 	require.NoError(t, err)
 	senderFile := proof.NewEmptyFile(proof.V0)
 	require.NoError(t, senderFile.Decode(bytes.NewReader(senderBlob)))
 	_, err = senderFile.Verify(
-		context.TODO(), proof.MockHeaderVerifier,
-		proof.MockMerkleVerifier, proof.MockGroupVerifier,
-		proof.MockChainLookup,
+		context.TODO(), proof.MockVerifierCtx,
 	)
 	require.NoError(t, err)
 
 	receiverBlob, _, err := proof.AppendTransition(
-		genesisProofBlob, &proofParams[1], proof.MockHeaderVerifier,
-		proof.MockMerkleVerifier, proof.MockGroupVerifier,
-		proof.MockChainLookup,
+		genesisProofBlob, &proofParams[1], proof.MockVerifierCtx,
 	)
 	require.NoError(t, err)
 	receiverFile, err := proof.NewFile(proof.V0)
 	require.NoError(t, err)
 	require.NoError(t, receiverFile.Decode(bytes.NewReader(receiverBlob)))
-	_, err = receiverFile.Verify(
-		context.TODO(), proof.MockHeaderVerifier,
-		proof.MockMerkleVerifier, proof.MockGroupVerifier,
-		proof.MockChainLookup,
-	)
+	_, err = receiverFile.Verify(context.TODO(), proof.MockVerifierCtx)
 	require.NoError(t, err)
 }
 
@@ -1864,34 +1854,22 @@ func TestProofVerifyFullValueSplit(t *testing.T) {
 
 	// Create a proof for each receiver and verify it.
 	senderBlob, _, err := proof.AppendTransition(
-		genesisProofBlob, &proofParams[0], proof.MockHeaderVerifier,
-		proof.MockMerkleVerifier, proof.MockGroupVerifier,
-		proof.MockChainLookup,
+		genesisProofBlob, &proofParams[0], proof.MockVerifierCtx,
 	)
 	require.NoError(t, err)
 	senderFile, err := proof.NewFile(proof.V0)
 	require.NoError(t, err)
 	require.NoError(t, senderFile.Decode(bytes.NewReader(senderBlob)))
-	_, err = senderFile.Verify(
-		context.TODO(), proof.MockHeaderVerifier,
-		proof.MockMerkleVerifier, proof.MockGroupVerifier,
-		proof.MockChainLookup,
-	)
+	_, err = senderFile.Verify(context.TODO(), proof.MockVerifierCtx)
 	require.NoError(t, err)
 
 	receiverBlob, _, err := proof.AppendTransition(
-		genesisProofBlob, &proofParams[1], proof.MockHeaderVerifier,
-		proof.MockMerkleVerifier, proof.MockGroupVerifier,
-		proof.MockChainLookup,
+		genesisProofBlob, &proofParams[1], proof.MockVerifierCtx,
 	)
 	require.NoError(t, err)
 	receiverFile := proof.NewEmptyFile(proof.V0)
 	require.NoError(t, receiverFile.Decode(bytes.NewReader(receiverBlob)))
-	_, err = receiverFile.Verify(
-		context.TODO(), proof.MockHeaderVerifier,
-		proof.MockMerkleVerifier, proof.MockGroupVerifier,
-		proof.MockChainLookup,
-	)
+	_, err = receiverFile.Verify(context.TODO(), proof.MockVerifierCtx)
 	require.NoError(t, err)
 }
 

--- a/universe/base.go
+++ b/universe/base.go
@@ -338,6 +338,13 @@ func (a *Archive) verifyIssuanceProof(ctx context.Context, id Identifier,
 	key LeafKey, newProof *proof.Proof,
 	prevAssetSnapshot *proof.AssetSnapshot) (*proof.AssetSnapshot, error) {
 
+	vCtx := proof.VerifierCtx{
+		HeaderVerifier: a.cfg.HeaderVerifier,
+		MerkleVerifier: a.cfg.MerkleVerifier,
+		GroupVerifier:  a.cfg.GroupVerifier,
+		ChainLookupGen: a.cfg.ChainLookupGenerator,
+	}
+
 	lookup, err := a.cfg.ChainLookupGenerator.GenProofChainLookup(newProof)
 	if err != nil {
 		return nil, fmt.Errorf("unable to generate chain lookup: %w",
@@ -345,8 +352,7 @@ func (a *Archive) verifyIssuanceProof(ctx context.Context, id Identifier,
 	}
 
 	assetSnapshot, err := newProof.Verify(
-		ctx, prevAssetSnapshot, a.cfg.HeaderVerifier,
-		a.cfg.MerkleVerifier, a.cfg.GroupVerifier, lookup,
+		ctx, prevAssetSnapshot, lookup, vCtx,
 	)
 	if err != nil {
 		var skBytes []byte


### PR DESCRIPTION
In this PR, we introduce a new proof.VerifierCtx struct to cut down
on line noise when verifying single proofs and proof files. This also
lets us centralize the creation of the various interfaces we need to
verify a proof.

We then add a new interface, the IgnoreChecker. This is to be
used as a proof rejection cache, which allows us to ensure that we don't
continue to validate proofs that we already know to be invalid. The
underlying cache implementation is also intended to support its own
invalidation to handle re-org edge cases.