### PR TITLE
Remove redundant PayToTaprootScript functions

### DIFF
--- a/itest/utils.go
+++ b/itest/utils.go
@@ -27,7 +27,6 @@ import (
 	"github.com/lightninglabs/taproot-assets/taprpc/tapdevrpc"
 	"github.com/lightninglabs/taproot-assets/taprpc/universerpc"
 	unirpc "github.com/lightninglabs/taproot-assets/taprpc/universerpc"
-	"github.com/lightninglabs/taproot-assets/tapscript"
 	"github.com/lightninglabs/taproot-assets/universe"
 	"github.com/lightningnetwork/lnd/chainntnfs"
 	"github.com/lightningnetwork/lnd/lnrpc"
@@ -637,7 +636,7 @@ func ManualMintSimpleAsset(t *harnessTest, lndNode *node.HarnessNode,
 	mintPubkey := txscript.ComputeTaprootOutputKey(
 		internalKey.PubKey, fn.ByteSlice(anchorCommitRoot),
 	)
-	genesisScript, err := tapscript.PayToTaprootScript(mintPubkey)
+	genesisScript, err := txscript.PayToTaprootScript(mintPubkey)
 	require.NoError(t.t, err)
 
 	// Add the genesis script to the funded PSBT, and then sign at the

--- a/tapchannel/allocation.go
+++ b/tapchannel/allocation.go
@@ -17,7 +17,6 @@ import (
 	"github.com/lightninglabs/taproot-assets/fn"
 	"github.com/lightninglabs/taproot-assets/proof"
 	"github.com/lightninglabs/taproot-assets/tappsbt"
-	"github.com/lightninglabs/taproot-assets/tapscript"
 	"github.com/lightninglabs/taproot-assets/tapsend"
 	"github.com/lightningnetwork/lnd/input"
 )
@@ -185,7 +184,7 @@ func (a *Allocation) finalPkScript() ([]byte, error) {
 			return nil, err
 		}
 
-		return tapscript.PayToTaprootScript(taprootKey)
+		return txscript.PayToTaprootScript(taprootKey)
 	}
 
 	if a.OutputCommitment == nil {
@@ -210,7 +209,7 @@ func (a *Allocation) finalPkScript() ([]byte, error) {
 		a.InternalKey, tapscriptRoot[:],
 	)
 
-	return tapscript.PayToTaprootScript(taprootOutputKey)
+	return txscript.PayToTaprootScript(taprootOutputKey)
 }
 
 // AuxLeaf returns the auxiliary leaf for the allocation. If the output

--- a/tapdb/asset_minting_test.go
+++ b/tapdb/asset_minting_test.go
@@ -910,7 +910,7 @@ func addRandAssets(t *testing.T, ctx context.Context,
 	mintingOutputKey, _, err := mintingBatch.MintingOutputKey(&randSibling)
 	require.NoError(t, err)
 
-	script, err := tapscript.PayToTaprootScript(mintingOutputKey)
+	script, err := txscript.PayToTaprootScript(mintingOutputKey)
 	require.NoError(t, err)
 
 	genesisPacket.Pkt.UnsignedTx.TxOut[anchorOutputIndex].PkScript = script

--- a/tapgarden/batch.go
+++ b/tapgarden/batch.go
@@ -256,7 +256,7 @@ func (m *MintingBatch) genesisScript(sibling *commitment.TapscriptPreimage) (
 		return nil, err
 	}
 
-	return tapscript.PayToTaprootScript(mintingOutputKey)
+	return txscript.PayToTaprootScript(mintingOutputKey)
 }
 
 // State returns the private state of the batch.

--- a/tapgarden/custodian_test.go
+++ b/tapgarden/custodian_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/lndclient"
 	"github.com/lightninglabs/taproot-assets/address"
@@ -23,7 +24,6 @@ import (
 	"github.com/lightninglabs/taproot-assets/proof"
 	"github.com/lightninglabs/taproot-assets/tapdb"
 	"github.com/lightninglabs/taproot-assets/tapgarden"
-	"github.com/lightninglabs/taproot-assets/tapscript"
 	"github.com/lightninglabs/taproot-assets/universe"
 	"github.com/lightningnetwork/lnd/clock"
 	"github.com/lightningnetwork/lnd/lnrpc"
@@ -403,7 +403,7 @@ func randWalletTx(addr *address.AddrWithKeyInfo) (int, *lndclient.Transaction) {
 		// We've randomly chosen an index where we place our Taproot
 		// output key of the address.
 		if addr != nil && idx == taprootOutput {
-			out.PkScript, _ = tapscript.PayToTaprootScript(
+			out.PkScript, _ = txscript.PayToTaprootScript(
 				&addr.TaprootOutputKey,
 			)
 			detail.OutputType = txTypeTaproot

--- a/tappsbt/encode.go
+++ b/tappsbt/encode.go
@@ -9,7 +9,6 @@ import (
 	"net/url"
 
 	"github.com/btcsuite/btcd/btcec/v2"
-	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/btcutil/psbt"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
@@ -226,7 +225,7 @@ func (o *VOutput) encode(coinType uint32) (psbt.POutput, *wire.TxOut, error) {
 	// Before we start with any fields that need to go into the Unknowns
 	// slice, we add the information that we can stuff into the wire TX or
 	// existing PSBT fields.
-	assetPkScript, err := payToTaprootScript(o.ScriptKey.PubKey)
+	assetPkScript, err := txscript.PayToTaprootScript(o.ScriptKey.PubKey)
 	if err != nil {
 		return pOut, nil, fmt.Errorf("error creating asset taproot "+
 			"script: %w", err)
@@ -485,16 +484,6 @@ func tapscriptPreimageEncoder(t *commitment.TapscriptPreimage) encoderFunc {
 	}
 
 	return tlvEncoder(&t, commitment.TapscriptPreimageEncoder)
-}
-
-// payToTaprootScript creates a pk script for a pay-to-taproot output key. We
-// create a copy of the tapscript.PayToTaprootScript function here to avoid a
-// circular dependency.
-func payToTaprootScript(taprootKey *btcec.PublicKey) ([]byte, error) {
-	return txscript.NewScriptBuilder().
-		AddOp(txscript.OP_1).
-		AddData(schnorr.SerializePubKey(taprootKey)).
-		Script()
 }
 
 // vOutputTypeEncoder is a TLV encoder that encodes the given VOutputType to the

--- a/tapscript/tx.go
+++ b/tapscript/tx.go
@@ -221,7 +221,9 @@ func VirtualTx(newAsset *asset.Asset, prevAssets commitment.InputSet) (
 func InputAssetPrevOut(prevAsset asset.Asset) (*wire.TxOut, error) {
 	switch prevAsset.ScriptVersion {
 	case asset.ScriptV0:
-		pkScript, err := PayToTaprootScript(prevAsset.ScriptKey.PubKey)
+		pkScript, err := txscript.PayToTaprootScript(
+			prevAsset.ScriptKey.PubKey,
+		)
 		if err != nil {
 			return nil, err
 		}

--- a/tapscript/util.go
+++ b/tapscript/util.go
@@ -2,7 +2,6 @@ package tapscript
 
 import (
 	"github.com/btcsuite/btcd/btcec/v2"
-	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/txscript"
@@ -26,15 +25,7 @@ func PayToAddrScript(internalKey btcec.PublicKey, sibling *chainhash.Hash,
 		&internalKey, tapscriptRoot[:],
 	)
 
-	return PayToTaprootScript(outputKey)
-}
-
-// PayToTaprootScript creates a pk script for a pay-to-taproot output key.
-func PayToTaprootScript(taprootKey *btcec.PublicKey) ([]byte, error) {
-	return txscript.NewScriptBuilder().
-		AddOp(txscript.OP_1).
-		AddData(schnorr.SerializePubKey(taprootKey)).
-		Script()
+	return txscript.PayToTaprootScript(outputKey)
 }
 
 // FlipParity turns the given public key from even to odd parity or vice versa.


### PR DESCRIPTION
Replace redundant `PayToTaprootScript` function definitions with `txscript.PayToTaprootScript` to eliminate unnecessary duplicate code.