### PR TITLE
itest: fix flake in address v2 test

### DIFF
--- a/itest/addrs_v2_test.go
+++ b/itest/addrs_v2_test.go
@@ -356,11 +356,11 @@ func testAddressV2WithGroupKey(t *harnessTest) {
 		[]uint64{0, totalAmount/2 - 50, 50, 0, totalAmount / 2}, 1,
 		2, 5, true,
 	)
-	AssertAddrEventByStatus(t.t, t.tapd, statusCompleted, 1)
 	AssertBalanceByGroup(
 		t.t, t.tapd, hex.EncodeToString(groupKey), totalAmount,
 		WithNumUtxos(4),
 	)
+	AssertAddrEventByStatus(t.t, t.tapd, statusCompleted, 2)
 
 	// The sending node should only have two tombstone outputs, but the
 	// total value should be zero.

--- a/itest/assertions.go
+++ b/itest/assertions.go
@@ -941,8 +941,9 @@ func AssertAddrEventByStatus(t *testing.T, client taprpc.TaprootAssetsClient,
 		require.NoError(t, err)
 
 		if len(resp.Events) != numEvents {
-			return fmt.Errorf("got %d events, wanted %d",
-				len(resp.Events), numEvents)
+			return fmt.Errorf("got %d events, wanted %d, events: "+
+				"%v", len(resp.Events), numEvents,
+				toJSON(t, resp))
 		}
 
 		for _, event := range resp.Events {


### PR DESCRIPTION
We always expect two events. So asserting for just one only worked when things ran very quickly and only the first one was persisted. Always waiting for two will fix this timing-dependent flake.

Fixes the flake observed here: https://github.com/lightninglabs/taproot-assets/actions/runs/16798226160/job/47573276733?pr=1713