### PR TITLE
universe: fix asset stats being extremely slow

### DIFF
--- a/address/book.go
+++ b/address/book.go
@@ -423,6 +423,20 @@ func (b *Book) FetchAssetMetaForAsset(ctx context.Context,
 	return meta, nil
 }
 
+// DecDisplayForAssetID attempts to fetch the meta reveal for a specific asset
+// ID and extract the decimal display value from it.
+func (b *Book) DecDisplayForAssetID(ctx context.Context,
+	id asset.ID) (fn.Option[uint32], error) {
+
+	meta, err := b.FetchAssetMetaForAsset(ctx, id)
+	if err != nil {
+		return fn.None[uint32](), fmt.Errorf("unable to fetch asset "+
+			"meta for asset_id=%v :%v", id, err)
+	}
+
+	return meta.DecDisplayOption()
+}
+
 // NewAddress creates a new Taproot Asset address based on the input parameters.
 func (b *Book) NewAddress(ctx context.Context, addrVersion Version,
 	specifier asset.Specifier, amount uint64,

--- a/address/book_test.go
+++ b/address/book_test.go
@@ -175,6 +175,13 @@ type MockStorage struct {
 	mock.Mock
 }
 
+func (m *MockStorage) FetchAllAssetMeta(
+	ctx context.Context) (map[asset.ID]*proof.MetaReveal, error) {
+
+	args := m.Called(ctx)
+	return args.Get(0).(map[asset.ID]*proof.MetaReveal), args.Error(1)
+}
+
 func (m *MockStorage) AddrByScriptKeyAndVersion(ctx context.Context,
 	key *btcec.PublicKey, version Version) (*AddrWithKeyInfo, error) {
 

--- a/chain_bridge.go
+++ b/chain_bridge.go
@@ -27,10 +27,10 @@ import (
 
 const (
 	// maxNumBlocksInCache is the maximum number of blocks we'll cache
-	// timestamps for. With 100k blocks we should only take up approximately
-	// 800kB of memory (4 bytes for the block height and 4 bytes for the
+	// timestamps for. With 400k blocks we should only take up approximately
+	// 3200kB of memory (4 bytes for the block height and 4 bytes for the
 	// timestamp, not including any map/cache overhead).
-	maxNumBlocksInCache = 100_000
+	maxNumBlocksInCache = 400_000
 )
 
 // cacheableTimestamp is a wrapper around an uint32 that can be used as a value

--- a/tapdb/addrs.go
+++ b/tapdb/addrs.go
@@ -86,6 +86,10 @@ type (
 
 	// AssetMeta is the metadata record for an asset.
 	AssetMeta = sqlc.FetchAssetMetaForAssetRow
+
+	// AllAssetMetaRow is a type alias for fetching all asset metadata
+	// records.
+	AllAssetMetaRow = sqlc.FetchAllAssetMetaRow
 )
 
 var (
@@ -186,6 +190,10 @@ type AddrBook interface {
 	// FetchAssetMetaForAsset fetches the asset meta for a given asset.
 	FetchAssetMetaForAsset(ctx context.Context,
 		assetID []byte) (AssetMeta, error)
+
+	// FetchAllAssetMeta fetches all asset metadata records from the
+	// database.
+	FetchAllAssetMeta(ctx context.Context) ([]AllAssetMetaRow, error)
 }
 
 // AddrBookTxOptions defines the set of db txn options the AddrBook
@@ -1250,6 +1258,49 @@ func (t *TapAddressBook) FetchAssetMetaForAsset(ctx context.Context,
 	}
 
 	return assetMeta, nil
+}
+
+// FetchAllAssetMeta attempts to fetch all asset meta known to the database.
+func (t *TapAddressBook) FetchAllAssetMeta(
+	ctx context.Context) (map[asset.ID]*proof.MetaReveal, error) {
+
+	var assetMetas map[asset.ID]*proof.MetaReveal
+
+	readOpts := NewAssetStoreReadTx()
+	dbErr := t.db.ExecTx(ctx, &readOpts, func(q AddrBook) error {
+		dbMetas, err := q.FetchAllAssetMeta(ctx)
+		if err != nil {
+			return err
+		}
+
+		assetMetas = make(map[asset.ID]*proof.MetaReveal, len(dbMetas))
+		for _, dbMeta := range dbMetas {
+			// If no record is present, we should get a
+			// sql.ErrNoRows error
+			// above.
+			metaOpt, err := parseAssetMetaReveal(dbMeta.AssetsMetum)
+			if err != nil {
+				return fmt.Errorf("unable to parse asset "+
+					"meta: %w", err)
+			}
+
+			metaOpt.WhenSome(func(meta proof.MetaReveal) {
+				var id asset.ID
+				copy(id[:], dbMeta.AssetID)
+				assetMetas[id] = &meta
+			})
+		}
+
+		return nil
+	})
+	switch {
+	case errors.Is(dbErr, sql.ErrNoRows):
+		return nil, address.ErrAssetMetaNotFound
+	case dbErr != nil:
+		return nil, dbErr
+	}
+
+	return assetMetas, nil
 }
 
 // insertFullAssetGen inserts a new asset genesis and optional asset group

--- a/tapdb/sqlc/assets.sql.go
+++ b/tapdb/sqlc/assets.sql.go
@@ -529,6 +529,52 @@ func (q *Queries) DeleteUTXOLease(ctx context.Context, outpoint []byte) error {
 	return err
 }
 
+const FetchAllAssetMeta = `-- name: FetchAllAssetMeta :many
+SELECT assets_meta.meta_id, assets_meta.meta_data_hash, assets_meta.meta_data_blob, assets_meta.meta_data_type, assets_meta.meta_decimal_display, assets_meta.meta_universe_commitments, assets_meta.meta_canonical_universes, assets_meta.meta_delegation_key, genesis_assets.asset_id
+FROM assets_meta
+JOIN genesis_assets
+    ON genesis_assets.meta_data_id = assets_meta.meta_id
+ORDER BY assets_meta.meta_id
+`
+
+type FetchAllAssetMetaRow struct {
+	AssetsMetum AssetsMetum
+	AssetID     []byte
+}
+
+func (q *Queries) FetchAllAssetMeta(ctx context.Context) ([]FetchAllAssetMetaRow, error) {
+	rows, err := q.db.QueryContext(ctx, FetchAllAssetMeta)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []FetchAllAssetMetaRow
+	for rows.Next() {
+		var i FetchAllAssetMetaRow
+		if err := rows.Scan(
+			&i.AssetsMetum.MetaID,
+			&i.AssetsMetum.MetaDataHash,
+			&i.AssetsMetum.MetaDataBlob,
+			&i.AssetsMetum.MetaDataType,
+			&i.AssetsMetum.MetaDecimalDisplay,
+			&i.AssetsMetum.MetaUniverseCommitments,
+			&i.AssetsMetum.MetaCanonicalUniverses,
+			&i.AssetsMetum.MetaDelegationKey,
+			&i.AssetID,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const FetchAssetID = `-- name: FetchAssetID :many
 SELECT asset_id
     FROM assets

--- a/tapdb/sqlc/querier.go
+++ b/tapdb/sqlc/querier.go
@@ -51,6 +51,7 @@ type Querier interface {
 	FetchAddrEvent(ctx context.Context, id int64) (FetchAddrEventRow, error)
 	FetchAddrEventByAddrKeyAndOutpoint(ctx context.Context, arg FetchAddrEventByAddrKeyAndOutpointParams) (FetchAddrEventByAddrKeyAndOutpointRow, error)
 	FetchAddrs(ctx context.Context, arg FetchAddrsParams) ([]FetchAddrsRow, error)
+	FetchAllAssetMeta(ctx context.Context) ([]FetchAllAssetMetaRow, error)
 	FetchAllNodes(ctx context.Context) ([]MssmtNode, error)
 	FetchAssetID(ctx context.Context, arg FetchAssetIDParams) ([]int64, error)
 	FetchAssetMeta(ctx context.Context, metaID int64) (FetchAssetMetaRow, error)

--- a/tapdb/sqlc/queries/assets.sql
+++ b/tapdb/sqlc/queries/assets.sql
@@ -1046,6 +1046,13 @@ JOIN assets_meta
     ON assets.meta_data_id = assets_meta.meta_id
 WHERE assets.asset_id = $1;
 
+-- name: FetchAllAssetMeta :many
+SELECT sqlc.embed(assets_meta), genesis_assets.asset_id
+FROM assets_meta
+JOIN genesis_assets
+    ON genesis_assets.meta_data_id = assets_meta.meta_id
+ORDER BY assets_meta.meta_id;
+
 -- name: UpsertMintAnchorUniCommitment :one
 -- Upsert a record into the mint_anchor_uni_commitments table.
 -- If a record with the same batch ID and tx output index already exists, update


### PR DESCRIPTION
It turns out it's not actually the stats query itself that is slow but the two pieces of information we need to fetch for each asset returned in the result:
 - The genesis timestamp: Needs to be fetched by looking up a block in the chain backend. Is already cached, but we increase the cache. https://github.com/lightninglabs/taproot-assets/blob/eff99b84184dbe72dccdbcafb6915e07e76572f2/rpcserver.go#L6545
 - The decimal display value: We used to do a DB lookup for each asset (which takes forever with a cardinality of ~100k on mainnet). We now cache this. https://github.com/lightninglabs/taproot-assets/blob/eff99b84184dbe72dccdbcafb6915e07e76572f2/rpcserver.go#L6551
