### PR TITLE
Invoice manager tolerance tweaks

### DIFF
--- a/docs/release-notes/release-notes-0.7.0.md
+++ b/docs/release-notes/release-notes-0.7.0.md
@@ -35,10 +35,17 @@
   optimized sending to V2 TAP addresses by removing the need for creating
   tombstone outputs on a full-value send (by using interactive transfers for V2
   addresses).
+
 - [Updated](https://github.com/lightninglabs/taproot-assets/pull/1774) 
   `BuyOrderRequest` and `SellOrderRequest` proto docs to mark `peer_pub_key` as
   required. Previously, the field was incorrectly documented as optional.
   This change corrects the documentation to match the current implementation.
+
+- [Invoice tolerance calculations were fixed to properly account for per-HTLC
+  conversion errors](https://github.com/lightninglabs/taproot-assets/pull/1673).
+  This improves the accuracy of asset payment acceptance by correctly modeling
+  rounding errors that accumulate when converting between asset units and
+  millisatoshis across multiple HTLCs.
 
 # New Features
 

--- a/tapchannel/aux_traffic_shaper_test.go
+++ b/tapchannel/aux_traffic_shaper_test.go
@@ -89,26 +89,46 @@ func TestUnitConversionToleranceRapid(t *testing.T) {
 
 		shardSizeMSat := invoiceAmtMsat / lnwire.MilliSatoshi(numHTLCs)
 		shardSizeFP := rfqmath.MilliSatoshiToUnits(shardSizeMSat, rate)
-		shardSizeUnit := shardSizeFP.ScaleTo(0).ToUint64()
 
-		shardSumFP := rfqmath.NewBigIntFixedPoint(
-			shardSizeUnit*numHTLCs, 0,
+		// In order to account for the full invoice amt we need to also
+		// somehow carry the remainder of invoiceAmt/numHTLCs. We do so
+		// by appending it to the last shard.
+		invoiceMod := invoiceAmtMsat % lnwire.MilliSatoshi(numHTLCs)
+		lastShardMsat := shardSizeMSat + invoiceMod
+		lastShardFP := rfqmath.MilliSatoshiToUnits(lastShardMsat, rate)
+
+		var inboundAmountMSat lnwire.MilliSatoshi
+
+		// Each shard calls individually into the rfqmath library. This
+		// allows for a total error that scales with the number of
+		// shards. We go up to numHTLCS-1 because we want to add any
+		// leftovers to the last shard.
+		for range numHTLCs - 1 {
+			shardPartialSum := rfqmath.UnitsToMilliSatoshi(
+				shardSizeFP, rate,
+			)
+
+			inboundAmountMSat += shardPartialSum
+		}
+
+		// Make a single pass over the last shard, which may also carry
+		// the remainder of the payment amt.
+		lastShardMsat = rfqmath.UnitsToMilliSatoshi(lastShardFP, rate)
+		inboundAmountMSat += lastShardMsat
+
+		allowedMarginUnits := rfqmath.NewBigIntFixedPoint(
+			numHTLCs, 0,
 		)
-		inboundAmountMSat := rfqmath.UnitsToMilliSatoshi(
-			shardSumFP, rate,
+		marginAmt := rfqmath.UnitsToMilliSatoshi(
+			allowedMarginUnits, rate,
 		)
 
-		newMarginAssetUnits := rfqmath.NewBigIntFixedPoint(
-			numHTLCs+1, 0,
-		)
-		newAllowedMarginMSat := rfqmath.UnitsToMilliSatoshi(
-			newMarginAssetUnits, rate,
-		)
+		marginAmt += lnwire.MilliSatoshi(numHTLCs)
 
 		// The difference should be within the newly allowed margin.
 		require.LessOrEqual(
 			t,
-			invoiceAmtMsat-inboundAmountMSat, newAllowedMarginMSat,
+			invoiceAmtMsat-inboundAmountMSat, marginAmt,
 		)
 	})
 }

--- a/tapchannel/aux_traffic_shaper_test.go
+++ b/tapchannel/aux_traffic_shaper_test.go
@@ -19,7 +19,7 @@ func TestUnitConversionTolerance(t *testing.T) {
 	)
 	var (
 		rate = rfqmath.BigIntFixedPoint{
-			Coefficient: rfqmath.NewBigIntFromUint64(9852216748),
+			Coefficient: rfqmath.NewBigIntFromUint64(9_852_216_748),
 			Scale:       0,
 		}
 	)
@@ -61,8 +61,12 @@ func TestUnitConversionTolerance(t *testing.T) {
 		newMarginAssetUnits, rate,
 	)
 
+	proposedMargin := rfqmath.UnitsToMilliSatoshi(marginAssetUnits, rate) +
+		lnwire.MilliSatoshi(numHTLCs)
+
 	t.Logf("Old tolerance allowed in msat: %d", allowedMarginMSat)
 	t.Logf("New tolerance allowed in msat: %d", newAllowedMarginMSat)
+	t.Logf("Proposed tolerance allowed in msat: %d", proposedMargin)
 }
 
 // TestUnitConversionToleranceRapid uses rapid to randomly draw invoice amounts,

--- a/tapchannel/aux_traffic_shaper_test.go
+++ b/tapchannel/aux_traffic_shaper_test.go
@@ -74,7 +74,7 @@ func TestUnitConversionToleranceRapid(t *testing.T) {
 			Draw(t, "invoiceAmtUnits")
 		numHTLCs := rapid.Uint64Range(1, 16).
 			Draw(t, "numHTLCs")
-		coefficient := rapid.Uint64Range(1, 20_000_000_000).
+		coefficient := rapid.Uint64Range(1, 300_000_000_000).
 			Draw(t, "coefficient")
 
 		rate := rfqmath.BigIntFixedPoint{


### PR DESCRIPTION
## Description

First commit exposes our current tolerance, leading to new rounding errors.

There was also an inaccuracy in the way we sharded the amount across the number of HTLCs. We had to also carry the remainder of `invoiceAmt / numHTLCs`, which is currently added to the last shard.

Then we modify the tolerance model to instead be `(1unit + 1msat)*numHTLCs`

Let's use this topology to put things in order
```
Alice --[units]--> Bob --[msat]--> Carol --[units]--> Dave 
```

Dave creates an asset invoice, Alice pays to it (with `N` HTLCs)

- When an HTLC is forwarded to Carol: Carol converts msats to units, this justifies `N units` of tolerance
- When an HTLC is received by Dave: Dave converts the units of the HTLC back to msats, as the invoice is measured in msats, this justifies `N msats` of tolerance

The current rapid test tolerance model follows the above model and seems to be happy (for `rapid.checks` up to 10M)
