### PR TITLE
[group key addrs 2/?]: internal/ecies: add encrypt/decrypt with ECIES

### DIFF
--- a/internal/ecies/ecies.go
+++ b/internal/ecies/ecies.go
@@ -1,0 +1,144 @@
+// This package implements an ECIES (Elliptic Curve Integrated Encryption
+// Scheme) encryption. It uses AES256-GCM for encryption and HKDF with SHA256
+// for key derivation. The package provides functions to encrypt and decrypt
+// messages using a shared secret derived between two parties using ECDH
+// (Elliptic Curve Diffie-Hellman).
+// Inspiration for parts of the code in this package was taken from
+// https://github.com/ecies/go.
+
+package ecies
+
+import (
+	"bytes"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/sha256"
+	"fmt"
+	"io"
+
+	"golang.org/x/crypto/hkdf"
+)
+
+const (
+	// GCMNonceSize is the size of the nonce used in AES-GCM mode.
+	GCMNonceSize = 16
+)
+
+// EncryptSha256Aes256 encrypts the given message using AES256-GCM with a shared
+// secret (usually derived using ECDH between the sender's ephemeral key and the
+// receiver's public key) that is stretched using HKDF with SHA256. The output
+// is a byte slice containing:
+//
+//	<16 bytes nonce> <16 bytes tag> <... bytes ciphertext>
+func EncryptSha256Aes256(sharedSecret [32]byte, msg []byte) ([]byte, error) {
+	// We begin by stretching the shared secret using HKDF with SHA256.
+	stretchedKey, err := HkdfSha256(sharedSecret[:])
+	if err != nil {
+		return nil, fmt.Errorf("cannot derive hkdf key: %w", err)
+	}
+
+	// Then we create a new AES block cipher using the stretched key. With
+	// the stretched key length of 32 bytes, this will be AES256.
+	block, err := aes.NewCipher(stretchedKey[:])
+	if err != nil {
+		return nil, fmt.Errorf("cannot create new aes block: %w", err)
+	}
+
+	nonce := make([]byte, GCMNonceSize)
+	if _, err := rand.Read(nonce); err != nil {
+		return nil, fmt.Errorf("cannot read random bytes for nonce: "+
+			"%w", err)
+	}
+
+	// The buffer will contain the nonce, tag and ciphertext. We preallocate
+	// the buffer to the final size to avoid multiple allocations.
+	var result bytes.Buffer
+	result.Write(nonce)
+
+	gcm, err := cipher.NewGCMWithNonceSize(block, GCMNonceSize)
+	if err != nil {
+		return nil, fmt.Errorf("cannot create aes gcm: %w", err)
+	}
+
+	ciphertext := gcm.Seal(nil, nonce, msg, nil)
+
+	// The tag is the last 16 bytes of the ciphertext. We want to move it
+	// to before the ciphertext, so we extract it and write it into the
+	// result buffer first.
+	tag := ciphertext[len(ciphertext)-gcm.NonceSize():]
+	result.Write(tag)
+	ciphertext = ciphertext[:len(ciphertext)-len(tag)]
+	result.Write(ciphertext)
+
+	return result.Bytes(), nil
+}
+
+// DecryptSha256Aes256 decrypts the given ciphertext using AES256-GCM with a
+// shared secret (usually derived using ECDH between the sender's ephemeral key
+// and the receiver's public key) that is stretched using HKDF with SHA256. The
+// ciphertext must be in the format:
+//
+//	<16 bytes nonce> <16 bytes tag> <... bytes ciphertext>
+func DecryptSha256Aes256(sharedSecret [32]byte, msg []byte) ([]byte, error) {
+	// Before we start, we check that the ciphertext is at least 32 bytes
+	// long. This is the minimum size for a valid ciphertext, as it
+	// contains a nonce (16 bytes) and a tag (16 bytes).
+	if len(msg) < 32 {
+		return nil, fmt.Errorf("ciphertext too short: %d bytes "+
+			"given, 32 bytes minimum", len(msg))
+	}
+
+	var (
+		nonce       = make([]byte, GCMNonceSize)
+		tag         = make([]byte, GCMNonceSize)
+		payloadSize = len(msg) - GCMNonceSize*2
+	)
+	copy(nonce, msg[:GCMNonceSize])
+	copy(tag, msg[GCMNonceSize:GCMNonceSize*2])
+
+	// The ciphertext is the rest of the input message, after the nonce and
+	// tag. But we need to assemble `<payload> <tag>` again, as the GCM mode
+	// needs the data in that form to decrypt the ciphertext.
+	ciphertext := make([]byte, payloadSize+GCMNonceSize)
+	copy(ciphertext, msg[GCMNonceSize*2:])
+	copy(ciphertext[payloadSize:], tag)
+
+	// We begin by stretching the shared secret using HKDF with SHA256.
+	stretchedKey, err := HkdfSha256(sharedSecret[:])
+	if err != nil {
+		return nil, fmt.Errorf("cannot derive hkdf key: %w", err)
+	}
+
+	// Then we create a new AES block cipher using the stretched key. With
+	// the stretched key length of 32 bytes, this will be AES256.
+	block, err := aes.NewCipher(stretchedKey[:])
+	if err != nil {
+		return nil, fmt.Errorf("cannot create new aes block: %w", err)
+	}
+
+	gcm, err := cipher.NewGCMWithNonceSize(block, GCMNonceSize)
+	if err != nil {
+		return nil, fmt.Errorf("cannot create aes gcm: %w", err)
+	}
+
+	plaintext, err := gcm.Open(nil, nonce, ciphertext, nil)
+	if err != nil {
+		return nil, fmt.Errorf("cannot decrypt message: %w", err)
+	}
+
+	return plaintext, nil
+}
+
+// HkdfSha256 derives a 32-byte key from the given secret using HKDF with
+// SHA256.
+func HkdfSha256(secret []byte) ([32]byte, error) {
+	var key [32]byte
+	kdf := hkdf.New(sha256.New, secret, nil, nil)
+	if _, err := io.ReadFull(kdf, key[:]); err != nil {
+		return [32]byte{}, fmt.Errorf("cannot read secret from HKDF "+
+			"reader: %w", err)
+	}
+
+	return key, nil
+}

--- a/internal/ecies/ecies_test.go
+++ b/internal/ecies/ecies_test.go
@@ -1,0 +1,187 @@
+package ecies
+
+import (
+	"bytes"
+	crand "crypto/rand"
+	"crypto/sha256"
+	"math/rand/v2"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEncryptDecryptSha256Aes256 tests the EncryptSha256Aes256 and
+// DecryptSha256Aes256 functions. It generates a shared secret using ECDH
+// between a sender and receiver key pair, encrypts a message using the shared
+// secret, and then decrypts it to verify that the original message is
+// recovered.
+func TestEncryptDecryptSha256Aes256(t *testing.T) {
+	tests := []struct {
+		name    string
+		message []byte
+	}{
+		{
+			name:    "short message",
+			message: []byte("hello"),
+		},
+		{
+			name:    "empty message",
+			message: nil,
+		},
+		{
+			name:    "long message",
+			message: bytes.Repeat([]byte("a"), 1024),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			senderPriv, err := btcec.NewPrivateKey()
+			require.NoError(t, err)
+
+			receiverPriv, err := btcec.NewPrivateKey()
+			require.NoError(t, err)
+			receiverPub := receiverPriv.PubKey()
+
+			sharedSecret, err := ecdh(senderPriv, receiverPub)
+
+			// Encrypt the message.
+			ciphertext, err := EncryptSha256Aes256(
+				sharedSecret, tt.message,
+			)
+			require.NoError(t, err)
+
+			require.NotContains(t, ciphertext, tt.message)
+			require.GreaterOrEqual(t, len(ciphertext), 32)
+
+			// Decrypt the message.
+			plaintext, err := DecryptSha256Aes256(
+				sharedSecret, ciphertext,
+			)
+			require.NoError(t, err)
+
+			// Verify the decrypted message matches the original.
+			require.Equal(t, tt.message, plaintext)
+		})
+	}
+}
+
+// TestEncryptDecryptSha256Aes256Random tests the EncryptSha256Aes256 and
+// DecryptSha256Aes256 functions with random messages.
+func TestEncryptDecryptSha256Aes256Random(t *testing.T) {
+	for i := 0; i < 100; i++ {
+		msgLen := rand.Int()%65536 + 1
+		msg := make([]byte, msgLen)
+		_, err := crand.Read(msg)
+		require.NoError(t, err)
+
+		senderPriv, err := btcec.NewPrivateKey()
+		require.NoError(t, err)
+
+		receiverPriv, err := btcec.NewPrivateKey()
+		require.NoError(t, err)
+		receiverPub := receiverPriv.PubKey()
+
+		sharedSecret, err := ecdh(senderPriv, receiverPub)
+
+		// Encrypt the message.
+		ciphertext, err := EncryptSha256Aes256(sharedSecret, msg)
+		require.NoError(t, err)
+
+		require.NotContains(t, ciphertext, msg)
+		require.GreaterOrEqual(t, len(ciphertext), 32)
+
+		// Decrypt the message.
+		plaintext, err := DecryptSha256Aes256(sharedSecret, ciphertext)
+		require.NoError(t, err)
+
+		// Verify the decrypted message matches the original.
+		require.Equal(t, msg, plaintext)
+	}
+}
+
+// BenchmarkEncryptSha256Aes256 tests the performance of the EncryptSha256Aes256
+// function.
+func BenchmarkEncryptSha256Aes256(b *testing.B) {
+	senderPriv, err := btcec.NewPrivateKey()
+	require.NoError(b, err)
+
+	receiverPriv, err := btcec.NewPrivateKey()
+	require.NoError(b, err)
+	receiverPub := receiverPriv.PubKey()
+
+	sharedSecret, err := ecdh(senderPriv, receiverPub)
+
+	longMessage := bytes.Repeat([]byte("secret"), 10240)
+	for i := 0; i < b.N; i++ {
+		_, err := EncryptSha256Aes256(sharedSecret, longMessage)
+		if err != nil {
+			b.Fail()
+		}
+	}
+}
+
+// BenchmarkDecryptSha256Aes256 tests the performance of the
+// DecryptSha256Aes256 function.
+func BenchmarkDecryptSha256Aes256(b *testing.B) {
+	senderPriv, err := btcec.NewPrivateKey()
+	require.NoError(b, err)
+
+	receiverPriv, err := btcec.NewPrivateKey()
+	require.NoError(b, err)
+	receiverPub := receiverPriv.PubKey()
+
+	sharedSecret, err := ecdh(senderPriv, receiverPub)
+
+	longMessage := bytes.Repeat([]byte("secret"), 10240)
+
+	ciphertext, err := EncryptSha256Aes256(sharedSecret, longMessage)
+	require.NoError(b, err)
+
+	for i := 0; i < b.N; i++ {
+		_, err := DecryptSha256Aes256(sharedSecret, ciphertext)
+		if err != nil {
+			b.Fail()
+		}
+	}
+}
+
+// FuzzEncryptSha256Aes256 is a fuzz test for the EncryptSha256Aes256 function.
+func FuzzEncryptSha256Aes256(f *testing.F) {
+	f.Fuzz(func(t *testing.T, secretBytes []byte, msg []byte) {
+		var sharedSecret [32]byte
+		copy(sharedSecret[:], secretBytes)
+		_, _ = EncryptSha256Aes256(sharedSecret, msg)
+	})
+}
+
+// FuzzDecryptSha256Aes256 is a fuzz test for the DecryptSha256Aes256 function.
+func FuzzDecryptSha256Aes256(f *testing.F) {
+	f.Fuzz(func(t *testing.T, secretBytes []byte, msg []byte) {
+		var sharedSecret [32]byte
+		copy(sharedSecret[:], secretBytes)
+		_, _ = DecryptSha256Aes256(sharedSecret, msg)
+	})
+}
+
+// ecdh performs a scalar multiplication (ECDH-like operation) between the
+// target private key and remote public key. The output returned will be
+// the sha256 of the resulting shared point serialized in compressed format. If
+// k is our private key, and P is the public key, we perform the following
+// operation:
+//
+//	sx = k*P
+//	s = sha256(sx.SerializeCompressed())
+func ecdh(privKey *btcec.PrivateKey, pub *btcec.PublicKey) ([32]byte, error) {
+	var (
+		pubJacobian btcec.JacobianPoint
+		s           btcec.JacobianPoint
+	)
+	pub.AsJacobian(&pubJacobian)
+
+	btcec.ScalarMultNonConst(&privKey.Key, &pubJacobian, &s)
+	s.ToAffine()
+	sPubKey := btcec.NewPublicKey(&s.X, &s.Y)
+	return sha256.Sum256(sPubKey.SerializeCompressed()), nil
+}


### PR DESCRIPTION
Implements the ECIES encryption scheme as mentioned here: https://github.com/lightninglabs/taproot-assets/issues/874#issuecomment-2752783389

This commit creates a simple encryption and decryption function that uses AES256-GCM for tne symmetric encryption and HKDF with SHA256 for the key derivation.
The shared key generation is not part of these functions, because we'll need to use lnd RPCs in some cases to be able to derive it.