### PR TITLE
rpcserver: fix "mutually exclusive" err when using sats

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -8056,7 +8056,13 @@ func (r *rpcServer) AddInvoice(ctx context.Context,
 		return nil, fmt.Errorf("error validating invoice amount: %w",
 			err)
 	}
+
+	// We'll forward the invoice request to lnd, where we can only set one
+	// of the two values. Since we've calculated the amount in mSat (but the
+	// user might've set the satoshi value initially), we need to reset the
+	// value field.
 	iReq.ValueMsat = int64(invoiceAmtMsat)
+	iReq.Value = 0
 
 	// The last step is to create a hop hint that includes the fake SCID of
 	// the quote, alongside the channel's routing policy. We need to choose


### PR DESCRIPTION
Fixes https://github.com/lightninglabs/lightning-terminal/pull/1075#pullrequestreview-2853005100.

If the user specifies sats but we end up setting the (validated) mSat amount, we run into the error "sat and msat arguments are mutually exclusive" in lnd.
To fix that, we need to reset the sat value.