### PR TITLE
tapchannel: check custom records contain assets

### DIFF
--- a/tapchannel/aux_traffic_shaper.go
+++ b/tapchannel/aux_traffic_shaper.go
@@ -243,7 +243,7 @@ func (s *AuxTrafficShaper) ProduceHtlcExtraData(totalAmount lnwire.MilliSatoshi,
 	htlcCustomRecords lnwire.CustomRecords) (lnwire.MilliSatoshi,
 	lnwire.CustomRecords, error) {
 
-	if len(htlcCustomRecords) == 0 {
+	if !rfqmsg.HasAssetHTLCCustomRecords(htlcCustomRecords) {
 		return totalAmount, nil, nil
 	}
 


### PR DESCRIPTION
Currently (*AuxTrafficShaper).ProduceHtlcExtraData exits early if the htlcCustomRecords are empty. However, we need to cater for the case when htlc custom records exist from other contexts (such as endorsement signaling) and so we change this check to be more strict and to check that the records dont contain any asset records.