### PR TITLE
Use nonce as HKDF salt and protocol name as info in ECIES encryption

### DIFF
--- a/internal/ecies/ecies.go
+++ b/internal/ecies/ecies.go
@@ -79,8 +79,9 @@ func EncryptSha256ChaCha20Poly1305(sharedSecret [32]byte, msg []byte,
 		return nil, fmt.Errorf("cannot read random nonce: %w", err)
 	}
 
-	// We begin by hardening the shared secret against brute forcing by
-	// using HKDF with SHA256.
+	// Derive a strong session key from the shared secret using HKDF-SHA256.
+	// The nonce is used as the salt, and the protocol name as the info
+	// label. This mitigates risks from weak shared secrets.
 	stretchedKey, err := HkdfSha256(
 		sharedSecret[:], nonce, []byte(protocolName),
 	)
@@ -197,8 +198,9 @@ func DecryptSha256ChaCha20Poly1305(sharedSecret [32]byte,
 	nonce := remainder[:nonceSize]
 	ciphertext := remainder[nonceSize:]
 
-	// We begin by hardening the shared secret against brute forcing by
-	// using HKDF with SHA256.
+	// Derive a strong session key from the shared secret using HKDF-SHA256.
+	// The nonce is used as the salt, and the protocol name as the info
+	// label. This mitigates risks from weak shared secrets.
 	stretchedKey, err := HkdfSha256(
 		sharedSecret[:], nonce, []byte(protocolName),
 	)

--- a/internal/ecies/ecies.go
+++ b/internal/ecies/ecies.go
@@ -81,7 +81,9 @@ func EncryptSha256ChaCha20Poly1305(sharedSecret [32]byte, msg []byte,
 
 	// We begin by hardening the shared secret against brute forcing by
 	// using HKDF with SHA256.
-	stretchedKey, err := HkdfSha256(sharedSecret[:], []byte(protocolName))
+	stretchedKey, err := HkdfSha256(
+		sharedSecret[:], nonce, []byte(protocolName),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("cannot derive hkdf key: %w", err)
 	}
@@ -197,7 +199,9 @@ func DecryptSha256ChaCha20Poly1305(sharedSecret [32]byte,
 
 	// We begin by hardening the shared secret against brute forcing by
 	// using HKDF with SHA256.
-	stretchedKey, err := HkdfSha256(sharedSecret[:], []byte(protocolName))
+	stretchedKey, err := HkdfSha256(
+		sharedSecret[:], nonce, []byte(protocolName),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("cannot derive hkdf key: %w", err)
 	}
@@ -226,9 +230,9 @@ func DecryptSha256ChaCha20Poly1305(sharedSecret [32]byte,
 
 // HkdfSha256 derives a 32-byte key from the given secret and salt using HKDF
 // with SHA256.
-func HkdfSha256(secret, salt []byte) ([32]byte, error) {
+func HkdfSha256(secret, salt, info []byte) ([32]byte, error) {
 	var key [32]byte
-	kdf := hkdf.New(sha256.New, secret, salt, nil)
+	kdf := hkdf.New(sha256.New, secret, salt, info)
 	if _, err := io.ReadFull(kdf, key[:]); err != nil {
 		return [32]byte{}, fmt.Errorf("cannot read secret from HKDF "+
 			"reader: %w", err)


### PR DESCRIPTION
This PR updates the HKDF parameters used in ECIES encryption to improve key derivation security:

- The per-message nonce is now used as the `salt` input to `HkdfSha256`. This improves brute-force resistance by introducing entropy that changes with each encryption.
- The protocol name, previously used as a constant salt, is now passed as the `info` parameter. This better aligns with the intended purpose of `info`, which is to provide domain/context separation.

Using a random, per-message salt ensures that the derived keys are unique even if the input key material is reused or predictable, and prevents pre-computation attacks. The change follows HKDF best practices.