### PR TITLE
bugfix: fix btc-only balance force close, fix incorrect policy in invoice hop hint

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/lightninglabs/lightning-node-connect/hashmailrpc v1.0.3
 	github.com/lightninglabs/lndclient v0.19.0-7
 	github.com/lightninglabs/neutrino/cache v1.1.2
-	github.com/lightninglabs/taproot-assets/taprpc v1.0.6
+	github.com/lightninglabs/taproot-assets/taprpc v1.0.7
 	github.com/lightningnetwork/lnd v0.19.0-beta
 	github.com/lightningnetwork/lnd/cert v1.2.2
 	github.com/lightningnetwork/lnd/clock v1.1.1

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -8553,8 +8553,10 @@ func (r *rpcServer) getInboundPolicy(ctx context.Context, chanID uint64,
 		return nil, fmt.Errorf("unable to fetch channel: %w", err)
 	}
 
+	// We want the policy that corresponds to the node that is the remote
+	// peer in the channel.
 	policy := edge.Node2Policy
-	if edge.Node2Pub == remotePubStr {
+	if edge.Node1Pub == remotePubStr {
 		policy = edge.Node1Policy
 	}
 


### PR DESCRIPTION
Fixes root cause of https://github.com/lightninglabs/taproot-assets/issues/1595.
Also fixes https://github.com/lightninglabs/taproot-assets/issues/1598.

Corresponding integration tests can be found here: https://github.com/lightninglabs/lightning-terminal/pull/1089