### PR TITLE
proof: verify stxo proofs if present in v0 proofs

### DIFF
--- a/proof/mint.go
+++ b/proof/mint.go
@@ -266,7 +266,7 @@ func NewMintingBlobs(params *MintParams, vCtx VerifierCtx,
 
 	base, err := baseProof(
 		&params.BaseProofParams, params.GenesisPoint,
-		opts.genConfig.transitionVersion,
+		opts.genConfig.TransitionVersion,
 	)
 	if err != nil {
 		return nil, err

--- a/proof/verifier.go
+++ b/proof/verifier.go
@@ -206,10 +206,12 @@ func (p *Proof) verifyInclusionProof() (*commitment.TapCommitment, error) {
 			ErrStxoInputProofMissing)
 	}
 
-	// We ignore the STXO proofs if the proof signals version 0, or if there
-	// are no STXO proofs present (because they're not needed for this type
-	// of asset).
-	if p.IsVersionV0() || !hasStxoProofs {
+	// We ignore the STXO proofs if they're not needed for this type of
+	// asset or if there are no STXO proofs. At this point we can be sure
+	// that if they are needed they also are present (because of the check
+	// above). If they are not needed, but still present we verify them for
+	// good measure.
+	if !p.Asset.IsTransferRoot() || !hasStxoProofs {
 		return v0Commitment, nil
 	}
 
@@ -292,7 +294,7 @@ func (p *Proof) verifyExclusionProofs() (*commitment.TapCommitmentVersion,
 		maps.Clone(p2trOutputs),
 	)
 	if err != nil {
-		return nil, fmt.Errorf("error veryfying v0 exclusion proof: %w",
+		return nil, fmt.Errorf("error verifying v0 exclusion proof: %w",
 			err)
 	}
 
@@ -318,10 +320,12 @@ func (p *Proof) verifyExclusionProofs() (*commitment.TapCommitmentVersion,
 			ErrStxoInputProofMissing)
 	}
 
-	// We ignore the STXO proofs if the proof signals version 0, or if there
-	// are no STXO proofs present (because they're not needed for this type
-	// of asset).
-	if p.IsVersionV0() || !hasStxoProofs {
+	// We ignore the STXO proofs if they're not needed for this type of
+	// asset or if there are no STXO proofs. At this point we can be sure
+	// that if they are needed they also are present (because of the check
+	// above). If they are not needed, but still present we verify them for
+	// good measure.
+	if !p.Asset.IsTransferRoot() || !hasStxoProofs {
 		return assertVersionConsistency(commitVersions)
 	}
 

--- a/tapchannel/aux_closer.go
+++ b/tapchannel/aux_closer.go
@@ -726,6 +726,7 @@ func (a *AuxChanCloser) FinalizeClose(desc chancloser.AuxCloseDesc,
 			proofSuffix, err := tapsend.CreateProofSuffixCustom(
 				closeTx, vPkt, closeInfo.outputCommitments,
 				outIdx, closeInfo.vPackets, exclusionCreator,
+				proof.WithNoSTXOProofs(),
 			)
 			if err != nil {
 				return fmt.Errorf("unable to create proof "+

--- a/tapchannel/aux_funding_controller.go
+++ b/tapchannel/aux_funding_controller.go
@@ -1114,6 +1114,7 @@ func (f *FundingController) anchorVPackets(fundedPkt *tapsend.FundedPsbt,
 			proofSuffix, err := tapsend.CreateProofSuffix(
 				fundedPkt.Pkt.UnsignedTx, fundedPkt.Pkt.Outputs,
 				vPkt, outputCommitments, vOutIdx, allPackets,
+				proof.WithNoSTXOProofs(),
 			)
 			if err != nil {
 				return nil, fmt.Errorf("unable to create "+

--- a/tapchannel/aux_sweeper.go
+++ b/tapchannel/aux_sweeper.go
@@ -1612,6 +1612,7 @@ func (a *AuxSweeper) importCommitTx(req lnwallet.ResolutionReq,
 			proofSuffix, err := tapsend.CreateProofSuffixCustom(
 				req.CommitTx, vPkt, outCommitments, outIdx,
 				vPackets, exclusionCreator,
+				proof.WithNoSTXOProofs(),
 			)
 			if err != nil {
 				return fmt.Errorf("unable to create "+
@@ -2450,7 +2451,7 @@ func (a *AuxSweeper) registerAndBroadcastSweep(req *sweep.BumpRequest,
 
 			proofSuffix, err := tapsend.CreateProofSuffixCustom(
 				sweepTx, vPkt, outCommitments, outIdx, allVpkts,
-				exclusionCreator,
+				exclusionCreator, proof.WithNoSTXOProofs(),
 			)
 			if err != nil {
 				return fmt.Errorf("unable to create proof "+

--- a/tapchannel/commitment.go
+++ b/tapchannel/commitment.go
@@ -612,7 +612,7 @@ func GenerateCommitmentAllocations(prevState *cmsg.Commitment,
 				fakeCommitTx, vPkt, outCommitments, outIdx,
 				vPackets, tapsend.NonAssetExclusionProofs(
 					allocations,
-				),
+				), proof.WithNoSTXOProofs(),
 			)
 			if err != nil {
 				return nil, nil, fmt.Errorf("unable to create "+


### PR DESCRIPTION
Because we do not bump the proof version yet, but we still create v1
proofs, we at least verify them if they are present.

This was the state table for choosing which verification would occur before this PR:

|    | hasStxoProofs<br><br>IsTransferRoot | hasStxoProofs<br><br>!IsTransferRoot | !hasStxoProofs<br><br>IsTransferRoot | !hasStxoProofs<br><br>!IsTransferRoot |
|----|-------------------------------------|--------------------------------------|--------------------------------------|---------------------------------------|
| V0 | verifyV0                            | verifyV0                             | verifyV0                             | verifyV0                              |
| V1 | verifyV0, verifyV1            | verifyV0                             | ERR                                  | verifyV0                              |

This will be the state table after this PR:

|    | hasStxoProofs<br><br>IsTransferRoot | hasStxoProofs<br><br>!IsTransferRoot | !hasStxoProofs<br><br>IsTransferRoot | !hasStxoProofs<br><br>!IsTransferRoot |
|----|-------------------------------------|--------------------------------------|--------------------------------------|---------------------------------------|
| V0 | verifyV0, verifyV1            | verifyV0                             | verifyV0                             | verifyV0                              |
| V1 | verifyV0, verifyV1            | verifyV0                             | ERR                                  | verifyV0                              |