### PR TITLE
proof: return early if mailbox is nil.

### DIFF
--- a/proof/courier.go
+++ b/proof/courier.go
@@ -1052,6 +1052,14 @@ func (h *HashMailCourier) publishSubscriberEvent(event fn.Event) {
 
 // Close closes the underlying connection to the hashmail server.
 func (h *HashMailCourier) Close() error {
+	// In case we never fully established a connection, the mailbox client
+	// might not yet be instantiated.
+	if h.mailbox == nil {
+		log.Warnf("HashMailCourier mailbox not instantiated, " +
+			"skipping close")
+		return nil
+	}
+
 	if err := h.mailbox.Close(); err != nil {
 		log.Warnf("Unable to close mailbox session: %v", err)
 		return err


### PR DESCRIPTION
Fixes #1195 by adding a nil check for the mailbox client.