### PR TITLE
asset: tighten GroupKey equality checks and update tests

### DIFF
--- a/asset/group_key.go
+++ b/asset/group_key.go
@@ -986,7 +986,7 @@ func (g *GroupKey) IsEqual(otherGroupKey *GroupKey) bool {
 		return false
 	}
 
-	equalGroup := g.IsEqualGroup(otherGroupKey)
+	equalGroup := g.IsSameGroup(otherGroupKey)
 	if !equalGroup {
 		return false
 	}
@@ -1002,9 +1002,9 @@ func (g *GroupKey) IsEqual(otherGroupKey *GroupKey) bool {
 	return slices.EqualFunc(g.Witness, otherGroupKey.Witness, bytes.Equal)
 }
 
-// IsEqualGroup returns true if this group key describes the same asset group
-// as the passed other group key.
-func (g *GroupKey) IsEqualGroup(otherGroupKey *GroupKey) bool {
+// IsSameGroup returns true if this group key refers to the same asset group
+// as the given group key.
+func (g *GroupKey) IsSameGroup(otherGroupKey *GroupKey) bool {
 	// If this key is nil, the other must be nil too.
 	if g == nil {
 		return otherGroupKey == nil

--- a/asset/group_key.go
+++ b/asset/group_key.go
@@ -975,6 +975,40 @@ func GroupPubKeyV0(rawKey *btcec.PublicKey, singleTweak, tapTweak []byte) (
 	}
 }
 
+// IsEqualCustomTapscriptRoot reports whether the receiver and the provided
+// GroupKey define the same custom tapscript root.
+//
+// Equality semantics:
+//  1. If neither key sets a custom tapscript root (both options are None),
+//     the keys are considered equal.
+//  2. If both keys set a custom tapscript root (both options are Some), the
+//     underlying root hashes must be identical.
+//  3. If the presence bits differ (one Some, the other None) the keys are
+//     unequal.
+//
+// Fields other than CustomTapscriptRoot are intentionally ignored.
+func (g *GroupKey) IsEqualCustomTapscriptRoot(otherGroupKey *GroupKey) bool {
+	// If the two presence flags differ, the roots cannot be equal.
+	if g.CustomTapscriptRoot.IsSome() !=
+		otherGroupKey.CustomTapscriptRoot.IsSome() {
+
+		return false
+	}
+
+	// Both option flags are None -> neither key specifies a custom root;
+	// they match trivially.
+	if g.CustomTapscriptRoot.IsNone() {
+		return true
+	}
+
+	// At this point both option flags are Some. Compare the underlying
+	// hashes.
+	root := g.CustomTapscriptRoot.UnwrapToPtr()
+	otherRoot := otherGroupKey.CustomTapscriptRoot.UnwrapToPtr()
+
+	return root.IsEqual(otherRoot)
+}
+
 // IsEqual returns true if this group key and signature are exactly equivalent
 // to the passed other group key.
 func (g *GroupKey) IsEqual(otherGroupKey *GroupKey) bool {
@@ -992,6 +1026,10 @@ func (g *GroupKey) IsEqual(otherGroupKey *GroupKey) bool {
 	}
 
 	if !bytes.Equal(g.TapscriptRoot, otherGroupKey.TapscriptRoot) {
+		return false
+	}
+
+	if !g.IsEqualCustomTapscriptRoot(otherGroupKey) {
 		return false
 	}
 

--- a/asset/group_key.go
+++ b/asset/group_key.go
@@ -1020,6 +1020,10 @@ func (g *GroupKey) IsEqual(otherGroupKey *GroupKey) bool {
 		return false
 	}
 
+	if g.Version != otherGroupKey.Version {
+		return false
+	}
+
 	equalGroup := g.IsSameGroup(otherGroupKey)
 	if !equalGroup {
 		return false

--- a/commitment/asset.go
+++ b/commitment/asset.go
@@ -117,7 +117,7 @@ func parseCommon(assets ...*asset.Asset) (*AssetCommitment, error) {
 		}
 
 		switch {
-		case !expectedGroupKey.IsEqualGroup(newAsset.GroupKey):
+		case !expectedGroupKey.IsSameGroup(newAsset.GroupKey):
 			return nil, ErrAssetGroupKeyMismatch
 
 		case expectedGroupKey == nil:

--- a/tapdb/assets_store_test.go
+++ b/tapdb/assets_store_test.go
@@ -2058,82 +2058,104 @@ func TestAssetGroupComplexWitness(t *testing.T) {
 	require.True(t, groupKey.IsEqual(storedGroup.GroupKey))
 }
 
-// TestAssetGroupV1 tests that we can store and fetch an asset group version 1.
-func TestAssetGroupV1(t *testing.T) {
+// TestStoreFetchAssetGroupV1 tests that we can store and fetch an asset group
+// version 1.
+func TestStoreFetchAssetGroupV1(t *testing.T) {
 	t.Parallel()
 
-	mintingStore, assetStore, db := newAssetStore(t)
-	ctx := context.Background()
-
-	internalKey := test.RandPubKey(t)
-	groupAnchorGen := asset.RandGenesis(t, asset.RandAssetType(t))
-	groupAnchorGen.MetaHash = [32]byte{}
-	tapscriptRoot := test.RandBytes(32)
-	customTapscriptRoot := test.RandHash()
-	groupSig := test.RandBytes(64)
-
-	// First, we'll insert all the required rows we need to satisfy the
-	// foreign key constraints needed to insert a new genesis witness.
-	genesisPointID, err := upsertGenesisPoint(
-		ctx, db, groupAnchorGen.FirstPrevOut,
-	)
-	require.NoError(t, err)
-
-	genAssetID, err := upsertGenesis(
-		ctx, db, genesisPointID, groupAnchorGen,
-	)
-	require.NoError(t, err)
-
-	groupKey := asset.GroupKey{
-		Version: asset.GroupKeyV1,
-		RawKey: keychain.KeyDescriptor{
-			PubKey: internalKey,
+	testCases := []struct {
+		name                string
+		customTapscriptRoot fn.Option[chainhash.Hash]
+		witnessData         [][]byte
+		expectedError       error
+	}{{
+		name:                "group key with custom tapscript root",
+		customTapscriptRoot: fn.Some(test.RandHash()),
+		witnessData: [][]byte{
+			test.RandBytes(32),
+			test.RandBytes(64),
 		},
-		GroupPubKey:   *internalKey,
-		TapscriptRoot: tapscriptRoot,
-		CustomTapscriptRoot: fn.Some[chainhash.Hash](
-			customTapscriptRoot,
-		),
-		Witness: fn.MakeSlice(tapscriptRoot, groupSig),
-	}
-
-	// Upsert, fetch, and check the group key.
-	_, err = upsertGroupKey(
-		ctx, &groupKey, assetStore.db, genesisPointID, genAssetID,
-	)
-	require.NoError(t, err)
-
-	storedGroup, err := mintingStore.FetchGroupByGroupKey(ctx, internalKey)
-	require.NoError(t, err)
-
-	require.Equal(t, groupAnchorGen, *storedGroup.Genesis)
-	require.True(t, groupKey.IsEqual(storedGroup.GroupKey))
-
-	// Formulate a new group key where the custom tapscript root is None.
-	// Check that we can insert and fetch the group key.
-	groupKeyCustomRootNone := asset.GroupKey{
-		Version: asset.GroupKeyV1,
-		RawKey: keychain.KeyDescriptor{
-			PubKey: internalKey,
+		expectedError: nil,
+	}, {
+		name: "group key without custom tapscript " +
+			"root",
+		customTapscriptRoot: fn.None[chainhash.Hash](),
+		witnessData: [][]byte{
+			test.RandBytes(32),
+			test.RandBytes(64),
 		},
-		GroupPubKey:         *internalKey,
-		TapscriptRoot:       tapscriptRoot,
-		CustomTapscriptRoot: fn.None[chainhash.Hash](),
-		Witness:             fn.MakeSlice(tapscriptRoot, groupSig),
+		expectedError: nil,
+	}}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(tt *testing.T) {
+			tt.Parallel()
+
+			mintingStore, assetStore, db := newAssetStore(tt)
+			ctx := context.Background()
+
+			internalKey := test.RandPubKey(tt)
+			groupAnchorGen := asset.RandGenesis(
+				tt, asset.RandAssetType(tt),
+			)
+			groupAnchorGen.MetaHash = [32]byte{}
+			tapscriptRoot := test.RandBytes(32)
+
+			// First, we'll insert all the required rows we need to
+			// satisfy the foreign key constraints needed to insert
+			// a new genesis witness.
+			genesisPointID, err := upsertGenesisPoint(
+				ctx, db, groupAnchorGen.FirstPrevOut,
+			)
+			require.NoError(tt, err)
+
+			genAssetID, err := upsertGenesis(
+				ctx, db, genesisPointID, groupAnchorGen,
+			)
+			require.NoError(tt, err)
+
+			groupKey := asset.GroupKey{
+				Version: asset.GroupKeyV1,
+				RawKey: keychain.KeyDescriptor{
+					PubKey: internalKey,
+				},
+				GroupPubKey:         *internalKey,
+				TapscriptRoot:       tapscriptRoot,
+				CustomTapscriptRoot: tc.customTapscriptRoot,
+				Witness:             tc.witnessData,
+			}
+
+			// Upsert the group key
+			_, err = upsertGroupKey(
+				ctx, &groupKey, assetStore.db, genesisPointID,
+				genAssetID,
+			)
+			if tc.expectedError != nil {
+				require.ErrorIs(tt, err, tc.expectedError)
+				return
+			}
+			require.NoError(tt, err)
+
+			// Fetch and verify the group key
+			storedGroup, err := mintingStore.FetchGroupByGroupKey(
+				ctx, internalKey,
+			)
+			require.NoError(tt, err)
+
+			// Verify the genesis matches
+			require.Equal(tt, groupAnchorGen, *storedGroup.Genesis)
+
+			// Verify the group key matches
+			require.True(tt, groupKey.IsEqual(storedGroup.GroupKey))
+
+			// Additional verification for V1 specific fields
+			require.Equal(
+				tt, asset.GroupKeyV1,
+				storedGroup.GroupKey.Version,
+			)
+		})
 	}
-
-	// Upsert, fetch, and check the group key.
-	_, err = upsertGroupKey(
-		ctx, &groupKeyCustomRootNone, assetStore.db, genesisPointID,
-		genAssetID,
-	)
-	require.NoError(t, err)
-
-	storedGroup2, err := mintingStore.FetchGroupByGroupKey(ctx, internalKey)
-	require.NoError(t, err)
-
-	require.Equal(t, groupAnchorGen, *storedGroup2.Genesis)
-	require.True(t, groupKeyCustomRootNone.IsEqual(storedGroup2.GroupKey))
 }
 
 // TestAssetGroupKeyUpsert tests that if you try to insert another asset group


### PR DESCRIPTION
## Overview

Strengthens asset-group equality checks and tightens related tests/APIs.

## Key changes

* **GroupKey equality**

  * `IsEqual` now compares `Version` and `CustomTapscriptRoot` (via new `IsEqualCustomTapscriptRoot` helper).
* **Tests**

  * Replaced `TestAssetGroupV1` with more rigorous `TestStoreFetchAssetGroupV1`.
* **API cleanup**

  * Renamed `IsEqualGroup` → `IsSameGroup`.
* **Refactor**

  * Pure code-motion tidy-up in `commitment.parseCommon`; no behavioural change.