### PR TITLE
universe+tapdb: add new `block_height` field to `universe_leaves` use that to implement block height based supply tree queries

### DIFF
--- a/tapdb/burn_tree.go
+++ b/tapdb/burn_tree.go
@@ -116,11 +116,17 @@ func insertBurnsInternal(ctx context.Context, db BaseUniverseStore,
 			IsBurn:   true,
 		}
 
+		var blockHeight lfn.Option[uint32]
+		height := burnLeaf.BurnProof.BlockHeight
+		if height > 0 {
+			blockHeight = lfn.Some(height)
+		}
+
 		// Call the generic upsert function for the burn sub-tree to
 		// update DB records. MetaReveal is nil for burns.
 		_, err = universeUpsertProofLeaf(
 			ctx, db, subNs, supplycommit.BurnTreeType.String(),
-			groupKey, leafKey, leaf, nil,
+			groupKey, leafKey, leaf, nil, blockHeight,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("unable to upsert burn "+

--- a/tapdb/ignore_tree.go
+++ b/tapdb/ignore_tree.go
@@ -113,6 +113,21 @@ func addTuplesInternal(ctx context.Context, db BaseUniverseStore,
 				"universe root: %w", err)
 		}
 
+		var blockHeight lfn.Option[uint32]
+		height := tup.IgnoreTuple.Val.BlockHeight
+		if height > 0 {
+			blockHeight = lfn.Some(height)
+		}
+
+		sqlBlockHeight := lfn.MapOptionZ(
+			blockHeight, func(num uint32) sql.NullInt32 {
+				return sql.NullInt32{
+					Int32: int32(num),
+					Valid: true,
+				}
+			},
+		)
+
 		scriptKey := ignoreTup.ScriptKey
 		err = db.UpsertUniverseLeaf(ctx, UpsertUniverseLeaf{
 			AssetGenesisID:    assetGenID,
@@ -121,6 +136,7 @@ func addTuplesInternal(ctx context.Context, db BaseUniverseStore,
 			LeafNodeKey:       smtKey[:],
 			LeafNodeNamespace: namespace,
 			MintingPoint:      ignorePointBytes,
+			BlockHeight:       sqlBlockHeight,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to upsert ignore "+

--- a/tapdb/migrations.go
+++ b/tapdb/migrations.go
@@ -24,7 +24,7 @@ const (
 	// daemon.
 	//
 	// NOTE: This MUST be updated when a new migration is added.
-	LatestMigrationVersion = 37
+	LatestMigrationVersion = 38
 )
 
 // DatabaseBackend is an interface that contains all methods our different

--- a/tapdb/sqlc/migrations/000038_universe_leaf_height.down.sql
+++ b/tapdb/sqlc/migrations/000038_universe_leaf_height.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE universe_leaves DROP COLUMN block_height;

--- a/tapdb/sqlc/migrations/000038_universe_leaf_height.up.sql
+++ b/tapdb/sqlc/migrations/000038_universe_leaf_height.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE universe_leaves ADD COLUMN block_height INTEGER;

--- a/tapdb/sqlc/models.go
+++ b/tapdb/sqlc/models.go
@@ -429,6 +429,7 @@ type UniverseLeafe struct {
 	UniverseRootID    int64
 	LeafNodeKey       []byte
 	LeafNodeNamespace string
+	BlockHeight       sql.NullInt32
 }
 
 type UniverseRoot struct {

--- a/tapdb/sqlc/querier.go
+++ b/tapdb/sqlc/querier.go
@@ -164,6 +164,7 @@ type Querier interface {
 	QueryProofTransferAttempts(ctx context.Context, arg QueryProofTransferAttemptsParams) ([]time.Time, error)
 	QuerySupplyCommitStateMachine(ctx context.Context, groupKey []byte) (QuerySupplyCommitStateMachineRow, error)
 	QuerySupplyCommitment(ctx context.Context, commitID int64) (SupplyCommitment, error)
+	QuerySupplyLeavesByHeight(ctx context.Context, arg QuerySupplyLeavesByHeightParams) ([]QuerySupplyLeavesByHeightRow, error)
 	QuerySupplyUpdateEvents(ctx context.Context, transitionID int64) ([]QuerySupplyUpdateEventsRow, error)
 	// TODO(roasbeef): use the universe id instead for the grouping? so namespace
 	// root, simplifies queries

--- a/tapdb/sqlc/queries/supply_tree.sql
+++ b/tapdb/sqlc/queries/supply_tree.sql
@@ -44,6 +44,25 @@ JOIN universe_supply_roots r
 WHERE r.id = @supply_root_id AND
       (l.sub_tree_type = sqlc.narg('sub_tree_type') OR sqlc.narg('sub_tree_type') IS NULL);
 
+-- name: QuerySupplyLeavesByHeight :many
+SELECT
+    leaves.script_key_bytes,
+    gen.gen_asset_id,
+    nodes.value AS supply_leaf_bytes,
+    nodes.sum AS sum_amt,
+    gen.asset_id,
+    leaves.block_height
+FROM universe_leaves AS leaves
+JOIN mssmt_nodes AS nodes
+    ON leaves.leaf_node_key = nodes.key
+    AND leaves.leaf_node_namespace = nodes.namespace
+JOIN genesis_info_view AS gen
+    ON leaves.asset_genesis_id = gen.gen_asset_id
+WHERE
+    leaves.leaf_node_namespace = @namespace AND
+    (leaves.block_height >= sqlc.narg('start_height') OR sqlc.narg('start_height') IS NULL) AND
+    (leaves.block_height <= sqlc.narg('end_height') OR sqlc.narg('end_height') IS NULL);
+
 -- name: DeleteUniverseSupplyLeaves :exec
 DELETE FROM universe_supply_leaves
 WHERE supply_root_id = (

--- a/tapdb/sqlc/queries/universe.sql
+++ b/tapdb/sqlc/queries/universe.sql
@@ -38,17 +38,18 @@ WHERE namespace_root = @namespace_root;
 
 -- name: UpsertUniverseLeaf :exec
 INSERT INTO universe_leaves (
-    asset_genesis_id, script_key_bytes, universe_root_id, leaf_node_key, 
-    leaf_node_namespace, minting_point
+    asset_genesis_id, script_key_bytes, universe_root_id, leaf_node_key,
+    leaf_node_namespace, minting_point, block_height
 ) VALUES (
     @asset_genesis_id, @script_key_bytes, @universe_root_id, @leaf_node_key,
-    @leaf_node_namespace, @minting_point
+    @leaf_node_namespace, @minting_point, @block_height
 ) ON CONFLICT (minting_point, script_key_bytes, leaf_node_namespace)
     -- This is a NOP, minting_point and script_key_bytes are the unique fields
     -- that caused the conflict.
     DO UPDATE SET minting_point = EXCLUDED.minting_point,
                   script_key_bytes = EXCLUDED.script_key_bytes,
-                  leaf_node_namespace = EXCLUDED.leaf_node_namespace;
+                  leaf_node_namespace = EXCLUDED.leaf_node_namespace,
+                  block_height = EXCLUDED.block_height;
 
 -- name: DeleteUniverseLeaves :exec
 DELETE FROM universe_leaves

--- a/tapdb/sqlc/schemas/generated_schema.sql
+++ b/tapdb/sqlc/schemas/generated_schema.sql
@@ -899,7 +899,7 @@ CREATE TABLE "universe_leaves" (
     universe_root_id BIGINT NOT NULL REFERENCES universe_roots(id),
     leaf_node_key BLOB,
     leaf_node_namespace VARCHAR NOT NULL
-);
+, block_height INTEGER);
 
 CREATE INDEX universe_leaves_key_idx ON universe_leaves(leaf_node_key);
 

--- a/tapdb/sqlc/universe.sql.go
+++ b/tapdb/sqlc/universe.sql.go
@@ -1011,7 +1011,7 @@ func (q *Queries) QueryUniverseStats(ctx context.Context) (QueryUniverseStatsRow
 }
 
 const UniverseLeaves = `-- name: UniverseLeaves :many
-SELECT id, asset_genesis_id, minting_point, script_key_bytes, universe_root_id, leaf_node_key, leaf_node_namespace FROM universe_leaves
+SELECT id, asset_genesis_id, minting_point, script_key_bytes, universe_root_id, leaf_node_key, leaf_node_namespace, block_height FROM universe_leaves
 `
 
 func (q *Queries) UniverseLeaves(ctx context.Context) ([]UniverseLeafe, error) {
@@ -1031,6 +1031,7 @@ func (q *Queries) UniverseLeaves(ctx context.Context) ([]UniverseLeafe, error) {
 			&i.UniverseRootID,
 			&i.LeafNodeKey,
 			&i.LeafNodeNamespace,
+			&i.BlockHeight,
 		); err != nil {
 			return nil, err
 		}
@@ -1292,17 +1293,18 @@ func (q *Queries) UpsertMultiverseRoot(ctx context.Context, arg UpsertMultiverse
 
 const UpsertUniverseLeaf = `-- name: UpsertUniverseLeaf :exec
 INSERT INTO universe_leaves (
-    asset_genesis_id, script_key_bytes, universe_root_id, leaf_node_key, 
-    leaf_node_namespace, minting_point
+    asset_genesis_id, script_key_bytes, universe_root_id, leaf_node_key,
+    leaf_node_namespace, minting_point, block_height
 ) VALUES (
     $1, $2, $3, $4,
-    $5, $6
+    $5, $6, $7
 ) ON CONFLICT (minting_point, script_key_bytes, leaf_node_namespace)
     -- This is a NOP, minting_point and script_key_bytes are the unique fields
     -- that caused the conflict.
     DO UPDATE SET minting_point = EXCLUDED.minting_point,
                   script_key_bytes = EXCLUDED.script_key_bytes,
-                  leaf_node_namespace = EXCLUDED.leaf_node_namespace
+                  leaf_node_namespace = EXCLUDED.leaf_node_namespace,
+                  block_height = EXCLUDED.block_height
 `
 
 type UpsertUniverseLeafParams struct {
@@ -1312,6 +1314,7 @@ type UpsertUniverseLeafParams struct {
 	LeafNodeKey       []byte
 	LeafNodeNamespace string
 	MintingPoint      []byte
+	BlockHeight       sql.NullInt32
 }
 
 func (q *Queries) UpsertUniverseLeaf(ctx context.Context, arg UpsertUniverseLeafParams) error {
@@ -1322,6 +1325,7 @@ func (q *Queries) UpsertUniverseLeaf(ctx context.Context, arg UpsertUniverseLeaf
 		arg.LeafNodeKey,
 		arg.LeafNodeNamespace,
 		arg.MintingPoint,
+		arg.BlockHeight,
 	)
 	return err
 }

--- a/tapdb/sqlutils.go
+++ b/tapdb/sqlutils.go
@@ -1,6 +1,7 @@
 package tapdb
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"encoding/binary"
@@ -14,7 +15,9 @@ import (
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/taproot-assets/fn"
 	"github.com/lightninglabs/taproot-assets/internal/test"
+	"github.com/lightninglabs/taproot-assets/proof"
 	"github.com/lightninglabs/taproot-assets/tapdb/sqlc"
+	lfn "github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/constraints"
 )
@@ -92,6 +95,24 @@ func sqlStr(s string) sql.NullString {
 		String: s,
 		Valid:  true,
 	}
+}
+
+// SparseDecodeBlockHeight sparse decodes a proof to extract the block height.
+func SparseDecodeBlockHeight(rawProof []byte) (lfn.Option[uint32], error) {
+	var blockHeightVal uint32
+	err := proof.SparseDecode(
+		bytes.NewReader(rawProof),
+		proof.BlockHeightRecord(&blockHeightVal),
+	)
+	if err != nil {
+		return lfn.None[uint32](), fmt.Errorf("unable to sparse decode proof: %w", err)
+	}
+
+	if blockHeightVal == 0 {
+		return lfn.None[uint32](), nil
+	}
+
+	return lfn.Some(blockHeightVal), nil
 }
 
 // extractSqlInt64 turns a NullInt64 into a numerical type. This can be useful

--- a/tapdb/supply_tree.go
+++ b/tapdb/supply_tree.go
@@ -1,14 +1,18 @@
 package tapdb
 
 import (
+	"bytes"
 	"context"
+	"database/sql"
 	"encoding/hex"
+	"errors"
 	"fmt"
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/lightninglabs/taproot-assets/asset"
 	"github.com/lightninglabs/taproot-assets/mssmt"
 	"github.com/lightninglabs/taproot-assets/proof"
+	"github.com/lightninglabs/taproot-assets/tapdb/sqlc"
 	"github.com/lightninglabs/taproot-assets/universe"
 	"github.com/lightninglabs/taproot-assets/universe/supplycommit"
 
@@ -270,18 +274,19 @@ func (s *SupplyTreeStore) FetchRootSupplyTree(ctx context.Context,
 // NOTE: This function must be called within a database transaction.
 func registerMintSupplyInternal(ctx context.Context, dbTx BaseUniverseStore,
 	assetSpec asset.Specifier, key universe.LeafKey, leaf *universe.Leaf,
-	metaReveal *proof.MetaReveal) (*universe.Proof, error) {
+	metaReveal *proof.MetaReveal, blockHeight lfn.Option[uint32]) (*universe.Proof,
+	error) {
 
 	groupKey, err := assetSpec.UnwrapGroupKeyOrErr()
 	if err != nil {
-		return nil, fmt.Errorf("group key must be specified for mint supply: %w", err)
+		return nil, fmt.Errorf("group key must be specified for mint supply: %w", err) //nolint:lll
 	}
 	subNs := subTreeNamespace(groupKey, supplycommit.MintTreeType)
 
 	// Upsert the leaf into the mint supply sub-tree SMT and DB.
 	mintSupplyProof, err := universeUpsertProofLeaf(
 		ctx, dbTx, subNs, supplycommit.MintTreeType.String(), groupKey,
-		key, leaf, metaReveal,
+		key, leaf, metaReveal, blockHeight,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed mint supply universe "+
@@ -307,15 +312,21 @@ func (s *SupplyTreeStore) RegisterMintSupply(ctx context.Context,
 
 	var (
 		writeTx           BaseUniverseStoreOptions
-		err               error
 		mintSupplyProof   *universe.Proof
 		newRootSupplyRoot mssmt.Node
 	)
 	dbErr := s.db.ExecTx(ctx, &writeTx, func(dbTx BaseUniverseStore) error {
+		// We don't need to decode the whole proof, we just need the
+		// block height.
+		blockHeight, err := SparseDecodeBlockHeight(leaf.RawProof)
+		if err != nil {
+			return err
+		}
+
 		// Upsert the leaf into the mint supply sub-tree SMT and DB
 		// first.
 		mintSupplyProof, err = registerMintSupplyInternal(
-			ctx, dbTx, spec, key, leaf, nil,
+			ctx, dbTx, spec, key, leaf, nil, blockHeight,
 		)
 		if err != nil {
 			return fmt.Errorf("failed mint supply universe "+
@@ -387,9 +398,15 @@ func applySupplyUpdatesInternal(ctx context.Context, dbTx BaseUniverseStore,
 					"type: %T", update)
 			}
 
+			var blockHeight lfn.Option[uint32]
+			height := mintEvent.BlockHeight()
+			if height > 0 {
+				blockHeight = lfn.Some(height)
+			}
+
 			mintProof, err := registerMintSupplyInternal(
 				ctx, dbTx, spec, mintEvent.LeafKey,
-				&mintEvent.IssuanceProof, nil,
+				&mintEvent.IssuanceProof, nil, blockHeight,
 			)
 			if err != nil {
 				return nil, fmt.Errorf("failed to register "+
@@ -578,3 +595,4 @@ func (s *SupplyTreeStore) ApplySupplyUpdates(ctx context.Context,
 
 	return finalRoot, nil
 }
+

--- a/tapdb/supply_tree.go
+++ b/tapdb/supply_tree.go
@@ -596,3 +596,111 @@ func (s *SupplyTreeStore) ApplySupplyUpdates(ctx context.Context,
 	return finalRoot, nil
 }
 
+// SupplyUpdate is a struct that holds a supply update event and its block
+// height.
+type SupplyUpdate struct {
+	supplycommit.SupplyUpdateEvent
+	BlockHeight uint32
+}
+
+// FetchSupplyLeavesByHeight fetches all supply leaves for a given asset
+// specifier within a given block height range.
+func (s *SupplyTreeStore) FetchSupplyLeavesByHeight(ctx context.Context,
+	spec asset.Specifier, startHeight, endHeight uint32) ([]SupplyUpdate, error) {
+
+	groupKey, err := spec.UnwrapGroupKeyOrErr()
+	if err != nil {
+		return nil, fmt.Errorf("group key must be "+
+			"specified for supply tree: %w", err)
+	}
+
+	var updates []SupplyUpdate
+
+	readTx := NewBaseUniverseReadTx()
+	dbErr := s.db.ExecTx(ctx, &readTx, func(db BaseUniverseStore) error {
+		for _, treeType := range []supplycommit.SupplySubTree{
+			supplycommit.MintTreeType, supplycommit.BurnTreeType,
+			supplycommit.IgnoreTreeType,
+		} {
+			namespace := subTreeNamespace(groupKey, treeType)
+
+			leaves, err := db.QuerySupplyLeavesByHeight(
+				ctx, sqlc.QuerySupplyLeavesByHeightParams{
+					Namespace:   namespace,
+					StartHeight: sqlInt32(startHeight),
+					EndHeight:   sqlInt32(endHeight),
+				},
+			)
+			if err != nil {
+				if errors.Is(err, sql.ErrNoRows) {
+					continue
+				}
+
+				return fmt.Errorf("failed to query "+
+					"supply leaves: %w", err)
+			}
+
+			for _, leaf := range leaves {
+				var event supplycommit.SupplyUpdateEvent
+				switch treeType {
+				case supplycommit.MintTreeType:
+					var mintEvent supplycommit.NewMintEvent
+					err = mintEvent.Decode(
+						bytes.NewReader(
+							leaf.SupplyLeafBytes,
+						),
+					)
+					if err != nil {
+						return fmt.Errorf("failed "+
+							"to decode mint "+
+							"event: %w", err)
+					}
+
+					event = &mintEvent
+
+				case supplycommit.BurnTreeType:
+					var burnEvent supplycommit.NewBurnEvent
+					err = burnEvent.Decode(
+						bytes.NewReader(
+							leaf.SupplyLeafBytes,
+						),
+					)
+					if err != nil {
+						return fmt.Errorf("failed "+
+							"to decode burn "+
+							"event: %w", err)
+					}
+
+					event = &burnEvent
+
+				case supplycommit.IgnoreTreeType:
+					var ignoreEvent supplycommit.NewIgnoreEvent
+					err = ignoreEvent.Decode(
+						bytes.NewReader(
+							leaf.SupplyLeafBytes,
+						),
+					)
+					if err != nil {
+						return fmt.Errorf("failed "+
+							"to decode ignore "+
+							"event: %w", err)
+					}
+					event = &ignoreEvent
+				}
+
+				updates = append(updates, SupplyUpdate{
+					SupplyUpdateEvent: event,
+					BlockHeight: extractSqlInt32[uint32](
+						leaf.BlockHeight,
+					),
+				})
+			}
+		}
+		return nil
+	})
+	if dbErr != nil {
+		return nil, dbErr
+	}
+
+	return updates, nil
+}

--- a/tapdb/supply_tree_test.go
+++ b/tapdb/supply_tree_test.go
@@ -248,7 +248,8 @@ func randIgnoreTupleGen(t *rapid.T,
 			ScriptKey: asset.ToSerialized(scriptKey.PubKey),
 			OutPoint:  op,
 		},
-		Amount: 100,
+		Amount:      100,
+		BlockHeight: rapid.Uint32Range(1, 1000).Draw(t, "block_height"),
 	}
 
 	// Create a signature for the ignore tuple.
@@ -365,6 +366,101 @@ func setupSupplyTreeTestForProps(t *testing.T) (*SupplyTreeStore,
 	eventGen := randSupplyUpdateEventGen(baseGenesis, groupKey, dbTxer)
 
 	return supplyStore, spec, eventGen
+}
+
+// createMintEventWithHeight creates a mint event with a specific block height.
+func createMintEventWithHeight(t *testing.T, groupKey *btcec.PublicKey,
+	height uint32) *supplycommit.NewMintEvent {
+
+	mintAsset := asset.RandAsset(t, asset.Normal)
+	mintAsset.GroupKey = &asset.GroupKey{GroupPubKey: *groupKey}
+	mintAsset.GroupKey.Witness = mintAsset.PrevWitnesses[0].TxWitness
+
+	mintProof := randProof(t, mintAsset)
+	mintProof.BlockHeight = height
+	mintProof.GroupKeyReveal = asset.NewGroupKeyRevealV0(
+		asset.ToSerialized(groupKey), nil,
+	)
+
+	var proofBuf bytes.Buffer
+	require.NoError(t, mintProof.Encode(&proofBuf))
+
+	mintLeaf := universe.Leaf{
+		GenesisWithGroup: universe.GenesisWithGroup{
+			Genesis:  mintAsset.Genesis,
+			GroupKey: mintAsset.GroupKey,
+		},
+		Asset:    &mintProof.Asset,
+		Amt:      mintProof.Asset.Amount,
+		RawProof: proofBuf.Bytes(),
+	}
+
+	mintKey := universe.AssetLeafKey{
+		BaseLeafKey: universe.BaseLeafKey{
+			OutPoint:  mintProof.OutPoint(),
+			ScriptKey: &mintProof.Asset.ScriptKey,
+		},
+		AssetID: mintProof.Asset.ID(),
+	}
+
+	return &supplycommit.NewMintEvent{
+		LeafKey:       mintKey,
+		IssuanceProof: mintLeaf,
+	}
+}
+
+// createBurnEventWithHeight creates a burn event with a specific block height.
+func createBurnEventWithHeight(t *testing.T, baseGenesis asset.Genesis,
+	groupKey *asset.GroupKey, db BatchedUniverseTree,
+	height uint32) *supplycommit.NewBurnEvent {
+
+	burnAsset := createBurnAsset(t)
+	burnAsset.Genesis = baseGenesis
+	burnAsset.GroupKey = groupKey
+
+	burnProof := randProof(t, burnAsset)
+	burnProof.BlockHeight = height
+	burnProof.GenesisReveal = &baseGenesis
+
+	// Ensure genesis exists for this burn leaf in the DB.
+	ctx := context.Background()
+	genesisPointID, err := upsertGenesisPoint(
+		ctx, db, burnAsset.Genesis.FirstPrevOut,
+	)
+	require.NoError(t, err)
+	_, err = upsertGenesis(
+		ctx, db, genesisPointID, burnAsset.Genesis,
+	)
+	require.NoError(t, err)
+
+	burnLeaf := &universe.BurnLeaf{
+		UniverseKey: universe.AssetLeafKey{
+			BaseLeafKey: universe.BaseLeafKey{
+				OutPoint:  burnProof.OutPoint(),
+				ScriptKey: &burnProof.Asset.ScriptKey,
+			},
+			AssetID: burnProof.Asset.ID(),
+		},
+		BurnProof: burnProof,
+	}
+
+	return &supplycommit.NewBurnEvent{
+		BurnLeaf: *burnLeaf,
+	}
+}
+
+// createIgnoreEventWithHeight creates an ignore event with a specific block
+// height.
+func createIgnoreEventWithHeight(t *testing.T, baseAssetID asset.ID,
+	db BatchedUniverseTree, height uint32) *supplycommit.NewIgnoreEvent {
+
+	signedTuple := randIgnoreTuple(t, db)
+	signedTuple.IgnoreTuple.Val.ID = baseAssetID
+	signedTuple.IgnoreTuple.Val.BlockHeight = height
+
+	return &supplycommit.NewIgnoreEvent{
+		SignedIgnoreTuple: signedTuple,
+	}
 }
 
 // TestSupplyTreeStoreApplySupplyUpdates tests that the ApplySupplyUpdates meets
@@ -543,4 +639,115 @@ func TestSupplyTreeStoreApplySupplyUpdates(t *testing.T) {
 		ctxb, spec, updates,
 	)
 	require.NoError(t, err)
+}
+
+// TestSupplyTreeStoreFetchSupplyLeavesByHeight tests the
+// FetchSupplyLeavesByHeight method.
+func TestSupplyTreeStoreFetchSupplyLeavesByHeight(t *testing.T) {
+	t.Parallel()
+
+	supplyStore, spec, _ := setupSupplyTreeTestForProps(t)
+	ctxb := context.Background()
+	dbTxer := supplyStore.db.(BatchedUniverseTree)
+
+	groupKey, err := spec.UnwrapGroupKeyOrErr()
+	require.NoError(t, err)
+	assetID := spec.UnwrapIdToPtr()
+
+	fullGroupKey := &asset.GroupKey{
+		GroupPubKey: *groupKey,
+	}
+
+	// Create events with specific block heights, we'll use these heights
+	// below to ensure that the new leaf height is properly set/read all the
+	// way down the call stack.
+	mintEvent100 := createMintEventWithHeight(t, groupKey, 100)
+	burnEvent200 := createBurnEventWithHeight(
+		t, asset.RandGenesis(t, asset.Normal), fullGroupKey, dbTxer,
+		200,
+	)
+	ignoreEvent300 := createIgnoreEventWithHeight(t, *assetID, dbTxer, 300)
+	mintEvent400 := createMintEventWithHeight(t, groupKey, 400)
+
+	updates := []supplycommit.SupplyUpdateEvent{
+		mintEvent100, burnEvent200, ignoreEvent300, mintEvent400,
+	}
+
+	// Apply updates.
+	_, err = supplyStore.ApplySupplyUpdates(ctxb, spec, updates)
+	require.NoError(t, err)
+
+	testCases := []struct {
+		name            string
+		startHeight     uint32
+		endHeight       uint32
+		expectedCount   int
+		expectedHeights []uint32
+	}{
+		{
+			name:            "range including first",
+			startHeight:     0,
+			endHeight:       150,
+			expectedCount:   1,
+			expectedHeights: []uint32{100},
+		},
+		{
+			name:            "range including second",
+			startHeight:     150,
+			endHeight:       250,
+			expectedCount:   1,
+			expectedHeights: []uint32{200},
+		},
+		{
+			name:            "range including all",
+			startHeight:     0,
+			endHeight:       500,
+			expectedCount:   4,
+			expectedHeights: []uint32{100, 200, 300, 400},
+		},
+		{
+			name:            "exact range",
+			startHeight:     100,
+			endHeight:       400,
+			expectedCount:   4,
+			expectedHeights: []uint32{100, 200, 300, 400},
+		},
+		{
+			name:            "inner range",
+			startHeight:     101,
+			endHeight:       399,
+			expectedCount:   2,
+			expectedHeights: []uint32{200, 300},
+		},
+		{
+			name:            "range after all",
+			startHeight:     501,
+			endHeight:       1000,
+			expectedCount:   0,
+			expectedHeights: nil,
+		},
+		{
+			name:            "range before all",
+			startHeight:     0,
+			endHeight:       99,
+			expectedCount:   0,
+			expectedHeights: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			leaves, err := supplyStore.FetchSupplyLeavesByHeight(
+				ctxb, spec, tc.startHeight, tc.endHeight,
+			)
+			require.NoError(t, err)
+			require.Len(t, leaves, tc.expectedCount)
+
+			var heights []uint32
+			for _, leaf := range leaves {
+				heights = append(heights, leaf.BlockHeight)
+			}
+			require.ElementsMatch(t, tc.expectedHeights, heights)
+		})
+	}
 }

--- a/tapdb/universe.go
+++ b/tapdb/universe.go
@@ -58,6 +58,10 @@ type (
 
 	// UpsertUniverseSupplyLeaf is used to upsert a universe supply leaf.
 	UpsertUniverseSupplyLeaf = sqlc.UpsertUniverseSupplyLeafParams
+
+	// QuerySupplyLeavesByHeightParams is used to query for supply leaves
+	// by height.
+	QuerySupplyLeavesByHeightParams = sqlc.QuerySupplyLeavesByHeightParams
 )
 
 // BaseUniverseStore is the main interface for the Taproot Asset universe store.
@@ -128,6 +132,11 @@ type BaseUniverseStore interface {
 	// supply tree for a given asset.
 	UpsertUniverseSupplyRoot(ctx context.Context,
 		arg UpsertUniverseSupplyRoot) (int64, error)
+
+	// QuerySupplyLeavesByHeight is used to query for supply leaves by
+	// height.
+	QuerySupplyLeavesByHeight(ctx context.Context,
+		arg QuerySupplyLeavesByHeightParams) ([]sqlc.QuerySupplyLeavesByHeightRow, error)
 }
 
 // specifierToIdentifier converts an asset.Specifier into a universe.Identifier
@@ -595,9 +604,17 @@ func (b *BaseUniverseTree) UpsertProofLeaf(ctx context.Context,
 	)
 	dbErr := b.db.ExecTx(ctx, &writeTx, func(dbTx BaseUniverseStore) error {
 		namespace := b.id.String()
+
+		// We don't need to decode the whole proof, we just need the
+		// block height.
+		blockHeight, err := SparseDecodeBlockHeight(leaf.RawProof)
+		if err != nil {
+			return err
+		}
+
 		issuanceProof, err := universeUpsertProofLeaf(
-			ctx, dbTx, namespace, b.id.ProofType.String(),
-			b.id.GroupKey, key, leaf, metaReveal,
+			ctx, dbTx, namespace, b.id.ProofType.String(), b.id.GroupKey,
+			key, leaf, metaReveal, blockHeight,
 		)
 		if err != nil {
 			return fmt.Errorf("failed universe upsert: %w", err)
@@ -727,7 +744,8 @@ func upsertMultiverseLeafEntry(ctx context.Context, dbTx BaseUniverseStore,
 func universeUpsertProofLeaf(ctx context.Context, dbTx BaseUniverseStore,
 	namespace string, proofTypeStr string, groupKey *btcec.PublicKey,
 	key universe.LeafKey, leaf *universe.Leaf,
-	metaReveal *proof.MetaReveal) (*universe.Proof, error) {
+	metaReveal *proof.MetaReveal, blockHeight lfn.Option[uint32]) (*universe.Proof,
+	error) {
 
 	// With the tree store created, we'll now obtain byte representation of
 	// the minting key, as that'll be the key in the SMT itself.
@@ -798,6 +816,23 @@ func universeUpsertProofLeaf(ctx context.Context, dbTx BaseUniverseStore,
 		return nil, err
 	}
 
+	// If the block height isn't specified, then we'll attempt to extract it
+	// from the proof itself.
+	if blockHeight.IsNone() {
+		if leafProof.BlockHeight > 0 {
+			blockHeight = lfn.Some(leafProof.BlockHeight)
+		}
+	}
+
+	sqlBlockHeight := lfn.MapOptionZ(
+		blockHeight, func(num uint32) sql.NullInt32 {
+			return sql.NullInt32{
+				Int32: int32(num),
+				Valid: true,
+			}
+		},
+	)
+
 	scriptKey := key.LeafScriptKey()
 	scriptKeyBytes := schnorr.SerializePubKey(scriptKey.PubKey)
 	err = dbTx.UpsertUniverseLeaf(ctx, UpsertUniverseLeaf{
@@ -807,6 +842,7 @@ func universeUpsertProofLeaf(ctx context.Context, dbTx BaseUniverseStore,
 		LeafNodeKey:       smtKey[:],
 		LeafNodeNamespace: namespace,
 		MintingPoint:      mintingPointBytes,
+		BlockHeight:       sqlBlockHeight,
 	})
 	if err != nil {
 		return nil, err

--- a/universe/ignore_records_test.go
+++ b/universe/ignore_records_test.go
@@ -31,8 +31,9 @@ var IgnoreSigGen = rapid.Custom(func(t *rapid.T) IgnoreSig {
 // (PrevID) objects. It reuses the NonGenesisPrevIDGen from the asset package.
 var IgnoreTupleGen = rapid.Custom(func(t *rapid.T) IgnoreTuple {
 	return IgnoreTuple{
-		PrevID: asset.NonGenesisPrevIDGen.Draw(t, "ignore_tuple"),
-		Amount: rapid.Uint64().Draw(t, "amount"),
+		PrevID:      asset.NonGenesisPrevIDGen.Draw(t, "ignore_tuple"),
+		Amount:      rapid.Uint64().Draw(t, "amount"),
+		BlockHeight: rapid.Uint32().Draw(t, "block_height"),
 	}
 })
 


### PR DESCRIPTION
In this PR, we add a new method `FetchSupplyLeavesByHeight`, that can be used to query for the leaves of a supply tree by height. This will be useful for writing the new syncing state machine and the sub-system that serves the supply tree syncer. Such a syncer would start from the initially created pre-commitment, then fetch all the leaves for the future updates, assemble those into the supply tree, then verify that everything matches up. 

<details>

<summary> Prompts used during development (aider+Gemini 2.5-pro-06-5) </summary>

### Initial draft creation

Based on by working memory of this new feature, I scanned the relevant files, then made mental nodes of what needed to be updated. I then drafted this fairly detailed prompt that guided `aider` w.r.t which files to update, and the set of high level changes to make. 
 
```
#### Today we assemble the individual updates (burn, ignore, mint) for a given asset  
#### specifier (group key is what we care about) into distinct trees for each type.  
#### We then further aggregrate each of those roots into a unified supply tree for  
#### the entire asset specifier. This tree commits to a root sum of the supply (you  
#### can subtract out any of the roots from the root sum to derive a snapshot of the  
#### supply such as the amt burnt, etc).  
####   
#### We then also have a system to assemble these updates, then commit then in a  
#### batch, this exists in: tapdb/supply_commit.go and tapdb/supply_tree.go.  
####   
#### For each of the supply sub-trees, we actually re-use the existing  
#### universe_leaves table to point to each of the respective leaves.  
####   
#### In this task, we want to add a block height to this leaf, as this'll allow us  
#### to scan the leaves in order, based on the type, so we can send out the set of  
#### leaves added in a state transition to a party that wants to sync the set of  
#### leaves.  
####   
####   
#### For this, we may need to update the set of queries in:  
#### tapdb/sqlc/queries/universe.sql. Of interest is also the  
#### applySupplyUpdatesInternal helper function, as we'll want to make sure that the  
#### helper functions that it calls properly inserts the height into the ultimately  
#### universe leaf. For the mint and burn types, we can obtain this height from the  
#### issuance proof.  
####   
#### For the ignore type, we'll need to add a block height field to  
#### universe.IgnoreTuple (universe/ignore_records.go).  
####   
#### For the leaves, we'll likely need to add a new migration (38) which adds the  
#### new height field (can be NULL) to the universe_leaves table.  
####   
#### We'll likely also want to add a new BlockHeight() method to the  
#### SupplyUpdateEvent interface.  
####   
#### Next, we'll want a new method on the SupplyTreeStore that given a start+end  
#### height and a specifier, the set of updates whose universe_leaves have a block  
#### height between that param. This may need to update  
#### tapdb/sqlc/queries/supply_tree.sql.  
####   
#### Also see tapdb/querier.go.  
####   
#### Ruminate on my sketch above, then let's create an execution plan remembering  
#### the ultimate goal. From there we'll implement each portion.  
```

### Subsequent iterations 

From here I made an edit or two to get things compiling. Then I executed a series of prompts to refine the code, refactor slightly, then add unit tests. 


> #### inside multiverse.UpsertProof Leaf, let's use `SparseDecode` instead along with `BlockHeightRecord` as we don't need to decode the entire proof just to get the block height  

> #### let's use the same sparse decode in `BaseUniverseStore`.UpsertProofLeaf  

> #### let's do the same for `SupplyTreeStore`.RegisterMintSupply (sparse decode)  

> #### can we morph that into a function closure invocation that itself returns lfn.Option[uint32]? so we don't leak that intermediate variable to the higher scope  

> #### great! but now we have a bit of duplication, can we make a helper function can call that intead of having the same duplication everywhere? we can put the helper function in tapdb/sqlutils.go  

> #### nice! now let's extend the unit tests in tapdb/supply_tree_test.go to cover the new `FetchSupplyLeavesByHeight` method.  

I messed when committing and dropped a commit entirely (lol), so I had `aider` re-add it: 
> #### help me ree-add `QuerySupplyLeavesByHeight` back to tapdb/sqlc/queries/supply_tree.sql, I deleted it accidentally  





</details>