### PR TITLE
Adjust Max Fee Ratio

### DIFF
--- a/wallet_anchor.go
+++ b/wallet_anchor.go
@@ -91,6 +91,9 @@ func (l *LndRpcWalletAnchor) FundPsbt(ctx context.Context, packet *psbt.Packet,
 			},
 			MinConfs:   int32(minConfs),
 			ChangeType: defaultChangeType,
+			// Adjust the max fee tolerance to be 100% of the value to avoid false positives with small anchor outputs.
+			// https://github.com/lightninglabs/taproot-assets/issues/1417
+			MaxFeeRatio: 1,
 		},
 	)
 	if err != nil {


### PR DESCRIPTION
Fixes #1417 with the suggested solution by @GeorgeTsagk. While the issue shows a 38.31% fee ratio, I've seen as much as high as a 100% fee ratio from my testing.

From my perspective, the ideal solution would be a way to disable the fee ratio check all together. As it's not factoring in the value of the assets just the anchor output.