### PR TITLE
monitoring: expand Prometheus buckets for RPC endpoint latency

### DIFF
--- a/monitoring/monitoring_on.go
+++ b/monitoring/monitoring_on.go
@@ -29,7 +29,14 @@ func GetPromInterceptors(cfg *PrometheusConfig) ([]grpc.UnaryServerInterceptor,
 	}
 
 	if cfg.PerfHistograms {
-		opt := grpc_prometheus.WithServerHandlingTimeHistogram()
+		// Set the histogram buckets in seconds.
+		histogramBuckets := []float64{
+			0.01, 0.1, 0.5, 1, 5, 10, 60, 120, 240, 600, 1200,
+		}
+		opt := grpc_prometheus.WithServerHandlingTimeHistogram(
+			grpc_prometheus.WithHistogramBuckets(histogramBuckets),
+		)
+
 		opts = append(opts, opt)
 	}
 


### PR DESCRIPTION
Closes https://github.com/lightninglabs/taproot-assets/issues/1495

---

Default bucket sizes top out at 10s, causing longer-running RPC calls to be grouped into the largest bucket. This commit adds more buckets to provide finer-grained visibility into endpoint latency.

Terminal Web team report that a unary endpoint took 45mins to run one day and 4mins the next. We should be able to track that sort of variability.