### PR TITLE
make: fix sqlc-check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -252,7 +252,7 @@ sqlc:
 	@$(call print, "Merging SQL migrations into consolidated schemas")
 	go run ./cmd/merge-sql-schemas/main.go
 
-sqlc-check: 
+sqlc-check: sqlc
 	@$(call print, "Verifying sql code generation.")
 	@if [ ! -f tapdb/sqlc/schemas/generated_schema.sql ]; then \
 		echo "Missing file: tapdb/sqlc/schemas/generated_schema.sql"; \


### PR DESCRIPTION
https://github.com/lightninglabs/taproot-assets/pull/1387#discussion_r1961154190

Fixes incorrect removal of the sqlc target in #1387. Without this dependency, the check doesn't actually check anything.