### PR TITLE
[custom channels]: refactor channel JSON, add more custom data parsers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.1.0
 	github.com/btcsuite/btclog v0.0.0-20241003133417-09c4e92e319c
 	github.com/btcsuite/btclog/v2 v2.0.1-0.20250110154127-3ae4bf1cb318
-	github.com/btcsuite/btcwallet v0.16.10-0.20241127094224-93c858b2ad63
+	github.com/btcsuite/btcwallet v0.16.10
 	github.com/btcsuite/btcwallet/wallet/txsizes v1.2.5
 	github.com/btcsuite/btcwallet/wtxmgr v1.5.4
 	github.com/caddyserver/certmagic v0.17.2
@@ -34,7 +34,7 @@ require (
 	github.com/lightningnetwork/lnd/clock v1.1.1
 	github.com/lightningnetwork/lnd/fn/v2 v2.0.8
 	github.com/lightningnetwork/lnd/tlv v1.3.0
-	github.com/lightningnetwork/lnd/tor v1.1.4
+	github.com/lightningnetwork/lnd/tor v1.1.5
 	github.com/ory/dockertest/v3 v3.10.0
 	github.com/prometheus/client_golang v1.14.0
 	github.com/stretchr/testify v1.9.0
@@ -209,3 +209,5 @@ require (
 // We want to format raw bytes as hex instead of base64. The forked version
 // allows us to specify that as an option.
 replace google.golang.org/protobuf => github.com/lightninglabs/protobuf-go-hex-display v1.33.0-hex-display
+
+replace github.com/lightningnetwork/lnd => github.com/guggero/lnd v0.11.0-beta.rc4.0.20250313195613-c175d22bf81f

--- a/go.sum
+++ b/go.sum
@@ -97,8 +97,8 @@ github.com/btcsuite/btclog v0.0.0-20241003133417-09c4e92e319c/go.mod h1:w7xnGOhw
 github.com/btcsuite/btclog/v2 v2.0.1-0.20250110154127-3ae4bf1cb318 h1:oCjIcinPt7XQ644MP/22JcjYEC84qRc3bRBH0d7Hhd4=
 github.com/btcsuite/btclog/v2 v2.0.1-0.20250110154127-3ae4bf1cb318/go.mod h1:XItGUfVOxotJL8kkuk2Hj3EVow5KCugXl3wWfQ6K0AE=
 github.com/btcsuite/btcutil v0.0.0-20190425235716-9e5f4b9a998d/go.mod h1:+5NJ2+qvTyV9exUAL/rxXi3DcLg2Ts+ymUAY5y4NvMg=
-github.com/btcsuite/btcwallet v0.16.10-0.20241127094224-93c858b2ad63 h1:YN+PekOLlLoGxE3P5RJaGgodZD5DDJSU8eXQZVwwCxM=
-github.com/btcsuite/btcwallet v0.16.10-0.20241127094224-93c858b2ad63/go.mod h1:1HJXYbjJzgumlnxOC2+ViR1U+gnHWoOn7WeK5OfY1eU=
+github.com/btcsuite/btcwallet v0.16.10 h1:SDMS0Gp7oEJVvyZNQ6gDYkpkvp/cSMRcAAy3fvO3vTk=
+github.com/btcsuite/btcwallet v0.16.10/go.mod h1:1HJXYbjJzgumlnxOC2+ViR1U+gnHWoOn7WeK5OfY1eU=
 github.com/btcsuite/btcwallet/wallet/txauthor v1.3.5 h1:Rr0njWI3r341nhSPesKQ2JF+ugDSzdPoeckS75SeDZk=
 github.com/btcsuite/btcwallet/wallet/txauthor v1.3.5/go.mod h1:+tXJ3Ym0nlQc/iHSwW1qzjmPs3ev+UVWMbGgfV1OZqU=
 github.com/btcsuite/btcwallet/wallet/txrules v1.2.2 h1:YEO+Lx1ZJJAtdRrjuhXjWrYsmAk26wLTlNzxt2q0lhk=
@@ -346,6 +346,8 @@ github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFb
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.5.0/go.mod h1:r1hZAcvfFXuYmcKyCJI9wlyOPIZUJl6FCB8Cpca/NLE=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0 h1:YBftPWNWd4WwGqtY2yeZL2ef8rHAxPBD8KFhJpmcqms=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0/go.mod h1:YN5jB8ie0yfIUg6VvR9Kz84aCaG7AsGZnLjhHbUqwPg=
+github.com/guggero/lnd v0.11.0-beta.rc4.0.20250313195613-c175d22bf81f h1:Fe56v6YtTbN1sUINb8+zr178n2wPPOX1vVwRqxbPHsw=
+github.com/guggero/lnd v0.11.0-beta.rc4.0.20250313195613-c175d22bf81f/go.mod h1:oOf/h8P5F6Mqh7P9LYyBTl7zuKv2pOgaClXWp0Oh6Vg=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
@@ -502,8 +504,6 @@ github.com/lightninglabs/protobuf-go-hex-display v1.33.0-hex-display h1:Y2WiPkBS
 github.com/lightninglabs/protobuf-go-hex-display v1.33.0-hex-display/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 github.com/lightningnetwork/lightning-onion v1.2.1-0.20240712235311-98bd56499dfb h1:yfM05S8DXKhuCBp5qSMZdtSwvJ+GFzl94KbXMNB1JDY=
 github.com/lightningnetwork/lightning-onion v1.2.1-0.20240712235311-98bd56499dfb/go.mod h1:c0kvRShutpj3l6B9WtTsNTBUtjSmjZXbJd9ZBRQOSKI=
-github.com/lightningnetwork/lnd v0.18.0-beta.rc4.0.20250304192711-9feb761b4ec4 h1:3UfT25sO71q3V7RSb/wE0ruiwk3ex30h7ZvPZ0O2Z80=
-github.com/lightningnetwork/lnd v0.18.0-beta.rc4.0.20250304192711-9feb761b4ec4/go.mod h1:5fYMAma+ylPOV+wycJuxSIwPLyRYRqKZTfiqk+59c+s=
 github.com/lightningnetwork/lnd/cert v1.2.2 h1:71YK6hogeJtxSxw2teq3eGeuy4rHGKcFf0d0Uy4qBjI=
 github.com/lightningnetwork/lnd/cert v1.2.2/go.mod h1:jQmFn/Ez4zhDgq2hnYSw8r35bqGVxViXhX6Cd7HXM6U=
 github.com/lightningnetwork/lnd/clock v1.1.1 h1:OfR3/zcJd2RhH0RU+zX/77c0ZiOnIMsDIBjgjWdZgA0=
@@ -522,8 +522,8 @@ github.com/lightningnetwork/lnd/ticker v1.1.1 h1:J/b6N2hibFtC7JLV77ULQp++QLtCwT6
 github.com/lightningnetwork/lnd/ticker v1.1.1/go.mod h1:waPTRAAcwtu7Ji3+3k+u/xH5GHovTsCoSVpho0KDvdA=
 github.com/lightningnetwork/lnd/tlv v1.3.0 h1:exS/KCPEgpOgviIttfiXAPaUqw2rHQrnUOpP7HPBPiY=
 github.com/lightningnetwork/lnd/tlv v1.3.0/go.mod h1:pJuiBj1ecr1WWLOtcZ+2+hu9Ey25aJWFIsjmAoPPnmc=
-github.com/lightningnetwork/lnd/tor v1.1.4 h1:TUW27EXqoZCcCAQPlD4aaDfh8jMbBS9CghNz50qqwtA=
-github.com/lightningnetwork/lnd/tor v1.1.4/go.mod h1:qSRB8llhAK+a6kaTPWOLLXSZc6Hg8ZC0mq1sUQ/8JfI=
+github.com/lightningnetwork/lnd/tor v1.1.5 h1:kZ1Ab4EcPFCny3a179rZGKeDUlgYilEcfKx3tD5+L+k=
+github.com/lightningnetwork/lnd/tor v1.1.5/go.mod h1:qSRB8llhAK+a6kaTPWOLLXSZc6Hg8ZC0mq1sUQ/8JfI=
 github.com/ltcsuite/ltcd v0.0.0-20190101042124-f37f8bf35796 h1:sjOGyegMIhvgfq5oaue6Td+hxZuf3tDC8lAPrFldqFw=
 github.com/ltcsuite/ltcd v0.0.0-20190101042124-f37f8bf35796/go.mod h1:3p7ZTf9V1sNPI5H8P3NkTFF4LuwMdPl2DodF60qAKqY=
 github.com/ltcsuite/ltcutil v0.0.0-20181217130922-17f3b04680b6/go.mod h1:8Vg/LTOO0KYa/vlHWJ6XZAevPQThGH5sufO0Hrou/lA=

--- a/rfq/manager.go
+++ b/rfq/manager.go
@@ -575,7 +575,7 @@ func (m *Manager) addScidAlias(scidAlias uint64, assetSpecifier asset.Specifier,
 		}
 
 		match, err := m.ChannelCompatible(
-			ctxb, assetData.Assets, assetSpecifier,
+			ctxb, assetData, assetSpecifier,
 		)
 		if err != nil {
 			return err
@@ -999,14 +999,13 @@ func (m *Manager) AssetMatchesSpecifier(ctx context.Context,
 // if the specifier is a group key, then all assets in the channel must belong
 // to that group.
 func (m *Manager) ChannelCompatible(ctx context.Context,
-	jsonAssets []rfqmsg.JsonAssetChanInfo, specifier asset.Specifier) (bool,
+	jsonChannel rfqmsg.JsonAssetChannel, specifier asset.Specifier) (bool,
 	error) {
 
-	for _, chanAsset := range jsonAssets {
-		gen := chanAsset.AssetInfo.AssetGenesis
-		assetIDBytes, err := hex.DecodeString(
-			gen.AssetID,
-		)
+	fundingAssets := jsonChannel.FundingAssets
+	for _, chanAsset := range fundingAssets {
+		gen := chanAsset.AssetGenesis
+		assetIDBytes, err := hex.DecodeString(gen.AssetID)
 		if err != nil {
 			return false, fmt.Errorf("error decoding asset ID: %w",
 				err)

--- a/rfqmsg/custom_channel_data.go
+++ b/rfqmsg/custom_channel_data.go
@@ -28,19 +28,19 @@ type JsonAssetUtxo struct {
 	DecimalDisplay uint8            `json:"decimal_display"`
 }
 
-// JsonAssetChanInfo is a struct that represents the channel information of a
-// single asset within a channel.
-type JsonAssetChanInfo struct {
-	AssetInfo     JsonAssetUtxo `json:"asset_utxo"`
-	Capacity      uint64        `json:"capacity"`
-	LocalBalance  uint64        `json:"local_balance"`
-	RemoteBalance uint64        `json:"remote_balance"`
-}
-
 // JsonAssetChannel is a struct that represents the channel information of all
 // assets within a channel.
 type JsonAssetChannel struct {
-	Assets []JsonAssetChanInfo `json:"assets"`
+	FundingAssets       []JsonAssetUtxo    `json:"funding_assets"`
+	LocalAssets         []JsonAssetTranche `json:"local_assets"`
+	RemoteAssets        []JsonAssetTranche `json:"remote_assets"`
+	OutgoingHtlcs       []JsonAssetTranche `json:"outgoing_htlcs"`
+	IncomingHtlcs       []JsonAssetTranche `json:"incoming_htlcs"`
+	Capacity            uint64             `json:"capacity"`
+	LocalBalance        uint64             `json:"local_balance"`
+	RemoteBalance       uint64             `json:"remote_balance"`
+	OutgoingHtlcBalance uint64             `json:"outgoing_htlc_balance"`
+	IncomingHtlcBalance uint64             `json:"incoming_htlc_balance"`
 }
 
 // JsonAssetChannelBalances is a struct that represents the balance information
@@ -58,9 +58,9 @@ type JsonCloseOutput struct {
 	ScriptKeys       map[string]string `json:"script_keys"`
 }
 
-// JsonHtlcBalance is a struct that represents the balance of a single asset
-// HTLC.
-type JsonHtlcBalance struct {
+// JsonAssetTranche is a struct that represents the balance of a single asset
+// tranche.
+type JsonAssetTranche struct {
 	AssetID string `json:"asset_id"`
 	Amount  uint64 `json:"amount"`
 }
@@ -68,6 +68,6 @@ type JsonHtlcBalance struct {
 // JsonHtlc is a struct that represents the asset information that can be
 // transferred via an HTLC.
 type JsonHtlc struct {
-	Balances []*JsonHtlcBalance `json:"balances"`
-	RfqID    string             `json:"rfq_id"`
+	Balances []*JsonAssetTranche `json:"balances"`
+	RfqID    string              `json:"rfq_id"`
 }

--- a/rfqmsg/records.go
+++ b/rfqmsg/records.go
@@ -177,7 +177,7 @@ func (h *Htlc) ToCustomRecords() (lnwire.CustomRecords, error) {
 // AsJson returns the Htlc record as a JSON blob.
 func (h *Htlc) AsJson() ([]byte, error) {
 	j := &JsonHtlc{
-		Balances: make([]*JsonHtlcBalance, len(h.Balances())),
+		Balances: make([]*JsonAssetTranche, len(h.Balances())),
 	}
 
 	h.RfqID.ValOpt().WhenSome(func(id ID) {
@@ -185,7 +185,7 @@ func (h *Htlc) AsJson() ([]byte, error) {
 	})
 
 	for idx, balance := range h.Balances() {
-		j.Balances[idx] = &JsonHtlcBalance{
+		j.Balances[idx] = &JsonAssetTranche{
 			AssetID: hex.EncodeToString(balance.AssetID.Val[:]),
 			Amount:  balance.Amount.Val,
 		}

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -8036,7 +8036,7 @@ type channelWithSpecifier struct {
 	channelInfo lndclient.ChannelInfo
 
 	// assetInfo contains the asset related info of the channel.
-	assetInfo rfqmsg.JsonAssetChanInfo
+	assetInfo rfqmsg.JsonAssetChannel
 }
 
 // computeChannelAssetBalance computes the total local and remote balance for
@@ -8066,29 +8066,17 @@ func (r *rpcServer) computeChannelAssetBalance(ctx context.Context,
 		// Check if the assets of this channel match the provided
 		// specifier.
 		pass, err := r.cfg.RfqManager.ChannelCompatible(
-			ctx, assetData.Assets, specifier,
+			ctx, assetData, specifier,
 		)
 		if err != nil {
 			return nil, err
 		}
 
 		if pass {
-			// Since the assets of the channel passed the above
-			// filter, we're safe to aggregate their info to be
-			// represented as a single entity.
-			var aggrInfo rfqmsg.JsonAssetChanInfo
-
-			// TODO(george): refactor when JSON gets fixed
-			for _, info := range assetData.Assets {
-				aggrInfo.Capacity += info.Capacity
-				aggrInfo.LocalBalance += info.LocalBalance
-				aggrInfo.RemoteBalance += info.RemoteBalance
-			}
-
 			channels = append(channels, channelWithSpecifier{
 				specifier:   specifier,
 				channelInfo: openChan,
-				assetInfo:   aggrInfo,
+				assetInfo:   assetData,
 			})
 		}
 	}

--- a/tapchannelmsg/custom_channel_data.go
+++ b/tapchannelmsg/custom_channel_data.go
@@ -13,6 +13,20 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
+// outputsToJsonTranches converts a list of asset outputs to a list of JSON
+// asset tranches.
+func outputsToJsonTranches(outputs []*AssetOutput) []rfqmsg.JsonAssetTranche {
+	tranches := make([]rfqmsg.JsonAssetTranche, len(outputs))
+	for idx, output := range outputs {
+		tranches[idx] = rfqmsg.JsonAssetTranche{
+			Amount:  output.Amount.Val,
+			AssetID: hex.EncodeToString(output.AssetID.Val[:]),
+		}
+	}
+
+	return tranches
+}
+
 // ReadOpenChannel reads the content of an OpenChannel struct from a reader.
 func ReadOpenChannel(r io.Reader, maxReadSize uint32) (*OpenChannel, error) {
 	openChanData, err := wire.ReadVarBytes(r, 0, maxReadSize, "chan data")
@@ -62,12 +76,21 @@ func (c *ChannelCustomData) AsJson() ([]byte, error) {
 		return []byte{}, nil
 	}
 
-	resp := &rfqmsg.JsonAssetChannel{}
+	resp := &rfqmsg.JsonAssetChannel{
+		Capacity:            OutputSum(c.OpenChan.Assets()),
+		LocalBalance:        c.LocalCommit.LocalAssets.Val.Sum(),
+		RemoteBalance:       c.LocalCommit.RemoteAssets.Val.Sum(),
+		OutgoingHtlcBalance: c.LocalCommit.OutgoingHtlcAssets.Val.Sum(),
+		IncomingHtlcBalance: c.LocalCommit.IncomingHtlcAssets.Val.Sum(),
+	}
+
+	// First, we encode the funding state, which lists all assets committed
+	// to the channel at the time of channel opening.
 	for _, output := range c.OpenChan.Assets() {
 		a := output.Proof.Val.Asset
 
 		assetID := a.ID()
-		utxo := rfqmsg.JsonAssetUtxo{
+		resp.FundingAssets = append(resp.FundingAssets, rfqmsg.JsonAssetUtxo{
 			Version: int64(a.Version),
 			AssetGenesis: rfqmsg.JsonAssetGenesis{
 				GenesisPoint: a.FirstPrevOut.String(),
@@ -82,14 +105,21 @@ func (c *ChannelCustomData) AsJson() ([]byte, error) {
 				a.ScriptKey.PubKey.SerializeCompressed(),
 			),
 			DecimalDisplay: c.OpenChan.DecimalDisplay.Val,
-		}
-		resp.Assets = append(resp.Assets, rfqmsg.JsonAssetChanInfo{
-			AssetInfo:     utxo,
-			Capacity:      output.Amount.Val,
-			LocalBalance:  c.LocalCommit.LocalAssets.Val.Sum(),
-			RemoteBalance: c.LocalCommit.RemoteAssets.Val.Sum(),
 		})
 	}
+
+	resp.LocalAssets = outputsToJsonTranches(
+		c.LocalCommit.LocalAssets.Val.Outputs,
+	)
+	resp.RemoteAssets = outputsToJsonTranches(
+		c.LocalCommit.RemoteAssets.Val.Outputs,
+	)
+	resp.OutgoingHtlcs = outputsToJsonTranches(
+		c.LocalCommit.OutgoingHtlcAssets.Val.Outputs(),
+	)
+	resp.IncomingHtlcs = outputsToJsonTranches(
+		c.LocalCommit.IncomingHtlcAssets.Val.Outputs(),
+	)
 
 	return json.Marshal(resp)
 }

--- a/tapchannelmsg/custom_channel_data.go
+++ b/tapchannelmsg/custom_channel_data.go
@@ -448,6 +448,60 @@ func ParseCustomChannelData(msg proto.Message) error {
 			rpcChannel.CustomChannelData = customData
 		}
 
+		for idx := range m.PendingForceClosingChannels {
+			pendingForceClose := m.PendingForceClosingChannels[idx]
+			rpcChannel := pendingForceClose.Channel
+
+			if rpcChannel == nil {
+				continue
+			}
+
+			customData, err := jsonFormatChannelCustomData(
+				rpcChannel.CustomChannelData,
+			)
+			if err != nil {
+				return err
+			}
+
+			rpcChannel.CustomChannelData = customData
+		}
+
+		for idx := range m.WaitingCloseChannels {
+			waitingClose := m.WaitingCloseChannels[idx]
+			rpcChannel := waitingClose.Channel
+
+			if rpcChannel == nil {
+				continue
+			}
+
+			customData, err := jsonFormatChannelCustomData(
+				rpcChannel.CustomChannelData,
+			)
+			if err != nil {
+				return err
+			}
+
+			rpcChannel.CustomChannelData = customData
+		}
+
+	case *lnrpc.ClosedChannelsResponse:
+		for idx := range m.Channels {
+			rpcChannel := m.Channels[idx]
+
+			if rpcChannel == nil {
+				continue
+			}
+
+			customData, err := jsonFormatChannelCustomData(
+				rpcChannel.CustomChannelData,
+			)
+			if err != nil {
+				return err
+			}
+
+			rpcChannel.CustomChannelData = customData
+		}
+
 	case *lnrpc.CloseStatusUpdate:
 		closeUpd, ok := m.Update.(*lnrpc.CloseStatusUpdate_ChanClose)
 		if !ok {

--- a/tapchannelmsg/custom_channel_data_test.go
+++ b/tapchannelmsg/custom_channel_data_test.go
@@ -1,0 +1,285 @@
+package tapchannelmsg
+
+import (
+	"bytes"
+	"encoding/hex"
+	"encoding/json"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/taproot-assets/fn"
+	"github.com/lightninglabs/taproot-assets/internal/test"
+	"github.com/lightninglabs/taproot-assets/rfqmsg"
+	"github.com/lightningnetwork/lnd/lnwallet"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	hexStr = func(bytes []byte) string {
+		return hex.EncodeToString(bytes)
+	}
+	pubKeyHexStr = func(pubKey *btcec.PublicKey) string {
+		return hex.EncodeToString(pubKey.SerializeCompressed())
+	}
+)
+
+// TestReadChannelCustomData tests that we can read the custom data from a
+// channel state response and format it as JSON.
+func TestReadChannelCustomData(t *testing.T) {
+	proof1 := randProof(t)
+	proof2 := randProof(t)
+	assetID1 := proof1.Asset.ID()
+	assetID2 := proof2.Asset.ID()
+	output1 := NewAssetOutput(assetID1, 1000, proof1)
+	output2 := NewAssetOutput(assetID2, 2000, proof2)
+
+	fundingState := NewOpenChannel([]*AssetOutput{output1, output2}, 11)
+	commitState := NewCommitment(
+		[]*AssetOutput{output1}, []*AssetOutput{output2}, nil, nil,
+		lnwallet.CommitAuxLeaves{},
+	)
+
+	fundingBlob := fundingState.Bytes()
+	commitBlob := commitState.Bytes()
+
+	var customChannelData bytes.Buffer
+	require.NoError(t, wire.WriteVarBytes(
+		&customChannelData, 0, fundingBlob,
+	))
+	require.NoError(t, wire.WriteVarBytes(
+		&customChannelData, 0, commitBlob,
+	))
+
+	channelJSON, err := jsonFormatChannelCustomData(
+		customChannelData.Bytes(),
+	)
+	require.NoError(t, err)
+
+	var formattedJSON bytes.Buffer
+	err = json.Indent(&formattedJSON, channelJSON, "", "  ")
+	require.NoError(t, err)
+
+	expected := `{
+  "assets": [
+    {
+      "asset_utxo": {
+        "version": 0,
+        "asset_genesis": {
+          "genesis_point": "` + proof1.Asset.FirstPrevOut.String() + `",
+          "name": "` + proof1.Asset.Tag + `",
+          "meta_hash": "` + hexStr(proof1.Asset.MetaHash[:]) + `",
+          "asset_id": "` + hexStr(assetID1[:]) + `"
+        },
+        "amount": 1,
+        "script_key": "` + pubKeyHexStr(proof1.Asset.ScriptKey.PubKey) + `",
+        "decimal_display": 11
+      },
+      "capacity": 3000,
+      "local_balance": 1000,
+      "remote_balance": 2000
+    },
+    {
+      "asset_utxo": {
+        "version": 0,
+        "asset_genesis": {
+          "genesis_point": "` + proof2.Asset.FirstPrevOut.String() + `",
+          "name": "` + proof2.Asset.Tag + `",
+          "meta_hash": "` + hexStr(proof2.Asset.MetaHash[:]) + `",
+          "asset_id": "` + hexStr(assetID2[:]) + `"
+        },
+        "amount": 1,
+        "script_key": "` + pubKeyHexStr(proof2.Asset.ScriptKey.PubKey) + `",
+        "decimal_display": 11
+      },
+      "capacity": 3000,
+      "local_balance": 1000,
+      "remote_balance": 2000
+    }
+  ]
+}`
+	require.Equal(t, expected, formattedJSON.String())
+}
+
+// TestReadBalanceCustomData tests that we can read the custom data from a
+// channel balance response and format it as JSON.
+func TestReadBalanceCustomData(t *testing.T) {
+	proof1 := randProof(t)
+	proof2 := randProof(t)
+	proof3 := randProof(t)
+	assetID1 := proof1.Asset.ID()
+	assetID2 := proof2.Asset.ID()
+	assetID3 := proof3.Asset.ID()
+	output1 := NewAssetOutput(assetID1, 1000, proof1)
+	output2 := NewAssetOutput(assetID2, 2000, proof2)
+	output3 := NewAssetOutput(assetID3, 3000, proof3)
+
+	openChannel1 := NewCommitment(
+		[]*AssetOutput{output1}, []*AssetOutput{output2}, nil, nil,
+		lnwallet.CommitAuxLeaves{},
+	)
+	openChannel2 := NewCommitment(
+		[]*AssetOutput{output2}, []*AssetOutput{output3}, nil, nil,
+		lnwallet.CommitAuxLeaves{},
+	)
+	pendingChannel1 := NewCommitment(
+		[]*AssetOutput{output3}, nil, nil, nil,
+		lnwallet.CommitAuxLeaves{},
+	)
+	pendingChannel2 := NewCommitment(
+		nil, []*AssetOutput{output1}, nil, nil,
+		lnwallet.CommitAuxLeaves{},
+	)
+
+	var customChannelData bytes.Buffer
+	require.NoError(t, wire.WriteVarInt(&customChannelData, 0, 2))
+	require.NoError(t, wire.WriteVarBytes(
+		&customChannelData, 0, openChannel1.Bytes(),
+	))
+	require.NoError(t, wire.WriteVarBytes(
+		&customChannelData, 0, openChannel2.Bytes(),
+	))
+	require.NoError(t, wire.WriteVarInt(&customChannelData, 0, 2))
+	require.NoError(t, wire.WriteVarBytes(
+		&customChannelData, 0, pendingChannel1.Bytes(),
+	))
+	require.NoError(t, wire.WriteVarBytes(
+		&customChannelData, 0, pendingChannel2.Bytes(),
+	))
+
+	channelJSON, err := jsonFormatBalanceCustomData(
+		customChannelData.Bytes(),
+	)
+	require.NoError(t, err)
+
+	var formattedJSON bytes.Buffer
+	err = json.Indent(&formattedJSON, channelJSON, "", "  ")
+	require.NoError(t, err)
+
+	// The results are in a map, so the order can't be predicted. But we
+	// have distinct balances, so we can just make sure the expected values
+	// appear in the JSON.
+	expectedOpen1 := `"` + hexStr(assetID1[:]) + `": {
+      "asset_id": "` + hexStr(assetID1[:]) + `",
+      "name": "` + proof1.Asset.Tag + `",
+      "local_balance": 1000,
+      "remote_balance": 0
+    }`
+	expectedOpen2 := `"` + hexStr(assetID2[:]) + `": {
+      "asset_id": "` + hexStr(assetID2[:]) + `",
+      "name": "` + proof2.Asset.Tag + `",
+      "local_balance": 2000,
+      "remote_balance": 2000
+    }`
+	expectedOpen3 := `"` + hexStr(assetID3[:]) + `": {
+      "asset_id": "` + hexStr(assetID3[:]) + `",
+      "name": "` + proof3.Asset.Tag + `",
+      "local_balance": 0,
+      "remote_balance": 3000
+    }`
+
+	expectedPending1 := `"` + hexStr(assetID1[:]) + `": {
+      "asset_id": "` + hexStr(assetID1[:]) + `",
+      "name": "` + proof1.Asset.Tag + `",
+      "local_balance": 0,
+      "remote_balance": 1000
+    }`
+	expectedPending2 := `"` + hexStr(assetID3[:]) + `": {
+      "asset_id": "` + hexStr(assetID3[:]) + `",
+      "name": "` + proof3.Asset.Tag + `",
+      "local_balance": 3000,
+      "remote_balance": 0
+    }`
+
+	require.Contains(t, formattedJSON.String(), expectedOpen1)
+	require.Contains(t, formattedJSON.String(), expectedOpen2)
+	require.Contains(t, formattedJSON.String(), expectedOpen3)
+	require.Contains(t, formattedJSON.String(), expectedPending1)
+	require.Contains(t, formattedJSON.String(), expectedPending2)
+}
+
+// TestCloseOutCustomData tests that we can read the custom data from a channel
+// close response and format it as JSON.
+func TestCloseOutCustomData(t *testing.T) {
+	testAssetInternalKey := test.RandPubKey(t)
+	testBtcInternalKey := test.RandPubKey(t)
+
+	testScriptKeys := make(ScriptKeyMap)
+
+	const numScriptKeys = 10
+	for i := 0; i < numScriptKeys; i++ {
+		testScriptKeys[[32]byte{byte(i)}] = *test.RandPubKey(t)
+	}
+
+	shutdownMsg := NewAuxShutdownMsg(
+		testBtcInternalKey, testAssetInternalKey,
+		testScriptKeys, nil,
+	)
+
+	var customChannelData bytes.Buffer
+	require.NoError(t, shutdownMsg.Encode(&customChannelData))
+
+	channelJSON, err := jsonFormatCloseOutCustomData(
+		customChannelData.Bytes(),
+	)
+	require.NoError(t, err)
+
+	var formattedJSON bytes.Buffer
+	err = json.Indent(&formattedJSON, channelJSON, "", "  ")
+	require.NoError(t, err)
+
+	expectedStart := `{
+  "btc_internal_key": "` + pubKeyHexStr(testBtcInternalKey) + `",
+  "asset_internal_key": "` + pubKeyHexStr(testAssetInternalKey) + `",
+  "script_keys": {`
+	require.Contains(t, formattedJSON.String(), expectedStart)
+
+	for id, key := range testScriptKeys {
+		expected := `"` + hexStr(id[:]) + `": "` +
+			pubKeyHexStr(&key) + `"`
+		require.Contains(t, formattedJSON.String(), expected)
+	}
+}
+
+// TestHtlcCustomData tests that we can read the custom data from a HTLC
+// response and format it as JSON.
+func TestHtlcCustomData(t *testing.T) {
+	assetID1 := [32]byte{1}
+	assetID2 := [32]byte{2}
+	assetID3 := [32]byte{3}
+	rfqID := rfqmsg.ID{0, 1, 2, 3, 4, 5, 6, 7}
+	htlc := rfqmsg.NewHtlc([]*rfqmsg.AssetBalance{
+		rfqmsg.NewAssetBalance(assetID1, 1000),
+		rfqmsg.NewAssetBalance(assetID2, 2000),
+		rfqmsg.NewAssetBalance(assetID3, 5000),
+	}, fn.Some(rfqID))
+
+	var customChannelData bytes.Buffer
+	require.NoError(t, htlc.Encode(&customChannelData))
+
+	channelJSON, err := jsonFormatHtlcCustomData(customChannelData.Bytes())
+	require.NoError(t, err)
+
+	var formattedJSON bytes.Buffer
+	err = json.Indent(&formattedJSON, channelJSON, "", "  ")
+	require.NoError(t, err)
+
+	expected := `{
+  "balances": [
+    {
+      "asset_id": "` + hexStr(assetID1[:]) + `",
+      "amount": 1000
+    },
+    {
+      "asset_id": "` + hexStr(assetID2[:]) + `",
+      "amount": 2000
+    },
+    {
+      "asset_id": "` + hexStr(assetID3[:]) + `",
+      "amount": 5000
+    }
+  ],
+  "rfq_id": "` + hexStr(rfqID[:]) + `"
+}`
+	require.Equal(t, expected, formattedJSON.String())
+}

--- a/tapchannelmsg/custom_channel_data_test.go
+++ b/tapchannelmsg/custom_channel_data_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/lightninglabs/taproot-assets/fn"
 	"github.com/lightninglabs/taproot-assets/internal/test"
 	"github.com/lightninglabs/taproot-assets/rfqmsg"
+	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/stretchr/testify/require"
 )
@@ -29,15 +30,25 @@ var (
 func TestReadChannelCustomData(t *testing.T) {
 	proof1 := randProof(t)
 	proof2 := randProof(t)
+	proof3 := randProof(t)
+	proof4 := randProof(t)
 	assetID1 := proof1.Asset.ID()
 	assetID2 := proof2.Asset.ID()
+	assetID3 := proof3.Asset.ID()
+	assetID4 := proof4.Asset.ID()
 	output1 := NewAssetOutput(assetID1, 1000, proof1)
 	output2 := NewAssetOutput(assetID2, 2000, proof2)
+	output3 := NewAssetOutput(assetID3, 3000, proof3)
+	output4 := NewAssetOutput(assetID4, 4000, proof4)
 
 	fundingState := NewOpenChannel([]*AssetOutput{output1, output2}, 11)
 	commitState := NewCommitment(
-		[]*AssetOutput{output1}, []*AssetOutput{output2}, nil, nil,
-		lnwallet.CommitAuxLeaves{},
+		[]*AssetOutput{output1}, []*AssetOutput{output2},
+		map[input.HtlcIndex][]*AssetOutput{
+			1: {output3},
+		}, map[input.HtlcIndex][]*AssetOutput{
+			2: {output4},
+		}, lnwallet.CommitAuxLeaves{},
 	)
 
 	fundingBlob := fundingState.Bytes()
@@ -61,42 +72,61 @@ func TestReadChannelCustomData(t *testing.T) {
 	require.NoError(t, err)
 
 	expected := `{
-  "assets": [
+  "funding_assets": [
     {
-      "asset_utxo": {
-        "version": 0,
-        "asset_genesis": {
-          "genesis_point": "` + proof1.Asset.FirstPrevOut.String() + `",
-          "name": "` + proof1.Asset.Tag + `",
-          "meta_hash": "` + hexStr(proof1.Asset.MetaHash[:]) + `",
-          "asset_id": "` + hexStr(assetID1[:]) + `"
-        },
-        "amount": 1,
-        "script_key": "` + pubKeyHexStr(proof1.Asset.ScriptKey.PubKey) + `",
-        "decimal_display": 11
+      "version": 0,
+      "asset_genesis": {
+        "genesis_point": "` + proof1.Asset.FirstPrevOut.String() + `",
+        "name": "` + proof1.Asset.Tag + `",
+        "meta_hash": "` + hexStr(proof1.Asset.MetaHash[:]) + `",
+        "asset_id": "` + hexStr(assetID1[:]) + `"
       },
-      "capacity": 3000,
-      "local_balance": 1000,
-      "remote_balance": 2000
+      "amount": 1,
+      "script_key": "` + pubKeyHexStr(proof1.Asset.ScriptKey.PubKey) + `",
+      "decimal_display": 11
     },
     {
-      "asset_utxo": {
-        "version": 0,
-        "asset_genesis": {
-          "genesis_point": "` + proof2.Asset.FirstPrevOut.String() + `",
-          "name": "` + proof2.Asset.Tag + `",
-          "meta_hash": "` + hexStr(proof2.Asset.MetaHash[:]) + `",
-          "asset_id": "` + hexStr(assetID2[:]) + `"
-        },
-        "amount": 1,
-        "script_key": "` + pubKeyHexStr(proof2.Asset.ScriptKey.PubKey) + `",
-        "decimal_display": 11
+      "version": 0,
+      "asset_genesis": {
+        "genesis_point": "` + proof2.Asset.FirstPrevOut.String() + `",
+        "name": "` + proof2.Asset.Tag + `",
+        "meta_hash": "` + hexStr(proof2.Asset.MetaHash[:]) + `",
+        "asset_id": "` + hexStr(assetID2[:]) + `"
       },
-      "capacity": 3000,
-      "local_balance": 1000,
-      "remote_balance": 2000
+      "amount": 1,
+      "script_key": "` + pubKeyHexStr(proof2.Asset.ScriptKey.PubKey) + `",
+      "decimal_display": 11
     }
-  ]
+  ],
+  "local_assets": [
+    {
+      "asset_id": "` + hexStr(assetID1[:]) + `",
+      "amount": 1000
+    }
+  ],
+  "remote_assets": [
+    {
+      "asset_id": "` + hexStr(assetID2[:]) + `",
+      "amount": 2000
+    }
+  ],
+  "outgoing_htlcs": [
+    {
+      "asset_id": "` + hexStr(assetID3[:]) + `",
+      "amount": 3000
+    }
+  ],
+  "incoming_htlcs": [
+    {
+      "asset_id": "` + hexStr(assetID4[:]) + `",
+      "amount": 4000
+    }
+  ],
+  "capacity": 3000,
+  "local_balance": 1000,
+  "remote_balance": 2000,
+  "outgoing_htlc_balance": 3000,
+  "incoming_htlc_balance": 4000
 }`
 	require.Equal(t, expected, formattedJSON.String())
 }

--- a/tapchannelmsg/records.go
+++ b/tapchannelmsg/records.go
@@ -19,6 +19,7 @@ import (
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/tlv"
+	"golang.org/x/exp/maps"
 )
 
 const (
@@ -1323,6 +1324,21 @@ func OutputSum(outputs []*AssetOutput) uint64 {
 // associated with a particular HTLC index.
 type HtlcAssetOutput struct {
 	HtlcOutputs map[input.HtlcIndex]AssetOutputListRecord
+}
+
+// Sum returns the sum of the amounts of all the asset outputs in the list.
+func (h *HtlcAssetOutput) Sum() uint64 {
+	return OutputSum(h.Outputs())
+}
+
+// Outputs returns a flat list of all the asset outputs in the list.
+func (h *HtlcAssetOutput) Outputs() []*AssetOutput {
+	return fn.FlatMap(
+		maps.Values(h.HtlcOutputs),
+		func(r AssetOutputListRecord) []*AssetOutput {
+			return r.Outputs
+		},
+	)
 }
 
 // NewHtlcAssetOutput creates a new HtlcAssetOutput record with the given HTLC

--- a/tapchannelmsg/records_test.go
+++ b/tapchannelmsg/records_test.go
@@ -35,10 +35,8 @@ var (
 	)
 )
 
-// TestOpenChannel tests encoding and decoding of the OpenChannel struct.
-func TestOpenChannel(t *testing.T) {
-	t.Parallel()
-
+// randProof creates a new, random proof.
+func randProof(t *testing.T) proof.Proof {
 	oddTxBlockHex, err := os.ReadFile(oddTxBlockHexFileName)
 	require.NoError(t, err)
 
@@ -53,12 +51,16 @@ func TestOpenChannel(t *testing.T) {
 
 	randGen := asset.RandGenesis(t, asset.Normal)
 	scriptKey1 := test.RandPubKey(t)
-	originalRandProof := proof.RandProof(
-		t, randGen, scriptKey1, oddTxBlock, 0, 1,
-	)
+	return proof.RandProof(t, randGen, scriptKey1, oddTxBlock, 0, 1)
+}
+
+// TestOpenChannel tests encoding and decoding of the OpenChannel struct.
+func TestOpenChannel(t *testing.T) {
+	t.Parallel()
 
 	// Proofs don't Encode everything, so we need to do a quick Encode/
 	// Decode cycle to make sure we can compare it afterward.
+	originalRandProof := randProof(t)
 	proofBytes, err := proof.Encode(&originalRandProof)
 	require.NoError(t, err)
 	randProof, err := proof.Decode(proofBytes)
@@ -183,26 +185,9 @@ func TestAuxLeaves(t *testing.T) {
 func TestCommitment(t *testing.T) {
 	t.Parallel()
 
-	oddTxBlockHex, err := os.ReadFile(oddTxBlockHexFileName)
-	require.NoError(t, err)
-
-	oddTxBlockBytes, err := hex.DecodeString(
-		strings.Trim(string(oddTxBlockHex), "\n"),
-	)
-	require.NoError(t, err)
-
-	var oddTxBlock wire.MsgBlock
-	err = oddTxBlock.Deserialize(bytes.NewReader(oddTxBlockBytes))
-	require.NoError(t, err)
-
-	randGen := asset.RandGenesis(t, asset.Normal)
-	scriptKey1 := test.RandPubKey(t)
-	originalRandProof := proof.RandProof(
-		t, randGen, scriptKey1, oddTxBlock, 0, 1,
-	)
-
 	// Proofs don't Encode everything, so we need to do a quick Encode/
 	// Decode cycle to make sure we can compare it afterward.
+	originalRandProof := randProof(t)
 	proofBytes, err := proof.Encode(&originalRandProof)
 	require.NoError(t, err)
 	randProof, err := proof.Decode(proofBytes)


### PR DESCRIPTION
Depends on https://github.com/lightningnetwork/lnd/pull/9504.

Improves the structure of the asset channel related JSON data for multi-asset (group key) support.