### PR TITLE
tapgarden: increase unit test default timeout from 10s to 30s

### DIFF
--- a/tapgarden/planter_test.go
+++ b/tapgarden/planter_test.go
@@ -46,7 +46,7 @@ import (
 // Default to a large interval so the planter never actually ticks and only
 // rely on our manual ticks.
 var (
-	defaultTimeout    = time.Second * 10
+	defaultTimeout    = time.Second * 30
 	noCaretakerStates = fn.NewSet(
 		tapgarden.BatchStatePending,
 		tapgarden.BatchStateSeedlingCancelled,


### PR DESCRIPTION
The `unit-race` CI job frequently flakes due to test timeouts. Raising the default timeout to 30s should help reduce these flakes without noticeably slowing down the unit tests.

Two example failed CI runs:
```
--- FAIL: TestBatchedAssetIssuance (54.87s)
    test_sqlite.go:11: Creating new SQLite DB handle for testing: /tmp/TestBatchedAssetIssuance904633052/001/tmp.db
    --- FAIL: TestBatchedAssetIssuance/basic_asset_creation (12.75s)
        planter_test.go:1153: 
            	Error Trace:	/home/runner/work/taproot-assets/taproot-assets/tapgarden/planter_test.go:1023
            	            				/home/runner/work/taproot-assets/taproot-assets/tapgarden/planter_test.go:1153
            	            				/home/runner/work/taproot-assets/taproot-assets/tapgarden/planter_test.go:2048
            	Error:      	Received unexpected error:
            	            	timeout hit
            	Test:       	TestBatchedAssetIssuance/basic_asset_creation
            	Messages:   	pubkey import req not sent
    test_sqlite.go:11: Creating new SQLite DB handle for testing: /tmp/TestBatchedAssetIssuance904633052/002/tmp.db
    test_sqlite.go:11: Creating new SQLite DB handle for testing: /tmp/TestBatchedAssetIssuance904633052/003/tmp.db
    test_sqlite.go:11: Creating new SQLite DB handle for testing: /tmp/TestBatchedAssetIssuance904633052/004/tmp.db
    test_sqlite.go:11: Creating new SQLite DB handle for testing: /tmp/TestBatchedAssetIssuance904633052/005/tmp.db
    test_sqlite.go:11: Creating new SQLite DB handle for testing: /tmp/TestBatchedAssetIssuance904633052/006/tmp.db
    test_sqlite.go:11: Creating new SQLite DB handle for testing: /tmp/TestBatchedAssetIssuance904633052/007/tmp.db


--- FAIL: TestBatchedAssetIssuance (54.97s)
    test_sqlite.go:11: Creating new SQLite DB handle for testing: /tmp/TestBatchedAssetIssuance2405190019/001/tmp.db
    --- FAIL: TestBatchedAssetIssuance/basic_asset_creation (12.79s)
        planter_test.go:1172: 
            	Error Trace:	/home/runner/work/taproot-assets/taproot-assets/tapgarden/planter_test.go:1033
            	            				/home/runner/work/taproot-assets/taproot-assets/tapgarden/planter_test.go:1172
            	            				/home/runner/work/taproot-assets/taproot-assets/tapgarden/planter_test.go:2048
            	Error:      	Received unexpected error:
            	            	timeout hit
            	Test:       	TestBatchedAssetIssuance/basic_asset_creation
```