### PR TITLE
Fix AuxInvoiceManager prop tests

### DIFF
--- a/tapchannel/aux_invoice_manager_test.go
+++ b/tapchannel/aux_invoice_manager_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/big"
+	"math/rand/v2"
 	"testing"
 	"time"
 
@@ -820,11 +821,10 @@ func genHtlc(t *rapid.T, balance []*rfqmsg.AssetBalance,
 // method also returns the assetUnits and the rfqID used by the htlc.
 func genRequest(t *rapid.T) (lndclient.InvoiceHtlcModifyRequest, uint64,
 	asset.ID, rfqmsg.ID) {
-
 	request := lndclient.InvoiceHtlcModifyRequest{
 		CircuitKey: invoices.CircuitKey{
 			ChanID: lnwire.NewShortChanIDFromInt(
-				rapid.Uint64().Draw(t, "chan_id"),
+				rand.Uint64(),
 			),
 		},
 	}


### PR DESCRIPTION
## Description

On the top level, this PR fixes the flake reported in https://github.com/lightninglabs/taproot-assets/issues/1670.

The actual moment in our development history where this flake could have been discovered was here https://github.com/lightninglabs/taproot-assets/pull/1478

By merging the above PR, we added an extra check to the HTLC validation by the aux invoice manager. That check compared the assets of the HTLC against the assets of the channel. We would draw the channel ID from `rapid.Uint64`, but due to the nature of rapid draws this would cause conflicts in the channel ID. That lead to failures when checking the HTLC against the channel.

> In detail, the channel asset info would source from `lndclient.ListChannels` which is mocked with the rapid-generated channels. After retrieving the responses we would check if the chanIDs match, which means that in many cases we could grab the wrong channel entry.

#### Why this is a flake

The current design of the aux invoice manager prop test allows rapid to draw many values randomly. Many of these values are flags that indicate whether a certain type of error should be caused. Due to the large number of draws related to "things that can go wrong" we would rarely run into the case where "nothing is going wrong, except for a chan ID collision".

> The above is true at least for our current default number of checks, which is 100. Even without the above fix (and without any rapid failure files present) you can run the tests with `-rapid.checks=100` a couple dozens of times before this error pops up. This allowed for the error introduction to be buried sufficiently deep for it to be ignored as a flake onwards.

With the assumption that we don't really want to account for non-sane cases where we have colliding channel IDs, we change the draw to be done from `rand.Uint64` instead. This way intentional collisions, which are not relevant, are avoided.

Closes https://github.com/lightninglabs/taproot-assets/issues/1670

> Given that this PR changes the set of drawn values, the seed referenced in the above issue becomes irrelevant. We can still draw and ignore the old value just to preserve the previously failing test case.