### PR TITLE
tapdb: use testing.TB for common test utilities, downgrade universe pref test to benchmark 

### DIFF
--- a/tapdb/postgres.go
+++ b/tapdb/postgres.go
@@ -171,7 +171,7 @@ func (s *PostgresStore) ExecuteMigrations(target MigrationTarget,
 
 // NewTestPostgresDB is a helper function that creates a Postgres database for
 // testing.
-func NewTestPostgresDB(t *testing.T) *PostgresStore {
+func NewTestPostgresDB(t testing.TB) *PostgresStore {
 	t.Helper()
 
 	t.Logf("Creating new Postgres DB for testing")
@@ -189,7 +189,7 @@ func NewTestPostgresDB(t *testing.T) *PostgresStore {
 
 // NewTestPostgresDBWithVersion is a helper function that creates a Postgres
 // database for testing and migrates it to the given version.
-func NewTestPostgresDBWithVersion(t *testing.T, version uint) *PostgresStore {
+func NewTestPostgresDBWithVersion(t testing.TB, version uint) *PostgresStore {
 	t.Helper()
 
 	t.Logf("Creating new Postgres DB for testing, migrating to version %d",

--- a/tapdb/postgres_fixture.go
+++ b/tapdb/postgres_fixture.go
@@ -35,7 +35,7 @@ type TestPgFixture struct {
 // NewTestPgFixture constructs a new TestPgFixture starting up a docker
 // container running Postgres 11. The started container will expire in after
 // the passed duration.
-func NewTestPgFixture(t *testing.T, expiry time.Duration,
+func NewTestPgFixture(t testing.TB, expiry time.Duration,
 	autoRemove bool) *TestPgFixture {
 
 	// Use a sensible default on Windows (tcp/http) and linux/osx (socket)
@@ -122,13 +122,13 @@ func (f *TestPgFixture) GetConfig() *PostgresConfig {
 }
 
 // TearDown stops the underlying docker container.
-func (f *TestPgFixture) TearDown(t *testing.T) {
+func (f *TestPgFixture) TearDown(t testing.TB) {
 	err := f.pool.Purge(f.resource)
 	require.NoError(t, err, "Could not purge resource")
 }
 
 // ClearDB clears the database.
-func (f *TestPgFixture) ClearDB(t *testing.T) {
+func (f *TestPgFixture) ClearDB(t testing.TB) {
 	dbConn, err := sql.Open("postgres", f.GetDSN())
 	require.NoError(t, err)
 

--- a/tapdb/sqlite.go
+++ b/tapdb/sqlite.go
@@ -256,7 +256,7 @@ func (s *SqliteStore) ExecuteMigrations(target MigrationTarget,
 
 // NewTestSqliteDB is a helper function that creates an SQLite database for
 // testing.
-func NewTestSqliteDB(t *testing.T) *SqliteStore {
+func NewTestSqliteDB(t testing.TB) *SqliteStore {
 	t.Helper()
 
 	// TODO(roasbeef): if we pass :memory: for the file name, then we get
@@ -269,7 +269,7 @@ func NewTestSqliteDB(t *testing.T) *SqliteStore {
 
 // NewTestSqliteDbHandleFromPath is a helper function that creates a SQLite
 // database handle given a database file path.
-func NewTestSqliteDbHandleFromPath(t *testing.T, dbPath string) *SqliteStore {
+func NewTestSqliteDbHandleFromPath(t testing.TB, dbPath string) *SqliteStore {
 	t.Helper()
 
 	sqlDB, err := NewSqliteStore(&SqliteConfig{
@@ -287,7 +287,7 @@ func NewTestSqliteDbHandleFromPath(t *testing.T, dbPath string) *SqliteStore {
 
 // NewTestSqliteDBWithVersion is a helper function that creates an SQLite
 // database for testing and migrates it to the given version.
-func NewTestSqliteDBWithVersion(t *testing.T, version uint) *SqliteStore {
+func NewTestSqliteDBWithVersion(t testing.TB, version uint) *SqliteStore {
 	t.Helper()
 
 	t.Logf("Creating new SQLite DB for testing, migrating to version %d",

--- a/tapdb/test_postgres.go
+++ b/tapdb/test_postgres.go
@@ -7,18 +7,18 @@ import (
 )
 
 // NewTestDB is a helper function that creates a Postgres database for testing.
-func NewTestDB(t *testing.T) *PostgresStore {
+func NewTestDB(t testing.TB) *PostgresStore {
 	return NewTestPostgresDB(t)
 }
 
 // NewTestDbHandleFromPath is a helper function that creates a new handle to an
 // existing SQLite database for testing.
-func NewTestDbHandleFromPath(t *testing.T, dbPath string) *PostgresStore {
+func NewTestDbHandleFromPath(t testing.TB, dbPath string) *PostgresStore {
 	return NewTestPostgresDB(t)
 }
 
 // NewTestDBWithVersion is a helper function that creates a Postgres database
 // for testing and migrates it to the given version.
-func NewTestDBWithVersion(t *testing.T, version uint) *PostgresStore {
+func NewTestDBWithVersion(t testing.TB, version uint) *PostgresStore {
 	return NewTestPostgresDBWithVersion(t, version)
 }

--- a/tapdb/test_sqlite.go
+++ b/tapdb/test_sqlite.go
@@ -7,18 +7,18 @@ import (
 )
 
 // NewTestDB is a helper function that creates an SQLite database for testing.
-func NewTestDB(t *testing.T) *SqliteStore {
+func NewTestDB(t testing.TB) *SqliteStore {
 	return NewTestSqliteDB(t)
 }
 
 // NewTestDbHandleFromPath is a helper function that creates a new handle to an
 // existing SQLite database for testing.
-func NewTestDbHandleFromPath(t *testing.T, dbPath string) *SqliteStore {
+func NewTestDbHandleFromPath(t testing.TB, dbPath string) *SqliteStore {
 	return NewTestSqliteDbHandleFromPath(t, dbPath)
 }
 
 // NewTestDBWithVersion is a helper function that creates an SQLite database for
 // testing and migrates it to the given version.
-func NewTestDBWithVersion(t *testing.T, version uint) *SqliteStore {
+func NewTestDBWithVersion(t testing.TB, version uint) *SqliteStore {
 	return NewTestSqliteDBWithVersion(t, version)
 }

--- a/tapdb/universe_stats_test.go
+++ b/tapdb/universe_stats_test.go
@@ -43,10 +43,10 @@ type uniStatsHarness struct {
 
 	db *UniverseStats
 
-	t *testing.T
+	t testing.TB
 }
 
-func newUniStatsHarness(t *testing.T, numAssets int, db *BaseDB,
+func newUniStatsHarness(t testing.TB, numAssets int, db *BaseDB,
 	statsDB *UniverseStats) *uniStatsHarness {
 
 	stats := &uniStatsHarness{
@@ -100,7 +100,7 @@ func (u *uniStatsHarness) logSyncEventByIndex(i int) {
 	require.NoError(u.t, err)
 }
 
-func (u *uniStatsHarness) assertUniverseStatsEqual(t *testing.T,
+func (u *uniStatsHarness) assertUniverseStatsEqual(t testing.TB,
 	stats universe.AggregateStats) {
 
 	var (

--- a/tapdb/universe_test.go
+++ b/tapdb/universe_test.go
@@ -68,7 +68,7 @@ func randUniverseID(t testing.TB, forceGroup bool,
 	return id
 }
 
-func newTestUniverse(t *testing.T,
+func newTestUniverse(t testing.TB,
 	id universe.Identifier) (*BaseUniverseTree, sqlc.Querier) {
 
 	db := NewTestDB(t)
@@ -82,7 +82,7 @@ func newTestUniverse(t *testing.T,
 	return NewBaseUniverseTree(dbTxer, id), db
 }
 
-func newTestMultiverse(t *testing.T) (*MultiverseStore, sqlc.Querier) {
+func newTestMultiverse(t testing.TB) (*MultiverseStore, sqlc.Querier) {
 	db := NewTestDB(t)
 
 	dbTxer := NewTransactionExecutor(
@@ -116,7 +116,7 @@ func newTestUniverseWithDb(db *BaseDB,
 	return NewBaseUniverseTree(dbTxer, id), db
 }
 
-func assertIDInList(t *testing.T, leaves []universe.MultiverseLeaf,
+func assertIDInList(t testing.TB, leaves []universe.MultiverseLeaf,
 	id universe.Identifier) {
 
 	require.True(t, fn.Any(leaves, func(l universe.MultiverseLeaf) bool {
@@ -155,14 +155,14 @@ func TestUniverseEmptyTree(t *testing.T) {
 	require.ErrorIs(t, err, universe.ErrNoUniverseRoot)
 }
 
-func randLeafKey(t *testing.T) universe.LeafKey {
+func randLeafKey(t testing.TB) universe.LeafKey {
 	return universe.BaseLeafKey{
 		OutPoint:  test.RandOp(t),
 		ScriptKey: fn.Ptr(asset.NewScriptKey(test.RandPubKey(t))),
 	}
 }
 
-func randProof(t *testing.T, argAsset *asset.Asset) *proof.Proof {
+func randProof(t testing.TB, argAsset *asset.Asset) *proof.Proof {
 	proofAsset := *asset.RandAsset(t, asset.Normal)
 	if argAsset != nil {
 		proofAsset = *argAsset
@@ -200,7 +200,7 @@ func randProof(t *testing.T, argAsset *asset.Asset) *proof.Proof {
 	}
 }
 
-func randMintingLeaf(t *testing.T, assetGen asset.Genesis,
+func randMintingLeaf(t testing.TB, assetGen asset.Genesis,
 	groupKey *btcec.PublicKey) universe.Leaf {
 
 	randProof := randProof(t, nil)
@@ -490,7 +490,7 @@ func TestUniverseMetaBlob(t *testing.T) {
 	require.Equal(t, assetGen.ID(), uniProof.Leaf.Genesis.ID())
 }
 
-func insertRandLeaf(t *testing.T, ctx context.Context, tree *BaseUniverseTree,
+func insertRandLeaf(t testing.TB, ctx context.Context, tree *BaseUniverseTree,
 	assetGen *asset.Genesis) (*universe.Proof, error) {
 
 	var targetGen asset.Genesis


### PR DESCRIPTION
In this PR, we eefactor various test helper functions within the `tapdb` package to accept `testing.TB` as an argument instead of `*testing.T`.

The `testing.TB` interface is implemented by both `*testing.T` (for standard tests) and `*testing.B` (for benchmarks). This change allows common test setup and utility functions to be reused seamlessly across both test and benchmark contexts.

Specifically, this enables the `TestUniverseIndexPerformance` function to be converted into a `BenchmarkUniverseIndexPerformance`, utilizing the same database setup and query execution logic. Corresponding logging calls within this benchmark were updated from `t.Logf` to `b.Logf`.

The ultimate goal is having the `TestUniverseIndexPerformance` instead be a benchmark rather than a test. It takes a while to run, so now with this change, it'll only be run if specified as a benchmark. 