### PR TITLE
multi: Add label to `PublishTransaction`

### DIFF
--- a/chain_bridge.go
+++ b/chain_bridge.go
@@ -227,9 +227,8 @@ func (l *LndRpcChainBridge) GetBlockTimestamp(ctx context.Context,
 // PublishTransaction attempts to publish a new transaction to the
 // network.
 func (l *LndRpcChainBridge) PublishTransaction(ctx context.Context,
-	tx *wire.MsgTx) error {
+	tx *wire.MsgTx, label string) error {
 
-	label := "tapd-asset-minting"
 	return l.lnd.WalletKit.PublishTransaction(ctx, tx, label)
 }
 

--- a/itest/utils.go
+++ b/itest/utils.go
@@ -698,7 +698,7 @@ func ManualMintSimpleAsset(t *harnessTest, lndNode *node.HarnessNode,
 	// can build the issuance proofs.
 	genesisTxHash := signedTx.TxHash()
 	err = lndServices.WalletKit.PublishTransaction(
-		ctxt, signedTx, "tapd-asset-minting",
+		ctxt, signedTx, tapgarden.IssuanceTxLabel,
 	)
 	require.NoError(t.t, err)
 

--- a/tapchannel/aux_funding_controller.go
+++ b/tapchannel/aux_funding_controller.go
@@ -181,7 +181,7 @@ type PsbtChannelFunder interface {
 type TxPublisher interface {
 	// PublishTransaction attempts to publish a new transaction to the
 	// network.
-	PublishTransaction(context.Context, *wire.MsgTx) error
+	PublishTransaction(context.Context, *wire.MsgTx, string) error
 }
 
 // AssetSyncer is used to ensure that we know of the set of assets that'll be

--- a/tapfreighter/chain_porter.go
+++ b/tapfreighter/chain_porter.go
@@ -1521,7 +1521,7 @@ func (p *ChainPorter) stateStep(currentPkg sendPackage) (*sendPackage, error) {
 		// With the public key imported, we can now broadcast to the
 		// network.
 		err = p.cfg.ChainBridge.PublishTransaction(
-			ctx, currentPkg.OutboundPkg.AnchorTx,
+			ctx, currentPkg.OutboundPkg.AnchorTx, TransferTxLabel,
 		)
 		switch {
 		case errors.Is(err, lnwallet.ErrDoubleSpend):

--- a/tapfreighter/interface.go
+++ b/tapfreighter/interface.go
@@ -25,6 +25,12 @@ import (
 	"github.com/lightningnetwork/lnd/keychain"
 )
 
+const (
+	// TransferTxLabel defines the label assigned to an on-chain transaction
+	// that represents a tapd asset transfer.
+	TransferTxLabel = "tapd-asset-transfer"
+)
+
 // CommitmentConstraints conveys the constraints on the type of Taproot asset
 // commitments needed to satisfy a send request. Typically, for Bitcoin we just
 // care about the amount. In the case of Taproot Asset, we also need to worry

--- a/tapgarden/caretaker.go
+++ b/tapgarden/caretaker.go
@@ -840,7 +840,9 @@ func (b *BatchCaretaker) stateStep(currentState BatchState) (BatchState, error) 
 		// transaction, then request a confirmation notification.
 		ctx, cancel := b.WithCtxQuit()
 		defer cancel()
-		err = b.cfg.ChainBridge.PublishTransaction(ctx, signedTx)
+		err = b.cfg.ChainBridge.PublishTransaction(
+			ctx, signedTx, IssuanceTxLabel,
+		)
 		if err != nil {
 			return 0, fmt.Errorf("unable to publish "+
 				"transaction: %w", err)

--- a/tapgarden/interface.go
+++ b/tapgarden/interface.go
@@ -22,6 +22,12 @@ import (
 	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
 )
 
+const (
+	// IssuanceTxLabel defines the label assigned to an on-chain transaction
+	// that represents a tapd asset issuance.
+	IssuanceTxLabel = "tapd-asset-issuance"
+)
+
 // FundBatchResp is the response returned from the FundBatch method.
 type FundBatchResp struct {
 	// Batch is the batch that was funded.
@@ -332,7 +338,7 @@ type ChainBridge interface {
 
 	// PublishTransaction attempts to publish a new transaction to the
 	// network.
-	PublishTransaction(context.Context, *wire.MsgTx) error
+	PublishTransaction(context.Context, *wire.MsgTx, string) error
 
 	// EstimateFee returns a fee estimate for the confirmation target.
 	EstimateFee(ctx context.Context,

--- a/tapgarden/mock.go
+++ b/tapgarden/mock.go
@@ -705,7 +705,7 @@ func (m *MockChainBridge) GetBlockTimestamp(_ context.Context, _ uint32) int64 {
 }
 
 func (m *MockChainBridge) PublishTransaction(_ context.Context,
-	tx *wire.MsgTx) error {
+	tx *wire.MsgTx, _ string) error {
 
 	m.PublishReq <- tx
 	return nil


### PR DESCRIPTION
This PR chanegs the label used for Txs published to the network. Before, *all* Txs got the label `tapd-asset-minting`. Now, the label depends on the context. Currently we use two labels:

- `tapd-asset-minting`
- `tapd-asset-send`

In the future we could even allow for more granular information being passed to the label.