### PR TITLE
tapdb: support delegation key and universe commitment flag in seedlings

### DIFF
--- a/tapdb/asset_minting.go
+++ b/tapdb/asset_minting.go
@@ -1336,12 +1336,9 @@ func marshalMintingBatch(ctx context.Context, q PendingAssetStore,
 				"genesis packet")
 		}
 
-		anchorOutputIndex := uint32(0)
-		if batch.GenesisPacket.ChangeOutputIndex == 0 {
-			anchorOutputIndex = 1
-		}
+		assetAnchorOutIdx := batch.GenesisPacket.AssetAnchorOutIdx
 		genesisTx := batch.GenesisPacket.Pkt.UnsignedTx
-		genesisScript := genesisTx.TxOut[anchorOutputIndex].PkScript
+		genesisScript := genesisTx.TxOut[assetAnchorOutIdx].PkScript
 		tapscriptSibling := batch.TapSibling()
 		batch.RootAssetCommitment, err = fetchAssetSprouts(
 			ctx, q, dbBatch.RawKey, tapscriptSibling, genesisScript,

--- a/tapdb/asset_minting.go
+++ b/tapdb/asset_minting.go
@@ -1266,8 +1266,9 @@ func marshalMintingBatch(ctx context.Context, q PendingAssetStore,
 			},
 			PubKey: batchKey,
 		},
-		HeightHint:   uint32(dbBatch.HeightHint),
-		CreationTime: dbBatch.CreationTimeUnix.UTC(),
+		HeightHint:          uint32(dbBatch.HeightHint),
+		CreationTime:        dbBatch.CreationTimeUnix.UTC(),
+		UniverseCommitments: dbBatch.UniverseCommitments,
 	}
 
 	batchState, err := tapgarden.NewBatchState(uint8(dbBatch.BatchState))

--- a/tapdb/asset_minting.go
+++ b/tapdb/asset_minting.go
@@ -481,9 +481,10 @@ func (a *AssetMintingStore) CommitMintingBatch(ctx context.Context,
 		// With our internal key inserted, we can now insert a new
 		// batch which references the target internal key.
 		if err := q.NewMintingBatch(ctx, MintingBatchInit{
-			BatchID:          batchID,
-			HeightHint:       int32(newBatch.HeightHint),
-			CreationTimeUnix: newBatch.CreationTime.UTC(),
+			BatchID:             batchID,
+			HeightHint:          int32(newBatch.HeightHint),
+			CreationTimeUnix:    newBatch.CreationTime.UTC(),
+			UniverseCommitments: newBatch.UniverseCommitments,
 		}); err != nil {
 			return fmt.Errorf("unable to insert minting "+
 				"batch: %w", err)

--- a/tapdb/asset_minting.go
+++ b/tapdb/asset_minting.go
@@ -855,6 +855,31 @@ func fetchAssetSeedlings(ctx context.Context, q PendingAssetStore,
 			}
 		}
 
+		// If the seedling has a delegation key, we'll parse it and
+		// store it in the seedling.
+		if dbSeedling.DelegationKeyRaw != nil {
+			delegationKeyPub, err := btcec.ParsePubKey(
+				dbSeedling.DelegationKeyRaw,
+			)
+			if err != nil {
+				return nil, err
+			}
+
+			locator := keychain.KeyLocator{
+				Index: extractSqlInt32[uint32](
+					dbSeedling.DelegationKeyIndex,
+				),
+				Family: extractSqlInt32[keychain.KeyFamily](
+					dbSeedling.DelegationKeyFam,
+				),
+			}
+
+			seedling.DelegationKey = fn.Some(keychain.KeyDescriptor{
+				KeyLocator: locator,
+				PubKey:     delegationKeyPub,
+			})
+		}
+
 		if len(dbSeedling.GroupTapscriptRoot) != 0 {
 			seedling.GroupTapscriptRoot = dbSeedling.
 				GroupTapscriptRoot

--- a/tapdb/asset_minting.go
+++ b/tapdb/asset_minting.go
@@ -550,6 +550,9 @@ func (a *AssetMintingStore) CommitMintingBatch(ctx context.Context,
 				AssetSupply:     int64(seedling.Amount),
 				AssetMetaID:     assetMetaID,
 				EmissionEnabled: seedling.EnableEmission,
+
+				// nolint: lll
+				UniverseCommitments: seedling.UniverseCommitments,
 			}
 
 			scriptKeyID, err := upsertScriptKey(
@@ -692,6 +695,9 @@ func (a *AssetMintingStore) AddSeedlingsToBatch(ctx context.Context,
 				AssetSupply:     int64(seedling.Amount),
 				AssetMetaID:     assetMetaID,
 				EmissionEnabled: seedling.EnableEmission,
+
+				// nolint: lll
+				UniverseCommitments: seedling.UniverseCommitments,
 			}
 
 			scriptKeyID, err := upsertScriptKey(
@@ -787,7 +793,8 @@ func fetchAssetSeedlings(ctx context.Context, q PendingAssetStore,
 			Amount: uint64(
 				dbSeedling.AssetSupply,
 			),
-			EnableEmission: dbSeedling.EmissionEnabled,
+			EnableEmission:      dbSeedling.EmissionEnabled,
+			UniverseCommitments: dbSeedling.UniverseCommitments,
 		}
 
 		if dbSeedling.TweakedScriptKey != nil {

--- a/tapdb/asset_minting.go
+++ b/tapdb/asset_minting.go
@@ -330,6 +330,45 @@ type OptionalSeedlingFields struct {
 	GroupAnchorID      sql.NullInt64
 }
 
+// upsertDelegationKey inserts the given delegation key descriptor into
+// the internal_keys SQL table and returns its ID.
+func upsertDelegationKey(ctx context.Context, q PendingAssetStore,
+	keyDescOpt fn.Option[keychain.KeyDescriptor]) (sql.NullInt64, error) {
+
+	var zero sql.NullInt64
+
+	// If the delegation key is not set, we can return a zero value.
+	if keyDescOpt.IsNone() {
+		return zero, nil
+	}
+
+	// Unwrap the key descriptor to get the actual key.
+	keyDesc, err := keyDescOpt.UnwrapOrErr(
+		fmt.Errorf("delegation key is unexpectedly not set"),
+	)
+	if err != nil {
+		return zero, err
+	}
+
+	// Sanity check the key descriptor.
+	if keyDesc.PubKey == nil {
+		return zero, fmt.Errorf("delegation key pubkey is nil")
+	}
+
+	// Insert the key descriptor into the internal_keys table.
+	keyID, err := q.UpsertInternalKey(ctx, InternalKey{
+		RawKey:    keyDesc.PubKey.SerializeCompressed(),
+		KeyFamily: int32(keyDesc.Family),
+		KeyIndex:  int32(keyDesc.Index),
+	})
+	if err != nil {
+		return zero, fmt.Errorf("unable to insert internal key: %w",
+			err)
+	}
+
+	return sqlInt64(keyID), nil
+}
+
 // insertMintAnchorTx inserts a mint anchor transaction into the database.
 func insertMintAnchorTx(ctx context.Context, q PendingAssetStore,
 	anchorPackage tapgarden.FundedMintAnchorPsbt,
@@ -544,6 +583,17 @@ func (a *AssetMintingStore) CommitMintingBatch(ctx context.Context,
 			dbSeedling.GroupGenesisID = optionalDbIDs.GroupGenesisID
 			dbSeedling.GroupAnchorID = optionalDbIDs.GroupAnchorID
 
+			// Upsert the seedling's delegation key if present.
+			delegationKeyID, err := upsertDelegationKey(
+				ctx, q, seedling.DelegationKey,
+			)
+			if err != nil {
+				return fmt.Errorf("unable to insert "+
+					"delegation key: %w", err)
+			}
+
+			dbSeedling.DelegationKeyID = delegationKeyID
+
 			err = q.InsertAssetSeedling(ctx, dbSeedling)
 			if err != nil {
 				return err
@@ -674,6 +724,18 @@ func (a *AssetMintingStore) AddSeedlingsToBatch(ctx context.Context,
 				optionalDbIDs.GroupInternalKeyID
 			dbSeedling.GroupGenesisID = optionalDbIDs.GroupGenesisID
 			dbSeedling.GroupAnchorID = optionalDbIDs.GroupAnchorID
+
+			// Handle delegation key: upsert to internal_keys and
+			// reference in seedling.
+			delegationKeyID, err := upsertDelegationKey(
+				ctx, q, seedling.DelegationKey,
+			)
+			if err != nil {
+				return fmt.Errorf("unable to insert "+
+					"delegation key: %w", err)
+			}
+
+			dbSeedling.DelegationKeyID = delegationKeyID
 
 			err = q.InsertAssetSeedlingIntoBatch(ctx, dbSeedling)
 			if err != nil {

--- a/tapdb/asset_minting_test.go
+++ b/tapdb/asset_minting_test.go
@@ -93,6 +93,7 @@ func assertBatchEqual(t *testing.T, a, b *tapgarden.MintingBatch) {
 		t, &a.GenesisPacket.FundedPsbt, &b.GenesisPacket.FundedPsbt,
 	)
 	require.Equal(t, a.RootAssetCommitment, b.RootAssetCommitment)
+	require.Equal(t, a.UniverseCommitments, b.UniverseCommitments)
 }
 
 func assertSeedlingBatchLen(t *testing.T, batches []*tapgarden.MintingBatch,

--- a/tapdb/asset_minting_test.go
+++ b/tapdb/asset_minting_test.go
@@ -609,6 +609,62 @@ func TestCommitMintingBatchSeedlings(t *testing.T) {
 	assertSeedlingBatchLen(t, mintingBatches, 1, numSeedlings)
 }
 
+// TestInsertFetchUniCommitBatch tests that we're able to properly write
+// and read a minting batch that has universe commitments enabled.
+func TestInsertFetchUniCommitBatch(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	assetStore, _, _ := newAssetStore(t)
+
+	// Generate a batch with a single seedling, we will set the group
+	// information later.
+	batch := tapgarden.RandMintingBatch(
+		t, tapgarden.WithTotalGroups([]int{1}),
+		tapgarden.WithUniverseCommitments(true),
+	)
+	require.True(t, batch.UniverseCommitments)
+
+	// Generate the group genesis, persist it, and assign the group details
+	// to the seedling.
+	assetName := maps.Keys(batch.Seedlings)[0]
+	assetType := batch.Seedlings[assetName].AssetType
+
+	privDesc, groupPriv := test.RandKeyDesc(t)
+	randGenesis := asset.RandGenesis(t, assetType)
+	_, _, group := storeGroupGenesis(
+		t, ctx, randGenesis, nil, assetStore, privDesc, groupPriv,
+	)
+
+	batch.Seedlings[assetName].GroupInfo = group
+
+	// Assert that the seedling is in the expected state.
+	seedling := batch.Seedlings[assetName]
+	require.True(t, seedling.UniverseCommitments)
+	require.True(t, seedling.DelegationKey.IsSome())
+
+	// Commit the minting batch to the database.
+	err := assetStore.CommitMintingBatch(ctx, batch)
+	require.NoError(t, err)
+
+	// Fetch the same batch from the database.
+	dbBatch, err := assetStore.FetchMintingBatch(
+		ctx, batch.BatchKey.PubKey,
+	)
+	require.NoError(t, err)
+
+	// Assert that the batch is in the expected state.
+	require.True(t, dbBatch.UniverseCommitments)
+
+	// Assert that the seedling is in the expected state.
+	require.Len(t, dbBatch.Seedlings, 1)
+
+	dbSeedling := dbBatch.Seedlings[assetName]
+	require.True(t, dbSeedling.UniverseCommitments)
+	require.True(t, dbSeedling.DelegationKey.IsSome())
+	require.Equal(t, dbSeedling.DelegationKey, seedling.DelegationKey)
+}
+
 // seedlingsToAssetRoot maps a set of seedlings to an asset root.
 //
 // TODO(roasbeef): same func in tapgarden can just re-use?

--- a/tapdb/migrations.go
+++ b/tapdb/migrations.go
@@ -24,7 +24,7 @@ const (
 	// daemon.
 	//
 	// NOTE: This MUST be updated when a new migration is added.
-	LatestMigrationVersion = 40
+	LatestMigrationVersion = 41
 )
 
 // DatabaseBackend is an interface that contains all methods our different

--- a/tapdb/sqlc/assets.sql.go
+++ b/tapdb/sqlc/assets.sql.go
@@ -2240,18 +2240,24 @@ func (q *Queries) InsertAssetSeedlingIntoBatch(ctx context.Context, arg InsertAs
 
 const NewMintingBatch = `-- name: NewMintingBatch :exec
 INSERT INTO asset_minting_batches (
-    batch_state, batch_id, height_hint, creation_time_unix
-) VALUES (0, $1, $2, $3)
+    batch_state, batch_id, height_hint, creation_time_unix, universe_commitments
+) VALUES (0, $1, $2, $3, $4)
 `
 
 type NewMintingBatchParams struct {
-	BatchID          int64
-	HeightHint       int32
-	CreationTimeUnix time.Time
+	BatchID             int64
+	HeightHint          int32
+	CreationTimeUnix    time.Time
+	UniverseCommitments bool
 }
 
 func (q *Queries) NewMintingBatch(ctx context.Context, arg NewMintingBatchParams) error {
-	_, err := q.db.ExecContext(ctx, NewMintingBatch, arg.BatchID, arg.HeightHint, arg.CreationTimeUnix)
+	_, err := q.db.ExecContext(ctx, NewMintingBatch,
+		arg.BatchID,
+		arg.HeightHint,
+		arg.CreationTimeUnix,
+		arg.UniverseCommitments,
+	)
 	return err
 }
 

--- a/tapdb/sqlc/migrations/000041_seedling_uni_commit.down.sql
+++ b/tapdb/sqlc/migrations/000041_seedling_uni_commit.down.sql
@@ -1,0 +1,3 @@
+-- Remove universe commitments flag column from seedling table.
+ALTER TABLE asset_seedlings
+DROP COLUMN IF EXISTS universe_commitments;

--- a/tapdb/sqlc/migrations/000041_seedling_uni_commit.up.sql
+++ b/tapdb/sqlc/migrations/000041_seedling_uni_commit.up.sql
@@ -1,0 +1,3 @@
+-- Add universe commitments flag column to asset_seedlings table.
+ALTER TABLE asset_seedlings
+ADD COLUMN universe_commitments BOOLEAN NOT NULL DEFAULT FALSE;

--- a/tapdb/sqlc/models.go
+++ b/tapdb/sqlc/models.go
@@ -100,20 +100,21 @@ type AssetProof struct {
 }
 
 type AssetSeedling struct {
-	SeedlingID         int64
-	AssetName          string
-	AssetVersion       int16
-	AssetType          int16
-	AssetSupply        int64
-	AssetMetaID        int64
-	EmissionEnabled    bool
-	BatchID            int64
-	GroupGenesisID     sql.NullInt64
-	GroupAnchorID      sql.NullInt64
-	ScriptKeyID        sql.NullInt64
-	GroupInternalKeyID sql.NullInt64
-	GroupTapscriptRoot []byte
-	DelegationKeyID    sql.NullInt64
+	SeedlingID          int64
+	AssetName           string
+	AssetVersion        int16
+	AssetType           int16
+	AssetSupply         int64
+	AssetMetaID         int64
+	EmissionEnabled     bool
+	BatchID             int64
+	GroupGenesisID      sql.NullInt64
+	GroupAnchorID       sql.NullInt64
+	ScriptKeyID         sql.NullInt64
+	GroupInternalKeyID  sql.NullInt64
+	GroupTapscriptRoot  []byte
+	DelegationKeyID     sql.NullInt64
+	UniverseCommitments bool
 }
 
 type AssetTransfer struct {

--- a/tapdb/sqlc/queries/assets.sql
+++ b/tapdb/sqlc/queries/assets.sql
@@ -58,13 +58,15 @@ WHERE batch_id in (SELECT batch_id FROM target_batch);
 INSERT INTO asset_seedlings (
     asset_name, asset_type, asset_version, asset_supply, asset_meta_id,
     emission_enabled, batch_id, group_genesis_id, group_anchor_id,
-    script_key_id, group_internal_key_id, group_tapscript_root, delegation_key_id
+    script_key_id, group_internal_key_id, group_tapscript_root,
+    delegation_key_id, universe_commitments
 ) VALUES (
    @asset_name, @asset_type, @asset_version, @asset_supply,
    @asset_meta_id, @emission_enabled, @batch_id,
    sqlc.narg('group_genesis_id'), sqlc.narg('group_anchor_id'),
    sqlc.narg('script_key_id'), sqlc.narg('group_internal_key_id'),
-   @group_tapscript_root, sqlc.narg('delegation_key_id')
+   @group_tapscript_root, sqlc.narg('delegation_key_id'),
+   @universe_commitments
 );
 
 -- name: FetchSeedlingID :one
@@ -114,14 +116,15 @@ INSERT INTO asset_seedlings(
     asset_name, asset_type, asset_version, asset_supply, asset_meta_id,
     emission_enabled, batch_id, group_genesis_id, group_anchor_id,
     script_key_id, group_internal_key_id, group_tapscript_root,
-    delegation_key_id
+    delegation_key_id, universe_commitments
 ) VALUES (
     @asset_name, @asset_type, @asset_version, @asset_supply,
     @asset_meta_id, @emission_enabled,
     (SELECT key_id FROM target_key_id),
     sqlc.narg('group_genesis_id'), sqlc.narg('group_anchor_id'),
     sqlc.narg('script_key_id'), sqlc.narg('group_internal_key_id'),
-    @group_tapscript_root, sqlc.narg('delegation_key_id')
+    @group_tapscript_root, sqlc.narg('delegation_key_id'),
+    @universe_commitments
 );
 
 -- name: FetchSeedlingsForBatch :many
@@ -150,7 +153,8 @@ SELECT seedling_id, asset_name, asset_type, asset_version, asset_supply,
     group_internal_keys.key_index AS group_key_index,
     delegation_internal_keys.raw_key AS delegation_key_raw,
     delegation_internal_keys.key_family AS delegation_key_fam,
-    delegation_internal_keys.key_index AS delegation_key_index
+    delegation_internal_keys.key_index AS delegation_key_index,
+    universe_commitments
 FROM asset_seedlings 
 LEFT JOIN assets_meta
     ON asset_seedlings.asset_meta_id = assets_meta.meta_id

--- a/tapdb/sqlc/queries/assets.sql
+++ b/tapdb/sqlc/queries/assets.sql
@@ -10,8 +10,8 @@ RETURNING key_id;
 
 -- name: NewMintingBatch :exec
 INSERT INTO asset_minting_batches (
-    batch_state, batch_id, height_hint, creation_time_unix
-) VALUES (0, $1, $2, $3);
+    batch_state, batch_id, height_hint, creation_time_unix, universe_commitments
+) VALUES (0, $1, $2, $3, $4);
 
 -- name: FetchMintingBatchesByInverseState :many
 SELECT *

--- a/tapdb/sqlc/schemas/generated_schema.sql
+++ b/tapdb/sqlc/schemas/generated_schema.sql
@@ -204,7 +204,7 @@ CREATE TABLE asset_seedlings (
 
     group_anchor_id BIGINT REFERENCES asset_seedlings(seedling_id)
 , script_key_id BIGINT REFERENCES script_keys(script_key_id), group_internal_key_id BIGINT REFERENCES internal_keys(key_id), group_tapscript_root BLOB, delegation_key_id
-BIGINT REFERENCES internal_keys(key_id));
+BIGINT REFERENCES internal_keys(key_id), universe_commitments BOOLEAN NOT NULL DEFAULT FALSE);
 
 CREATE TABLE asset_transfer_inputs (
     input_id INTEGER PRIMARY KEY,


### PR DESCRIPTION
This is part of the work towards completing https://github.com/lightninglabs/taproot-assets/issues/1534

---

  * Store and fetch delegation key references to/from the `asset_seedlings` table.
  * Add support for persisting the universe commitment flag in both `asset_seedlings` and `minting_batches`.
  * Add unit tests to verify flag round-trips correctly through the DB.

* **Other:**

  * Remove dependency on `ChangeOutputIndex` when deriving asset anchor output index.