### PR TITLE
tapdb: correctly fill pkScript for outputs of QueryParcels

### DIFF
--- a/tapdb/assets_store.go
+++ b/tapdb/assets_store.go
@@ -3542,6 +3542,13 @@ func (a *AssetStore) QueryParcels(ctx context.Context,
 					"anchor tx: %w", err)
 			}
 
+			// Fill in the anchor transaction's output pkScripts.
+			for i, out := range outputs {
+				outIdx := out.Anchor.OutPoint.Index
+				pkScript := anchorTx.TxOut[outIdx].PkScript
+				outputs[i].Anchor.PkScript = pkScript
+			}
+
 			// Marshal anchor tx block hash from the database to a
 			// Hash type.
 			var anchorTxBlockHash fn.Option[chainhash.Hash]

--- a/tapdb/assets_store_test.go
+++ b/tapdb/assets_store_test.go
@@ -1597,6 +1597,11 @@ func TestAssetExportLog(t *testing.T) {
 		PkScript: bytes.Repeat([]byte{0x01}, 34),
 		Value:    1000,
 	})
+	newAnchorTx.AddTxOut(&wire.TxOut{
+		PkScript: bytes.Repeat([]byte{0x02}, 34),
+		Value:    1000,
+	})
+
 	const heightHint = 1450
 
 	newScriptKey := asset.NewScriptKeyBip86(keychain.KeyDescriptor{
@@ -1691,6 +1696,7 @@ func TestAssetExportLog(t *testing.T) {
 				// application sets it properly.
 				TaprootAssetRoot: bytes.Repeat([]byte{0x1}, 32),
 				MerkleRoot:       bytes.Repeat([]byte{0x1}, 32),
+				PkScript:         bytes.Repeat([]byte{0x1}, 34),
 			},
 			ScriptKey:        newScriptKey,
 			ScriptKeyLocal:   true,
@@ -1727,6 +1733,7 @@ func TestAssetExportLog(t *testing.T) {
 				// application sets it properly.
 				TaprootAssetRoot: bytes.Repeat([]byte{0x1}, 32),
 				MerkleRoot:       bytes.Repeat([]byte{0x1}, 32),
+				PkScript:         bytes.Repeat([]byte{0x2}, 34),
 			},
 			ScriptKey:      newScriptKey2,
 			ScriptKeyLocal: true,


### PR DESCRIPTION
Previously, QueryParcels did not populate the pkScript field of the anchor outputs. This commit addresses that issue.