### PR TITLE
minting: fix re-issuing into existing group with external key

### DIFF
--- a/itest/mint_fund_seal_test.go
+++ b/itest/mint_fund_seal_test.go
@@ -577,6 +577,9 @@ func testMintExternalGroupKeyChantools(t *harnessTest) {
 	mintReq2 := CopyRequest(issuableAssets[0])
 	mintReq2.Asset.Name = "itestbuxx-money-printer-brrr-tranche-2"
 	mintReq2.Asset.ExternalGroupKey = externalGroupKey
+	mintReq2.Asset.GroupedAsset = true
+	mintReq2.Asset.NewGroupedAsset = false
+	mintReq2.Asset.GroupKey = batchAssets[0].AssetGroup.TweakedGroupKey
 
 	assetReqs2 := []*mintrpc.MintAssetRequest{mintReq2}
 

--- a/tapgarden/planter.go
+++ b/tapgarden/planter.go
@@ -2668,7 +2668,11 @@ func (c *ChainPlanter) prepAssetSeedling(ctx context.Context,
 	// If a group internal key or tapscript root is specified, emission must
 	// also be enabled.
 	if !req.EnableEmission {
-		if req.GroupInternalKey != nil {
+		// For re-issuance or regular assets, the group internal key
+		// shouldn't be set. It is, however, set for re-issuance with
+		// an external key, because the internal group key is the key
+		// we compare the external key against.
+		if req.GroupInternalKey != nil && req.ExternalKey.IsNone() {
 			return fmt.Errorf("cannot specify group internal key " +
 				"without enabling emission")
 		}


### PR DESCRIPTION
Fixes https://github.com/lightninglabs/taproot-assets/issues/1515.
Fixes https://github.com/lightninglabs/taproot-assets/issues/1516.
