### PR TITLE
rpcserver: stop SendPayment update stream when payment fails

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -7817,6 +7817,13 @@ func (r *rpcServer) SendPayment(req *tchrpc.SendPaymentRequest,
 		if err != nil {
 			return err
 		}
+
+		// If the payment failed, return an error and stop listening
+		// for updates immediately.
+		if update.Status == lnrpc.Payment_FAILED {
+			return fmt.Errorf("payment failed: %s",
+				update.FailureReason.String())
+		}
 	}
 }
 


### PR DESCRIPTION
Close: https://github.com/lightninglabs/taproot-assets/issues/1531

---

Updates the SendPayment RPC to return immediately upon receiving a payment failure update. This avoids unnecessary waiting for a context timeout or quit signal.