### PR TITLE
rfq: store outgoing request before sending message

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -21,7 +21,7 @@ env:
 
   GO_VERSION: '1.23.6'
   
-  LITD_ITEST_BRANCH: 'script-key-migrations'
+  LITD_ITEST_BRANCH: 'master'
 
 jobs:
   #######################


### PR DESCRIPTION
Fixes https://github.com/lightninglabs/taproot-assets/issues/1460.

We store the outgoing request in the request map, so we can interpret any response and map it to the original request. We do this before sending the message, because otherwise we could potentially receive the response while we're waiting for the atomic lock to be released, which would lead to us not knowing about the request in the first place, and we couldn't map the response.