### PR TITLE
tapdb+universe: implement new Universe tree for 1st party burns

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -5148,11 +5148,11 @@ func (r *rpcServer) DeleteAssetRoot(ctx context.Context,
 func marshalLeafKey(leafKey universe.LeafKey) *unirpc.AssetKey {
 	return &unirpc.AssetKey{
 		Outpoint: &unirpc.AssetKey_OpStr{
-			OpStr: leafKey.OutPoint.String(),
+			OpStr: leafKey.LeafOutPoint().String(),
 		},
 		ScriptKey: &unirpc.AssetKey_ScriptKeyBytes{
 			ScriptKeyBytes: schnorr.SerializePubKey(
-				leafKey.ScriptKey.PubKey,
+				leafKey.LeafScriptKey().PubKey,
 			),
 		},
 	}
@@ -5287,7 +5287,7 @@ func (r *rpcServer) AssetLeaves(ctx context.Context,
 
 // unmarshalLeafKey un-marshals a leaf key from the RPC form.
 func unmarshalLeafKey(key *unirpc.AssetKey) (universe.LeafKey, error) {
-	var leafKey universe.LeafKey
+	var leafKey universe.BaseLeafKey
 
 	switch {
 	case key.GetScriptKeyBytes() != nil:
@@ -5537,7 +5537,7 @@ func unmarshalUniverseKey(key *unirpc.UniverseKey) (universe.Identifier,
 
 	var (
 		uniID  = universe.Identifier{}
-		uniKey = universe.LeafKey{}
+		uniKey = universe.BaseLeafKey{}
 		err    error
 	)
 
@@ -5550,12 +5550,12 @@ func unmarshalUniverseKey(key *unirpc.UniverseKey) (universe.Identifier,
 		return uniID, uniKey, err
 	}
 
-	uniKey, err = unmarshalLeafKey(key.LeafKey)
+	leafKey, err := unmarshalLeafKey(key.LeafKey)
 	if err != nil {
 		return uniID, uniKey, err
 	}
 
-	return uniID, uniKey, nil
+	return uniID, leafKey, nil
 }
 
 // unmarshalAssetLeaf unmarshals an asset leaf from the RPC form.

--- a/tapdb/burn_tree.go
+++ b/tapdb/burn_tree.go
@@ -27,65 +27,18 @@ func NewBurnUniverseTree(db BatchedUniverseTree) *BurnUniverseTree {
 	return &BurnUniverseTree{db: db}
 }
 
-// burnSpecifierToIdentifier converts an asset.Specifier into a
-// universe.Identifier for the burn tree.
-func burnSpecifierToIdentifier(spec asset.Specifier) (universe.Identifier,
-	error) {
-
-	var id universe.Identifier
-
-	// The specifier must have a group key to be able to be used within the
-	// ignore tree context.
-	if !spec.HasGroupPubKey() {
-		return id, fmt.Errorf("group key must be set")
-	}
-
-	id.GroupKey = spec.UnwrapGroupKeyToPtr()
-	id.ProofType = universe.ProofTypeBurn
-
-	return id, nil
-}
-
 // Sum returns the sum of the burn leaves for the given asset.
 func (bt *BurnUniverseTree) Sum(ctx context.Context,
 	spec asset.Specifier) universe.BurnTreeSum {
 
 	// Derive identifier from the asset.Specifier.
-	id, err := burnSpecifierToIdentifier(spec)
+	id, err := specifierToIdentifier(spec, universe.ProofTypeBurn)
 	if err != nil {
 		return lfn.Err[lfn.Option[uint64]](err)
 	}
-	namespace := id.String()
 
-	var sumOpt lfn.Option[uint64]
-
-	readTx := NewBaseUniverseReadTx()
-	txErr := bt.db.ExecTx(ctx, &readTx, func(db BaseUniverseStore) error {
-		tree := mssmt.NewCompactedTree(
-			newTreeStoreWrapperTx(db, namespace),
-		)
-
-		// Get the root of the tree to retrieve the sum.
-		root, err := tree.Root(ctx)
-		if err != nil {
-			return err
-		}
-
-		// If root is empty, return empty sum.
-		if root.NodeHash() == mssmt.EmptyTreeRootHash {
-			return nil
-		}
-
-		// Return the sum from the root.
-		sumOpt = lfn.Some(root.NodeSum())
-
-		return nil
-	})
-	if txErr != nil {
-		return lfn.Err[lfn.Option[uint64]](txErr)
-	}
-
-	return lfn.Ok(sumOpt)
+	// Use the generic helper to get the sum.
+	return getUniverseTreeSum(ctx, bt.db, id)
 }
 
 // ErrNotBurn is returned when a proof is not a burn proof.
@@ -108,7 +61,7 @@ func (bt *BurnUniverseTree) InsertBurns(ctx context.Context,
 
 	// Derive identifier (and thereby the namespace) from the
 	// asset.Specifier.
-	id, err := burnSpecifierToIdentifier(spec)
+	id, err := specifierToIdentifier(spec, universe.ProofTypeBurn)
 	if err != nil {
 		return lfn.Err[[]*universe.AuthenticatedBurnLeaf](err)
 	}
@@ -185,6 +138,122 @@ func (bt *BurnUniverseTree) InsertBurns(ctx context.Context,
 	return lfn.Ok(finalResults)
 }
 
+// queryBurnLeaves retrieves UniverseLeaf records based on burn OutPoints.
+func queryBurnLeaves(ctx context.Context, dbtx BaseUniverseStore,
+	spec asset.Specifier,
+	burnPoints ...wire.OutPoint) ([]UniverseLeaf, error) {
+
+	uniNamespace, err := specifierToIdentifier(
+		spec, universe.ProofTypeBurn,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("error deriving identifier: %w", err)
+	}
+
+	namespace := uniNamespace.String()
+
+	// If no burn points are provided, we query all leaves in the namespace.
+	if len(burnPoints) == 0 {
+		// If no specific points, query all leaves in the namespace.
+		dbLeaves, err := dbtx.QueryUniverseLeaves(
+			ctx, UniverseLeafQuery{
+				Namespace: namespace,
+			},
+		)
+		if errors.Is(err, sql.ErrNoRows) {
+			// No leaves found is not an error in this case.
+			return nil, sql.ErrNoRows
+		}
+		if err != nil {
+			return nil, fmt.Errorf("error querying all leaves "+
+				"for namespace %s: %w", &uniNamespace, err)
+		}
+
+		return dbLeaves, nil
+	}
+
+	// Otherwise, we'll query for leaves matching the burn points.
+	var leavesToQuery []UniverseLeaf
+	for _, burnPoint := range burnPoints {
+		burnPointBytes, err := encodeOutpoint(burnPoint)
+		if err != nil {
+			return nil, fmt.Errorf("unable to encode burn "+
+				"point %v: %w", burnPoint, err)
+		}
+
+		// Query leaves matching the burn point and namespace.
+		// ScriptKeyBytes is nil here as we want all script keys for
+		// this burn point.
+		dbLeaves, err := dbtx.QueryUniverseLeaves(
+			ctx, UniverseLeafQuery{
+				MintingPointBytes: burnPointBytes,
+				Namespace:         namespace,
+			},
+		)
+		if errors.Is(err, sql.ErrNoRows) {
+			continue
+		}
+		if err != nil {
+			return nil, fmt.Errorf("error querying leaves "+
+				"for burn point %v: %w", burnPoint, err)
+		}
+
+		leavesToQuery = append(leavesToQuery, dbLeaves...)
+	}
+
+	if len(leavesToQuery) == 0 {
+		// Return sql.ErrNoRows if no leaves were found.
+		return nil, sql.ErrNoRows
+	}
+
+	return leavesToQuery, nil
+}
+
+// decodeAndBuildAuthBurnLeaf decodes the raw leaf, reconstructs the key, and
+// builds the AuthenticatedBurnLeaf.
+func decodeAndBuildAuthBurnLeaf(dbLeaf UniverseLeaf) (
+	*universe.BurnLeaf, uniKey, error) {
+
+	var burnProof proof.Proof
+	err := burnProof.Decode(bytes.NewReader(dbLeaf.GenesisProof))
+	if err != nil {
+		return nil, uniKey{}, fmt.Errorf("unable to decode burn "+
+			"proof: %w", err)
+	}
+
+	// Reconstruct the LeafKey used for SMT insertion.
+	scriptPub, err := schnorr.ParsePubKey(dbLeaf.ScriptKeyBytes)
+	if err != nil {
+		return nil, uniKey{}, fmt.Errorf("unable to parse script "+
+			"key: %w", err)
+	}
+	scriptKey := asset.NewScriptKey(scriptPub)
+
+	leafKey := universe.LeafKey{
+		OutPoint:  burnProof.OutPoint(),
+		ScriptKey: &scriptKey,
+	}
+
+	burnLeaf := &universe.BurnLeaf{
+		UniverseKey: leafKey,
+		BurnProof:   &burnProof,
+	}
+
+	return burnLeaf, leafKey.UniverseKey(), nil
+}
+
+// buildAuthBurnLeaf constructs the final AuthenticatedBurnLeaf.
+func buildAuthBurnLeaf(decodedLeaf *universe.BurnLeaf,
+	inclusionProof *mssmt.Proof,
+	root mssmt.Node) *universe.AuthenticatedBurnLeaf {
+
+	return &universe.AuthenticatedBurnLeaf{
+		BurnLeaf:     decodedLeaf,
+		BurnTreeRoot: root,
+		BurnProof:    inclusionProof,
+	}
+}
+
 // QueryBurns attempts to query a set of burn leaves for the given asset
 // specifier. If the burn leaf points are empty, then all burn leaves are
 // returned.
@@ -193,151 +262,40 @@ func (bt *BurnUniverseTree) QueryBurns(ctx context.Context,
 	burnPoints ...wire.OutPoint) universe.BurnLeafQueryResp {
 
 	// Derive identifier from the asset.Specifier.
-	id, err := burnSpecifierToIdentifier(spec)
+	id, err := specifierToIdentifier(spec, universe.ProofTypeBurn)
 	if err != nil {
 		return lfn.Err[lfn.Option[[]*universe.AuthenticatedBurnLeaf]](
 			err,
 		)
 	}
-	namespace := id.String()
 
-	var resultLeaves []*universe.AuthenticatedBurnLeaf
+	// Use the generic list helper to list the leaves from the universe
+	// Tree. We pass in our custom decode function to handle the logic
+	// specific to BurnLeaf.
+	return queryUniverseLeavesAndProofs(
+		ctx, bt.db, spec, id, queryBurnLeaves,
+		decodeAndBuildAuthBurnLeaf, buildAuthBurnLeaf, burnPoints...,
+	)
+}
 
-	readTx := NewBaseUniverseReadTx()
-	txErr := bt.db.ExecTx(ctx, &readTx, func(db BaseUniverseStore) error {
-		// Create the tree within the transaction for getting root and
-		// proofs.
-		tree := mssmt.NewCompactedTree(
-			newTreeStoreWrapperTx(db, namespace),
-		)
-
-		// Get the tree root once for all queries. Handle the case
-		// where the tree might be empty.
-		root, err := tree.Root(ctx)
-		if err != nil {
-			return err
-		}
-
-		var leavesToQuery []UniverseLeaf
-
-		switch {
-		// If specific burn points are provided, query for each of them.
-		case len(burnPoints) > 0:
-			for _, burnPoint := range burnPoints {
-				burnPointBytes, err := encodeOutpoint(burnPoint)
-				if err != nil {
-					return fmt.Errorf("unable to encode "+
-						"burn point %v: %w", burnPoint,
-						err)
-				}
-
-				// Query leaves matching the burn point and
-				// namespace. ScriptKeyBytes is nil here as we
-				// want all script keys for this burn point.
-				dbLeaves, err := db.QueryUniverseLeaves(
-					ctx, UniverseLeafQuery{
-						MintingPointBytes: burnPointBytes, //nolint:lll
-						Namespace:         namespace,
-					},
-				)
-				if err != nil {
-					// If no rows found for a specific
-					// point, continue to the next.
-					if errors.Is(err, sql.ErrNoRows) {
-						continue
-					}
-					return fmt.Errorf("error querying "+
-						"leaves for burn point %v: %w",
-						burnPoint, err)
-				}
-
-				if len(dbLeaves) == 0 {
-					continue
-				}
-
-				leavesToQuery = append(
-					leavesToQuery, dbLeaves...,
-				)
-			}
-		// If no specific points, query all leaves in the namespace.
-		default:
-			dbLeaves, err := db.QueryUniverseLeaves(
-				ctx, UniverseLeafQuery{
-					Namespace: namespace,
-				},
-			)
-
-			// It's okay if no leaves are found in the namespace.
-			if err != nil && !errors.Is(err, sql.ErrNoRows) {
-				return fmt.Errorf("error querying all "+
-					"leaves for namespace %s: %w",
-					namespace, err)
-			}
-			leavesToQuery = dbLeaves
-		}
-
-		// Process the found leaves. We'll generate the inclusion proof
-		// for each leaf, and then construct the final authenticated
-		// resp.
-		for _, dbLeaf := range leavesToQuery {
-			// Decode the stored proof blob.
-			var burnProof proof.Proof
-			err = burnProof.Decode(
-				bytes.NewReader(dbLeaf.GenesisProof),
-			)
-			if err != nil {
-				return fmt.Errorf("unable to decode burn "+
-					"proof: %w", err)
-			}
-
-			// Reconstruct the LeafKey used for SMT insertion.
-			scriptPub, err := schnorr.ParsePubKey(
-				dbLeaf.ScriptKeyBytes,
-			)
-			if err != nil {
-				return fmt.Errorf("unable to parse script "+
-					"key: %w", err)
-			}
-			scriptKey := asset.NewScriptKey(scriptPub)
-
-			leafKey := universe.LeafKey{
-				OutPoint:  burnProof.OutPoint(),
-				ScriptKey: &scriptKey,
-			}
-			smtKey := leafKey.UniverseKey()
-
-			// Generate the inclusion proof.
-			inclusionProof, err := tree.MerkleProof(ctx, smtKey)
-			if err != nil {
-				return fmt.Errorf("error generating proof "+
-					"for smt key %x: %w", smtKey, err)
-			}
-
-			// Construct the final authenticated leaf.
-			authLeaf := &universe.AuthenticatedBurnLeaf{
-				BurnLeaf: &universe.BurnLeaf{
-					UniverseKey: leafKey,
-					BurnProof:   &burnProof,
-				},
-				BurnTreeRoot: root,
-				BurnProof:    inclusionProof,
-			}
-			resultLeaves = append(resultLeaves, authLeaf)
-		}
-
-		return nil
-	})
-	if txErr != nil {
-		return lfn.Err[lfn.Option[[]*universe.AuthenticatedBurnLeaf]](
-			txErr,
-		)
+// decodeBurnDesc decodes the raw bytes into a BurnDesc.
+func decodeBurnDesc(dbLeaf UniverseLeaf) (*universe.BurnDesc, error) {
+	var burnProof proof.Proof
+	err := burnProof.Decode(bytes.NewReader(dbLeaf.GenesisProof))
+	if err != nil {
+		return nil, fmt.Errorf("unable to decode burn proof: %w", err)
 	}
 
-	if len(resultLeaves) == 0 {
-		return lfn.Ok(lfn.None[[]*universe.AuthenticatedBurnLeaf]())
-	}
+	// Extract information for BurnDesc.
+	assetSpec := burnProof.Asset.Specifier()
+	amt := burnProof.Asset.Amount
+	burnPoint := burnProof.OutPoint()
 
-	return lfn.Ok(lfn.Some(resultLeaves))
+	return &universe.BurnDesc{
+		AssetSpec: assetSpec,
+		Amt:       amt,
+		BurnPoint: burnPoint,
+	}, nil
 }
 
 // ListBurns attempts to list all burn leaves for the given asset.
@@ -345,61 +303,13 @@ func (bt *BurnUniverseTree) ListBurns(ctx context.Context,
 	spec asset.Specifier) universe.ListBurnsResp {
 
 	// Derive identifier from the asset.Specifier.
-	id, err := burnSpecifierToIdentifier(spec)
+	id, err := specifierToIdentifier(spec, universe.ProofTypeBurn)
 	if err != nil {
 		return lfn.Err[lfn.Option[[]*universe.BurnDesc]](err)
 	}
-	namespace := id.String()
 
-	var burnDescs []*universe.BurnDesc
-
-	readTx := NewBaseUniverseReadTx()
-	txErr := bt.db.ExecTx(ctx, &readTx, func(db BaseUniverseStore) error {
-		// Query all leaves in the namespace.
-		universeLeaves, err := db.QueryUniverseLeaves(
-			ctx, UniverseLeafQuery{
-				Namespace: namespace,
-			},
-		)
-
-		// If no leaves are found, then we'll just return an empty list.
-		if err != nil && !errors.Is(err, sql.ErrNoRows) {
-			return nil
-		}
-
-		for _, dbLeaf := range universeLeaves {
-			var burnProof proof.Proof
-			err = burnProof.Decode(
-				bytes.NewReader(dbLeaf.GenesisProof),
-			)
-			if err != nil {
-				return fmt.Errorf("unable to decode burn "+
-					"proof: %w", err)
-			}
-
-			// Extract information for BurnDesc.
-			assetSpec := burnProof.Asset.Specifier()
-			amt := burnProof.Asset.Amount
-			burnPoint := burnProof.OutPoint()
-
-			burnDescs = append(burnDescs, &universe.BurnDesc{
-				AssetSpec: assetSpec,
-				Amt:       amt,
-				BurnPoint: burnPoint,
-			})
-		}
-
-		return nil
-	})
-	if txErr != nil {
-		return lfn.Err[lfn.Option[[]*universe.BurnDesc]](txErr)
-	}
-
-	if len(burnDescs) == 0 {
-		return lfn.Ok(lfn.None[[]*universe.BurnDesc]())
-	}
-
-	return lfn.Ok(lfn.Some(burnDescs))
+	// Use the generic list helper.
+	return listUniverseLeaves(ctx, bt.db, id, decodeBurnDesc)
 }
 
 // Compile-time assertion to ensure BurnUniverseTree implements the

--- a/tapdb/burn_tree.go
+++ b/tapdb/burn_tree.go
@@ -229,7 +229,7 @@ func decodeAndBuildAuthBurnLeaf(dbLeaf UniverseLeaf) (
 	}
 	scriptKey := asset.NewScriptKey(scriptPub)
 
-	leafKey := universe.LeafKey{
+	leafKey := universe.BaseLeafKey{
 		OutPoint:  burnProof.OutPoint(),
 		ScriptKey: &scriptKey,
 	}

--- a/tapdb/burn_tree.go
+++ b/tapdb/burn_tree.go
@@ -1,0 +1,407 @@
+package tapdb
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/taproot-assets/asset"
+	"github.com/lightninglabs/taproot-assets/mssmt"
+	"github.com/lightninglabs/taproot-assets/proof"
+	"github.com/lightninglabs/taproot-assets/universe"
+
+	lfn "github.com/lightningnetwork/lnd/fn/v2"
+)
+
+// BurnUniverseTree is a structure that holds the DB for burn operations.
+type BurnUniverseTree struct {
+	db BatchedUniverseTree
+}
+
+// NewBurnUniverseTree returns a new BurnUniverseTree with the target DB.
+func NewBurnUniverseTree(db BatchedUniverseTree) *BurnUniverseTree {
+	return &BurnUniverseTree{db: db}
+}
+
+// burnSpecifierToIdentifier converts an asset.Specifier into a
+// universe.Identifier for the burn tree.
+func burnSpecifierToIdentifier(spec asset.Specifier) (universe.Identifier,
+	error) {
+
+	var id universe.Identifier
+
+	// The specifier must have a group key to be able to be used within the
+	// ignore tree context.
+	if !spec.HasGroupPubKey() {
+		return id, fmt.Errorf("group key must be set")
+	}
+
+	id.GroupKey = spec.UnwrapGroupKeyToPtr()
+	id.ProofType = universe.ProofTypeBurn
+
+	return id, nil
+}
+
+// Sum returns the sum of the burn leaves for the given asset.
+func (bt *BurnUniverseTree) Sum(ctx context.Context,
+	spec asset.Specifier) universe.BurnTreeSum {
+
+	// Derive identifier from the asset.Specifier.
+	id, err := burnSpecifierToIdentifier(spec)
+	if err != nil {
+		return lfn.Err[lfn.Option[uint64]](err)
+	}
+	namespace := id.String()
+
+	var sumOpt lfn.Option[uint64]
+
+	readTx := NewBaseUniverseReadTx()
+	txErr := bt.db.ExecTx(ctx, &readTx, func(db BaseUniverseStore) error {
+		tree := mssmt.NewCompactedTree(
+			newTreeStoreWrapperTx(db, namespace),
+		)
+
+		// Get the root of the tree to retrieve the sum.
+		root, err := tree.Root(ctx)
+		if err != nil {
+			return err
+		}
+
+		// If root is empty, return empty sum.
+		if root.NodeHash() == mssmt.EmptyTreeRootHash {
+			return nil
+		}
+
+		// Return the sum from the root.
+		sumOpt = lfn.Some(root.NodeSum())
+
+		return nil
+	})
+	if txErr != nil {
+		return lfn.Err[lfn.Option[uint64]](txErr)
+	}
+
+	return lfn.Ok(sumOpt)
+}
+
+// ErrNotBurn is returned when a proof is not a burn proof.
+var ErrNotBurn = errors.New("not a burn proof")
+
+// InsertBurns attempts to insert a set of new burn leaves into the burn tree
+// identified by the passed asset.Specifier. If a given proof isn't a true burn
+// proof, then an error is returned. This check is performed upfront. If the
+// proof is valid, then the burn leaf is inserted into the tree, with a new
+// merkle proof returned.
+func (bt *BurnUniverseTree) InsertBurns(ctx context.Context,
+	spec asset.Specifier,
+	burnLeaves ...*universe.BurnLeaf) universe.BurnLeafResp {
+
+	if len(burnLeaves) == 0 {
+		return lfn.Err[[]*universe.AuthenticatedBurnLeaf](
+			fmt.Errorf("no burn leaves provided"),
+		)
+	}
+
+	// Derive identifier (and thereby the namespace) from the
+	// asset.Specifier.
+	id, err := burnSpecifierToIdentifier(spec)
+	if err != nil {
+		return lfn.Err[[]*universe.AuthenticatedBurnLeaf](err)
+	}
+
+	// Perform upfront validation for all proofs. Make sure that all the
+	// assets are actually burns.
+	for _, burnLeaf := range burnLeaves {
+		if !burnLeaf.BurnProof.Asset.IsBurn() {
+			return lfn.Err[[]*universe.AuthenticatedBurnLeaf](
+				fmt.Errorf("%w: proof for asset %v is not a "+
+					"burn proof, has type %v",
+					ErrNotBurn,
+					burnLeaf.BurnProof.Asset.ID(),
+					burnLeaf.BurnProof.Asset.Type),
+			)
+		}
+	}
+
+	var finalResults []*universe.AuthenticatedBurnLeaf
+
+	var writeTx BaseUniverseStoreOptions
+	txErr := bt.db.ExecTx(ctx, &writeTx, func(db BaseUniverseStore) error {
+		for _, burnLeaf := range burnLeaves {
+			leafKey := burnLeaf.UniverseKey
+
+			// Encode the burn proof to get the raw bytes.
+			var proofBuf bytes.Buffer
+			err := burnLeaf.BurnProof.Encode(&proofBuf)
+			if err != nil {
+				return fmt.Errorf("unable to encode burn "+
+					"proof: %w", err)
+			}
+			rawProofBytes := proofBuf.Bytes()
+
+			// Construct the universe.Leaf required by
+			// universeUpsertProofLeaf.
+			burnProof := burnLeaf.BurnProof
+			leaf := &universe.Leaf{
+				GenesisWithGroup: universe.GenesisWithGroup{
+					Genesis:  burnProof.Asset.Genesis,
+					GroupKey: burnProof.Asset.GroupKey,
+				},
+				RawProof: rawProofBytes,
+				Asset:    &burnLeaf.BurnProof.Asset,
+				Amt:      burnLeaf.BurnProof.Asset.Amount,
+			}
+
+			// Call the generic upsert function. MetaReveal is nil
+			// for burns, as this isn't an issuance instance. We
+			// also skip inserting into the multi-verse tree for
+			// now.
+			uniProof, err := universeUpsertProofLeaf(
+				ctx, db, id, leafKey, leaf, nil, true,
+			)
+			if err != nil {
+				return fmt.Errorf("unable to upsert burn "+
+					"leaf for key %v: %w", leafKey, err)
+			}
+
+			authLeaf := &universe.AuthenticatedBurnLeaf{
+				BurnLeaf:     burnLeaf,
+				BurnTreeRoot: uniProof.UniverseRoot,
+				BurnProof:    uniProof.UniverseInclusionProof,
+			}
+			finalResults = append(finalResults, authLeaf)
+		}
+
+		return nil
+	})
+	if txErr != nil {
+		return lfn.Err[[]*universe.AuthenticatedBurnLeaf](txErr)
+	}
+
+	return lfn.Ok(finalResults)
+}
+
+// QueryBurns attempts to query a set of burn leaves for the given asset
+// specifier. If the burn leaf points are empty, then all burn leaves are
+// returned.
+func (bt *BurnUniverseTree) QueryBurns(ctx context.Context,
+	spec asset.Specifier,
+	burnPoints ...wire.OutPoint) universe.BurnLeafQueryResp {
+
+	// Derive identifier from the asset.Specifier.
+	id, err := burnSpecifierToIdentifier(spec)
+	if err != nil {
+		return lfn.Err[lfn.Option[[]*universe.AuthenticatedBurnLeaf]](
+			err,
+		)
+	}
+	namespace := id.String()
+
+	var resultLeaves []*universe.AuthenticatedBurnLeaf
+
+	readTx := NewBaseUniverseReadTx()
+	txErr := bt.db.ExecTx(ctx, &readTx, func(db BaseUniverseStore) error {
+		// Create the tree within the transaction for getting root and
+		// proofs.
+		tree := mssmt.NewCompactedTree(
+			newTreeStoreWrapperTx(db, namespace),
+		)
+
+		// Get the tree root once for all queries. Handle the case
+		// where the tree might be empty.
+		root, err := tree.Root(ctx)
+		if err != nil {
+			return err
+		}
+
+		var leavesToQuery []UniverseLeaf
+
+		switch {
+		// If specific burn points are provided, query for each of them.
+		case len(burnPoints) > 0:
+			for _, burnPoint := range burnPoints {
+				burnPointBytes, err := encodeOutpoint(burnPoint)
+				if err != nil {
+					return fmt.Errorf("unable to encode "+
+						"burn point %v: %w", burnPoint,
+						err)
+				}
+
+				// Query leaves matching the burn point and
+				// namespace. ScriptKeyBytes is nil here as we
+				// want all script keys for this burn point.
+				dbLeaves, err := db.QueryUniverseLeaves(
+					ctx, UniverseLeafQuery{
+						MintingPointBytes: burnPointBytes, //nolint:lll
+						Namespace:         namespace,
+					},
+				)
+				if err != nil {
+					// If no rows found for a specific
+					// point, continue to the next.
+					if errors.Is(err, sql.ErrNoRows) {
+						continue
+					}
+					return fmt.Errorf("error querying "+
+						"leaves for burn point %v: %w",
+						burnPoint, err)
+				}
+
+				if len(dbLeaves) == 0 {
+					continue
+				}
+
+				leavesToQuery = append(
+					leavesToQuery, dbLeaves...,
+				)
+			}
+		// If no specific points, query all leaves in the namespace.
+		default:
+			dbLeaves, err := db.QueryUniverseLeaves(
+				ctx, UniverseLeafQuery{
+					Namespace: namespace,
+				},
+			)
+
+			// It's okay if no leaves are found in the namespace.
+			if err != nil && !errors.Is(err, sql.ErrNoRows) {
+				return fmt.Errorf("error querying all "+
+					"leaves for namespace %s: %w",
+					namespace, err)
+			}
+			leavesToQuery = dbLeaves
+		}
+
+		// Process the found leaves. We'll generate the inclusion proof
+		// for each leaf, and then construct the final authenticated
+		// resp.
+		for _, dbLeaf := range leavesToQuery {
+			// Decode the stored proof blob.
+			var burnProof proof.Proof
+			err = burnProof.Decode(
+				bytes.NewReader(dbLeaf.GenesisProof),
+			)
+			if err != nil {
+				return fmt.Errorf("unable to decode burn "+
+					"proof: %w", err)
+			}
+
+			// Reconstruct the LeafKey used for SMT insertion.
+			scriptPub, err := schnorr.ParsePubKey(
+				dbLeaf.ScriptKeyBytes,
+			)
+			if err != nil {
+				return fmt.Errorf("unable to parse script "+
+					"key: %w", err)
+			}
+			scriptKey := asset.NewScriptKey(scriptPub)
+
+			leafKey := universe.LeafKey{
+				OutPoint:  burnProof.OutPoint(),
+				ScriptKey: &scriptKey,
+			}
+			smtKey := leafKey.UniverseKey()
+
+			// Generate the inclusion proof.
+			inclusionProof, err := tree.MerkleProof(ctx, smtKey)
+			if err != nil {
+				return fmt.Errorf("error generating proof "+
+					"for smt key %x: %w", smtKey, err)
+			}
+
+			// Construct the final authenticated leaf.
+			authLeaf := &universe.AuthenticatedBurnLeaf{
+				BurnLeaf: &universe.BurnLeaf{
+					UniverseKey: leafKey,
+					BurnProof:   &burnProof,
+				},
+				BurnTreeRoot: root,
+				BurnProof:    inclusionProof,
+			}
+			resultLeaves = append(resultLeaves, authLeaf)
+		}
+
+		return nil
+	})
+	if txErr != nil {
+		return lfn.Err[lfn.Option[[]*universe.AuthenticatedBurnLeaf]](
+			txErr,
+		)
+	}
+
+	if len(resultLeaves) == 0 {
+		return lfn.Ok(lfn.None[[]*universe.AuthenticatedBurnLeaf]())
+	}
+
+	return lfn.Ok(lfn.Some(resultLeaves))
+}
+
+// ListBurns attempts to list all burn leaves for the given asset.
+func (bt *BurnUniverseTree) ListBurns(ctx context.Context,
+	spec asset.Specifier) universe.ListBurnsResp {
+
+	// Derive identifier from the asset.Specifier.
+	id, err := burnSpecifierToIdentifier(spec)
+	if err != nil {
+		return lfn.Err[lfn.Option[[]*universe.BurnDesc]](err)
+	}
+	namespace := id.String()
+
+	var burnDescs []*universe.BurnDesc
+
+	readTx := NewBaseUniverseReadTx()
+	txErr := bt.db.ExecTx(ctx, &readTx, func(db BaseUniverseStore) error {
+		// Query all leaves in the namespace.
+		universeLeaves, err := db.QueryUniverseLeaves(
+			ctx, UniverseLeafQuery{
+				Namespace: namespace,
+			},
+		)
+
+		// If no leaves are found, then we'll just return an empty list.
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			return nil
+		}
+
+		for _, dbLeaf := range universeLeaves {
+			var burnProof proof.Proof
+			err = burnProof.Decode(
+				bytes.NewReader(dbLeaf.GenesisProof),
+			)
+			if err != nil {
+				return fmt.Errorf("unable to decode burn "+
+					"proof: %w", err)
+			}
+
+			// Extract information for BurnDesc.
+			assetSpec := burnProof.Asset.Specifier()
+			amt := burnProof.Asset.Amount
+			burnPoint := burnProof.OutPoint()
+
+			burnDescs = append(burnDescs, &universe.BurnDesc{
+				AssetSpec: assetSpec,
+				Amt:       amt,
+				BurnPoint: burnPoint,
+			})
+		}
+
+		return nil
+	})
+	if txErr != nil {
+		return lfn.Err[lfn.Option[[]*universe.BurnDesc]](txErr)
+	}
+
+	if len(burnDescs) == 0 {
+		return lfn.Ok(lfn.None[[]*universe.BurnDesc]())
+	}
+
+	return lfn.Ok(lfn.Some(burnDescs))
+}
+
+// Compile-time assertion to ensure BurnUniverseTree implements the
+// universe.BurnTree interface.
+var _ universe.BurnTree = (*BurnUniverseTree)(nil)

--- a/tapdb/burn_tree.go
+++ b/tapdb/burn_tree.go
@@ -229,13 +229,16 @@ func decodeAndBuildAuthBurnLeaf(dbLeaf UniverseLeaf) (
 	}
 	scriptKey := asset.NewScriptKey(scriptPub)
 
-	leafKey := universe.BaseLeafKey{
-		OutPoint:  burnProof.OutPoint(),
-		ScriptKey: &scriptKey,
+	leafKey := universe.AssetLeafKey{
+		BaseLeafKey: universe.BaseLeafKey{
+			OutPoint:  burnProof.OutPoint(),
+			ScriptKey: &scriptKey,
+		},
+		AssetID: burnProof.Asset.ID(),
 	}
 
 	burnLeaf := &universe.BurnLeaf{
-		UniverseKey: leafKey,
+		UniverseKey: &leafKey,
 		BurnProof:   &burnProof,
 	}
 

--- a/tapdb/burn_tree_test.go
+++ b/tapdb/burn_tree_test.go
@@ -42,7 +42,7 @@ func createBurnLeaf(t *testing.T) *universe.BurnLeaf {
 	scriptKey := asset.RandScriptKey(t)
 
 	return &universe.BurnLeaf{
-		UniverseKey: universe.LeafKey{
+		UniverseKey: universe.BaseLeafKey{
 			OutPoint:  burnProof.OutPoint(),
 			ScriptKey: &scriptKey,
 		},
@@ -189,7 +189,7 @@ func TestBurnUniverseTreeInsertBurns(t *testing.T) {
 		}
 
 		nonBurnLeaf := &universe.BurnLeaf{
-			UniverseKey: universe.LeafKey{
+			UniverseKey: universe.BaseLeafKey{
 				OutPoint:  op,
 				ScriptKey: &a.ScriptKey,
 			},
@@ -270,10 +270,10 @@ func TestBurnUniverseTreeInsertBurns(t *testing.T) {
 		count := 0
 		for _, leaf := range queryLeaves {
 			//nolint:lll
-			if leaf.BurnLeaf.UniverseKey.OutPoint ==
-				burnLeaf.UniverseKey.OutPoint &&
-				leaf.BurnLeaf.UniverseKey.ScriptKey.PubKey.IsEqual(
-					burnLeaf.UniverseKey.ScriptKey.PubKey,
+			if leaf.BurnLeaf.UniverseKey.LeafOutPoint() ==
+				burnLeaf.UniverseKey.LeafOutPoint() &&
+				leaf.BurnLeaf.UniverseKey.LeafScriptKey().PubKey.IsEqual(
+					burnLeaf.UniverseKey.LeafScriptKey().PubKey,
 				) {
 
 				count++

--- a/tapdb/burn_tree_test.go
+++ b/tapdb/burn_tree_test.go
@@ -1,0 +1,612 @@
+package tapdb
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/taproot-assets/asset"
+	"github.com/lightninglabs/taproot-assets/internal/test"
+	"github.com/lightninglabs/taproot-assets/mssmt"
+	"github.com/lightninglabs/taproot-assets/proof"
+	"github.com/lightninglabs/taproot-assets/universe"
+	"github.com/stretchr/testify/require"
+)
+
+const numBurnLeaves = 10
+
+// createBurnAsset creates a burn asset for testing purposes.
+func createBurnAsset(t *testing.T) *asset.Asset {
+	a := asset.RandAsset(t, asset.Normal)
+
+	a.ScriptKey = asset.NewScriptKey(
+		asset.DeriveBurnKey(*a.PrevWitnesses[0].PrevID),
+	)
+
+	return a
+}
+
+// createBurnProof creates a valid burn proof for testing.
+func createBurnProof(t *testing.T) *proof.Proof {
+	a := createBurnAsset(t)
+
+	return randProof(t, a)
+}
+
+// createBurnLeaf creates a burn leaf from a burn proof.
+func createBurnLeaf(t *testing.T) *universe.BurnLeaf {
+	burnProof := createBurnProof(t)
+	scriptKey := asset.RandScriptKey(t)
+
+	return &universe.BurnLeaf{
+		UniverseKey: universe.LeafKey{
+			OutPoint:  burnProof.OutPoint(),
+			ScriptKey: &scriptKey,
+		},
+		BurnProof: burnProof,
+	}
+}
+
+// setupBurnTreeTest sets up a test environment for BurnUniverseTree testing.
+func setupBurnTreeTest(t *testing.T) (*BurnUniverseTree, asset.Specifier,
+	[]*universe.BurnLeaf) {
+
+	// Create the burn tree instance backed by the usual set of batched db
+	// abstractions.
+	sqlDB := NewTestDB(t)
+	dbTxer := NewTransactionExecutor(
+		sqlDB, func(tx *sql.Tx) BaseUniverseStore {
+			return sqlDB.WithTx(tx)
+		},
+	)
+	burnTree := NewBurnUniverseTree(dbTxer)
+
+	// Create a context for the test.
+	ctx := context.Background()
+
+	// Generate a random group key for testing.
+	groupPrivKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	groupPub := groupPrivKey.PubKey()
+	groupKey := asset.GroupKey{
+		GroupPubKey: *groupPub,
+	}
+
+	genesis := asset.RandGenesis(t, asset.Normal)
+	assetID := genesis.ID()
+
+	// Create an asset specifier with the group key.
+	spec, err := asset.NewSpecifier(
+		&assetID, &groupKey.GroupPubKey, nil, true,
+	)
+	require.NoError(t, err)
+
+	// Create burn leaves.
+	burnLeaves := make([]*universe.BurnLeaf, numBurnLeaves)
+	for i := 0; i < numBurnLeaves; i++ {
+		burnLeaves[i] = createBurnLeaf(t)
+
+		// Insert the asset genesis for each burn leaf into the DB.
+		burnAsset := burnLeaves[i].BurnProof.Asset
+		burnGenesis := burnAsset.Genesis
+		burnGenesisOutpoint := burnGenesis.FirstPrevOut
+
+		genesisPointID, err := upsertGenesisPoint(
+			ctx, dbTxer, burnGenesisOutpoint,
+		)
+		require.NoError(t, err)
+		_, err = upsertGenesis(ctx, dbTxer, genesisPointID, burnGenesis)
+		require.NoError(t, err)
+	}
+
+	genesisOutpoint := genesis.FirstPrevOut
+
+	// Insert the asset genesis, genesis point, and group key into the
+	// database. We'll need this to be able to create universe leaves
+	// properly.
+	genesisPointID, err := upsertGenesisPoint(ctx, dbTxer, genesisOutpoint)
+	require.NoError(t, err)
+	genAssetID, err := upsertGenesis(ctx, dbTxer, genesisPointID, genesis)
+	require.NoError(t, err)
+
+	_, err = upsertGroupKey(
+		ctx, &groupKey, dbTxer, genesisPointID, genAssetID,
+	)
+	require.NoError(t, err)
+
+	return burnTree, spec, burnLeaves
+}
+
+// TestBurnUniverseTreeInsertBurns tests the InsertBurns method.
+func TestBurnUniverseTreeInsertBurns(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	burnTree, spec, burnLeaves := setupBurnTreeTest(t)
+
+	// Test case 1: Inserting valid burn leaves should succeed.
+	t.Run("valid_insert", func(t *testing.T) {
+		result := burnTree.InsertBurns(ctx, spec, burnLeaves...)
+
+		authLeaves, err := result.Unpack()
+		require.NoError(t, err)
+
+		require.Len(t, authLeaves, numBurnLeaves)
+		for i, authLeaf := range authLeaves {
+			require.NotNil(t, authLeaf.BurnTreeRoot)
+			require.NotNil(t, authLeaf.BurnProof)
+			require.Equal(t, burnLeaves[i], authLeaf.BurnLeaf)
+
+			// The returned inclusion proof should be valid.
+			leafNode, err := authLeaf.BurnLeaf.UniverseLeafNode()
+			require.NoError(t, err)
+			key := authLeaf.BurnLeaf.UniverseKey.UniverseKey()
+
+			valid := mssmt.VerifyMerkleProof(
+				key, leafNode, authLeaf.BurnProof,
+				authLeaf.BurnTreeRoot,
+			)
+			require.True(t, valid)
+		}
+	})
+
+	// Test case 2: Inserting with no burn leaves should return an error.
+	t.Run("no_leaves", func(t *testing.T) {
+		result := burnTree.InsertBurns(ctx, spec)
+		require.Error(t, result.Err())
+		require.Contains(
+			t, result.Err().Error(), "no burn leaves provided",
+		)
+	})
+
+	// Test case 3: Inserting with a specifier without a group key should
+	// fail.
+	t.Run("no_group_key", func(t *testing.T) {
+		invalidSpec := asset.Specifier{}
+		result := burnTree.InsertBurns(
+			ctx, invalidSpec, burnLeaves...,
+		)
+		require.Error(t, result.Err())
+		require.Contains(
+			t, result.Err().Error(), "group key must be set",
+		)
+	})
+
+	// Test case 4: Inserting non-burn proof should fail.
+	t.Run("non_burn_proof", func(t *testing.T) {
+		// Create a non-burn leaf, the script key won't be an actual
+		// burn.
+		a := asset.RandAsset(t, asset.Normal)
+
+		op := test.RandOp(t)
+
+		nonBurnProof := &proof.Proof{
+			Asset:   *a,
+			PrevOut: op,
+		}
+
+		nonBurnLeaf := &universe.BurnLeaf{
+			UniverseKey: universe.LeafKey{
+				OutPoint:  op,
+				ScriptKey: &a.ScriptKey,
+			},
+			BurnProof: nonBurnProof,
+		}
+
+		result := burnTree.InsertBurns(ctx, spec, nonBurnLeaf)
+		require.Error(t, result.Err())
+		require.True(t, errors.Is(result.Err(), ErrNotBurn))
+	})
+
+	// Test case 5: Test idempotency - inserting the same burn leaf multiple
+	// times.
+	t.Run("idempotency", func(t *testing.T) {
+		// Create a new test environment to isolate the test.
+		burnTree, spec, burnLeaves := setupBurnTreeTest(t)
+
+		// Select a single burn leaf for the test.
+		burnLeaf := burnLeaves[0]
+
+		// Initial insertion.
+		result1 := burnTree.InsertBurns(ctx, spec, burnLeaf)
+		authLeaves1, err := result1.Unpack()
+		require.NoError(t, err)
+		require.Len(t, authLeaves1, 1)
+
+		// Store the root and proof from the first insertion.
+		originalRoot := authLeaves1[0].BurnTreeRoot
+
+		// Check sum after first insertion.
+		sumResult1 := burnTree.Sum(ctx, spec)
+		sumOpt1, err := sumResult1.Unpack()
+		require.NoError(t, err)
+
+		originalSum := sumOpt1.UnwrapOrFail(t)
+		require.Equal(t, burnLeaf.BurnProof.Asset.Amount, originalSum)
+
+		// Insert the same burn leaf again.
+		result2 := burnTree.InsertBurns(ctx, spec, burnLeaf)
+		authLeaves2, err := result2.Unpack()
+		require.NoError(t, err)
+		require.Len(t, authLeaves2, 1)
+
+		// The root should be the same as the original, indicating the
+		// tree didn't change.
+		require.Equal(
+			t, originalRoot.NodeHash(),
+			authLeaves2[0].BurnTreeRoot.NodeHash(),
+		)
+		require.Equal(
+			t, originalRoot.NodeSum(),
+			authLeaves2[0].BurnTreeRoot.NodeSum(),
+		)
+
+		// The sum should not change after inserting the same leaf
+		// again.
+		sumResult2 := burnTree.Sum(ctx, spec)
+		sumOpt2, err := sumResult2.Unpack()
+		require.NoError(t, err)
+
+		newSum := sumOpt2.UnwrapOrFail(t)
+		require.Equal(t, originalSum, newSum)
+
+		// Insert the same burn leaf a third time.
+		result3 := burnTree.InsertBurns(ctx, spec, burnLeaf)
+		require.NoError(t, result3.Err())
+
+		// Query for the burn leaf - should only find one instance.
+		queryResult := burnTree.QueryBurns(
+			ctx, spec, burnLeaf.BurnProof.OutPoint(),
+		)
+		queryOpt, err := queryResult.Unpack()
+		require.NoError(t, err)
+		queryLeaves := queryOpt.UnwrapOrFail(t)
+
+		// There should be exactly one leaf for this outpoint+scriptkey
+		// combination, not multiple.
+		count := 0
+		for _, leaf := range queryLeaves {
+			//nolint:lll
+			if leaf.BurnLeaf.UniverseKey.OutPoint ==
+				burnLeaf.UniverseKey.OutPoint &&
+				leaf.BurnLeaf.UniverseKey.ScriptKey.PubKey.IsEqual(
+					burnLeaf.UniverseKey.ScriptKey.PubKey,
+				) {
+
+				count++
+			}
+		}
+		require.Equal(
+			t, 1, count,
+			"expected only one leaf for the same UniverseKey",
+		)
+	})
+
+	// Test case 6: Test idempotency with multiple leaves, including
+	// duplicates.
+	t.Run("idempotency_multiple_leaves", func(t *testing.T) {
+		// Create a new test environment to isolate the test.
+		burnTree, spec, burnLeaves := setupBurnTreeTest(t)
+
+		// Initial insertion of all burn leaves.
+		result1 := burnTree.InsertBurns(ctx, spec, burnLeaves...)
+		require.NoError(t, result1.Err())
+
+		// Get the sum after inserting all leaves.
+		sumResult1 := burnTree.Sum(ctx, spec)
+		require.NoError(t, sumResult1.Err())
+		sumOpt1, err := sumResult1.Unpack()
+		require.NoError(t, err)
+		require.False(t, sumOpt1.IsNone())
+		originalSum := sumOpt1.UnwrapOrFail(t)
+
+		// Create a batch with some duplicates - first 3 leaves
+		// repeated.
+		duplicateBatch := append(
+			[]*universe.BurnLeaf{
+				burnLeaves[0],
+				burnLeaves[1],
+				burnLeaves[2],
+			},
+			burnLeaves...,
+		)
+
+		// Insert the batch with duplicates.
+		result2 := burnTree.InsertBurns(ctx, spec, duplicateBatch...)
+		require.NoError(t, result2.Err())
+
+		// The sum should not change after inserting duplicates.
+		sumResult2 := burnTree.Sum(ctx, spec)
+		require.NoError(t, sumResult2.Err())
+		sumOpt2, err := sumResult2.Unpack()
+		require.NoError(t, err)
+		require.False(t, sumOpt2.IsNone())
+		newSum := sumOpt2.UnwrapOrFail(t)
+		require.Equal(t, originalSum, newSum)
+
+		// ListBurns should show the correct number of unique burns.
+		listResult := burnTree.ListBurns(ctx, spec)
+		burnsOpt, err := listResult.Unpack()
+		require.NoError(t, err)
+
+		burnDescs := burnsOpt.UnwrapOrFail(t)
+		require.Len(
+			t, burnDescs, numBurnLeaves,
+			"expected burnDescs length to match original "+
+				"number of leaves",
+		)
+	})
+}
+
+// TestBurnUniverseTreeSum tests the Sum method.
+func TestBurnUniverseTreeSum(t *testing.T) {
+	t.Parallel()
+
+	burnTree, spec, burnLeaves := setupBurnTreeTest(t)
+
+	ctx := context.Background()
+
+	// Test case 1: Sum of an empty tree should return None.
+	t.Run("empty_tree", func(t *testing.T) {
+		result := burnTree.Sum(ctx, spec)
+		require.NoError(t, result.Err())
+
+		sumOption, err := result.Unpack()
+		require.NoError(t, err)
+		require.True(t, sumOption.IsNone())
+	})
+
+	// Test case 2: Sum after adding burn leaves should return their summed
+	// amount.
+	t.Run("with_burns", func(t *testing.T) {
+		// Insert the burn leaves first.
+		addResult := burnTree.InsertBurns(ctx, spec, burnLeaves...)
+		require.NoError(t, addResult.Err())
+
+		// Get the sum.
+		result := burnTree.Sum(ctx, spec)
+		require.NoError(t, result.Err())
+
+		// We should have a non-empty result with the correct sum>
+		sumOption, err := result.Unpack()
+		require.NoError(t, err)
+		require.False(t, sumOption.IsNone())
+
+		// Calculate the expected sum.
+		var expectedSum uint64
+		for _, leaf := range burnLeaves {
+			expectedSum += leaf.BurnProof.Asset.Amount
+		}
+
+		actualSum := sumOption.UnwrapOrFail(t)
+		require.Equal(t, expectedSum, actualSum)
+
+		// Add one more burn leaf and check sum is updated.
+		extraLeaf := createBurnLeaf(t)
+		extraAmount := extraLeaf.BurnProof.Asset.Amount
+
+		addResult = burnTree.InsertBurns(ctx, spec, extraLeaf)
+		require.NoError(t, addResult.Err())
+
+		newSumRes := burnTree.Sum(ctx, spec)
+		require.NoError(t, newSumRes.Err())
+
+		newSumOption, err := newSumRes.Unpack()
+		require.NoError(t, err)
+		require.False(t, newSumOption.IsNone())
+
+		newSum := newSumOption.UnwrapOrFail(t)
+		expectedNewSum := expectedSum + extraAmount
+		require.Equal(t, expectedNewSum, newSum)
+	})
+
+	// Test case 3: Failed sum from invalid specifier.
+	t.Run("invalid_specifier", func(t *testing.T) {
+		var invalidSpec asset.Specifier
+		result := burnTree.Sum(ctx, invalidSpec)
+		require.Error(t, result.Err())
+		require.Contains(
+			t, result.Err().Error(), "group key must be set",
+		)
+	})
+}
+
+// TestBurnUniverseTreeQueryBurns tests the QueryBurns method.
+func TestBurnUniverseTreeQueryBurns(t *testing.T) {
+	t.Parallel()
+
+	burnTree, spec, burnLeaves := setupBurnTreeTest(t)
+
+	ctx := context.Background()
+
+	// Test case 1: Query on empty tree should return None.
+	t.Run("empty_tree", func(t *testing.T) {
+		result := burnTree.QueryBurns(ctx, spec)
+		require.NoError(t, result.Err())
+
+		burnOption, err := result.Unpack()
+		require.NoError(t, err)
+		require.True(t, burnOption.IsNone())
+	})
+
+	// Test case 2: Query after inserting burns should return correct
+	// results.
+	t.Run("query_all", func(t *testing.T) {
+		// Insert the burn leaves first
+		addResult := burnTree.InsertBurns(ctx, spec, burnLeaves...)
+		require.NoError(t, addResult.Err())
+
+		// Query all burns.
+		result := burnTree.QueryBurns(ctx, spec)
+		require.NoError(t, result.Err())
+
+		burnOption, err := result.Unpack()
+		require.NoError(t, err)
+		require.False(t, burnOption.IsNone())
+
+		authLeaves := burnOption.UnwrapOrFail(t)
+		require.Len(t, authLeaves, numBurnLeaves)
+
+		// Verify each burn leaf has correct data and proofs.
+		for _, authLeaf := range authLeaves {
+			require.NotNil(t, authLeaf.BurnTreeRoot)
+			require.NotNil(t, authLeaf.BurnProof)
+			require.NotNil(t, authLeaf.BurnLeaf)
+			require.NotNil(t, authLeaf.BurnLeaf.BurnProof)
+
+			// The proofs should be valid.
+			leafNode, err := authLeaf.BurnLeaf.UniverseLeafNode()
+			require.NoError(t, err)
+			leafKey := authLeaf.BurnLeaf.UniverseKey
+			key := leafKey.UniverseKey()
+
+			valid := mssmt.VerifyMerkleProof(
+				key, leafNode, authLeaf.BurnProof,
+				authLeaf.BurnTreeRoot,
+			)
+			require.True(t, valid)
+		}
+	})
+
+	// Test case 3: Query specific burn points.
+	t.Run("query_specific_point", func(t *testing.T) {
+		// Insert the burn leaves first if not already done.
+		addResult := burnTree.InsertBurns(ctx, spec, burnLeaves...)
+		require.NoError(t, addResult.Err())
+
+		// Query for a specific burn point.
+		targetPoint := burnLeaves[0].BurnProof.OutPoint()
+		result := burnTree.QueryBurns(ctx, spec, targetPoint)
+		require.NoError(t, result.Err())
+
+		burnOption, err := result.Unpack()
+		require.NoError(t, err)
+		require.False(t, burnOption.IsNone())
+
+		authLeaves := burnOption.UnwrapOrFail(t)
+		require.NotEmpty(t, authLeaves)
+
+		// All returned leaves should match the target outpoint.
+		for _, authLeaf := range authLeaves {
+			require.Equal(
+				t, targetPoint,
+				authLeaf.BurnLeaf.BurnProof.OutPoint(),
+			)
+		}
+
+		// Query for a non-existent point.
+		nonExistentPoint := wire.OutPoint{
+			Index: 99999,
+		}
+		nonExistResult := burnTree.QueryBurns(
+			ctx, spec, nonExistentPoint,
+		)
+		require.NoError(t, nonExistResult.Err())
+
+		nonExistOption, err := nonExistResult.Unpack()
+		require.NoError(t, err)
+		require.True(t, nonExistOption.IsNone())
+	})
+
+	// Test case 4: Invalid specifier.
+	t.Run("invalid_specifier", func(t *testing.T) {
+		var invalidSpec asset.Specifier
+		result := burnTree.QueryBurns(ctx, invalidSpec)
+		require.Error(t, result.Err())
+		require.Contains(
+			t, result.Err().Error(), "group key must be set",
+		)
+	})
+}
+
+// TestBurnUniverseTreeListBurns tests the ListBurns method.
+func TestBurnUniverseTreeListBurns(t *testing.T) {
+	t.Parallel()
+
+	burnTree, spec, burnLeaves := setupBurnTreeTest(t)
+
+	ctx := context.Background()
+
+	// Test case 1: List from an empty tree should return None.
+	t.Run("empty_tree", func(t *testing.T) {
+		result := burnTree.ListBurns(ctx, spec)
+		require.NoError(t, result.Err())
+
+		burnsOption, err := result.Unpack()
+		require.NoError(t, err)
+		require.True(t, burnsOption.IsNone())
+	})
+
+	// Test case 2: List after adding burn leaves should return all burns
+	t.Run("with_burns", func(t *testing.T) {
+		// Insert the burn leaves first.
+		addResult := burnTree.InsertBurns(ctx, spec, burnLeaves...)
+		require.NoError(t, addResult.Err())
+
+		// List all burns.
+		result := burnTree.ListBurns(ctx, spec)
+		require.NoError(t, result.Err())
+
+		burnsOption, err := result.Unpack()
+		require.NoError(t, err)
+		require.False(t, burnsOption.IsNone())
+
+		burnDescs := burnsOption.UnwrapOrFail(t)
+		require.Len(t, burnDescs, numBurnLeaves)
+
+		// Verify the returned burn descriptions match our inserted
+		// leaves Create a map to help with verification.
+		burnMap := make(map[wire.OutPoint]*universe.BurnDesc)
+		for _, desc := range burnDescs {
+			burnMap[desc.BurnPoint] = desc
+		}
+
+		// Check each original leaf has a matching description.
+		for _, leaf := range burnLeaves {
+			burnPoint := leaf.BurnProof.OutPoint()
+			desc, found := burnMap[burnPoint]
+			require.True(t, found)
+
+			// Verify the data matches.
+			require.Equal(
+				t, int64(leaf.BurnProof.Asset.Amount),
+				int64(desc.Amt),
+			)
+			require.Equal(t, burnPoint, desc.BurnPoint)
+			assetSpec := leaf.BurnProof.Asset.Specifier()
+			require.Equal(t, assetSpec, desc.AssetSpec)
+		}
+
+		// Add another burn leaf and check it appears in the list.
+		extraLeaf := createBurnLeaf(t)
+		addResult = burnTree.InsertBurns(ctx, spec, extraLeaf)
+		require.NoError(t, addResult.Err())
+
+		newResult := burnTree.ListBurns(ctx, spec)
+		require.NoError(t, newResult.Err())
+
+		newBurnsOption, err := newResult.Unpack()
+		require.NoError(t, err)
+		require.False(t, newBurnsOption.IsNone())
+
+		newBurnDescs := newBurnsOption.UnwrapOrFail(t)
+		require.Len(t, newBurnDescs, numBurnLeaves+1)
+	})
+
+	// Test case 3: List with invalid specifier should fail.
+	t.Run("invalid_specifier", func(t *testing.T) {
+		invalidSpec := asset.Specifier{}
+		result := burnTree.ListBurns(ctx, invalidSpec)
+		require.Error(t, result.Err())
+		require.Contains(
+			t, result.Err().Error(), "group key must be set",
+		)
+	})
+}
+
+// A compile-time assertion to ensure BurnUniverseTree implements the
+// universe.BurnTree interface.
+var _ universe.BurnTree = (*BurnUniverseTree)(nil)

--- a/tapdb/burn_tree_test.go
+++ b/tapdb/burn_tree_test.go
@@ -42,9 +42,12 @@ func createBurnLeaf(t *testing.T) *universe.BurnLeaf {
 	scriptKey := asset.RandScriptKey(t)
 
 	return &universe.BurnLeaf{
-		UniverseKey: universe.BaseLeafKey{
-			OutPoint:  burnProof.OutPoint(),
-			ScriptKey: &scriptKey,
+		UniverseKey: universe.AssetLeafKey{
+			BaseLeafKey: universe.BaseLeafKey{
+				OutPoint:  burnProof.OutPoint(),
+				ScriptKey: &scriptKey,
+			},
+			AssetID: burnProof.Asset.ID(),
 		},
 		BurnProof: burnProof,
 	}
@@ -189,9 +192,12 @@ func TestBurnUniverseTreeInsertBurns(t *testing.T) {
 		}
 
 		nonBurnLeaf := &universe.BurnLeaf{
-			UniverseKey: universe.BaseLeafKey{
-				OutPoint:  op,
-				ScriptKey: &a.ScriptKey,
+			UniverseKey: universe.AssetLeafKey{
+				BaseLeafKey: universe.BaseLeafKey{
+					OutPoint:  op,
+					ScriptKey: &a.ScriptKey,
+				},
+				AssetID: a.ID(),
 			},
 			BurnProof: nonBurnProof,
 		}

--- a/tapdb/ignore_tree.go
+++ b/tapdb/ignore_tree.go
@@ -2,6 +2,8 @@ package tapdb
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 	"fmt"
 
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
@@ -22,21 +24,6 @@ func NewIgnoreUniverseTree(db BatchedUniverseTree) *IgnoreUniverseTree {
 	return &IgnoreUniverseTree{db: db}
 }
 
-// specifierToIdentifier converts an asset.Specifier into a universe.Identifier.
-func specifierToIdentifier(spec asset.Specifier) (universe.Identifier, error) {
-	var id universe.Identifier
-
-	groupKey, err := spec.UnwrapGroupKeyOrErr()
-	if err != nil {
-		return id, fmt.Errorf("group key must be set: %w", err)
-	}
-
-	id.GroupKey = groupKey
-
-	id.ProofType = universe.ProofTypeIgnore
-	return id, nil
-}
-
 // AddTuple adds a new ignore tuples to the ignore tree.
 func (it *IgnoreUniverseTree) AddTuples(ctx context.Context,
 	spec asset.Specifier, tuples ...universe.SignedIgnoreTuple,
@@ -50,7 +37,7 @@ func (it *IgnoreUniverseTree) AddTuples(ctx context.Context,
 
 	// Derive identifier (and thereby the namespace) from the
 	// asset.Specifier.
-	id, err := specifierToIdentifier(spec)
+	id, err := specifierToIdentifier(spec, universe.ProofTypeIgnore)
 	if err != nil {
 		return lfn.Err[universe.AuthIgnoreTuples](err)
 	}
@@ -171,98 +158,110 @@ func (it *IgnoreUniverseTree) Sum(ctx context.Context,
 	spec asset.Specifier) universe.SumQueryResp {
 
 	// Derive identifier from the asset.Specifier.
-	id, err := specifierToIdentifier(spec)
+	id, err := specifierToIdentifier(spec, universe.ProofTypeIgnore)
 	if err != nil {
 		return lfn.Err[lfn.Option[uint64]](err)
 	}
-	namespace := id.String()
 
-	var sumValue uint64
-	var foundSum bool
+	// Use the generic helper to get the sum of the universe tree.
+	return getUniverseTreeSum(ctx, it.db, id)
+}
 
-	readTx := NewBaseUniverseReadTx()
-	txErr := it.db.ExecTx(ctx, &readTx, func(db BaseUniverseStore) error {
-		tree := mssmt.NewCompactedTree(
-			newTreeStoreWrapperTx(db, namespace),
-		)
-
-		// Get the root of the tree to retrieve the sum.
-		root, err := tree.Root(ctx)
-		if err != nil {
-			return err
-		}
-
-		// If root is empty, return empty sum.
-		if root.NodeHash() == mssmt.EmptyTreeRootHash {
-			return nil
-		}
-
-		// Return the sum from the root.
-		sumValue = root.NodeSum()
-		foundSum = true
-		return nil
-	})
-	if txErr != nil {
-		return lfn.Err[lfn.Option[uint64]](txErr)
+// decodeIgnoreTuple decodes the raw bytes into an IgnoreTuple.
+func decodeIgnoreTuple(dbLeaf UniverseLeaf) (*universe.IgnoreTuple, error) {
+	signedTuple, err := universe.DecodeSignedIgnoreTuple(
+		dbLeaf.GenesisProof,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("error decoding signed ignore "+
+			"tuple: %w", err)
 	}
 
-	if !foundSum {
-		return lfn.Ok(lfn.None[uint64]())
-	}
-
-	return lfn.Ok(lfn.Some(sumValue))
+	return &signedTuple.IgnoreTuple.Val, nil
 }
 
 // ListTuples returns the list of ignore tuples for the given asset.
 func (it *IgnoreUniverseTree) ListTuples(ctx context.Context,
-	spec asset.Specifier) lfn.Result[[]*universe.IgnoreTuple] {
+	spec asset.Specifier) universe.ListTuplesResp {
 
 	// Derive identifier from the asset.Specifier.
-	id, err := specifierToIdentifier(spec)
+	id, err := specifierToIdentifier(spec, universe.ProofTypeIgnore)
 	if err != nil {
-		return lfn.Err[[]*universe.IgnoreTuple](err)
+		return lfn.Err[lfn.Option[universe.IgnoreTuples]](err)
 	}
 
-	namespace := id.String()
+	// Use the generic list helper to list the leaves from the universe
+	// Tree. We pass in our custom decode function to handle the logic
+	// specific to IgnoreTuples.
+	return listUniverseLeaves(ctx, it.db, id, decodeIgnoreTuple)
+}
 
-	var tuples []*universe.IgnoreTuple
+// queryIgnoreLeaves retrieves UniverseLeaf records based on IgnoreTuple
+// criteria.
+func queryIgnoreLeaves(ctx context.Context, dbtx BaseUniverseStore,
+	spec asset.Specifier,
+	tuples ...universe.IgnoreTuple) ([]UniverseLeaf, error) {
 
-	readTx := NewBaseUniverseReadTx()
-	txErr := it.db.ExecTx(ctx, &readTx, func(db BaseUniverseStore) error {
-		// To list all the tuples, we'll just query for all the universe
-		// leaves for this namespace. The namespace is derived from the
-		// group key, and the proof type, which in this case is ignore.
-		universeLeaves, err := db.QueryUniverseLeaves(
-			ctx, UniverseLeafQuery{
-				Namespace: namespace,
-			},
-		)
+	uniNamespace, err := specifierToIdentifier(
+		spec, universe.ProofTypeIgnore,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("error deriving identifier: %w", err)
+	}
+
+	var allLeaves []UniverseLeaf
+	for _, queryTuple := range tuples {
+		// Create a leaf query for this specific key.
+		//
+		// TODO(roasbeef): need a more specific key here?
+		//   * also add outpoint?
+		scriptKey := queryTuple.ScriptKey
+		leafQuery := UniverseLeafQuery{
+			ScriptKeyBytes: scriptKey.SchnorrSerialized(),
+			Namespace:      uniNamespace.String(),
+		}
+
+		leaves, err := dbtx.QueryUniverseLeaves(ctx, leafQuery)
+
+		// We'll continue on to the next query if no leaves are found
+		// for this query.
+		if errors.Is(err, sql.ErrNoRows) {
+			continue
+		}
 		if err != nil {
-			return err
+			return nil, fmt.Errorf("error querying leaf for tuple "+
+				"(script_key=%x): %w", leafQuery.ScriptKeyBytes,
+				err)
 		}
 
-		for _, leaf := range universeLeaves {
-			leafBytes := leaf.GenesisProof
-
-			tuple, err := universe.DecodeSignedIgnoreTuple(
-				leafBytes,
-			)
-			if err != nil {
-				return fmt.Errorf("error decoding tuple: "+
-					"%w", err)
-			}
-
-			tuples = append(tuples, &tuple.IgnoreTuple.Val)
+		// Since the query is specific, we expect at most one leaf.
+		if len(leaves) > 0 {
+			allLeaves = append(allLeaves, leaves[0])
 		}
-
-		return nil
-	})
-
-	if txErr != nil {
-		return lfn.Err[[]*universe.IgnoreTuple](txErr)
 	}
 
-	return lfn.Ok(tuples)
+	// Return sql.ErrNoRows if no leaves were found across all tuples.
+	if len(allLeaves) == 0 {
+		return nil, sql.ErrNoRows
+	}
+
+	return allLeaves, nil
+}
+
+// parseDbSignedIgnoreTuple decodes the raw leaf, reconstructs the key, and
+// builds the AuthenticatedIgnoreTuple.
+func parseDbSignedIgnoreTuple(dbLeaf UniverseLeaf,
+) (universe.SignedIgnoreTuple, uniKey, error) {
+
+	signedTuple, err := universe.DecodeSignedIgnoreTuple(
+		dbLeaf.GenesisProof,
+	)
+	if err != nil {
+		return universe.SignedIgnoreTuple{}, uniKey{},
+			fmt.Errorf("error decoding tuple: %w", err)
+	}
+
+	return signedTuple, signedTuple.UniverseKey(), nil
 }
 
 // QueryTuples returns the ignore tuples for the given asset.
@@ -275,104 +274,19 @@ func (it *IgnoreUniverseTree) QueryTuples(ctx context.Context,
 	}
 
 	// Derive identifier from the asset.Specifier.
-	id, err := specifierToIdentifier(spec)
+	id, err := specifierToIdentifier(spec, universe.ProofTypeIgnore)
 	if err != nil {
 		return lfn.Err[lfn.Option[[]universe.AuthenticatedIgnoreTuple]](
 			err,
 		)
 	}
 
-	namespace := id.String()
-
-	var (
-		resultTuples []universe.AuthenticatedIgnoreTuple
-		foundAny     bool
+	// Use the generic query helper, which will handle: doing the initial
+	// query, decoding the ignore tuples, and finally building the merkle
+	// proof for the tuples.
+	return queryUniverseLeavesAndProofs(
+		ctx, it.db, spec, id, queryIgnoreLeaves,
+		parseDbSignedIgnoreTuple, universe.NewAuthIgnoreTuple,
+		queryTuples...,
 	)
-
-	readTx := NewBaseUniverseReadTx()
-	txErr := it.db.ExecTx(ctx, &readTx, func(db BaseUniverseStore) error {
-		// Create the tree within the transaction for getting root and
-		// proofs.
-		tree := mssmt.NewCompactedTree(
-			newTreeStoreWrapperTx(db, namespace),
-		)
-
-		// Get the tree root once for all queries
-		root, err := tree.Root(ctx)
-		if err != nil {
-			return err
-		}
-
-		for _, queryTuple := range queryTuples {
-			// Generate the SMT key for the query tuple.
-			smtKey := queryTuple.Hash()
-
-			// Create a leaf query for this specific key.
-			scriptKey := queryTuple.ScriptKey
-			leafQuery := UniverseLeafQuery{
-				ScriptKeyBytes: scriptKey.SchnorrSerialized(),
-				Namespace:      namespace,
-			}
-
-			leaves, err := db.QueryUniverseLeaves(
-				ctx, leafQuery,
-			)
-			if err != nil {
-				return fmt.Errorf("error querying leaf "+
-					"for tuple: %w", err)
-			}
-
-			// Skip if no leaves found for this tuple.
-			//
-			// TODO(roasbeef): move to slice of results? then can
-			// see if one failed or not for each
-			if len(leaves) == 0 {
-				continue
-			}
-
-			// Get the first leaf (there should only be one for this
-			// specific key).
-			rawLeaf := leaves[0].GenesisProof
-
-			// With the key, we can generate the inclusion proof for
-			// this tuple.
-			proof, err := tree.MerkleProof(ctx, smtKey)
-			if err != nil {
-				return fmt.Errorf("error generating proof for "+
-					"tuple: %w", err)
-			}
-
-			// With all the data gathered, we can now create the
-			// signed tuple along side the universe root and its
-			// inclusion proof.
-			signedTuple, err := universe.DecodeSignedIgnoreTuple(
-				rawLeaf,
-			)
-			if err != nil {
-				return fmt.Errorf("error deserializing "+
-					"tuple: %w", err)
-			}
-			tup := universe.AuthenticatedIgnoreTuple{
-				SignedIgnoreTuple: signedTuple,
-				InclusionProof:    proof,
-				IgnoreTreeRoot:    root,
-			}
-			resultTuples = append(resultTuples, tup)
-
-			foundAny = true
-		}
-
-		return nil
-	})
-	if txErr != nil {
-		return lfn.Err[lfn.Option[[]universe.AuthenticatedIgnoreTuple]](
-			txErr,
-		)
-	}
-
-	if !foundAny {
-		return lfn.Ok(lfn.None[[]universe.AuthenticatedIgnoreTuple]())
-	}
-
-	return lfn.Ok(lfn.Some(resultTuples))
 }

--- a/tapdb/ignore_tree_test.go
+++ b/tapdb/ignore_tree_test.go
@@ -286,13 +286,15 @@ func TestIgnoreUniverseTreeListTuples(t *testing.T) {
 		// that we added.
 		resTuples, err := ignoreTree.ListTuples(ctx, spec).Unpack()
 		require.NoError(t, err)
-		require.Len(t, resTuples, 10)
+
+		dbTuples := resTuples.UnwrapOrFail(t)
+		require.Len(t, dbTuples, 10)
 
 		// To make our next assertion easier, we'll create a map of the
 		// results keyed by their asset ID, then use that to assert that
 		// all the tuples are found and identical.
 		tupleMap := make(map[[32]byte]*universe.IgnoreTuple)
-		for _, tuple := range resTuples {
+		for _, tuple := range dbTuples {
 			tupleMap[tuple.ID] = tuple
 		}
 
@@ -313,7 +315,8 @@ func TestIgnoreUniverseTreeListTuples(t *testing.T) {
 		newTuples, err := ignoreTree.ListTuples(ctx, spec).Unpack()
 		require.NoError(t, err)
 
-		require.Len(t, newTuples, len(signedTuples)+1)
+		dbTuples = newTuples.UnwrapOrFail(t)
+		require.Len(t, dbTuples, len(signedTuples)+1)
 	})
 
 	// Test case 3: List with invalid specifier should fail.

--- a/tapdb/multiverse.go
+++ b/tapdb/multiverse.go
@@ -698,7 +698,7 @@ func (b *MultiverseStore) FetchProof(ctx context.Context,
 			ProofType: universe.ProofTypeTransfer,
 		}
 		scriptKey := asset.NewScriptKey(&loc.ScriptKey)
-		leafKey := universe.LeafKey{
+		leafKey := universe.BaseLeafKey{
 			ScriptKey: &scriptKey,
 		}
 		if loc.OutPoint != nil {
@@ -1028,7 +1028,7 @@ func (b *MultiverseStore) RegisterSubscriber(
 			ProofType: universe.ProofTypeTransfer,
 		}
 		scriptKey := asset.NewScriptKey(&loc.ScriptKey)
-		key := universe.LeafKey{
+		key := universe.BaseLeafKey{
 			ScriptKey: &scriptKey,
 		}
 

--- a/tapdb/multiverse.go
+++ b/tapdb/multiverse.go
@@ -766,7 +766,7 @@ func (b *MultiverseStore) UpsertProofLeaf(ctx context.Context,
 		// tree.
 		var err error
 		issuanceProof, err = universeUpsertProofLeaf(
-			ctx, dbTx, id, key, leaf, metaReveal,
+			ctx, dbTx, id, key, leaf, metaReveal, false,
 		)
 		if err != nil {
 			return err
@@ -812,7 +812,7 @@ func (b *MultiverseStore) UpsertProofLeafBatch(ctx context.Context,
 		// tree.
 		return universeUpsertProofLeaf(
 			ctx, dbTx, item.ID, item.Key, item.Leaf,
-			item.MetaReveal,
+			item.MetaReveal, false,
 		)
 	}
 

--- a/tapdb/sqlutils_test.go
+++ b/tapdb/sqlutils_test.go
@@ -191,7 +191,7 @@ func (d *DbHandler) AddUniProofLeaf(t *testing.T, testAsset *asset.Asset,
 	// populate the universe root and universe leaves tables.
 	uniId := universe.NewUniIDFromAsset(*testAsset)
 
-	leafKey := universe.LeafKey{
+	leafKey := universe.BaseLeafKey{
 		OutPoint:  annotatedProof.AssetSnapshot.OutPoint,
 		ScriptKey: &testAsset.ScriptKey,
 	}

--- a/tapdb/universe.go
+++ b/tapdb/universe.go
@@ -15,6 +15,7 @@ import (
 	"github.com/lightninglabs/taproot-assets/proof"
 	"github.com/lightninglabs/taproot-assets/tapdb/sqlc"
 	"github.com/lightninglabs/taproot-assets/universe"
+	lfn "github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/lightningnetwork/lnd/keychain"
 )
 
@@ -110,6 +111,245 @@ type BaseUniverseStore interface {
 	// DeleteMultiverseLeaf deletes a multiverse leaf from the database.
 	DeleteMultiverseLeaf(ctx context.Context,
 		arg DeleteMultiverseLeaf) error
+}
+
+// specifierToIdentifier converts an asset.Specifier into a universe.Identifier
+// for a specific proof type.
+//
+// NOTE: This makes an assumption that only specifiers with a group key are
+// valid.
+func specifierToIdentifier(spec asset.Specifier,
+	proofType universe.ProofType) (universe.Identifier, error) {
+
+	var id universe.Identifier
+
+	// The specifier must have a group key to be able to be used within the
+	// ignore or burn tree context.
+	if !spec.HasGroupPubKey() {
+		return id, fmt.Errorf("group key must be set for proof type %v",
+			proofType)
+	}
+
+	id.GroupKey = spec.UnwrapGroupKeyToPtr()
+	id.ProofType = proofType
+
+	return id, nil
+}
+
+// getUniverseTreeSum retrieves the sum of a universe tree specified by its
+// identifier.
+func getUniverseTreeSum(ctx context.Context, db BatchedUniverseTree,
+	id universe.Identifier) universe.SumQueryResp {
+
+	namespace := id.String()
+	var sumOpt lfn.Option[uint64]
+
+	readTx := NewBaseUniverseReadTx()
+	txErr := db.ExecTx(ctx, &readTx, func(dbtx BaseUniverseStore) error {
+		tree := mssmt.NewCompactedTree(
+			newTreeStoreWrapperTx(dbtx, namespace),
+		)
+
+		// Get the root of the tree to retrieve the sum.
+		root, err := tree.Root(ctx)
+		if err != nil {
+			return err
+		}
+
+		// If root is empty, return empty sum.
+		if root.NodeHash() == mssmt.EmptyTreeRootHash {
+			return nil
+		}
+
+		// Return the sum from the root.
+		sumOpt = lfn.Some(root.NodeSum())
+		return nil
+	})
+	if txErr != nil {
+		return lfn.Err[lfn.Option[uint64]](txErr)
+	}
+
+	// If sumOpt was never set (empty tree), return None explicitly.
+	if !sumOpt.IsSome() {
+		return lfn.Ok(lfn.None[uint64]())
+	}
+
+	return lfn.Ok(sumOpt)
+}
+
+// uniKey is a type alias for a 32-byte array used as a key in the universe
+// tree.
+type uniKey = [32]byte
+
+// universeLeafQueryFunc defines the function signature for retrieving
+// UniverseLeaf records based on specific query parameters.
+type universeLeafQueryFunc[QueryType any] func(context.Context,
+	BaseUniverseStore, asset.Specifier, ...QueryType,
+) ([]UniverseLeaf, error)
+
+// universeLeafDecodeFunc defines the function signature for decoding a raw
+// proof from a UniverseLeaf into a specific type and extracting the universe
+// key.
+type universeLeafDecodeFunc[DecodedLeafType any] func(
+	UniverseLeaf,
+) (DecodedLeafType, uniKey, error)
+
+// authProofBuilder defines the function signature for constructing the final
+// authenticated proof structure using the decoded leaf, the SMT proof, and the
+// SMT root.
+type authProofBuilder[DecodedLeafType any, AuthProofType any] func(
+	DecodedLeafType, *mssmt.Proof, mssmt.Node,
+) AuthProofType
+
+// queryUniverseLeavesAndProofs executes a query against universe leaves,
+// fetches their inclusion proofs, and builds authenticated results.
+//
+// The LeafType is the concrete type of the leaf, AuthType is the
+// type of the wrapper of the LeafType that includes MS-SMT merkle proof
+// info, and finally the QueryType is the type that is used to query the leaves.
+func queryUniverseLeavesAndProofs[LeafType any, AuthType any, QueryType any](
+	ctx context.Context, db BatchedUniverseTree, assetSpec asset.Specifier,
+	id universe.Identifier, leafQuery universeLeafQueryFunc[QueryType],
+	leafDecode universeLeafDecodeFunc[LeafType],
+	proofBuild authProofBuilder[LeafType, AuthType],
+	queryParams ...QueryType) lfn.Result[lfn.Option[[]AuthType]] {
+
+	namespace := id.String()
+	var (
+		resultAuths []AuthType
+		foundAny    bool
+	)
+
+	readTx := NewBaseUniverseReadTx()
+	txErr := db.ExecTx(ctx, &readTx, func(dbtx BaseUniverseStore) error {
+		tree := mssmt.NewCompactedTree(
+			newTreeStoreWrapperTx(dbtx, namespace),
+		)
+
+		root, err := tree.Root(ctx)
+		if err != nil {
+			return fmt.Errorf("unable to get tree root: %w", err)
+		}
+
+		// If the root is the empty hash, there are no leaves.
+		if root.NodeHash() == mssmt.EmptyTreeRootHash {
+			return nil
+		}
+
+		// First, we'll query for the set of leaves using the query
+		// params.
+		leavesToQuery, err := leafQuery(
+			ctx, dbtx, assetSpec, queryParams...,
+		)
+		if err != nil {
+			// It's okay if no leaves match the query.
+			if errors.Is(err, sql.ErrNoRows) {
+				return nil
+			}
+			return fmt.Errorf("error querying leaves: %w", err)
+		}
+
+		if len(leavesToQuery) == 0 {
+			return nil
+		}
+
+		// Mark that we found leaves matching the query.
+		foundAny = true
+
+		// At this point, we have responses, so we'll decode them,
+		// generate a merkle proof using the leaf key, then finally
+		// assembled the final result which includes the merkle proofs.
+		for _, dbLeaf := range leavesToQuery {
+			decodedLeaf, leafKey, err := leafDecode(dbLeaf)
+			if err != nil {
+				return fmt.Errorf("error decoding "+
+					"leaf: %w", err)
+			}
+
+			inclusionProof, err := tree.MerkleProof(ctx, leafKey)
+			if err != nil {
+				// If proof generation fails for a specific key,
+				// it might indicate inconsistency. Return
+				// error.
+				return fmt.Errorf("error generating proof for "+
+					"smt key %x: %w", leafKey, err)
+			}
+
+			authResult := proofBuild(
+				decodedLeaf, inclusionProof, root,
+			)
+
+			resultAuths = append(resultAuths, authResult)
+		}
+
+		return nil
+	})
+	if txErr != nil {
+		return lfn.Err[lfn.Option[[]AuthType]](txErr)
+	}
+
+	if !foundAny {
+		return lfn.Ok(lfn.None[[]AuthType]())
+	}
+
+	return lfn.Ok(lfn.Some(resultAuths))
+}
+
+// listUniverseLeaves retrieves and decodes all leaves within a universe
+// namespace.
+//
+// We accept and return an abstract type T, which can be created by reading the
+// raw value of the universe leaf, and decoding that.
+//
+// decodeFunc decodes the raw proof bytes from a UniverseLeaf into the
+// desired domain-specific type.
+func listUniverseLeaves[T any](ctx context.Context, db BatchedUniverseTree,
+	id universe.Identifier, decodeFunc func(UniverseLeaf) (T, error),
+) lfn.Result[lfn.Option[[]T]] {
+
+	namespace := id.String()
+	var results []T
+
+	readTx := NewBaseUniverseReadTx()
+	txErr := db.ExecTx(ctx, &readTx, func(dbtx BaseUniverseStore) error {
+		universeLeaves, err := dbtx.QueryUniverseLeaves(
+			ctx, UniverseLeafQuery{
+				Namespace: namespace,
+			},
+		)
+
+		// If no leaves are found, return successfully with empty
+		// results.
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("error querying universe leaves: %w",
+				err)
+		}
+
+		for _, dbLeaf := range universeLeaves {
+			decodedResult, err := decodeFunc(dbLeaf)
+			if err != nil {
+				// If decoding fails for one leaf, return error.
+				return fmt.Errorf(
+					"error decoding leaf: %w", err,
+				)
+			}
+			results = append(results, decodedResult)
+		}
+
+		return nil
+	})
+	if txErr != nil {
+		return lfn.Err[lfn.Option[[]T]](txErr)
+	}
+
+	if len(results) == 0 {
+		return lfn.Ok(lfn.None[[]T]())
+	}
+
+	return lfn.Ok(lfn.Some(results))
 }
 
 // BaseUniverseStoreOptions is the set of options for universe tree queries.

--- a/tapdb/universe_federation.go
+++ b/tapdb/universe_federation.go
@@ -319,7 +319,7 @@ func (u *UniverseFederationDB) UpsertFederationProofSyncLog(
 
 	// Encode the leaf key outpoint as bytes. We'll use this to look up the
 	// leaf ID in the DB.
-	leafKeyOutpointBytes, err := encodeOutpoint(leafKey.OutPoint)
+	leafKeyOutpointBytes, err := encodeOutpoint(leafKey.LeafOutPoint())
 	if err != nil {
 		return 0, err
 	}
@@ -327,7 +327,7 @@ func (u *UniverseFederationDB) UpsertFederationProofSyncLog(
 	// Encode the leaf script key pub key as bytes. We'll use this to look
 	// up the leaf ID in the DB.
 	scriptKeyPubKeyBytes := schnorr.SerializePubKey(
-		leafKey.ScriptKey.PubKey,
+		leafKey.LeafScriptKey().PubKey,
 	)
 
 	var (
@@ -369,7 +369,7 @@ func (u *UniverseFederationDB) QueryFederationProofSyncLog(
 
 	// Encode the leaf key outpoint as bytes. We'll use this to look up the
 	// leaf ID in the DB.
-	leafKeyOutpointBytes, err := encodeOutpoint(leafKey.OutPoint)
+	leafKeyOutpointBytes, err := encodeOutpoint(leafKey.LeafOutPoint())
 	if err != nil {
 		return nil, err
 	}
@@ -377,7 +377,7 @@ func (u *UniverseFederationDB) QueryFederationProofSyncLog(
 	// Encode the leaf script key pub key as bytes. We'll use this to look
 	// up the leaf ID in the DB.
 	scriptKeyPubKeyBytes := schnorr.SerializePubKey(
-		leafKey.ScriptKey.PubKey,
+		leafKey.LeafScriptKey().PubKey,
 	)
 
 	var (
@@ -531,7 +531,7 @@ func fetchProofSyncLogEntry(ctx context.Context, entry ProofSyncLogEntry,
 		return nil, err
 	}
 
-	leafKey := universe.LeafKey{
+	leafKey := universe.BaseLeafKey{
 		OutPoint:  outPoint,
 		ScriptKey: &scriptKey,
 	}

--- a/tapdb/universe_federation_test.go
+++ b/tapdb/universe_federation_test.go
@@ -332,7 +332,10 @@ func assertProofSyncLogLeafKey(t *testing.T, actualLeafKey universe.LeafKey,
 	// We can safely ignore the tweaked script key as it is the derivation
 	// information for the script key. It is only ever known to the owner of
 	// the asset and is never serialized in a proof
-	actualLeafKey.ScriptKey.TweakedScriptKey = nil
+	baseKey, ok := actualLeafKey.(universe.BaseLeafKey)
+	require.True(t, ok)
+	baseKey.ScriptKey.TweakedScriptKey = nil
+	actualLeafKey = baseKey
 	require.Equal(t, actualLeafKey, logLeafKey)
 }
 

--- a/tapdb/universe_test.go
+++ b/tapdb/universe_test.go
@@ -2,6 +2,7 @@ package tapdb
 
 import (
 	"context"
+	crand "crypto/rand"
 	"database/sql"
 	"math"
 	"math/rand"
@@ -167,6 +168,14 @@ func randProof(t *testing.T, argAsset *asset.Asset) *proof.Proof {
 		proofAsset = *argAsset
 	}
 
+	var witnessData [32]byte
+	_, err := crand.Read(witnessData[:])
+	require.NoError(t, err)
+
+	var pkScript [32]byte
+	_, err = crand.Read(pkScript[:])
+	require.NoError(t, err)
+
 	return &proof.Proof{
 		PrevOut: wire.OutPoint{},
 		BlockHeader: wire.BlockHeader{
@@ -175,7 +184,11 @@ func randProof(t *testing.T, argAsset *asset.Asset) *proof.Proof {
 		AnchorTx: wire.MsgTx{
 			Version: 2,
 			TxIn: []*wire.TxIn{{
-				Witness: [][]byte{[]byte("foo")},
+				Witness: [][]byte{witnessData[:]},
+			}},
+			TxOut: []*wire.TxOut{{
+				PkScript: pkScript[:],
+				Value:    1000,
 			}},
 		},
 		TxMerkleProof: proof.TxMerkleProof{},

--- a/tapdb/universe_test.go
+++ b/tapdb/universe_test.go
@@ -156,7 +156,7 @@ func TestUniverseEmptyTree(t *testing.T) {
 }
 
 func randLeafKey(t *testing.T) universe.LeafKey {
-	return universe.LeafKey{
+	return universe.BaseLeafKey{
 		OutPoint:  test.RandOp(t),
 		ScriptKey: fn.Ptr(asset.NewScriptKey(test.RandPubKey(t))),
 	}
@@ -649,12 +649,13 @@ func TestUniverseLeafQuery(t *testing.T) {
 
 	// We'll create three new leaves, all of them will share the exact same
 	// minting outpoint, but will have distinct script keys.
-	rootMintingPoint := randLeafKey(t).OutPoint
+	rootMintingPoint := randLeafKey(t).LeafOutPoint()
 
 	leafToScriptKey := make(map[asset.SerializedKey]universe.Leaf)
 	for i := 0; i < numLeafs; i++ {
-		targetKey := randLeafKey(t)
-		targetKey.OutPoint = rootMintingPoint
+		baseKey := randLeafKey(t).(universe.BaseLeafKey)
+		baseKey.OutPoint = rootMintingPoint
+		targetKey := baseKey
 
 		leaf := randMintingLeaf(t, assetGen, id.GroupKey)
 		if id.GroupKey != nil {
@@ -673,7 +674,9 @@ func TestUniverseLeafQuery(t *testing.T) {
 			}
 		}
 
-		scriptKey := asset.ToSerialized(targetKey.ScriptKey.PubKey)
+		scriptKey := asset.ToSerialized(
+			targetKey.LeafScriptKey().PubKey,
+		)
 
 		leafToScriptKey[scriptKey] = leaf
 
@@ -685,9 +688,11 @@ func TestUniverseLeafQuery(t *testing.T) {
 
 	// If we query for only the minting point, then all three leaves should
 	// be returned.
-	proofs, err := baseUniverse.FetchIssuanceProof(ctx, universe.LeafKey{
-		OutPoint: rootMintingPoint,
-	})
+	proofs, err := baseUniverse.FetchIssuanceProof(
+		ctx, universe.BaseLeafKey{
+			OutPoint: rootMintingPoint,
+		},
+	)
 	require.NoError(t, err)
 	require.Len(t, proofs, numLeafs)
 
@@ -698,12 +703,14 @@ func TestUniverseLeafQuery(t *testing.T) {
 		scriptKey, err := btcec.ParsePubKey(scriptKeyBytes[:])
 		require.NoError(t, err)
 
-		p, err := baseUniverse.FetchIssuanceProof(ctx, universe.LeafKey{
-			OutPoint: rootMintingPoint,
-			ScriptKey: &asset.ScriptKey{
-				PubKey: scriptKey,
+		p, err := baseUniverse.FetchIssuanceProof(
+			ctx, universe.BaseLeafKey{
+				OutPoint: rootMintingPoint,
+				ScriptKey: &asset.ScriptKey{
+					PubKey: scriptKey,
+				},
 			},
-		})
+		)
 		require.NoError(t, err)
 		require.Len(t, p, 1)
 

--- a/tapgarden/caretaker.go
+++ b/tapgarden/caretaker.go
@@ -1219,7 +1219,7 @@ func (b *BatchCaretaker) storeMintingProof(ctx context.Context,
 	// The base key is the set of bytes that keys into the universe, this'll
 	// be the outpoint where it was created at and the script key for that
 	// asset.
-	leafKey := universe.LeafKey{
+	leafKey := universe.BaseLeafKey{
 		OutPoint: wire.OutPoint{
 			Hash:  mintTxHash,
 			Index: b.anchorOutputIndex,

--- a/tapgarden/custodian_test.go
+++ b/tapgarden/custodian_test.go
@@ -269,7 +269,7 @@ func (h *custodianHarness) addProofFileToMultiverse(p *proof.AnnotatedProof) {
 		require.NoError(h.t, err)
 
 		id := universe.NewUniIDFromAsset(transition.Asset)
-		key := universe.LeafKey{
+		key := universe.BaseLeafKey{
 			OutPoint: transition.OutPoint(),
 			ScriptKey: fn.Ptr(asset.NewScriptKey(
 				transition.Asset.ScriptKey.PubKey,

--- a/tapgarden/planter.go
+++ b/tapgarden/planter.go
@@ -2802,7 +2802,7 @@ func (c *ChainPlanter) updateMintingProofs(proofs []*proof.Proof) error {
 		// The base key is the set of bytes that keys into the universe,
 		// this'll be the outpoint where it was created at and the
 		// script key for that asset.
-		leafKey := universe.LeafKey{
+		leafKey := universe.BaseLeafKey{
 			OutPoint: wire.OutPoint{
 				Hash:  p.AnchorTx.TxHash(),
 				Index: p.InclusionProof.OutputIndex,

--- a/universe/base.go
+++ b/universe/base.go
@@ -354,12 +354,11 @@ func (a *Archive) verifyIssuanceProof(ctx context.Context, id Identifier,
 	)
 	if err != nil {
 		var skBytes []byte
-		if key.ScriptKey != nil {
-			skBytes = key.ScriptKey.PubKey.SerializeCompressed()
-		}
+		scriptKey := key.LeafScriptKey()
+		skBytes = scriptKey.PubKey.SerializeCompressed()
 		return nil, fmt.Errorf("unable to verify proof (%v, "+
 			"outpoint=%v, scriptKey=%x): %w", id.StringForLog(),
-			key.OutPoint.String(), skBytes, err)
+			key.LeafOutPoint().String(), skBytes, err)
 	}
 
 	newAsset := assetSnapshot.Asset
@@ -383,9 +382,9 @@ func (a *Archive) verifyIssuanceProof(ctx context.Context, id Identifier,
 			id.AssetID, newAsset.ID())
 
 	// The script key should also match exactly.
-	case !newAsset.ScriptKey.PubKey.IsEqual(key.ScriptKey.PubKey):
+	case !newAsset.ScriptKey.PubKey.IsEqual(key.LeafScriptKey().PubKey):
 		return nil, fmt.Errorf("script key mismatch: expected %v, got "+
-			"%v", key.ScriptKey.PubKey.SerializeCompressed(),
+			"%v", key.LeafScriptKey().PubKey.SerializeCompressed(),
 			newAsset.ScriptKey.PubKey.SerializeCompressed())
 	}
 
@@ -582,7 +581,7 @@ func (a *Archive) getPrevAssetSnapshot(ctx context.Context,
 	}
 	prevScriptKey := asset.NewScriptKey(prevScriptKeyPubKey)
 
-	prevLeafKey := LeafKey{
+	prevLeafKey := BaseLeafKey{
 		OutPoint:  prevID.OutPoint,
 		ScriptKey: &prevScriptKey,
 	}

--- a/universe/interface.go
+++ b/universe/interface.go
@@ -1210,6 +1210,17 @@ type AuthenticatedIgnoreTuple struct {
 	InclusionProof *mssmt.Proof
 }
 
+// NewAuthIgnoreTuple constructs the final AuthenticatedIgnoreTuple.
+func NewAuthIgnoreTuple(decodedLeaf SignedIgnoreTuple,
+	proof *mssmt.Proof, root mssmt.Node) AuthenticatedIgnoreTuple {
+
+	return AuthenticatedIgnoreTuple{
+		SignedIgnoreTuple: decodedLeaf,
+		InclusionProof:    proof,
+		IgnoreTreeRoot:    root,
+	}
+}
+
 // TupleQueryResp is the response to a query for ignore tuples.
 type TupleQueryResp = lfn.Result[lfn.Option[[]AuthenticatedIgnoreTuple]]
 
@@ -1219,6 +1230,9 @@ type SumQueryResp = lfn.Result[lfn.Option[uint64]]
 
 // AuthIgnoreTuples is a type alias for a slice of AuthenticatedIgnoreTuple.
 type AuthIgnoreTuples = []AuthenticatedIgnoreTuple
+
+// ListTuplesResp is the response to a query for ignore tuples.
+type ListTuplesResp = lfn.Result[lfn.Option[IgnoreTuples]]
 
 // IgnoreTree represents a tree of ignore tuples which can be used to
 // effectively cache rejection of invalid proofs.
@@ -1233,7 +1247,7 @@ type IgnoreTree interface {
 		...SignedIgnoreTuple) lfn.Result[AuthIgnoreTuples]
 
 	// ListTuples returns the list of ignore tuples for the given asset.
-	ListTuples(context.Context, asset.Specifier) lfn.Result[IgnoreTuples]
+	ListTuples(context.Context, asset.Specifier) ListTuplesResp
 
 	// QueryTuples returns the ignore tuples for the given asset.
 	QueryTuples(context.Context, asset.Specifier,

--- a/universe/interface.go
+++ b/universe/interface.go
@@ -1320,7 +1320,7 @@ type IgnoreTree interface {
 // BurnLeaf is a type that represents a burn leaf within the universe tree.
 type BurnLeaf struct {
 	// UniverseKey is the key that the burn leaf is stored at.
-	UniverseKey LeafKey
+	UniverseKey UniqueLeafKey
 
 	// BurnProof is the burn proof that is stored within the burn leaf.
 	BurnProof *proof.Proof

--- a/universe/interface.go
+++ b/universe/interface.go
@@ -274,6 +274,17 @@ type LeafKey interface {
 	LeafOutPoint() wire.OutPoint
 }
 
+// UniqueLeafKey is an interface that allows us to obtain the universe key for a
+// leaf within a universe. This is used to uniquely identify a leaf within a
+// universe. Compared to LeafKey, it includes the asset ID of a leaf within the
+// universe key calculation.
+type UniqueLeafKey interface {
+	LeafKey
+
+	// LeafAssetID returns the asset ID for the leaf.
+	LeafAssetID() asset.ID
+}
+
 // BaseLeafKey is the top level leaf key for a universe. This will be used to
 // key into a universe's MS-SMT data structure. The final serialized key is:
 // sha256(mintingOutpoint || scriptKey). This ensures that all leaves for a
@@ -312,6 +323,35 @@ func (b BaseLeafKey) LeafScriptKey() asset.ScriptKey {
 // LeafOutPoint returns the outpoint for the leaf.
 func (b BaseLeafKey) LeafOutPoint() wire.OutPoint {
 	return b.OutPoint
+}
+
+// AssetLeafKey is a super-set of the BaseLeafKey struct that also includes the
+// asset ID.
+type AssetLeafKey struct {
+	BaseLeafKey
+
+	// AssetID is the asset ID of the asset that the leaf is associated
+	// with.
+	AssetID asset.ID
+}
+
+// LeafAssetID returns the asset ID for the leaf.
+func (a AssetLeafKey) LeafAssetID() asset.ID {
+	return a.AssetID
+}
+
+// UniverseKey returns the universe key for the leaf.
+func (a AssetLeafKey) UniverseKey() [32]byte {
+	// key = sha256(mintingOutpoint || scriptKey || assetID)
+	h := sha256.New()
+	_ = wire.WriteOutPoint(h, 0, 0, &a.OutPoint)
+	h.Write(schnorr.SerializePubKey(a.ScriptKey.PubKey))
+	h.Write(a.AssetID[:])
+
+	var k [32]byte
+	copy(k[:], h.Sum(nil))
+
+	return k
 }
 
 // Proof associates a universe leaf (and key) with its corresponding multiverse


### PR DESCRIPTION
In this commit, we add a new interface, the BurnTree. This interface
will be used by a future sub-system to maintain the on-chain asset
commitment for a given asset group.

The structure of this tree is very similar to the existing issuance
tree. The main difference is that we'll only insert burn proofs into
this tree.

We then implement a concrete implementation of this interface 
using the existing universe tree routines. 