### PR TITLE
GitHub: use master again for litd itests

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -21,7 +21,7 @@ env:
 
   GO_VERSION: '1.23.6'
   
-  LITD_ITEST_BRANCH: 'group-key-support'
+  LITD_ITEST_BRANCH: 'master'
 
 jobs:
   #######################


### PR DESCRIPTION
Since the group-key-support branch was merged, we can use the master branch to run tests against.