### PR TITLE
mod+server: update to lnd v0.19.2-beta.rc2, taprpc to v1.0.9

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,8 +29,8 @@ require (
 	github.com/lightninglabs/lightning-node-connect/hashmailrpc v1.0.3
 	github.com/lightninglabs/lndclient v0.19.0-9
 	github.com/lightninglabs/neutrino/cache v1.1.2
-	github.com/lightninglabs/taproot-assets/taprpc v1.0.8
-	github.com/lightningnetwork/lnd v0.19.1-beta.rc1.0.20250623232057-b48e2763a798
+	github.com/lightninglabs/taproot-assets/taprpc v1.0.9
+	github.com/lightningnetwork/lnd v0.19.2-beta.rc2
 	github.com/lightningnetwork/lnd/cert v1.2.2
 	github.com/lightningnetwork/lnd/clock v1.1.1
 	github.com/lightningnetwork/lnd/fn/v2 v2.0.8

--- a/go.sum
+++ b/go.sum
@@ -1149,8 +1149,8 @@ github.com/lightninglabs/protobuf-go-hex-display v1.34.2-hex-display h1:w7FM5LH9
 github.com/lightninglabs/protobuf-go-hex-display v1.34.2-hex-display/go.mod h1:qYOHts0dSfpeUzUFpOMr/WGzszTmLH+DiWniOlNbLDw=
 github.com/lightningnetwork/lightning-onion v1.2.1-0.20240712235311-98bd56499dfb h1:yfM05S8DXKhuCBp5qSMZdtSwvJ+GFzl94KbXMNB1JDY=
 github.com/lightningnetwork/lightning-onion v1.2.1-0.20240712235311-98bd56499dfb/go.mod h1:c0kvRShutpj3l6B9WtTsNTBUtjSmjZXbJd9ZBRQOSKI=
-github.com/lightningnetwork/lnd v0.19.1-beta.rc1.0.20250623232057-b48e2763a798 h1:nSnOCqilf+ynsJlTOVOoNXEhjjxTrvcv6jxMyUlZJJE=
-github.com/lightningnetwork/lnd v0.19.1-beta.rc1.0.20250623232057-b48e2763a798/go.mod h1:iHZ/FHFK00BqV6qgDkZZfqWE3LGtgE0U5KdO5WrM+eQ=
+github.com/lightningnetwork/lnd v0.19.2-beta.rc2 h1:vPIMjQr8SWZJHn/j3QSFct4AbCVa0WA7k0j0lHqFDAA=
+github.com/lightningnetwork/lnd v0.19.2-beta.rc2/go.mod h1:+yKUfIGKKYRHGewgzQ6xi0S26DIfBiMv1zCdB3m6YxA=
 github.com/lightningnetwork/lnd/cert v1.2.2 h1:71YK6hogeJtxSxw2teq3eGeuy4rHGKcFf0d0Uy4qBjI=
 github.com/lightningnetwork/lnd/cert v1.2.2/go.mod h1:jQmFn/Ez4zhDgq2hnYSw8r35bqGVxViXhX6Cd7HXM6U=
 github.com/lightningnetwork/lnd/clock v1.1.1 h1:OfR3/zcJd2RhH0RU+zX/77c0ZiOnIMsDIBjgjWdZgA0=

--- a/server.go
+++ b/server.go
@@ -40,6 +40,7 @@ import (
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/macaroons"
 	"github.com/lightningnetwork/lnd/msgmux"
+	"github.com/lightningnetwork/lnd/routing/route"
 	"github.com/lightningnetwork/lnd/sweep"
 	"github.com/lightningnetwork/lnd/tlv"
 	"google.golang.org/grpc"
@@ -1045,13 +1046,14 @@ func (s *Server) ShouldHandleTraffic(cid lnwire.ShortChannelID,
 // NOTE: This method is part of the routing.TlvTrafficShaper interface.
 func (s *Server) PaymentBandwidth(fundingBlob, htlcBlob,
 	commitmentBlob lfn.Option[tlv.Blob], linkBandwidth,
-	htlcAmt lnwire.MilliSatoshi,
-	htlcView lnwallet.AuxHtlcView) (lnwire.MilliSatoshi, error) {
+	htlcAmt lnwire.MilliSatoshi, htlcView lnwallet.AuxHtlcView,
+	peer route.Vertex) (lnwire.MilliSatoshi, error) {
 
 	srvrLog.Debugf("PaymentBandwidth called, fundingBlob=%v, htlcBlob=%v, "+
-		"commitmentBlob=%v", lnutils.SpewLogClosure(fundingBlob),
+		"commitmentBlob=%v, peer=%x",
+		lnutils.SpewLogClosure(fundingBlob),
 		lnutils.SpewLogClosure(htlcBlob),
-		lnutils.SpewLogClosure(commitmentBlob))
+		lnutils.SpewLogClosure(commitmentBlob), peer[:])
 
 	if err := s.waitForReady(); err != nil {
 		return 0, err
@@ -1069,12 +1071,12 @@ func (s *Server) PaymentBandwidth(fundingBlob, htlcBlob,
 //
 // NOTE: This method is part of the routing.TlvTrafficShaper interface.
 func (s *Server) ProduceHtlcExtraData(totalAmount lnwire.MilliSatoshi,
-	htlcCustomRecords lnwire.CustomRecords) (lnwire.MilliSatoshi,
-	lnwire.CustomRecords, error) {
+	htlcCustomRecords lnwire.CustomRecords,
+	peer route.Vertex) (lnwire.MilliSatoshi, lnwire.CustomRecords, error) {
 
 	srvrLog.Debugf("ProduceHtlcExtraData called, totalAmount=%d, "+
-		"htlcBlob=%v", totalAmount,
-		lnutils.SpewLogClosure(htlcCustomRecords))
+		"htlcBlob=%v, peer=%x", totalAmount,
+		lnutils.SpewLogClosure(htlcCustomRecords), peer[:])
 
 	if err := s.waitForReady(); err != nil {
 		return 0, nil, err


### PR DESCRIPTION
Fixes the litd itest.

This only makes the `server.go` compile with the latest changes in the `PaymentBandwidth` and `ProduceHtlcExtraData` methods of the aux interface. The actual changes that will use this information will be in https://github.com/lightninglabs/taproot-assets/pull/1613.