### PR TITLE
rpcserver: enforce keysend minimum carrier HTLC amount

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -7798,6 +7798,16 @@ func (r *rpcServer) SendPayment(req *tchrpc.SendPaymentRequest,
 				"pubkey: %w", err)
 		}
 
+		// We must enforce a minimum satoshi amount to make sure the
+		// carrier HTLC is above dust. This is handled by the traffic
+		// shaper for invoice-based payments, but for keysend payments
+		// we need to do it here.
+		if pReq.Amt < int64(rfqmath.DefaultOnChainHtlcSat) {
+			return fmt.Errorf("keysend payment satoshi amount "+
+				"must be greater than or equal to %d satoshis",
+				rfqmath.DefaultOnChainHtlcSat)
+		}
+
 		// We check that we have the asset amount available in the
 		// channel.
 		_, err = r.cfg.RfqManager.FetchChannel(


### PR DESCRIPTION
Fixes an issue where attempting to pay a below-dust carrier HTLC satoshi amount would knock a channel offline.

Found after attempting the negative test mentioned here: https://github.com/lightninglabs/lightning-terminal/pull/1089#discussion_r2150457951
Nice catch, @GeorgeTsagk.