### PR TITLE
universe: use correct ID comparison for sync config

### DIFF
--- a/universe/auto_syncer.go
+++ b/universe/auto_syncer.go
@@ -951,7 +951,7 @@ func (s *SyncConfigs) IsSyncInsertEnabled(id Identifier) bool {
 	// Check for universe specific config. This takes precedence over the
 	// global config.
 	for _, cfg := range s.UniSyncConfigs {
-		if cfg.UniverseID == id {
+		if cfg.UniverseID.IsEqual(id) {
 			return cfg.AllowSyncInsert
 		}
 	}
@@ -972,7 +972,7 @@ func (s *SyncConfigs) IsSyncExportEnabled(id Identifier) bool {
 	// Check for universe specific config. This takes precedence over the
 	// global config.
 	for _, cfg := range s.UniSyncConfigs {
-		if cfg.UniverseID == id {
+		if cfg.UniverseID.IsEqual(id) {
 			return cfg.AllowSyncExport
 		}
 	}


### PR DESCRIPTION
Fixes a bug where the error "proof insert is disabled for the given universe" is returned, even though group key specific configs have been set. This was because the == operator checks pointer equality instead of content equality for pointer struct members.
