### PR TITLE
itest: increase proof courier timeout

### DIFF
--- a/itest/tapd_harness.go
+++ b/itest/tapd_harness.go
@@ -274,7 +274,7 @@ func newTapdHarness(t *testing.T, ht *harnessTest, cfg tapdConfig,
 	}
 	finalCfg.UniverseRpcCourier = &proof.UniverseRpcCourierCfg{
 		BackoffCfg:            &universeRpcBackoffCfg,
-		ServiceRequestTimeout: 50 * time.Millisecond,
+		ServiceRequestTimeout: 5 * time.Second,
 	}
 
 	switch typedProofCourier := (opts.proofCourier).(type) {


### PR DESCRIPTION
Fixes a flake where uploading proofs to the proof courier would take more than 50 milliseconds in CPU constrained environments such as CI.