### PR TITLE
Add method `Proof.Bytes`

### DIFF
--- a/proof/courier.go
+++ b/proof/courier.go
@@ -1316,14 +1316,14 @@ func (c *UniverseRpcCourier) DeliverProof(ctx context.Context,
 			return err
 		}
 
-		var proofBuf bytes.Buffer
-		if err := transitionProof.Encode(&proofBuf); err != nil {
+		transitionProofBytes, err := transitionProof.Bytes()
+		if err != nil {
 			return fmt.Errorf("error encoding proof file: %w", err)
 		}
 
 		assetLeaf := unirpc.AssetLeaf{
 			Asset: rpcAsset,
-			Proof: proofBuf.Bytes(),
+			Proof: transitionProofBytes,
 		}
 
 		// Construct universe key.

--- a/proof/file.go
+++ b/proof/file.go
@@ -106,7 +106,7 @@ func NewFile(v Version, proofs ...Proof) (*File, error) {
 	for idx := range proofs {
 		proof := proofs[idx]
 
-		proofBytes, err := encodeProof(&proof)
+		proofBytes, err := proof.Bytes()
 		if err != nil {
 			return nil, err
 		}
@@ -380,7 +380,7 @@ func (f *File) AppendProof(proof Proof) error {
 		prevHash = f.proofs[len(f.proofs)-1].hash
 	}
 
-	proofBytes, err := encodeProof(&proof)
+	proofBytes, err := proof.Bytes()
 	if err != nil {
 		return err
 	}
@@ -437,7 +437,7 @@ func (f *File) ReplaceProofAt(index uint32, proof Proof) error {
 		prevHash = f.proofs[index-1].hash
 	}
 
-	proofBytes, err := encodeProof(&proof)
+	proofBytes, err := proof.Bytes()
 	if err != nil {
 		return err
 	}
@@ -455,16 +455,6 @@ func (f *File) ReplaceProofAt(index uint32, proof Proof) error {
 	}
 
 	return nil
-}
-
-// encodeProof encodes the given proof and returns its raw bytes.
-func encodeProof(proof *Proof) ([]byte, error) {
-	var buf bytes.Buffer
-	if err := proof.Encode(&buf); err != nil {
-		return nil, err
-	}
-
-	return buf.Bytes(), nil
 }
 
 // hashProof hashes a proof's content together with the previous hash and

--- a/proof/proof.go
+++ b/proof/proof.go
@@ -460,6 +460,16 @@ func (p *Proof) Decode(r io.Reader) error {
 	return nil
 }
 
+// Bytes returns the serialized proof.
+func (p *Proof) Bytes() ([]byte, error) {
+	var buf bytes.Buffer
+	err := p.Encode(&buf)
+	if err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
 // Record returns a TLV record that can be used to encode/decode a Proof to/from
 // a TLV stream.
 //

--- a/proof/proof.go
+++ b/proof/proof.go
@@ -476,12 +476,11 @@ func (p *Proof) Bytes() ([]byte, error) {
 // NOTE: This is part of the tlv.RecordProducer interface.
 func (p *Proof) Record() tlv.Record {
 	sizeFunc := func() uint64 {
-		var buf bytes.Buffer
-		err := p.Encode(&buf)
+		proofBytes, err := p.Bytes()
 		if err != nil {
 			panic(err)
 		}
-		return uint64(len(buf.Bytes()))
+		return uint64(len(proofBytes))
 	}
 
 	// Note that we set the type here as zero, as when used with a
@@ -564,15 +563,6 @@ func SparseDecode(r io.Reader, records ...tlv.Record) error {
 	}
 
 	return proofStream.Decode(r)
-}
-
-// Encode encodes a proof into a byte slice.
-func Encode(p *Proof) ([]byte, error) {
-	var b bytes.Buffer
-	if err := p.Encode(&b); err != nil {
-		return nil, err
-	}
-	return b.Bytes(), nil
 }
 
 // Decode decodes a proof from a byte slice.

--- a/proof/proof_test.go
+++ b/proof/proof_test.go
@@ -297,9 +297,8 @@ func TestProofEncodingGroupKeyRevealV1(t *testing.T) {
 		require.NoError(t, err)
 		proof.AdditionalInputs = []File{*file, *file}
 
-		var proofBuf bytes.Buffer
-		require.NoError(t, proof.Encode(&proofBuf))
-		proofBytes := proofBuf.Bytes()
+		proofBytes, err := proof.Bytes()
+		require.NoError(t, err)
 
 		var decodedProof Proof
 		require.NoError(
@@ -324,9 +323,8 @@ func TestProofEncoding(t *testing.T) {
 	require.NoError(t, err)
 	proof.AdditionalInputs = []File{*file, *file}
 
-	var proofBuf bytes.Buffer
-	require.NoError(t, proof.Encode(&proofBuf))
-	proofBytes := proofBuf.Bytes()
+	proofBytes, err := proof.Bytes()
+	require.NoError(t, err)
 
 	var decodedProof Proof
 	require.NoError(t, decodedProof.Decode(bytes.NewReader(proofBytes)))
@@ -363,7 +361,7 @@ func TestProofEncoding(t *testing.T) {
 	require.NoError(t, err)
 	proof.AdditionalInputs = []File{*file, *file}
 
-	proofBuf.Reset()
+	var proofBuf bytes.Buffer
 	require.NoError(t, proof.Encode(&proofBuf))
 	var decodedProof2 Proof
 	require.NoError(t, decodedProof2.Decode(&proofBuf))
@@ -821,8 +819,7 @@ func TestGenesisProofVerification(t *testing.T) {
 			)
 			require.ErrorIs(t, err, tc.expectedErr)
 
-			var buf bytes.Buffer
-			err = genesisProof.Encode(&buf)
+			genesisProofBytes, err := genesisProof.Bytes()
 			require.NoError(tt, err)
 
 			if tc.expectedErr == nil {
@@ -833,7 +830,7 @@ func TestGenesisProofVerification(t *testing.T) {
 							t, &genesisProof,
 						),
 						Expected: hex.EncodeToString(
-							buf.Bytes(),
+							genesisProofBytes,
 						),
 						Comment: tc.name,
 					},
@@ -1233,12 +1230,11 @@ func runBIPTestVector(t *testing.T, testVectors *TestVectors) {
 
 			p := validCase.Proof.ToProof(tt)
 
-			var buf bytes.Buffer
-			err := p.Encode(&buf)
+			proofBytes, err := p.Bytes()
 			require.NoError(tt, err)
 
 			areEqual := validCase.Expected == hex.EncodeToString(
-				buf.Bytes(),
+				proofBytes,
 			)
 
 			// Make sure the proof in the test vectors doesn't use
@@ -1302,7 +1298,7 @@ func runBIPTestVector(t *testing.T, testVectors *TestVectors) {
 				// Make sure we still fail the test.
 				require.Equal(
 					tt, validCase.Expected,
-					hex.EncodeToString(buf.Bytes()),
+					hex.EncodeToString(proofBytes),
 				)
 			}
 
@@ -1453,11 +1449,10 @@ func TestProofUnknownOddType(t *testing.T) {
 			// The proof should've changed, to make sure the unknown
 			// value was taken into account when creating the
 			// serialized proof.
-			var newBuf bytes.Buffer
-			err := parsedProof.Encode(&newBuf)
+			parsedProofBytes, err := parsedProof.Bytes()
 			require.NoError(t, err)
 
-			require.NotEqual(t, knownProofBytes, newBuf.Bytes())
+			require.NotEqual(t, knownProofBytes, parsedProofBytes)
 
 			parsedProof.UnknownOddTypes = nil
 			require.Equal(t, &knownProof, parsedProof)

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -6168,13 +6168,13 @@ func (r *rpcServer) ProveAssetOwnership(ctx context.Context,
 
 	lastProof.ChallengeWitness = challengeWitness
 
-	var buf bytes.Buffer
-	if err := lastProof.Encode(&buf); err != nil {
+	lastProofBytes, err := lastProof.Bytes()
+	if err != nil {
 		return nil, fmt.Errorf("error encoding proof file: %w", err)
 	}
 
 	return &wrpc.ProveAssetOwnershipResponse{
-		ProofWithWitness: buf.Bytes(),
+		ProofWithWitness: lastProofBytes,
 	}, nil
 }
 

--- a/tapchannel/auf_leaf_signer_test.go
+++ b/tapchannel/auf_leaf_signer_test.go
@@ -271,7 +271,7 @@ func randProof(t *testing.T) proof.Proof {
 
 	// Proofs don't Encode everything, so we need to do a quick Encode/
 	// Decode cycle to make sure we can compare it afterward.
-	proofBytes, err := proof.Encode(&originalRandProof)
+	proofBytes, err := originalRandProof.Bytes()
 	require.NoError(t, err)
 	p, err := proof.Decode(proofBytes)
 	require.NoError(t, err)

--- a/tapchannel/aux_funding_controller.go
+++ b/tapchannel/aux_funding_controller.go
@@ -917,7 +917,7 @@ func (f *FundingController) sendInputOwnershipProofs(peerPub btcec.PublicKey,
 	// With all our proofs assembled, we'll now send each of them to the
 	// remote peer in series.
 	for i := range fundingState.inputProofs {
-		proofBytes, _ := proof.Encode(fundingState.inputProofs[i])
+		proofBytes, _ := fundingState.inputProofs[i].Bytes()
 		log.Tracef("Sending input ownership proof to remote party: %x",
 			proofBytes)
 

--- a/tapchannelmsg/records_test.go
+++ b/tapchannelmsg/records_test.go
@@ -61,7 +61,7 @@ func TestOpenChannel(t *testing.T) {
 	// Proofs don't Encode everything, so we need to do a quick Encode/
 	// Decode cycle to make sure we can compare it afterward.
 	originalRandProof := randProof(t)
-	proofBytes, err := proof.Encode(&originalRandProof)
+	proofBytes, err := originalRandProof.Bytes()
 	require.NoError(t, err)
 	randProof, err := proof.Decode(proofBytes)
 	require.NoError(t, err)
@@ -188,7 +188,7 @@ func TestCommitment(t *testing.T) {
 	// Proofs don't Encode everything, so we need to do a quick Encode/
 	// Decode cycle to make sure we can compare it afterward.
 	originalRandProof := randProof(t)
-	proofBytes, err := proof.Encode(&originalRandProof)
+	proofBytes, err := originalRandProof.Bytes()
 	require.NoError(t, err)
 	randProof, err := proof.Decode(proofBytes)
 	require.NoError(t, err)

--- a/tapchannelmsg/wire_msgs_test.go
+++ b/tapchannelmsg/wire_msgs_test.go
@@ -41,7 +41,7 @@ func TestAssetFundingMsg(t *testing.T) {
 
 	// Proofs don't Encode everything, so we need to do a quick Encode/
 	// Decode cycle to make sure we can compare it afterward.
-	proofBytes, err := proof.Encode(&originalRandProof)
+	proofBytes, err := originalRandProof.Bytes()
 	require.NoError(t, err)
 	randProof, err := proof.Decode(proofBytes)
 	require.NoError(t, err)

--- a/tapdb/assets_store.go
+++ b/tapdb/assets_store.go
@@ -2910,8 +2910,7 @@ func logPendingPassiveAssets(ctx context.Context,
 		}
 
 		// Encode new proof.
-		var newProofBuf bytes.Buffer
-		err = passiveOut.ProofSuffix.Encode(&newProofBuf)
+		proofSuffixBytes, err := passiveOut.ProofSuffix.Bytes()
 		if err != nil {
 			return fmt.Errorf("unable to encode new passive "+
 				"asset proof: %w", err)
@@ -2935,7 +2934,7 @@ func logPendingPassiveAssets(ctx context.Context,
 				TransferID:      transferID,
 				NewAnchorUtxo:   newUtxoID,
 				NewWitnessStack: newWitnessBuf.Bytes(),
-				NewProof:        newProofBuf.Bytes(),
+				NewProof:        proofSuffixBytes,
 				PrevOutpoint:    prevOutpointBytes,
 				ScriptKey:       scriptKeyBytes,
 				AssetGenesisID:  passiveIn.PrevID.ID[:],

--- a/tapdb/sqlutils_test.go
+++ b/tapdb/sqlutils_test.go
@@ -93,11 +93,9 @@ func (d *DbHandler) AddRandomAssetProof(t *testing.T) (*asset.Asset,
 	testProof := randProof(t, testAsset)
 	testProof.AltLeaves = testAltLeaves
 
-	var proofBlobBuffer bytes.Buffer
-	err = testProof.Encode(&proofBlobBuffer)
+	proofBlob, err := testProof.Bytes()
 	require.NoError(t, err)
 
-	proofBlob := proofBlobBuffer.Bytes()
 	scriptKey := testAsset.ScriptKey
 
 	annotatedProof := &proof.AnnotatedProof{

--- a/tapdb/universe_test.go
+++ b/tapdb/universe_test.go
@@ -1,7 +1,6 @@
 package tapdb
 
 import (
-	"bytes"
 	"context"
 	"database/sql"
 	"math"
@@ -220,9 +219,10 @@ func randMintingLeaf(t *testing.T, assetGen asset.Genesis,
 
 	leaf.Asset = &randProof.Asset
 
-	var proofBuf bytes.Buffer
-	require.NoError(t, randProof.Encode(&proofBuf))
-	leaf.RawProof = proofBuf.Bytes()
+	proofBytes, err := randProof.Bytes()
+	require.NoError(t, err)
+
+	leaf.RawProof = proofBytes
 
 	return leaf
 }
@@ -385,11 +385,12 @@ func TestUniverseIssuanceProofs(t *testing.T) {
 	for idx := range testLeaves {
 		testLeaf := &testLeaves[idx]
 
-		var proofBuf bytes.Buffer
 		randProof := randProof(t, nil)
-		require.NoError(t, randProof.Encode(&proofBuf))
 
-		testLeaf.Leaf.RawProof = proofBuf.Bytes()
+		randProofBytes, err := randProof.Bytes()
+		require.NoError(t, err)
+
+		testLeaf.Leaf.RawProof = randProofBytes
 
 		targetKey := testLeaf.LeafKey
 		issuanceProof, err := baseUniverse.RegisterIssuance(

--- a/tapfreighter/parcel.go
+++ b/tapfreighter/parcel.go
@@ -1,7 +1,6 @@
 package tapfreighter
 
 import (
-	"bytes"
 	"fmt"
 	"time"
 
@@ -611,8 +610,7 @@ func transferOutput(vPkt *tappsbt.VPacket, vOutIdx int, position uint64,
 			"missing", vOutIdx)
 	}
 
-	var proofSuffixBuf bytes.Buffer
-	err := vOut.ProofSuffix.Encode(&proofSuffixBuf)
+	proofSuffixBytes, err := vOut.ProofSuffix.Bytes()
 	if err != nil {
 		return nil, fmt.Errorf("unable to encode proof %d: %w",
 			vOutIdx, err)
@@ -633,7 +631,7 @@ func transferOutput(vPkt *tappsbt.VPacket, vOutIdx int, position uint64,
 		AssetVersion:        vOut.AssetVersion,
 		WitnessData:         vOut.Asset.PrevWitnesses,
 		SplitCommitmentRoot: vOut.Asset.SplitCommitmentRoot,
-		ProofSuffix:         proofSuffixBuf.Bytes(),
+		ProofSuffix:         proofSuffixBytes,
 		ProofCourierAddr:    proofCourierAddrBytes,
 		ScriptKeyLocal:      isLocalKey(vOut.ScriptKey),
 		Position:            position,

--- a/tapgarden/caretaker.go
+++ b/tapgarden/caretaker.go
@@ -1227,8 +1227,8 @@ func (b *BatchCaretaker) storeMintingProof(ctx context.Context,
 		ScriptKey: &a.ScriptKey,
 	}
 
-	var proofBuf bytes.Buffer
-	if err = mintingProof.Encode(&proofBuf); err != nil {
+	mintingProofBytes, err := mintingProof.Bytes()
+	if err != nil {
 		return nil, nil, fmt.Errorf("unable to encode proof: %w", err)
 	}
 
@@ -1246,7 +1246,7 @@ func (b *BatchCaretaker) storeMintingProof(ctx context.Context,
 		// The universe tree store only the asset state transition and
 		// not also the proof file checksum (as the root is effectively
 		// a checksum), so we'll use just the state transition.
-		RawProof: proofBuf.Bytes(),
+		RawProof: mintingProofBytes,
 		Amt:      a.Amount,
 		Asset:    a,
 	}

--- a/tapgarden/planter.go
+++ b/tapgarden/planter.go
@@ -2812,8 +2812,8 @@ func (c *ChainPlanter) updateMintingProofs(proofs []*proof.Proof) error {
 
 		// The universe leaf stores the raw proof, so we'll encode it
 		// here now.
-		var proofBuf bytes.Buffer
-		if err := p.Encode(&proofBuf); err != nil {
+		proofBytes, err := p.Bytes()
+		if err != nil {
 			return fmt.Errorf("unable to encode proof: %w", err)
 		}
 
@@ -2827,7 +2827,7 @@ func (c *ChainPlanter) updateMintingProofs(proofs []*proof.Proof) error {
 		}
 		mintingLeaf := &universe.Leaf{
 			GenesisWithGroup: uniGen,
-			RawProof:         proofBuf.Bytes(),
+			RawProof:         proofBytes,
 			Amt:              p.Asset.Amount,
 			Asset:            &p.Asset,
 		}

--- a/tappsbt/encode.go
+++ b/tappsbt/encode.go
@@ -366,8 +366,7 @@ func proofEncoder(p *proof.Proof) encoderFunc {
 			return nil, nil
 		}
 
-		var buf bytes.Buffer
-		err := p.Encode(&buf)
+		proofBytes, err := p.Bytes()
 		if err != nil {
 			return nil, err
 		}
@@ -375,7 +374,7 @@ func proofEncoder(p *proof.Proof) encoderFunc {
 		return []*customPsbtField{
 			{
 				Key:   fn.CopySlice(key),
-				Value: buf.Bytes(),
+				Value: proofBytes,
 			},
 		}, nil
 	}


### PR DESCRIPTION
Add method `Proof.Bytes` and then use in many places. Removes redundant buffer variable and two redundant standalone functions.