### PR TITLE
itest: convert AssertBalanceByID to eventually-style call

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -321,7 +321,7 @@ jobs:
           go-version: '${{ env.GO_VERSION }}'
 
       - name: run itest
-        run: make itest-parallel dbbackend=postgres
+        run: make itest-parallel dbbackend=postgres tranches=4
 
       - name: Zip log files on failure
         if: ${{ failure() }}

--- a/asset/asset.go
+++ b/asset/asset.go
@@ -737,6 +737,11 @@ type Witness struct {
 // the witness should be encoded or not.
 func (w *Witness) encodeRecords(encodeType EncodeType) []tlv.Record {
 	var records []tlv.Record
+
+	if w == nil {
+		return records
+	}
+
 	if w.PrevID != nil {
 		records = append(records, NewWitnessPrevIDRecord(&w.PrevID))
 	}
@@ -771,6 +776,10 @@ func (w *Witness) DecodeRecords() []tlv.Record {
 
 // Encode encodes an asset witness into a TLV stream.
 func (w *Witness) Encode(writer io.Writer) error {
+	if w == nil {
+		return fmt.Errorf("cannot encode nil witness")
+	}
+
 	stream, err := tlv.NewStream(w.EncodeRecords()...)
 	if err != nil {
 		return err

--- a/asset/records.go
+++ b/asset/records.go
@@ -287,6 +287,10 @@ func NewWitnessPrevIDRecord(prevID **PrevID) tlv.Record {
 
 func NewWitnessTxWitnessRecord(witness *wire.TxWitness) tlv.Record {
 	recordSize := func() uint64 {
+		if witness == nil {
+			return 0
+		}
+
 		return uint64((*witness).SerializeSize())
 	}
 	return tlv.MakeDynamicRecord(

--- a/itest/addrs_test.go
+++ b/itest/addrs_test.go
@@ -1013,6 +1013,15 @@ func sendAsset(t *harnessTest, sender *tapdHarness,
 		options.sendAssetRequest.SkipProofCourierPingCheck = true
 	}
 
+	// The SubscribeSendEvents call returns immediately, but the server may
+	// still be setting up its event stream. If we emit an event too soon,
+	// it may be lost. We wait briefly to allow the server time to complete
+	// setup.
+	//
+	// TODO(ffranr): Remove this once the server supports buffering or
+	//  replaying early events for new subscribers.
+	time.Sleep(time.Second)
+
 	// Kick off the send asset request.
 	resp, err := sender.SendAsset(ctxt, &options.sendAssetRequest)
 	if options.errText != "" {

--- a/itest/test_list_on_test.go
+++ b/itest/test_list_on_test.go
@@ -290,7 +290,7 @@ var allTestCases = []*testCase{
 		test: testGetInfo,
 	},
 	{
-		name: "burn test",
+		name: "burn assets",
 		test: testBurnAssets,
 	},
 	{


### PR DESCRIPTION
Attempt to fix a flaky test: [GitHub Actions Run](https://github.com/lightninglabs/taproot-assets/actions/runs/16271389499/job/45942931750?pr=1643)

This change updates `AssertBalanceByID` to use an eventually-style assertion. This should eliminate timing-related flakiness by allowing for retries within a time window. While this may not fully resolve the issue, it helps rule out timing as a contributing factor.