### PR TITLE
Fix panic when listing unfunded pending batch with verbose

### DIFF
--- a/itest/assets_test.go
+++ b/itest/assets_test.go
@@ -174,7 +174,17 @@ func testMintBatchResume(t *harnessTest) {
 
 	// Build one batch, but leave it as pending.
 	BuildMintingBatch(t.t, t.tapd, simpleAssets)
-	batchResp, err := t.tapd.ListBatches(ctxt, &mintrpc.ListBatchRequest{})
+
+	// The batch is pending and unfunded, so the verbose batch listing
+	// should return an empty list. An anchor transaction (BTC funding) is
+	// required for verbose listing to include group key requests.
+	batchResp, err := t.tapd.ListBatches(ctxt, &mintrpc.ListBatchRequest{
+		Verbose: true,
+	})
+	require.NoError(t.t, err)
+	require.Empty(t.t, batchResp.Batches)
+
+	batchResp, err = t.tapd.ListBatches(ctxt, &mintrpc.ListBatchRequest{})
 	require.NoError(t.t, err)
 	require.Len(t.t, batchResp.Batches, 1)
 	t.Logf("batches: %v", toJSON(t.t, batchResp))

--- a/tapgarden/planter.go
+++ b/tapgarden/planter.go
@@ -1516,7 +1516,7 @@ func listBatches(ctx context.Context, batchStore MintingStore,
 	}
 
 	// Formulate verbose batches from the sorted batches.
-	verboseBatches := make([]*VerboseBatch, len(sortedBatches))
+	verboseBatches := make([]*VerboseBatch, 0, len(sortedBatches))
 
 	for idx := range sortedBatches {
 		currentBatch := sortedBatches[idx]
@@ -1527,6 +1527,10 @@ func listBatches(ctx context.Context, batchStore MintingStore,
 		case currentBatch.State() != BatchStatePending:
 			continue
 		case !currentBatch.IsFunded():
+			// The batch isn't funded yet, so we can't display any
+			// pending asset group information. Funding is required
+			// because the anchor transaction outpoint is needed to
+			// formulate pending asset group key requests.
 			continue
 		case len(currentBatch.Seedlings) == 0:
 			continue
@@ -1538,7 +1542,7 @@ func listBatches(ctx context.Context, batchStore MintingStore,
 			return nil, err
 		}
 
-		verboseBatches[idx] = verboseBatch
+		verboseBatches = append(verboseBatches, verboseBatch)
 	}
 
 	return verboseBatches, nil

--- a/taprpc/mintrpc/mint.pb.go
+++ b/taprpc/mintrpc/mint.pb.go
@@ -1325,8 +1325,8 @@ type ListBatchRequest struct {
 	//	*ListBatchRequest_BatchKey
 	//	*ListBatchRequest_BatchKeyStr
 	Filter isListBatchRequest_Filter `protobuf_oneof:"filter"`
-	// If true, pending asset group information will be shown for the pending
-	// batch.
+	// If true, pending asset group details will be included for any funded,
+	// non-empty pending batch. Unfunded or empty batches will be excluded.
 	Verbose bool `protobuf:"varint,3,opt,name=verbose,proto3" json:"verbose,omitempty"`
 }
 

--- a/taprpc/mintrpc/mint.proto
+++ b/taprpc/mintrpc/mint.proto
@@ -420,8 +420,8 @@ message ListBatchRequest {
         string batch_key_str = 2;
     }
 
-    // If true, pending asset group information will be shown for the pending
-    // batch.
+    // If true, pending asset group details will be included for any funded,
+    // non-empty pending batch. Unfunded or empty batches will be excluded.
     bool verbose = 3;
 }
 

--- a/taprpc/mintrpc/mint.swagger.json
+++ b/taprpc/mintrpc/mint.swagger.json
@@ -85,7 +85,7 @@
           },
           {
             "name": "verbose",
-            "description": "If true, pending asset group information will be shown for the pending\nbatch.",
+            "description": "If true, pending asset group details will be included for any funded,\nnon-empty pending batch. Unfunded or empty batches will be excluded.",
             "in": "query",
             "required": false,
             "type": "boolean"


### PR DESCRIPTION
Closes: https://github.com/lightninglabs/taproot-assets/issues/1535

---

This PR fixes a bug in `ListBatches` where a single nil element was left in the `verboseBatches` list, causing a panic during RPC marshalling. The bug occurred when a single unfunded pending batch was present.

Changes:

* Set `verboseBatches` length to zero to avoid uninitialized elements.
* Add a comment explaining why funding is required for verbose batch info.
* Add an itest to cover this edge case.
* Improve proto documentation for the `verbose` field in `ListBatches`.
