### PR TITLE
tapdb: fix unit race flakes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -232,6 +232,10 @@ flake-unit-race:
 	@$(call print, "Flake hunting races in unit tests.")
 	while [ $$? -eq 0 ]; do make unit-race nocache=1; done
 
+flake-unit-race-trace:
+	@$(call print, "Flake hunting races in unit tests.")
+	while [ $$? -eq 0 ]; do make unit-race log='stdout trace' nocache=1; done
+
 # =============
 # FUZZING
 # =============

--- a/make/testing_flags.mk
+++ b/make/testing_flags.mk
@@ -74,6 +74,7 @@ endif
 # are provided, we default to "nolog" which will be silent.
 ifneq ($(log),)
 LOG_TAGS := ${log}
+TEST_FLAGS += -test.v
 else
 LOG_TAGS := nolog
 endif

--- a/tapdb/sqlerrors.go
+++ b/tapdb/sqlerrors.go
@@ -55,7 +55,7 @@ func parseSqliteError(sqliteErr *sqlite.Error) error {
 
 	// A write operation could not continue because of a conflict within the
 	// same database connection.
-	case sqlite3.SQLITE_LOCKED:
+	case sqlite3.SQLITE_LOCKED, sqlite3.SQLITE_BUSY_SNAPSHOT:
 		return &ErrDeadlockError{
 			DbError: sqliteErr,
 		}


### PR DESCRIPTION
Actually fixes the CI failure shown in https://github.com/lightninglabs/taproot-assets/pull/1544#issue-3068802054 by eliminating the root cause: A database error code that we must add to the list of re-tryable errors.

Error message obtained from `make flake-unit-race-trace pkg=tapgarden`:

```
2025-05-20 12:55:50.089 [ERR] GRDN: Unable to advance state machine: unable to advance state machine: unable to commit genesis tx: unknown sqlite error: database is locked (517)
```