### PR TITLE
Support Directory Exclusion in Golang Version Linter Check

### DIFF
--- a/scripts/check-go-version-dockerfile.sh
+++ b/scripts/check-go-version-dockerfile.sh
@@ -34,6 +34,9 @@ exclude_list=(
     # Exclude the tools Dockerfile as otherwise the linter may need to be
     # considered every time the Go version is updated.
     "./tools/Dockerfile"
+
+    # Exclude chantools files as they are not in this project.
+    "./itest/chantools"
 )
 
 # is_excluded checks if a file or directory is in the exclude list.

--- a/scripts/check-go-version-dockerfile.sh
+++ b/scripts/check-go-version-dockerfile.sh
@@ -30,17 +30,26 @@ fi
 target_go_version="$1"
 
 # File paths to be excluded from the check.
-exception_list=(
+exclude_list=(
     # Exclude the tools Dockerfile as otherwise the linter may need to be
     # considered every time the Go version is updated.
     "./tools/Dockerfile"
 )
 
-# is_exception checks if a file is in the exception list.
-is_exception() {
+# is_excluded checks if a file or directory is in the exclude list.
+is_excluded() {
     local file="$1"
-    for exception in "${exception_list[@]}"; do
-        if [ "$file" == "$exception" ]; then
+    for exclude in "${exclude_list[@]}"; do
+
+        # Check if the file matches exactly with an exclusion entry.
+        if [[ "$file" == "$exclude" ]]; then
+            return 0
+        fi
+
+        # Check if the file is inside an excluded directory.
+        # The trailing slash ensures that similarly named directories
+        # (e.g., ./itest/chantools_other) are not mistakenly excluded.
+        if [[ "$file/" == "$exclude"* ]]; then
             return 0
         fi
     done
@@ -52,8 +61,8 @@ dockerfiles=$(find . -type f -name "*.Dockerfile" -o -name "Dockerfile")
 
 # Check each Dockerfile
 for file in $dockerfiles; do
-    # Skip the file if it is in the exception list.
-    if is_exception "$file"; then
+    # Skip the file if it is in the exclusion list.
+    if is_excluded "$file"; then
         echo "Skipping $file"
         continue
     fi

--- a/scripts/check-go-version-yaml.sh
+++ b/scripts/check-go-version-yaml.sh
@@ -64,17 +64,26 @@ fi
 target_go_version="$1"
 
 # File paths to be excluded from the check.
-exception_list=(
+exclude_list=(
     # Exclude chantools files as they are not in this project.
     "./itest/chantools/.golangci.yml"
     "./itest/chantools/.github/workflows/main.yml"
 )
 
-# is_exception checks if a file is in the exception list.
-is_exception() {
+# is_excluded checks if a file or directory is in the exclude list.
+is_excluded() {
     local file="$1"
-    for exception in "${exception_list[@]}"; do
-        if [ "$file" == "$exception" ]; then
+    for exclude in "${exclude_list[@]}"; do
+
+        # Check if the file matches exactly with an exclusion entry.
+        if [[ "$file" == "$exclude" ]]; then
+            return 0
+        fi
+
+        # Check if the file is inside an excluded directory.
+        # The trailing slash ensures that similarly named directories
+        # (e.g., ./itest/chantools_other) are not mistakenly excluded.
+        if [[ "$file/" == "$exclude"* ]]; then
             return 0
         fi
     done
@@ -87,7 +96,7 @@ yaml_files=$(find . -type f \( -name "*.yaml" -o -name "*.yml" \))
 # Check each YAML file.
 for file in $yaml_files; do
     # Skip the file if it is in the exception list.
-    if is_exception "$file"; then
+    if is_excluded "$file"; then
         echo "Skipping $file"
         continue
     fi

--- a/scripts/check-go-version-yaml.sh
+++ b/scripts/check-go-version-yaml.sh
@@ -66,8 +66,7 @@ target_go_version="$1"
 # File paths to be excluded from the check.
 exclude_list=(
     # Exclude chantools files as they are not in this project.
-    "./itest/chantools/.golangci.yml"
-    "./itest/chantools/.github/workflows/main.yml"
+    "./itest/chantools"
 )
 
 # is_excluded checks if a file or directory is in the exclude list.


### PR DESCRIPTION
Enhance the Golang version check linter by adding support for directory exclusions.  

**Changes:**  
- Updated the `is_exclude` function to allow excluding entire directories, not just individual files.  
- Applied this to exclude all files in `./itest/chantools` from the version check.  

This improves flexibility in managing linter exclusions for project directories.