### PR TITLE
proof: implement and hook up ignore checker

### DIFF
--- a/asset/asset.go
+++ b/asset/asset.go
@@ -769,6 +769,12 @@ func (id PrevID) Hash() [sha256.Size]byte {
 	return *(*[sha256.Size]byte)(h.Sum(nil))
 }
 
+// String returns a human-readable description of the PrevID.
+func (id PrevID) String() string {
+	return fmt.Sprintf("PrevID(outpoint=%s, id=%s, script_key=%x)",
+		id.OutPoint.String(), id.ID.String(), id.ScriptKey.CopyBytes())
+}
+
 // AnchorPoint is a type alias for an asset anchor outpoint. It relates the
 // on-chain anchor outpoint (txid:vout) to the corresponding committed asset.
 type AnchorPoint = PrevID

--- a/config.go
+++ b/config.go
@@ -197,6 +197,8 @@ type Config struct {
 	// attestations of the total supply of an asset.
 	SupplyCommitManager *supplycommit.MultiStateMachineManager
 
+	IgnoreChecker proof.IgnoreChecker
+
 	UniverseArchive *universe.Archive
 
 	UniverseSyncer universe.Syncer

--- a/proof/mock.go
+++ b/proof/mock.go
@@ -24,6 +24,7 @@ import (
 	"github.com/lightninglabs/taproot-assets/internal/test"
 	mboxrpc "github.com/lightninglabs/taproot-assets/taprpc/authmailboxrpc"
 	"github.com/lightninglabs/taproot-assets/taprpc/universerpc"
+	lfn "github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/lightningnetwork/lnd/lnutils"
 	"github.com/lightningnetwork/lnd/lnwire"
@@ -1080,8 +1081,10 @@ func newMockIgnoreChecker(ignoreAll bool,
 	}
 }
 
-func (m *mockIgnoreChecker) IsIgnored(assetPoint AssetPoint) bool {
-	return m.ignoreAll || m.ignoredAssetPoints.Contains(assetPoint)
+func (m *mockIgnoreChecker) IsIgnored(_ context.Context,
+	assetPoint AssetPoint) lfn.Result[bool] {
+
+	return lfn.Ok(m.ignoreAll || m.ignoredAssetPoints.Contains(assetPoint))
 }
 
 // MockUniverseServer is a mock implementation of the UniverseServer

--- a/proof/proof_test.go
+++ b/proof/proof_test.go
@@ -996,7 +996,8 @@ func TestProofVerification(t *testing.T) {
 
 	// Verifying the inclusion and exclusion proofs can also be done without
 	// the previous proof.
-	_, err = p.VerifyProofs()
+	vCtx := MockVerifierCtx
+	_, err = p.VerifyProofIntegrity(context.Background(), vCtx)
 	require.NoError(t, err)
 
 	// Ensure that verification of a proof of unknown version fails.

--- a/proof/verifier.go
+++ b/proof/verifier.go
@@ -838,7 +838,74 @@ func (p *Proof) Verify(ctx context.Context, prev *AssetSnapshot,
 	opts ...ProofVerificationOption) (*AssetSnapshot, error) {
 
 	var verificationParams proofVerificationParams
+	for _, opt := range opts {
+		opt(&verificationParams)
+	}
 
+	// We call the VerifyProofIntegrity method to check the integrity of the
+	// proof, which checks steps 0 to 7 (excluding step 1b that needs the
+	// previous asset snapshot).
+	tapCommitment, err := p.VerifyProofIntegrity(ctx, vCtx, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	// 1b. A transaction that spends the previous asset output has a valid
+	// merkle proof within a block in the chain.
+	if prev != nil && p.PrevOut != prev.OutPoint {
+		return nil, fmt.Errorf("%w: prev output mismatch",
+			commitment.ErrInvalidTaprootProof)
+	}
+
+	// 8. Either a set of asset inputs with valid witnesses is included that
+	// satisfy the resulting state transition or a challenge witness is
+	// provided as part of an ownership proof.
+	var splitAsset bool
+	switch {
+	case prev == nil && p.ChallengeWitness != nil:
+		splitAsset, err = p.verifyChallengeWitness(
+			ctx, chainLookup, verificationParams.ChallengeBytes,
+		)
+
+	default:
+		splitAsset, err = p.verifyAssetStateTransition(
+			ctx, prev, chainLookup, vCtx,
+		)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	// 8. At this point we know there is an inclusion proof, which must be
+	// a commitment proof. So we can extract the tapscript preimage directly
+	// from there.
+	tapscriptPreimage := p.InclusionProof.CommitmentProof.TapSiblingPreimage
+
+	// TODO(roasbeef): need tx index as well
+
+	return &AssetSnapshot{
+		Asset:             &p.Asset,
+		OutPoint:          p.OutPoint(),
+		AnchorBlockHash:   p.BlockHeader.BlockHash(),
+		AnchorBlockHeight: p.BlockHeight,
+		AnchorTx:          &p.AnchorTx,
+		OutputIndex:       p.InclusionProof.OutputIndex,
+		InternalKey:       p.InclusionProof.InternalKey,
+		ScriptRoot:        tapCommitment,
+		TapscriptSibling:  tapscriptPreimage,
+		SplitAsset:        splitAsset,
+		MetaReveal:        p.MetaReveal,
+	}, nil
+}
+
+// VerifyProofIntegrity verifies the integrity of the proof by checking all
+// fields that can be checked without knowing the previous asset snapshot. These
+// include steps 1 up to 7, but not 8 of the proof verification process as
+// described in the BIP.
+func (p *Proof) VerifyProofIntegrity(ctx context.Context, vCtx VerifierCtx,
+	opts ...ProofVerificationOption) (*commitment.TapCommitment, error) {
+
+	var verificationParams proofVerificationParams
 	for _, opt := range opts {
 		opt(&verificationParams)
 	}
@@ -850,8 +917,8 @@ func (p *Proof) Verify(ctx context.Context, prev *AssetSnapshot,
 
 	// Ensure proof asset is valid.
 	if err := p.Asset.Validate(); err != nil {
-		return nil, fmt.Errorf("failed to validate proof asset: "+
-			"%w", err)
+		return nil, fmt.Errorf("failed to validate proof asset: %w",
+			err)
 	}
 
 	assetPoint := AssetPoint{
@@ -869,16 +936,12 @@ func (p *Proof) Verify(ctx context.Context, prev *AssetSnapshot,
 		},
 	).Unpack()
 	if fail {
-		return prev, fmt.Errorf("%w: asset_point=%v is ignored",
+		return nil, fmt.Errorf("%w: asset_point=%v is ignored",
 			ErrProofInvalid, assetPoint)
 	}
 
 	// 1. A transaction that spends the previous asset output has a valid
 	// merkle proof within a block in the chain.
-	if prev != nil && p.PrevOut != prev.OutPoint {
-		return nil, fmt.Errorf("%w: prev output mismatch",
-			commitment.ErrInvalidTaprootProof)
-	}
 	if !txSpendsPrevOut(&p.AnchorTx, &p.PrevOut) {
 		return nil, fmt.Errorf("%w: doesn't spend prev output",
 			commitment.ErrInvalidTaprootProof)
@@ -970,45 +1033,7 @@ func (p *Proof) Verify(ctx context.Context, prev *AssetSnapshot,
 		}
 	}
 
-	// 8. Either a set of asset inputs with valid witnesses is included that
-	// satisfy the resulting state transition or a challenge witness is
-	// provided as part of an ownership proof.
-	var splitAsset bool
-	switch {
-	case prev == nil && p.ChallengeWitness != nil:
-		splitAsset, err = p.verifyChallengeWitness(
-			ctx, chainLookup, verificationParams.ChallengeBytes,
-		)
-
-	default:
-		splitAsset, err = p.verifyAssetStateTransition(
-			ctx, prev, chainLookup, vCtx,
-		)
-	}
-	if err != nil {
-		return nil, err
-	}
-
-	// 8. At this point we know there is an inclusion proof, which must be
-	// a commitment proof. So we can extract the tapscript preimage directly
-	// from there.
-	tapscriptPreimage := p.InclusionProof.CommitmentProof.TapSiblingPreimage
-
-	// TODO(roasbeef): need tx index as well
-
-	return &AssetSnapshot{
-		Asset:             &p.Asset,
-		OutPoint:          p.OutPoint(),
-		AnchorBlockHash:   p.BlockHeader.BlockHash(),
-		AnchorBlockHeight: p.BlockHeight,
-		AnchorTx:          &p.AnchorTx,
-		OutputIndex:       p.InclusionProof.OutputIndex,
-		InternalKey:       p.InclusionProof.InternalKey,
-		ScriptRoot:        tapCommitment,
-		TapscriptSibling:  tapscriptPreimage,
-		SplitAsset:        splitAsset,
-		MetaReveal:        p.MetaReveal,
-	}, nil
+	return tapCommitment, nil
 }
 
 // VerifyProofs verifies the inclusion and exclusion proofs as well as the split

--- a/proof/verifier.go
+++ b/proof/verifier.go
@@ -45,7 +45,7 @@ type IgnoreChecker interface {
 	// IsIgnored returns true if the given prevID is known to be invalid. A
 	// prevID is used here, but the check should be tested against a proof
 	// result, or produced output.
-	IsIgnored(prevID AssetPoint) bool
+	IsIgnored(ctx context.Context, prevID AssetPoint) lfn.Result[bool]
 }
 
 // VerifierCtx is a context struct that is used to pass in various interfaces
@@ -863,9 +863,11 @@ func (p *Proof) Verify(ctx context.Context, prev *AssetSnapshot,
 	// Before we do any other validation, we'll check to see if we can halt
 	// validation here, as the proof is already known to be invalid. This
 	// can be used as a rejection caching mechanism.
-	fail := lfn.MapOptionZ(vCtx.IgnoreChecker, func(c IgnoreChecker) bool {
-		return c.IsIgnored(assetPoint)
-	})
+	fail, err := lfn.MapOptionZ(
+		vCtx.IgnoreChecker, func(c IgnoreChecker) lfn.Result[bool] {
+			return c.IsIgnored(ctx, assetPoint)
+		},
+	).Unpack()
 	if fail {
 		return prev, fmt.Errorf("%w: asset_point=%v is ignored",
 			ErrProofInvalid, assetPoint)
@@ -883,7 +885,7 @@ func (p *Proof) Verify(ctx context.Context, prev *AssetSnapshot,
 	}
 
 	// Cross-check block header with a bitcoin node.
-	err := vCtx.HeaderVerifier(p.BlockHeader, p.BlockHeight)
+	err = vCtx.HeaderVerifier(p.BlockHeader, p.BlockHeight)
 	if err != nil {
 		return nil, fmt.Errorf("failed to validate proof block "+
 			"header: %w", err)
@@ -1103,8 +1105,9 @@ func (f *File) Verify(ctx context.Context,
 		// At this point, we'll check to see if we can halt validation
 		// here, as the proof is already known to be invalid. This can
 		// be used as a rejection caching mechanism.
-		fail := lfn.MapOptionZ(
-			vCtx.IgnoreChecker, func(checker IgnoreChecker) bool {
+		fail, err := lfn.MapOptionZ(
+			vCtx.IgnoreChecker,
+			func(checker IgnoreChecker) lfn.Result[bool] {
 				assetPoint := AssetPoint{
 					OutPoint: result.OutPoint,
 					ID:       result.Asset.ID(),
@@ -1113,9 +1116,13 @@ func (f *File) Verify(ctx context.Context,
 					),
 				}
 
-				return checker.IsIgnored(assetPoint)
+				return checker.IsIgnored(ctx, assetPoint)
 			},
-		)
+		).Unpack()
+		if err != nil {
+			return nil, fmt.Errorf("failed to check if proof "+
+				"file is ignored: %w", err)
+		}
 		if fail {
 			return prev, ErrProofFileInvalid
 		}

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -58,6 +58,7 @@ import (
 	"github.com/lightninglabs/taproot-assets/universe"
 	"github.com/lightninglabs/taproot-assets/universe/supplycommit"
 	"github.com/lightningnetwork/lnd/build"
+	lfn "github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/lnrpc/invoicesrpc"
@@ -1844,17 +1845,7 @@ func (r *rpcServer) VerifyProof(ctx context.Context,
 		return nil, fmt.Errorf("unable to decode proof file: %w", err)
 	}
 
-	headerVerifier := tapgarden.GenHeaderVerifier(ctx, r.cfg.ChainBridge)
-	groupVerifier := tapgarden.GenGroupVerifier(ctx, r.cfg.MintingStore)
-
-	vCtx := proof.VerifierCtx{
-		HeaderVerifier: headerVerifier,
-		MerkleVerifier: proof.DefaultMerkleVerifier,
-		GroupVerifier:  groupVerifier,
-		ChainLookupGen: r.cfg.ChainBridge,
-	}
-
-	_, err = proofFile.Verify(ctx, vCtx)
+	_, err = proofFile.Verify(ctx, r.ProofVerifierCtx(ctx))
 	if err != nil {
 		// We don't want to fail the RPC request because of a proof
 		// verification error, but we do want to log it for easier
@@ -2205,20 +2196,10 @@ func (r *rpcServer) ImportProof(ctx context.Context,
 		return nil, fmt.Errorf("error extracting last proof: %w", err)
 	}
 
-	headerVerifier := tapgarden.GenHeaderVerifier(ctx, r.cfg.ChainBridge)
-	groupVerifier := tapgarden.GenGroupVerifier(ctx, r.cfg.MintingStore)
-
-	vCtx := proof.VerifierCtx{
-		HeaderVerifier: headerVerifier,
-		MerkleVerifier: proof.DefaultMerkleVerifier,
-		GroupVerifier:  groupVerifier,
-		ChainLookupGen: r.cfg.ChainBridge,
-	}
-
 	// Now that we know the proof file is at least present, we'll attempt
 	// to import it into the main archive.
 	err = r.cfg.ProofArchive.ImportProofs(
-		ctx, vCtx, false, &proof.AnnotatedProof{
+		ctx, r.ProofVerifierCtx(ctx), false, &proof.AnnotatedProof{
 			Locator: proof.Locator{
 				AssetID:   fn.Ptr(lastProof.Asset.ID()),
 				ScriptKey: *lastProof.Asset.ScriptKey.PubKey,
@@ -7268,17 +7249,7 @@ func (r *rpcServer) ProveAssetOwnership(ctx context.Context,
 		return nil, fmt.Errorf("cannot decode proof: %w", err)
 	}
 
-	headerVerifier := tapgarden.GenHeaderVerifier(ctx, r.cfg.ChainBridge)
-	groupVerifier := tapgarden.GenGroupVerifier(ctx, r.cfg.MintingStore)
-
-	vCtx := proof.VerifierCtx{
-		HeaderVerifier: headerVerifier,
-		MerkleVerifier: proof.DefaultMerkleVerifier,
-		GroupVerifier:  groupVerifier,
-		ChainLookupGen: r.cfg.ChainBridge,
-	}
-
-	lastSnapshot, err := proofFile.Verify(ctx, vCtx)
+	lastSnapshot, err := proofFile.Verify(ctx, r.ProofVerifierCtx(ctx))
 	if err != nil {
 		return nil, fmt.Errorf("cannot verify proof: %w", err)
 	}
@@ -7349,28 +7320,17 @@ func (r *rpcServer) VerifyAssetOwnership(ctx context.Context,
 			"%w", err)
 	}
 
-	headerVerifier := tapgarden.GenHeaderVerifier(ctx, r.cfg.ChainBridge)
-	groupVerifier := tapgarden.GenGroupVerifier(ctx, r.cfg.MintingStore)
-
 	var (
 		challengeBytes [32]byte
 		opts           []proof.ProofVerificationOption
 	)
-
 	if len(req.Challenge) == 32 {
 		copy(challengeBytes[:], req.Challenge[:32])
 		opts = append(opts, proof.WithChallengeBytes(challengeBytes))
 	}
 
-	vCtx := proof.VerifierCtx{
-		HeaderVerifier: headerVerifier,
-		MerkleVerifier: proof.DefaultMerkleVerifier,
-		GroupVerifier:  groupVerifier,
-		ChainLookupGen: r.cfg.ChainBridge,
-	}
-
 	snapShot, err := p.Verify(
-		ctx, nil, lookup, vCtx, opts...,
+		ctx, nil, lookup, r.ProofVerifierCtx(ctx), opts...,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("error verifying proof: %w", err)
@@ -9999,18 +9959,8 @@ func (r *rpcServer) RegisterTransfer(ctx context.Context,
 
 	// All seems well, we can now import the proof into our local proof
 	// archive, which will also materialize an asset in the asset database.
-	headerVerifier := tapgarden.GenHeaderVerifier(ctx, r.cfg.ChainBridge)
-	groupVerifier := tapgarden.GenGroupVerifier(ctx, r.cfg.MintingStore)
-
-	vCtx := proof.VerifierCtx{
-		HeaderVerifier: headerVerifier,
-		MerkleVerifier: proof.DefaultMerkleVerifier,
-		GroupVerifier:  groupVerifier,
-		ChainLookupGen: r.cfg.ChainBridge,
-	}
-
 	err = r.cfg.ProofArchive.ImportProofs(
-		ctx, vCtx, false, &proof.AnnotatedProof{
+		ctx, r.ProofVerifierCtx(ctx), false, &proof.AnnotatedProof{
 			Locator: locator,
 			Blob:    fullProvenance,
 		},
@@ -10050,4 +10000,19 @@ func (r *rpcServer) RegisterTransfer(ctx context.Context,
 	return &taprpc.RegisterTransferResponse{
 		RegisteredAsset: rpcAsset,
 	}, nil
+}
+
+// ProofVerifierCtx returns a proof.VerifierCtx that can be used to verify
+// proofs in the RPC server.
+func (r *rpcServer) ProofVerifierCtx(ctx context.Context) proof.VerifierCtx {
+	headerVerifier := tapgarden.GenHeaderVerifier(ctx, r.cfg.ChainBridge)
+	groupVerifier := tapgarden.GenGroupVerifier(ctx, r.cfg.MintingStore)
+
+	return proof.VerifierCtx{
+		HeaderVerifier: headerVerifier,
+		MerkleVerifier: proof.DefaultMerkleVerifier,
+		GroupVerifier:  groupVerifier,
+		ChainLookupGen: r.cfg.ChainBridge,
+		IgnoreChecker:  lfn.Some(r.cfg.IgnoreChecker),
+	}
 }

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -2547,7 +2547,7 @@ func (r *rpcServer) SignVirtualPsbt(ctx context.Context,
 		}
 	}
 
-	signedInputs, err := r.cfg.AssetWallet.SignVirtualPacket(vPkt)
+	signedInputs, err := r.cfg.AssetWallet.SignVirtualPacket(ctx, vPkt)
 	if err != nil {
 		return nil, fmt.Errorf("error signing packet: %w", err)
 	}
@@ -3737,7 +3737,7 @@ func (r *rpcServer) BurnAsset(ctx context.Context,
 
 	// Now we can sign the packet and send it to the chain.
 	vPkt := fundResp.VPackets[0]
-	_, err = r.cfg.AssetWallet.SignVirtualPacket(vPkt)
+	_, err = r.cfg.AssetWallet.SignVirtualPacket(ctx, vPkt)
 	if err != nil {
 		return nil, fmt.Errorf("error signing packet: %w", err)
 	}
@@ -4013,6 +4013,9 @@ func (r *rpcServer) IgnoreAssetOutPoint(ctx context.Context,
 	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshal request: %w", err)
 	}
+
+	rpcsLog.Debugf("[IgnoreAssetOutPoint]: request to ignore %s",
+		req.AssetAnchorPoint)
 
 	assetID := req.AssetAnchorPoint.ID
 

--- a/tapcfg/server.go
+++ b/tapcfg/server.go
@@ -167,6 +167,15 @@ func genServerConfig(cfg *Config, cfgLogger btclog.Logger,
 		context.Background(), assetMintingStore,
 	)
 
+	// Construct the supply tree database backend so we can create the
+	// ignore checker that's used by a number of early initialized
+	// components in here.
+	supplyTreeStore := tapdb.NewSupplyTreeStore(uniDB)
+	ignoreChecker := tapdb.NewCachingIgnoreChecker(tapdb.IgnoreCheckerCfg{
+		GroupQuery: tapdbAddrBook,
+		Store:      supplyTreeStore,
+	})
+
 	uniArchiveCfg := universe.ArchiveConfig{
 		// nolint: lll
 		NewBaseTree: func(id universe.Identifier) universe.StorageBackend {
@@ -180,6 +189,7 @@ func genServerConfig(cfg *Config, cfgLogger btclog.Logger,
 		ChainLookupGenerator: chainBridge,
 		Multiverse:           multiverse,
 		UniverseStats:        universeStats,
+		IgnoreChecker:        ignoreChecker,
 	}
 
 	federationStore := tapdb.NewTransactionExecutor(db,
@@ -335,7 +345,8 @@ func genServerConfig(cfg *Config, cfgLogger btclog.Logger,
 		GroupVerifier: tapgarden.GenGroupVerifier(
 			context.Background(), assetMintingStore,
 		),
-		ProofArchive: proofArchive,
+		ProofArchive:  proofArchive,
+		IgnoreChecker: ignoreChecker,
 		NonBuriedAssetFetcher: func(ctx context.Context,
 			minHeight int32) ([]*asset.ChainAsset, error) {
 
@@ -499,6 +510,7 @@ func genServerConfig(cfg *Config, cfgLogger btclog.Logger,
 			ProofWriter:            proofFileStore,
 			ProofCourierDispatcher: proofCourierDispatcher,
 			ProofWatcher:           reOrgWatcher,
+			IgnoreChecker:          ignoreChecker,
 			ErrChan:                mainErrChan,
 		},
 	)
@@ -532,6 +544,7 @@ func genServerConfig(cfg *Config, cfgLogger btclog.Logger,
 			DefaultCourierAddr: proofCourierAddr,
 			AssetSyncer:        addrBook,
 			FeatureBits:        lndFeatureBitsVerifier,
+			IgnoreChecker:      ignoreChecker,
 			ErrChan:            mainErrChan,
 		},
 	)
@@ -561,7 +574,8 @@ func genServerConfig(cfg *Config, cfgLogger btclog.Logger,
 			GroupVerifier: tapgarden.GenGroupVerifier(
 				context.Background(), assetMintingStore,
 			),
-			ChainBridge: chainBridge,
+			ChainBridge:   chainBridge,
+			IgnoreChecker: ignoreChecker,
 		},
 	)
 	auxSweeper := tapchannel.NewAuxSweeper(
@@ -577,7 +591,8 @@ func genServerConfig(cfg *Config, cfgLogger btclog.Logger,
 			GroupVerifier: tapgarden.GenGroupVerifier(
 				context.Background(), assetMintingStore,
 			),
-			ChainBridge: chainBridge,
+			ChainBridge:   chainBridge,
+			IgnoreChecker: ignoreChecker,
 		},
 	)
 
@@ -600,14 +615,6 @@ func genServerConfig(cfg *Config, cfgLogger btclog.Logger,
 		},
 	)
 	supplyCommitStore := tapdb.NewSupplyCommitMachine(supplyCommitDb)
-
-	// Construct the supply tree database backend.
-	supplyTreeDb := tapdb.NewTransactionExecutor(
-		db, func(tx *sql.Tx) tapdb.BaseUniverseStore {
-			return db.WithTx(tx)
-		},
-	)
-	supplyTreeStore := tapdb.NewSupplyTreeStore(supplyTreeDb)
 
 	// Create the supply commitment state machine manager, which is used to
 	// manage the supply commitment state machines for each asset group.
@@ -632,6 +639,7 @@ func genServerConfig(cfg *Config, cfgLogger btclog.Logger,
 		ChainParams:           tapChainParams,
 		ReOrgWatcher:          reOrgWatcher,
 		AssetMinter: tapgarden.NewChainPlanter(tapgarden.PlanterConfig{
+			// nolint: lll
 			GardenKit: tapgarden.GardenKit{
 				Wallet:                walletAnchor,
 				ChainBridge:           chainBridge,
@@ -645,6 +653,7 @@ func genServerConfig(cfg *Config, cfgLogger btclog.Logger,
 				Universe:              universeFederation,
 				ProofWatcher:          reOrgWatcher,
 				UniversePushBatchSize: defaultUniverseSyncBatchSize,
+				IgnoreChecker:         ignoreChecker,
 			},
 			ChainParams:  tapChainParams,
 			ProofUpdates: proofArchive,
@@ -667,6 +676,7 @@ func genServerConfig(cfg *Config, cfgLogger btclog.Logger,
 			MboxBackoffCfg:         cfg.UniverseRpcCourier.BackoffCfg,
 			ProofRetrievalDelay:    cfg.CustodianProofRetrievalDelay,
 			ProofWatcher:           reOrgWatcher,
+			IgnoreChecker:          ignoreChecker,
 		}),
 		ChainBridge:              chainBridge,
 		AddrBook:                 addrBook,
@@ -678,6 +688,7 @@ func genServerConfig(cfg *Config, cfgLogger btclog.Logger,
 		ChainPorter:              chainPorter,
 		FsmDaemonAdapters:        lndFsmDaemonAdapters,
 		SupplyCommitManager:      supplyCommitManager,
+		IgnoreChecker:            ignoreChecker,
 		UniverseArchive:          uniArchive,
 		UniverseSyncer:           universeSyncer,
 		UniverseFederation:       universeFederation,

--- a/tapcfg/server.go
+++ b/tapcfg/server.go
@@ -341,10 +341,8 @@ func genServerConfig(cfg *Config, cfgLogger btclog.Logger,
 	}
 
 	reOrgWatcher := tapgarden.NewReOrgWatcher(&tapgarden.ReOrgWatcherConfig{
-		ChainBridge: chainBridge,
-		GroupVerifier: tapgarden.GenGroupVerifier(
-			context.Background(), assetMintingStore,
-		),
+		ChainBridge:   chainBridge,
+		GroupVerifier: groupVerifier,
 		ProofArchive:  proofArchive,
 		IgnoreChecker: ignoreChecker,
 		NonBuriedAssetFetcher: func(ctx context.Context,
@@ -416,6 +414,9 @@ func genServerConfig(cfg *Config, cfgLogger btclog.Logger,
 		Signer:           virtualTxSigner,
 		TxValidator:      &tap.ValidatorV0{},
 		WitnessValidator: &tap.WitnessValidatorV0{},
+		ChainBridge:      chainBridge,
+		GroupVerifier:    groupVerifier,
+		IgnoreChecker:    ignoreChecker,
 		Wallet:           walletAnchor,
 		ChainParams:      &tapChainParams,
 	})
@@ -495,14 +496,12 @@ func genServerConfig(cfg *Config, cfgLogger btclog.Logger,
 	)
 	chainPorter := tapfreighter.NewChainPorter(
 		&tapfreighter.ChainPorterConfig{
-			ChainParams: tapChainParams,
-			Signer:      virtualTxSigner,
-			TxValidator: &tap.ValidatorV0{},
-			ExportLog:   assetStore,
-			ChainBridge: chainBridge,
-			GroupVerifier: tapgarden.GenGroupVerifier(
-				context.Background(), assetMintingStore,
-			),
+			ChainParams:            tapChainParams,
+			Signer:                 virtualTxSigner,
+			TxValidator:            &tap.ValidatorV0{},
+			ExportLog:              assetStore,
+			ChainBridge:            chainBridge,
+			GroupVerifier:          groupVerifier,
 			Wallet:                 walletAnchor,
 			KeyRing:                keyRing,
 			AssetWallet:            assetWallet,
@@ -524,10 +523,8 @@ func genServerConfig(cfg *Config, cfgLogger btclog.Logger,
 	channelFunder := lndservices.NewLndPbstChannelFunder(lndServices)
 	auxFundingController := tapchannel.NewFundingController(
 		tapchannel.FundingControllerCfg{
-			HeaderVerifier: headerVerifier,
-			GroupVerifier: tapgarden.GenGroupVerifier(
-				context.Background(), assetMintingStore,
-			),
+			HeaderVerifier:     headerVerifier,
+			GroupVerifier:      groupVerifier,
 			ErrReporter:        msgTransportClient,
 			AssetWallet:        assetWallet,
 			CoinSelector:       coinSelect,
@@ -571,11 +568,9 @@ func genServerConfig(cfg *Config, cfgLogger btclog.Logger,
 			ProofArchive:       proofArchive,
 			ProofFetcher:       proofCourierDispatcher,
 			HeaderVerifier:     headerVerifier,
-			GroupVerifier: tapgarden.GenGroupVerifier(
-				context.Background(), assetMintingStore,
-			),
-			ChainBridge:   chainBridge,
-			IgnoreChecker: ignoreChecker,
+			GroupVerifier:      groupVerifier,
+			ChainBridge:        chainBridge,
+			IgnoreChecker:      ignoreChecker,
 		},
 	)
 	auxSweeper := tapchannel.NewAuxSweeper(
@@ -588,11 +583,9 @@ func genServerConfig(cfg *Config, cfgLogger btclog.Logger,
 			ProofArchive:       proofArchive,
 			ProofFetcher:       proofCourierDispatcher,
 			HeaderVerifier:     headerVerifier,
-			GroupVerifier: tapgarden.GenGroupVerifier(
-				context.Background(), assetMintingStore,
-			),
-			ChainBridge:   chainBridge,
-			IgnoreChecker: ignoreChecker,
+			GroupVerifier:      groupVerifier,
+			ChainBridge:        chainBridge,
+			IgnoreChecker:      ignoreChecker,
 		},
 	)
 
@@ -661,12 +654,10 @@ func genServerConfig(cfg *Config, cfgLogger btclog.Logger,
 		}),
 		// nolint: lll
 		AssetCustodian: tapgarden.NewCustodian(&tapgarden.CustodianConfig{
-			ChainParams:  &tapChainParams,
-			WalletAnchor: walletAnchor,
-			ChainBridge:  chainBridge,
-			GroupVerifier: tapgarden.GenGroupVerifier(
-				context.Background(), assetMintingStore,
-			),
+			ChainParams:            &tapChainParams,
+			WalletAnchor:           walletAnchor,
+			ChainBridge:            chainBridge,
+			GroupVerifier:          groupVerifier,
 			AddrBook:               addrBook,
 			Signer:                 lndServices.Signer,
 			ProofArchive:           proofArchive,

--- a/tapchannel/aux_closer.go
+++ b/tapchannel/aux_closer.go
@@ -62,6 +62,10 @@ type AuxChanCloserCfg struct {
 
 	// ChainBridge is used to fetch blocks from the main chain.
 	ChainBridge tapgarden.ChainBridge
+
+	// IgnoreChecker is an optional function that can be used to check if
+	// a proof should be ignored.
+	IgnoreChecker proof.IgnoreChecker
 }
 
 // assetCloseInfo houses the information we need to finalize the close of an
@@ -698,11 +702,17 @@ func (a *AuxChanCloser) FinalizeClose(desc chancloser.AuxCloseDesc,
 				return &a.Proof.Val
 			},
 		)
+		vCtx := proof.VerifierCtx{
+			HeaderVerifier: a.cfg.HeaderVerifier,
+			MerkleVerifier: proof.DefaultMerkleVerifier,
+			GroupVerifier:  a.cfg.GroupVerifier,
+			ChainLookupGen: a.cfg.ChainBridge,
+			IgnoreChecker:  lfn.Some(a.cfg.IgnoreChecker),
+		}
 		err = importOutputProofs(
 			desc.ShortChanID, fundingInputProofs,
 			a.cfg.DefaultCourierAddr, a.cfg.ProofFetcher,
-			a.cfg.ChainBridge, a.cfg.HeaderVerifier,
-			a.cfg.GroupVerifier, a.cfg.ProofArchive,
+			a.cfg.ChainBridge, vCtx, a.cfg.ProofArchive,
 		)
 		if err != nil {
 			return fmt.Errorf("unable to import output "+

--- a/tapchannel/aux_funding_controller.go
+++ b/tapchannel/aux_funding_controller.go
@@ -974,7 +974,9 @@ func (f *FundingController) sendInputOwnershipProofs(peerPub btcec.PublicKey,
 	// can't actually broadcast this without our signed Bitcoin inputs.
 	for idx := range vPackets {
 		vPkt := vPackets[idx]
-		signedInputs, err := f.cfg.AssetWallet.SignVirtualPacket(vPkt)
+		signedInputs, err := f.cfg.AssetWallet.SignVirtualPacket(
+			ctx, vPkt,
+		)
 		if err != nil {
 			return fmt.Errorf("unable to sign funding inputs: %w",
 				err)
@@ -1047,7 +1049,9 @@ func (f *FundingController) signAllVPackets(ctx context.Context,
 
 		log.Debugf("Active packet %d: %x", idx, encoded)
 
-		_, err = f.cfg.AssetWallet.SignVirtualPacket(activePackets[idx])
+		_, err = f.cfg.AssetWallet.SignVirtualPacket(
+			ctx, activePackets[idx],
+		)
 		if err != nil {
 			return nil, nil, nil, fmt.Errorf("unable to sign and "+
 				"commit virtual packet: %w", err)
@@ -1061,7 +1065,7 @@ func (f *FundingController) signAllVPackets(ctx context.Context,
 		return nil, nil, nil, fmt.Errorf("unable to create passive "+
 			"assets: %w", err)
 	}
-	err = f.cfg.AssetWallet.SignPassiveAssets(passivePkts)
+	err = f.cfg.AssetWallet.SignPassiveAssets(ctx, passivePkts)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("unable to sign passive "+
 			"assets: %w", err)

--- a/tapchannel/aux_funding_controller.go
+++ b/tapchannel/aux_funding_controller.go
@@ -265,6 +265,10 @@ type FundingControllerCfg struct {
 	// to fund asset channels.
 	FeatureBits FeatureBitVerifer
 
+	// IgnoreChecker is an optional function that can be used to check if
+	// a proof should be ignored.
+	IgnoreChecker proof.IgnoreChecker
+
 	// ErrChan is used to report errors back to the main server.
 	ErrChan chan<- error
 }
@@ -1498,6 +1502,7 @@ func (f *FundingController) processFundingMsg(ctx context.Context,
 				MerkleVerifier: proof.DefaultMerkleVerifier,
 				GroupVerifier:  f.cfg.GroupVerifier,
 				ChainLookupGen: f.cfg.ChainBridge,
+				IgnoreChecker:  lfn.Some(f.cfg.IgnoreChecker),
 			}
 
 			l, err := f.cfg.ChainBridge.GenProofChainLookup(&p)

--- a/tapchannel/aux_leaf_signer.go
+++ b/tapchannel/aux_leaf_signer.go
@@ -2,6 +2,7 @@ package tapchannel
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"math"
 	"math/big"
@@ -37,7 +38,7 @@ var shutdownErr = fmt.Errorf("tapd is shutting down")
 type VirtualPacketSigner interface {
 	// SignVirtualPacket signs the virtual transaction of the given packet
 	// and returns the input indexes that were signed.
-	SignVirtualPacket(vPkt *tappsbt.VPacket,
+	SignVirtualPacket(ctx context.Context, vPkt *tappsbt.VPacket,
 		signOpts ...tapfreighter.SignVirtualPacketOption) ([]uint32,
 		error)
 }
@@ -552,8 +553,9 @@ func (s *AuxLeafSigner) generateHtlcSignature(chanState lnwallet.AuxChanState,
 		// check the full witness. Instead, we use a custom Schnorr
 		// signature validator to validate the single signature we
 		// produced.
+		ctxb := context.Background()
 		signed, err := s.cfg.Signer.SignVirtualPacket(
-			vPacket, tapfreighter.SkipInputProofVerify(),
+			ctxb, vPacket, tapfreighter.SkipInputProofVerify(),
 			tapfreighter.WithValidator(&schnorrSigValidator{
 				pubKey:     signingKey,
 				tapLeaf:    lfn.Some(leafToSign),

--- a/tapchannel/aux_sweeper.go
+++ b/tapchannel/aux_sweeper.go
@@ -368,8 +368,9 @@ func (a *AuxSweeper) signSweepVpackets(vPackets []*tappsbt.VPacket,
 
 		// With everything set, we can now sign the new leaf we'll
 		// sweep into.
+		ctxb := context.Background()
 		signed, err := a.cfg.Signer.SignVirtualPacket(
-			vPacket, tapfreighter.SkipInputProofVerify(),
+			ctxb, vPacket, tapfreighter.SkipInputProofVerify(),
 			tapfreighter.WithValidator(&schnorrSigValidator{
 				pubKey:     signingKey,
 				tapLeaf:    lfn.Some(leafToSign),

--- a/tapchannel/aux_sweeper.go
+++ b/tapchannel/aux_sweeper.go
@@ -129,6 +129,10 @@ type AuxSweeperCfg struct {
 
 	// ChainBridge is used to fetch blocks from the main chain.
 	ChainBridge tapgarden.ChainBridge
+
+	// IgnoreChecker is an optional function that can be used to check if
+	// a proof should be ignored.
+	IgnoreChecker proof.IgnoreChecker
 }
 
 // AuxSweeper is used to sweep funds from a commitment transaction that has
@@ -1320,8 +1324,7 @@ func (a *AuxSweeper) importOutputScriptKeys(desc tapscriptSweepDescs) error {
 func importOutputProofs(scid lnwire.ShortChannelID,
 	outputProofs []*proof.Proof, courierAddr *url.URL,
 	proofDispatch proof.CourierDispatch, chainBridge tapgarden.ChainBridge,
-	headerVerifier proof.HeaderVerifier, groupVerifier proof.GroupVerifier,
-	proofArchive proof.Archiver) error {
+	vCtx proof.VerifierCtx, proofArchive proof.Archiver) error {
 
 	// TODO(roasbeef): should be part of post confirmation funding validate
 	// (chanvalidate)
@@ -1438,13 +1441,6 @@ func importOutputProofs(scid lnwire.ShortChannelID,
 			return fmt.Errorf("unable to encode proof: %w", err)
 		}
 
-		vCtx := proof.VerifierCtx{
-			HeaderVerifier: headerVerifier,
-			MerkleVerifier: proof.DefaultMerkleVerifier,
-			GroupVerifier:  groupVerifier,
-			ChainLookupGen: chainBridge,
-		}
-
 		fundingUTXO := proofToImport.Asset
 		err = proofArchive.ImportProofs(
 			ctxb, vCtx, false, &proof.AnnotatedProof{
@@ -1520,11 +1516,17 @@ func (a *AuxSweeper) importCommitTx(req lnwallet.ResolutionReq,
 	// for the funding transaction here so we can properly recognize the
 	// spent input below.
 	if !req.Initiator {
+		vCtx := proof.VerifierCtx{
+			HeaderVerifier: a.cfg.HeaderVerifier,
+			MerkleVerifier: proof.DefaultMerkleVerifier,
+			GroupVerifier:  a.cfg.GroupVerifier,
+			ChainLookupGen: a.cfg.ChainBridge,
+			IgnoreChecker:  lfn.Some(a.cfg.IgnoreChecker),
+		}
 		err := importOutputProofs(
 			req.ShortChanID, maps.Values(fundingInputProofs),
 			a.cfg.DefaultCourierAddr, a.cfg.ProofFetcher,
-			a.cfg.ChainBridge, a.cfg.HeaderVerifier,
-			a.cfg.GroupVerifier, a.cfg.ProofArchive,
+			a.cfg.ChainBridge, vCtx, a.cfg.ProofArchive,
 		)
 		if err != nil {
 			return fmt.Errorf("unable to import output "+

--- a/tapdb/supply_commit_test.go
+++ b/tapdb/supply_commit_test.go
@@ -1605,20 +1605,24 @@ func TestSupplyCommitFetchState(t *testing.T) {
 	// As a final step, we'll modify the state machine to finalize the
 	// transition, and go back to the default state.
 	writeTx := WriteTxOption()
-	err = h.commitMachine.db.ExecTx(h.ctx, writeTx, func(db SupplyCommitStore) error { //nolint:lll
-		_, err := db.UpsertSupplyCommitStateMachine(
-			h.ctx, SupplyCommitMachineParams{
+	err = h.commitMachine.db.ExecTx(
+		h.ctx, writeTx, func(db SupplyCommitStore) error {
+			//nolint:lll
+			params := SupplyCommitMachineParams{
 				GroupKey:           h.groupKeyBytes,
-				LatestCommitmentID: updatedTransition.NewCommitmentID, //nolint:lll
+				LatestCommitmentID: updatedTransition.NewCommitmentID,
 				StateName:          sqlStr("DefaultState"),
-			})
-		if err != nil {
-			return err
-		}
-		return db.FinalizeSupplyCommitTransition(
-			h.ctx, updatedTransition.TransitionID,
-		)
-	},
+			}
+			_, err := db.UpsertSupplyCommitStateMachine(
+				h.ctx, params,
+			)
+			if err != nil {
+				return err
+			}
+			return db.FinalizeSupplyCommitTransition(
+				h.ctx, updatedTransition.TransitionID,
+			)
+		},
 	)
 	require.NoError(t, err)
 

--- a/tapdb/supply_ignore_checker.go
+++ b/tapdb/supply_ignore_checker.go
@@ -1,0 +1,218 @@
+package tapdb
+
+import (
+	"context"
+	"errors"
+	"sync"
+
+	"github.com/lightninglabs/taproot-assets/address"
+	"github.com/lightninglabs/taproot-assets/asset"
+	"github.com/lightninglabs/taproot-assets/fn"
+	"github.com/lightninglabs/taproot-assets/proof"
+	"github.com/lightninglabs/taproot-assets/universe/supplycommit"
+	lfn "github.com/lightningnetwork/lnd/fn/v2"
+)
+
+var (
+	// nonGroupedAsset is a zeroed out public key that is used to identify a
+	// non-existent group key (for an asset that does not belong to a
+	// group).
+	nonGroupedAsset = asset.SerializedKey{}
+)
+
+// ignoreCheckerStore is an interface that defines the methods required to
+// fetch supply leaves for the ignore checker. It abstracts away the storage
+// implementation details, simplifying mocking for unit tests.
+type ignoreCheckerStore interface {
+	// FetchSupplyLeavesByType fetches all supply leaves for a given asset
+	// specifier and a specific supply sub-tree.
+	FetchSupplyLeavesByType(ctx context.Context, spec asset.Specifier,
+		tree supplycommit.SupplySubTree, startHeight,
+		endHeight uint32) lfn.Result[supplycommit.SupplyLeaves]
+}
+
+// assetGroupQuery is an interface that defines the method to query an asset
+// group by its asset ID. This is used to determine if an asset belongs to a
+// group and to fetch the group key if it does. It abstracts away the details
+// of how the asset group is stored, simplifying mocking for unit tests.
+type assetGroupQuery interface {
+	// QueryAssetGroup attempts to fetch an asset group by its asset ID. If
+	// the asset group cannot be found, then ErrAssetGroupUnknown is
+	// returned.
+	QueryAssetGroup(context.Context, asset.ID) (*asset.AssetGroup, error)
+}
+
+// IgnoreCheckerCfg is a configuration struct for the CachingIgnoreChecker.
+type IgnoreCheckerCfg struct {
+	GroupQuery assetGroupQuery
+	Store      ignoreCheckerStore
+}
+
+// CachingIgnoreChecker is a proof.IgnoreChecker that caches the results of
+// whether an asset is ignored or not. It uses a map to store the group keys
+// for asset IDs, and another map to store the best known height for each group
+// key. It also maintains a map of ignored assets, which is populated on demand
+// when checking if an asset is ignored.
+// Assuming ~200k known assets and 1000 groups and 50k ignored asset points, the
+// memory requirement for these three maps is approximately:
+// - groupKeyLookup:     200k * (32+33) bytes   = ~12.4 MiB
+// - bestHeightLookup:   1000 * 33 bytes        = 33 kiB
+// - ignoredAssetPoints: 50k * (36+32+33) bytes = ~4.81 MiB
+type CachingIgnoreChecker struct {
+	cfg IgnoreCheckerCfg
+
+	// Mutex is a mutex to protect concurrent access to the groupKeyLookup,
+	// bestHeightLookup, and ignoredAssetPoints maps.
+	sync.Mutex
+
+	// groupKeyLookup is a map that stores the group key for each asset ID.
+	// If an asset does not belong to a group, it is stored with a zeroed
+	// out public key (nonGroupedAsset).
+	groupKeyLookup map[asset.ID]asset.SerializedKey
+
+	// bestHeightLookup is a map that stores the best known height for each
+	// group key. This is used to speed up the lookup of ignored assets by
+	// only fetching the latest ignore tuples for the group if we haven't
+	// encountered the group key before or if the best height has changed.
+	bestHeightLookup map[asset.SerializedKey]uint32
+
+	// ignoredAssetPoints is a set that stores the asset points that are
+	// known to be ignored. This is populated on demand when checking if an
+	// asset is ignored. The set uses the asset point as the key, which
+	// includes the outpoint, asset ID, and script key.
+	ignoredAssetPoints fn.Set[proof.AssetPoint]
+}
+
+// NewCachingIgnoreChecker creates a new instance of CachingIgnoreChecker
+// with the provided configuration.
+func NewCachingIgnoreChecker(cfg IgnoreCheckerCfg) *CachingIgnoreChecker {
+	return &CachingIgnoreChecker{
+		cfg:                cfg,
+		groupKeyLookup:     make(map[asset.ID]asset.SerializedKey),
+		bestHeightLookup:   make(map[asset.SerializedKey]uint32),
+		ignoredAssetPoints: make(fn.Set[proof.AssetPoint]),
+	}
+}
+
+// A compile-time assertion to ensure CachingIgnoreChecker implements
+// the IgnoreChecker interface.
+var _ proof.IgnoreChecker = (*CachingIgnoreChecker)(nil)
+
+// IsIgnored returns true if the given prevID is known to be invalid. A prevID
+// is used here, but the check should be tested against a proof result, or
+// produced output.
+func (c *CachingIgnoreChecker) IsIgnored(ctx context.Context,
+	prevID proof.AssetPoint) lfn.Result[bool] {
+
+	c.Lock()
+	defer c.Unlock()
+
+	log.Debugf("Checking if asset point %s is ignored", prevID)
+
+	// Let's do a direct lookup first to see if we already know the asset is
+	// ignored.
+	if c.ignoredAssetPoints.Contains(prevID) {
+		log.Debugf("Asset point %s is already known to be ignored",
+			prevID)
+		return lfn.Ok(true)
+	}
+
+	// If it's not known to be ignored, we need to look up the group key for
+	// the asset ID associated with the previous ID. This will help us to
+	// decide whether it's a non-grouped asset (which is never ignored) or
+	// to fetch the latest ignore tuples for the asset group.
+	groupKey, groupKeyKnown := c.groupKeyLookup[prevID.ID]
+	if !groupKeyKnown {
+		log.Debugf("Asset point %s is not known, querying group "+
+			"key for asset ID %s", prevID, prevID.ID)
+
+		group, err := c.cfg.GroupQuery.QueryAssetGroup(ctx, prevID.ID)
+		switch {
+		// We found the group, and it has a valid group key, we can add
+		// it to our lookup map.
+		case err == nil && group.GroupKey != nil:
+			groupKey = asset.ToSerialized(
+				&group.GroupKey.GroupPubKey,
+			)
+			c.groupKeyLookup[prevID.ID] = groupKey
+
+			log.Debugf("Found group key %s for asset ID %s",
+				groupKey, prevID.ID)
+
+		// If the asset is not a grouped asset, we mark it as such in
+		// our lookup map.
+		case err == nil && group.GroupKey == nil:
+			groupKey = nonGroupedAsset
+			c.groupKeyLookup[prevID.ID] = groupKey
+
+			log.Debugf("Asset ID %s is not grouped, using "+
+				"non-grouped asset key", prevID.ID)
+
+		case err != nil:
+			// If something went wrong while querying the asset
+			// group, we return an error.
+			if !errors.Is(err, address.ErrAssetGroupUnknown) {
+				return lfn.Errf[bool]("unable to query asset "+
+					"group: %w", err)
+			}
+
+			// If we get here, it means we are not aware of this
+			// asset group, so we can assume it is not ignored.
+			return lfn.Ok(false)
+		}
+	}
+
+	// We now have the group key, so we can check if the asset is a
+	// non-grouped asset, which means it is not ignored (as that
+	// functionality is only supported for grouped assets).
+	if groupKey == nonGroupedAsset {
+		log.Debugf("Asset point %s is a non-grouped asset, ignore "+
+			"functionality not available", prevID)
+		return lfn.Ok(false)
+	}
+
+	groupPubKey, err := groupKey.ToPubKey()
+	if err != nil {
+		return lfn.Errf[bool]("unable to decode group key: %w", err)
+	}
+
+	// If we have a valid group key, we can fetch the latest ignore
+	// tuples for the asset group based on the best known height for the
+	// group (or 0 if we haven't encountered this group yet).
+	specifier := asset.NewSpecifierFromGroupKey(*groupPubKey)
+	bestHeight := c.bestHeightLookup[groupKey]
+	leaves, err := c.cfg.Store.FetchSupplyLeavesByType(
+		ctx, specifier, supplycommit.IgnoreTreeType, bestHeight, 0,
+	).Unpack()
+	if err != nil {
+		return lfn.Errf[bool]("unable to fetch supply leaves: %w", err)
+	}
+
+	// We now add all the leaves to our ignored assets map.
+	log.Debugf("Fetched %d ignore leaves for group key %s",
+		len(leaves.IgnoreLeafEntries), groupKey)
+	for _, leaf := range leaves.IgnoreLeafEntries {
+		point := proof.AssetPoint{
+			OutPoint:  leaf.IgnoreTuple.Val.OutPoint,
+			ID:        leaf.IgnoreTuple.Val.ID,
+			ScriptKey: leaf.IgnoreTuple.Val.ScriptKey,
+		}
+
+		if !c.ignoredAssetPoints.Contains(point) {
+			log.Tracef("Adding new asset point to ignore set %s",
+				point)
+			c.ignoredAssetPoints.Add(point)
+		}
+
+		if leaf.BlockHeight() > bestHeight {
+			bestHeight = leaf.BlockHeight()
+		}
+	}
+
+	// We update the best height for this group key in our lookup map, so
+	// that we can use it for future queries to speed them up.
+	c.bestHeightLookup[groupKey] = bestHeight
+
+	// And now we can check if the previous ID is in our ignored assets set.
+	return lfn.Ok(c.ignoredAssetPoints.Contains(prevID))
+}

--- a/tapdb/supply_ignore_checker_test.go
+++ b/tapdb/supply_ignore_checker_test.go
@@ -1,0 +1,262 @@
+package tapdb
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/lightninglabs/taproot-assets/address"
+	"github.com/lightninglabs/taproot-assets/asset"
+	"github.com/lightninglabs/taproot-assets/internal/test"
+	"github.com/lightninglabs/taproot-assets/proof"
+	"github.com/lightninglabs/taproot-assets/universe"
+	"github.com/lightninglabs/taproot-assets/universe/supplycommit"
+	lfn "github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// mockGroupQuery is a mock implementation of assetGroupQuery.
+type mockGroupQuery struct {
+	mock.Mock
+}
+
+func (m *mockGroupQuery) QueryAssetGroup(ctx context.Context,
+	id asset.ID) (*asset.AssetGroup, error) {
+
+	args := m.Called(ctx, id)
+	return args.Get(0).(*asset.AssetGroup), args.Error(1)
+}
+
+// mockIgnoreStore is a mock implementation of ignoreCheckerStore.
+type mockIgnoreStore struct {
+	mock.Mock
+}
+
+func (m *mockIgnoreStore) FetchSupplyLeavesByType(ctx context.Context,
+	spec asset.Specifier, tree supplycommit.SupplySubTree, startHeight,
+	endHeight uint32) lfn.Result[supplycommit.SupplyLeaves] {
+
+	args := m.Called(ctx, spec, tree, startHeight, endHeight)
+	return args.Get(0).(lfn.Result[supplycommit.SupplyLeaves])
+}
+
+// TestCachingIgnoreChecker_IsIgnored tests the IsIgnored method of
+// CachingIgnoreChecker for all possible cases.
+func TestCachingIgnoreChecker_IsIgnored(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	assetID := asset.ID{1, 2, 3}
+	groupPubKey := test.RandPubKey(t)
+	groupKeySpecifier := asset.NewSpecifierFromGroupKey(*groupPubKey)
+	otherAssetID := asset.ID{7, 8, 9}
+	outPoint := test.RandOp(t)
+	scriptKey := [33]byte{2}
+	assetPoint := proof.AssetPoint{
+		OutPoint:  outPoint,
+		ID:        assetID,
+		ScriptKey: scriptKey,
+	}
+
+	ignoreLeaf := supplycommit.NewIgnoreEvent{
+		SignedIgnoreTuple: universe.NewSignedIgnoreTuple(
+			universe.IgnoreTuple{
+				PrevID:      assetPoint,
+				Amount:      123,
+				BlockHeight: 345,
+			}, universe.IgnoreSig{},
+		),
+	}
+
+	leaves := supplycommit.SupplyLeaves{
+		IgnoreLeafEntries: []supplycommit.NewIgnoreEvent{ignoreLeaf},
+	}
+
+	testCases := []struct {
+		name          string
+		setupMocks    func(*mockGroupQuery, *mockIgnoreStore)
+		assetPoint    proof.AssetPoint
+		preIgnored    bool
+		expectIgnored bool
+		expectErr     bool
+	}{
+		{
+			name: "already ignored asset point",
+			setupMocks: func(*mockGroupQuery, *mockIgnoreStore) {
+			},
+			assetPoint:    assetPoint,
+			preIgnored:    true,
+			expectIgnored: true,
+			expectErr:     false,
+		},
+		{
+			name: "non-grouped asset",
+			setupMocks: func(g *mockGroupQuery,
+				s *mockIgnoreStore) {
+
+				g.On(
+					"QueryAssetGroup", mock.Anything,
+					assetID,
+				).Return(&asset.AssetGroup{
+					GroupKey: nil,
+				}, nil).Once()
+			},
+			assetPoint:    assetPoint,
+			preIgnored:    false,
+			expectIgnored: false,
+			expectErr:     false,
+		},
+		{
+			name: "grouped asset, not ignored",
+			setupMocks: func(g *mockGroupQuery,
+				s *mockIgnoreStore) {
+
+				g.On(
+					"QueryAssetGroup", mock.Anything,
+					otherAssetID,
+				).Return(&asset.AssetGroup{
+					GroupKey: &asset.GroupKey{
+						GroupPubKey: *groupPubKey,
+					},
+				}, nil).Once()
+				s.On(
+					"FetchSupplyLeavesByType",
+					mock.Anything, groupKeySpecifier,
+					supplycommit.IgnoreTreeType, uint32(0),
+					uint32(0),
+				).Return(lfn.Ok(leaves)).Once()
+			},
+			assetPoint: proof.AssetPoint{
+				OutPoint:  outPoint,
+				ID:        otherAssetID,
+				ScriptKey: scriptKey,
+			},
+			preIgnored:    false,
+			expectIgnored: false,
+			expectErr:     false,
+		},
+		{
+			name: "grouped asset, is ignored",
+			setupMocks: func(g *mockGroupQuery,
+				s *mockIgnoreStore) {
+
+				g.On(
+					"QueryAssetGroup", mock.Anything,
+					assetID,
+				).Return(&asset.AssetGroup{
+					GroupKey: &asset.GroupKey{
+						GroupPubKey: *groupPubKey,
+					},
+				}, nil).Once()
+				s.On(
+					"FetchSupplyLeavesByType",
+					mock.Anything, groupKeySpecifier,
+					supplycommit.IgnoreTreeType, uint32(0),
+					uint32(0),
+				).Return(lfn.Ok(leaves)).Once()
+			},
+			assetPoint:    assetPoint,
+			preIgnored:    false,
+			expectIgnored: true,
+			expectErr:     false,
+		},
+		{
+			name: "asset group unknown error",
+			setupMocks: func(g *mockGroupQuery,
+				s *mockIgnoreStore) {
+
+				g.On(
+					"QueryAssetGroup", mock.Anything,
+					assetID,
+				).Return(
+					&asset.AssetGroup{},
+					address.ErrAssetGroupUnknown,
+				).Once()
+			},
+			assetPoint:    assetPoint,
+			preIgnored:    false,
+			expectIgnored: false,
+			expectErr:     false,
+		},
+		{
+			name: "asset group query error",
+			setupMocks: func(g *mockGroupQuery,
+				s *mockIgnoreStore) {
+
+				g.On(
+					"QueryAssetGroup", mock.Anything,
+					assetID,
+				).Return(
+					&asset.AssetGroup{}, errors.New("fail"),
+				).Once()
+			},
+			assetPoint:    assetPoint,
+			preIgnored:    false,
+			expectIgnored: false,
+			expectErr:     true,
+		},
+		{
+			name: "fetch supply leaves error",
+			setupMocks: func(g *mockGroupQuery,
+				s *mockIgnoreStore) {
+
+				g.On(
+					"QueryAssetGroup", mock.Anything,
+					assetID,
+				).Return(&asset.AssetGroup{
+					GroupKey: &asset.GroupKey{
+						GroupPubKey: *groupPubKey,
+					},
+				}, nil).Once()
+				s.On(
+					"FetchSupplyLeavesByType",
+					mock.Anything, groupKeySpecifier,
+					supplycommit.IgnoreTreeType, uint32(0),
+					uint32(0),
+				).Return(lfn.Errf[supplycommit.SupplyLeaves](
+					"fail",
+				)).Once()
+			},
+			assetPoint:    assetPoint,
+			preIgnored:    false,
+			expectIgnored: false,
+			expectErr:     true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			groupQuery := &mockGroupQuery{}
+			store := &mockIgnoreStore{}
+
+			t.Cleanup(func() {
+				groupQuery.AssertExpectations(t)
+				store.AssertExpectations(t)
+			})
+
+			if tc.setupMocks != nil {
+				tc.setupMocks(groupQuery, store)
+			}
+
+			checker := NewCachingIgnoreChecker(IgnoreCheckerCfg{
+				GroupQuery: groupQuery,
+				Store:      store,
+			})
+
+			if tc.preIgnored {
+				checker.ignoredAssetPoints.Add(tc.assetPoint)
+			}
+
+			res, err := checker.IsIgnored(ctx, tc.assetPoint).
+				Unpack()
+			if tc.expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.expectIgnored, res)
+			}
+		})
+	}
+}

--- a/tapdb/supply_tree.go
+++ b/tapdb/supply_tree.go
@@ -15,7 +15,6 @@ import (
 	"github.com/lightninglabs/taproot-assets/tapdb/sqlc"
 	"github.com/lightninglabs/taproot-assets/universe"
 	"github.com/lightninglabs/taproot-assets/universe/supplycommit"
-
 	lfn "github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/lightningnetwork/lnd/lnutils"
 )
@@ -616,6 +615,38 @@ func fetchSupplyLeavesByHeight(ctx context.Context, db BaseUniverseStore,
 	groupKey btcec.PublicKey, startHeight,
 	endHeight uint32) (*supplycommit.SupplyLeaves, error) {
 
+	var resp supplycommit.SupplyLeaves
+	for _, treeType := range allSupplyTreeTypes {
+		treeResp, err := fetchSupplyLeaves(
+			ctx, db, groupKey, treeType, startHeight, endHeight,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch supply leaves "+
+				"for %v: %w", treeType, err)
+		}
+
+		resp.IssuanceLeafEntries = append(
+			resp.IssuanceLeafEntries,
+			treeResp.IssuanceLeafEntries...,
+		)
+		resp.BurnLeafEntries = append(
+			resp.BurnLeafEntries, treeResp.BurnLeafEntries...,
+		)
+		resp.IgnoreLeafEntries = append(
+			resp.IgnoreLeafEntries, treeResp.IgnoreLeafEntries...,
+		)
+	}
+
+	return &resp, nil
+}
+
+// fetchSupplyLeaves fetches all supply leaves for a given group key and
+// sub-tree type within a specified block height range.
+func fetchSupplyLeaves(ctx context.Context, db BaseUniverseStore,
+	groupKey btcec.PublicKey, treeType supplycommit.SupplySubTree,
+	startHeight, endHeight uint32) (supplycommit.SupplyLeaves,
+	error) {
+
 	// Convert the start and end heights to SQL nullable integers.
 	// If the height is zero, we use a null value to indicate no limit.
 	var (
@@ -633,73 +664,70 @@ func fetchSupplyLeavesByHeight(ctx context.Context, db BaseUniverseStore,
 
 	var resp supplycommit.SupplyLeaves
 
-	for _, treeType := range allSupplyTreeTypes {
-		namespace := subTreeNamespace(&groupKey, treeType)
-
-		leaves, err := db.QuerySupplyLeavesByHeight(
-			ctx, sqlc.QuerySupplyLeavesByHeightParams{
-				Namespace:   namespace,
-				StartHeight: sqlStartHeight,
-				EndHeight:   sqlEndHeight,
-			},
-		)
-		if err != nil {
-			if errors.Is(err, sql.ErrNoRows) {
-				continue
-			}
-
-			return nil, fmt.Errorf("failed to query supply "+
-				"leaves: %w", err)
+	namespace := subTreeNamespace(&groupKey, treeType)
+	leaves, err := db.QuerySupplyLeavesByHeight(
+		ctx, sqlc.QuerySupplyLeavesByHeightParams{
+			Namespace:   namespace,
+			StartHeight: sqlStartHeight,
+			EndHeight:   sqlEndHeight,
+		},
+	)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return resp, nil
 		}
 
-		for _, leaf := range leaves {
-			switch treeType {
-			case supplycommit.MintTreeType:
-				var event supplycommit.NewMintEvent
-				err = event.Decode(
-					bytes.NewReader(leaf.SupplyLeafBytes),
-				)
-				if err != nil {
-					return nil, fmt.Errorf("failed to "+
-						"decode mint event: %w", err)
-				}
+		return resp, fmt.Errorf("failed to query supply "+
+			"leaves: %w", err)
+	}
 
-				resp.IssuanceLeafEntries = append(
-					resp.IssuanceLeafEntries, event,
-				)
-
-			case supplycommit.BurnTreeType:
-				var event supplycommit.NewBurnEvent
-				err = event.Decode(
-					bytes.NewReader(leaf.SupplyLeafBytes),
-				)
-				if err != nil {
-					return nil, fmt.Errorf("failed to "+
-						"decode burn event: %w", err)
-				}
-
-				resp.BurnLeafEntries = append(
-					resp.BurnLeafEntries, event,
-				)
-
-			case supplycommit.IgnoreTreeType:
-				var event supplycommit.NewIgnoreEvent
-				err = event.Decode(
-					bytes.NewReader(leaf.SupplyLeafBytes),
-				)
-				if err != nil {
-					return nil, fmt.Errorf("failed to "+
-						"decode ignore event: %w", err)
-				}
-
-				resp.IgnoreLeafEntries = append(
-					resp.IgnoreLeafEntries, event,
-				)
+	for _, leaf := range leaves {
+		switch treeType {
+		case supplycommit.MintTreeType:
+			var event supplycommit.NewMintEvent
+			err = event.Decode(
+				bytes.NewReader(leaf.SupplyLeafBytes),
+			)
+			if err != nil {
+				return resp, fmt.Errorf("failed to decode "+
+					"mint event: %w", err)
 			}
+
+			resp.IssuanceLeafEntries = append(
+				resp.IssuanceLeafEntries, event,
+			)
+
+		case supplycommit.BurnTreeType:
+			var event supplycommit.NewBurnEvent
+			err = event.Decode(
+				bytes.NewReader(leaf.SupplyLeafBytes),
+			)
+			if err != nil {
+				return resp, fmt.Errorf("failed to decode "+
+					"burn event: %w", err)
+			}
+
+			resp.BurnLeafEntries = append(
+				resp.BurnLeafEntries, event,
+			)
+
+		case supplycommit.IgnoreTreeType:
+			var event supplycommit.NewIgnoreEvent
+			err = event.Decode(
+				bytes.NewReader(leaf.SupplyLeafBytes),
+			)
+			if err != nil {
+				return resp, fmt.Errorf("failed to decode "+
+					"ignore event: %w", err)
+			}
+
+			resp.IgnoreLeafEntries = append(
+				resp.IgnoreLeafEntries, event,
+			)
 		}
 	}
 
-	return &resp, nil
+	return resp, nil
 }
 
 // FetchSupplyLeavesByHeight fetches all supply leaves for a given asset
@@ -734,6 +762,43 @@ func (s *SupplyTreeStore) FetchSupplyLeavesByHeight(ctx context.Context,
 	if dbErr != nil {
 		return lfn.Errf[respType]("failed to execute database "+
 			"transaction: %w", dbErr)
+	}
+
+	return lfn.Ok(resp)
+}
+
+// FetchSupplyLeavesByType fetches all supply leaves for a given asset specifier
+// and a specific supply sub-tree.
+func (s *SupplyTreeStore) FetchSupplyLeavesByType(ctx context.Context,
+	spec asset.Specifier, tree supplycommit.SupplySubTree, startHeight,
+	endHeight uint32) lfn.Result[supplycommit.SupplyLeaves] {
+
+	type respType = supplycommit.SupplyLeaves
+
+	groupKey, err := spec.UnwrapGroupKeyOrErr()
+	if err != nil {
+		return lfn.Errf[respType]("group key must be specified for "+
+			"supply tree: %w", err)
+	}
+
+	var (
+		resp   supplycommit.SupplyLeaves
+		readTx = NewBaseUniverseReadTx()
+	)
+	dbErr := s.db.ExecTx(ctx, &readTx, func(db BaseUniverseStore) error {
+		var err error
+		resp, err = fetchSupplyLeaves(
+			ctx, db, *groupKey, tree, startHeight, endHeight,
+		)
+		if err != nil {
+			return fmt.Errorf("failed to fetch all supply "+
+				"leaves: %w", err)
+		}
+
+		return nil
+	})
+	if dbErr != nil {
+		return lfn.Err[respType](dbErr)
 	}
 
 	return lfn.Ok(resp)

--- a/tapfreighter/chain_porter.go
+++ b/tapfreighter/chain_porter.go
@@ -1342,7 +1342,7 @@ func (p *ChainPorter) stateStep(currentPkg sendPackage) (*sendPackage, error) {
 
 			logPacket(vPkt, "Generating Taproot Asset witnesses")
 
-			_, err := p.cfg.AssetWallet.SignVirtualPacket(vPkt)
+			_, err := p.cfg.AssetWallet.SignVirtualPacket(ctx, vPkt)
 			if err != nil {
 				p.unlockInputs(ctx, &currentPkg)
 
@@ -1450,7 +1450,7 @@ func (p *ChainPorter) stateStep(currentPkg sendPackage) (*sendPackage, error) {
 		log.Debugf("Signing %d passive assets",
 			len(currentPkg.PassiveAssets))
 
-		err = wallet.SignPassiveAssets(currentPkg.PassiveAssets)
+		err = wallet.SignPassiveAssets(ctx, currentPkg.PassiveAssets)
 		if err != nil {
 			p.unlockInputs(ctx, &currentPkg)
 

--- a/tapfreighter/chain_porter.go
+++ b/tapfreighter/chain_porter.go
@@ -25,6 +25,7 @@ import (
 	"github.com/lightninglabs/taproot-assets/tapscript"
 	"github.com/lightninglabs/taproot-assets/tapsend"
 	"github.com/lightningnetwork/lnd/chainntnfs"
+	lfn "github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
 )
@@ -96,6 +97,10 @@ type ChainPorterConfig struct {
 	// ProofWatcher is used to watch new proofs for their anchor transaction
 	// to be confirmed safely with a minimum number of confirmations.
 	ProofWatcher proof.Watcher
+
+	// IgnoreChecker is an optional function that can be used to check if
+	// a proof should be ignored.
+	IgnoreChecker proof.IgnoreChecker
 
 	// ErrChan is the main error channel the custodian will report back
 	// critical errors to the main server.
@@ -500,6 +505,7 @@ func (p *ChainPorter) storeProofs(sendPkg *sendPackage) error {
 		MerkleVerifier: proof.DefaultMerkleVerifier,
 		GroupVerifier:  p.cfg.GroupVerifier,
 		ChainLookupGen: p.cfg.ChainBridge,
+		IgnoreChecker:  lfn.Some(p.cfg.IgnoreChecker),
 	}
 
 	log.Infof("Importing %d passive asset proofs into local Proof "+
@@ -584,6 +590,7 @@ func (p *ChainPorter) storeProofs(sendPkg *sendPackage) error {
 			MerkleVerifier: proof.DefaultMerkleVerifier,
 			GroupVerifier:  p.cfg.GroupVerifier,
 			ChainLookupGen: p.cfg.ChainBridge,
+			IgnoreChecker:  lfn.Some(p.cfg.IgnoreChecker),
 		}
 
 		// Before we import the proof into the proof archive, we'll

--- a/tapfreighter/wallet.go
+++ b/tapfreighter/wallet.go
@@ -1,7 +1,6 @@
 package tapfreighter
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -22,9 +21,11 @@ import (
 	"github.com/lightninglabs/taproot-assets/commitment"
 	"github.com/lightninglabs/taproot-assets/fn"
 	"github.com/lightninglabs/taproot-assets/proof"
+	"github.com/lightninglabs/taproot-assets/tapgarden"
 	"github.com/lightninglabs/taproot-assets/tappsbt"
 	"github.com/lightninglabs/taproot-assets/tapscript"
 	"github.com/lightninglabs/taproot-assets/tapsend"
+	lfn "github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
 	"golang.org/x/exp/maps"
@@ -88,7 +89,7 @@ type Wallet interface {
 
 	// SignVirtualPacket signs the virtual transaction of the given packet
 	// and returns the input indexes that were signed.
-	SignVirtualPacket(vPkt *tappsbt.VPacket,
+	SignVirtualPacket(ctx context.Context, vPkt *tappsbt.VPacket,
 		optFuncs ...SignVirtualPacketOption) ([]uint32, error)
 
 	// CreatePassiveAssets creates passive asset packets for the given
@@ -99,7 +100,8 @@ type Wallet interface {
 		error)
 
 	// SignPassiveAssets signs the given passive asset packets.
-	SignPassiveAssets(passiveAssets []*tappsbt.VPacket) error
+	SignPassiveAssets(ctx context.Context,
+		passiveAssets []*tappsbt.VPacket) error
 
 	// AnchorVirtualTransactions creates a BTC level anchor transaction that
 	// anchors all the virtual transactions of the given packets (for both
@@ -208,6 +210,17 @@ type WalletConfig struct {
 	// WitnessValidator allows us to validate the witnesses of vPSBTs
 	// we create.
 	WitnessValidator tapscript.WitnessValidator
+
+	// ChainBridge is our bridge to the chain we operate on.
+	ChainBridge ChainBridge
+
+	// GroupVerifier is used to verify the validity of the group key for a
+	// genesis proof.
+	GroupVerifier proof.GroupVerifier
+
+	// IgnoreChecker is an optional function that can be used to check if
+	// a proof should be ignored.
+	IgnoreChecker proof.IgnoreChecker
 
 	// Wallet is used to fund+sign PSBTs for the transfer transaction.
 	Wallet WalletAnchor
@@ -910,12 +923,22 @@ func WithValidator(
 // transaction's inputs).
 //
 // NOTE: This is part of the Wallet interface.
-func (f *AssetWallet) SignVirtualPacket(vPkt *tappsbt.VPacket,
-	signOpts ...SignVirtualPacketOption) ([]uint32, error) {
+func (f *AssetWallet) SignVirtualPacket(ctx context.Context,
+	vPkt *tappsbt.VPacket, signOpts ...SignVirtualPacketOption) ([]uint32,
+	error) {
 
 	opts := defaultSignVirtualPacketOptions(f.cfg.WitnessValidator)
 	for _, optFunc := range signOpts {
 		optFunc(opts)
+	}
+
+	headerVerifier := tapgarden.GenHeaderVerifier(ctx, f.cfg.ChainBridge)
+	vCtx := proof.VerifierCtx{
+		HeaderVerifier: headerVerifier,
+		MerkleVerifier: proof.DefaultMerkleVerifier,
+		GroupVerifier:  f.cfg.GroupVerifier,
+		ChainLookupGen: f.cfg.ChainBridge,
+		IgnoreChecker:  lfn.Some(f.cfg.IgnoreChecker),
 	}
 
 	for idx := range vPkt.Inputs {
@@ -927,7 +950,12 @@ func (f *AssetWallet) SignVirtualPacket(vPkt *tappsbt.VPacket,
 			// Before we sign the transaction, we want to make sure
 			// the inclusion proof is valid and the asset is
 			// actually committed in the anchor transaction.
-			err := verifyInclusionProof(vPkt.Inputs[idx])
+			assetProof := vPkt.Inputs[idx].Proof
+			if assetProof == nil {
+				return nil, fmt.Errorf("input proof is nil")
+			}
+
+			_, err := assetProof.VerifyProofIntegrity(ctx, vCtx)
 			if err != nil {
 				return nil, fmt.Errorf("unable to verify "+
 					"inclusion proof: %w", err)
@@ -953,62 +981,6 @@ func (f *AssetWallet) SignVirtualPacket(vPkt *tappsbt.VPacket,
 	}
 
 	return signedInputs, nil
-}
-
-// verifyInclusionProof verifies that the given virtual input's asset is
-// actually committed in the anchor transaction.
-func verifyInclusionProof(vIn *tappsbt.VInput) error {
-	assetProof := vIn.Proof
-
-	if assetProof == nil {
-		return fmt.Errorf("input proof is nil")
-	}
-
-	// Before we look at the inclusion proof, we'll make sure that the input
-	// anchor information matches the proof's anchor transaction.
-	//
-	// TODO(guggero): Also check if the block is in the chain by calling
-	// into ChainBridge.
-	op := vIn.PrevID.OutPoint
-	anchorTxHash := assetProof.AnchorTx.TxHash()
-
-	if op.Hash != anchorTxHash {
-		return fmt.Errorf("proof anchor tx hash %v doesn't match "+
-			"input anchor outpoint %v", anchorTxHash, op.Hash)
-	}
-	if op.Index >= uint32(len(assetProof.AnchorTx.TxOut)) {
-		return fmt.Errorf("input anchor outpoint index out of range")
-	}
-
-	anchorTxOut := assetProof.AnchorTx.TxOut[op.Index]
-	if !bytes.Equal(anchorTxOut.PkScript, vIn.Anchor.PkScript) {
-		return fmt.Errorf("proof anchor tx pk script %x doesn't "+
-			"match input anchor script %x", anchorTxOut.PkScript,
-			vIn.Anchor.PkScript)
-	}
-
-	anchorKey, err := proof.ExtractTaprootKeyFromScript(vIn.Anchor.PkScript)
-	if err != nil {
-		return fmt.Errorf("unable to parse anchor pk script %x "+
-			"taproot key: %w", vIn.Anchor.PkScript, err)
-	}
-
-	inclusionProof := assetProof.InclusionProof
-	proofKeys, err := inclusionProof.DeriveByAssetInclusion(
-		vIn.Asset(), nil,
-	)
-	if err != nil {
-		return fmt.Errorf("unable to derive inclusion proof: %w", err)
-	}
-
-	anchorKeyBytes := schnorr.SerializePubKey(anchorKey)
-	for proofKey := range proofKeys {
-		if bytes.Equal(anchorKeyBytes, proofKey.SchnorrSerialized()) {
-			return nil
-		}
-	}
-
-	return fmt.Errorf("proof key doesn't match anchor key")
 }
 
 // determinePassiveAssetAnchorOutput determines the best anchor output to attach
@@ -1216,13 +1188,13 @@ func CreatePassiveAssets(ctx context.Context, keyRing KeyRing,
 }
 
 // SignPassiveAssets signs the given passive asset packets.
-func (f *AssetWallet) SignPassiveAssets(
+func (f *AssetWallet) SignPassiveAssets(ctx context.Context,
 	passiveAssets []*tappsbt.VPacket) error {
 
 	// Sign all the passive assets virtual packets.
 	for idx := range passiveAssets {
 		passiveAsset := passiveAssets[idx]
-		_, err := f.SignVirtualPacket(passiveAsset)
+		_, err := f.SignVirtualPacket(ctx, passiveAsset)
 		if err != nil {
 			return fmt.Errorf("unable to sign passive asset "+
 				"virtual packet: %w", err)

--- a/tapgarden/caretaker.go
+++ b/tapgarden/caretaker.go
@@ -24,6 +24,7 @@ import (
 	"github.com/lightninglabs/taproot-assets/tapsend"
 	"github.com/lightninglabs/taproot-assets/universe"
 	"github.com/lightningnetwork/lnd/chainntnfs"
+	lfn "github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
 	"golang.org/x/exp/maps"
 	"golang.org/x/sync/errgroup"
@@ -1609,5 +1610,6 @@ func (b *BatchCaretaker) verifierCtx(ctx context.Context) proof.VerifierCtx {
 		GroupVerifier:       groupVerifier,
 		GroupAnchorVerifier: groupAnchorVerifier,
 		ChainLookupGen:      b.cfg.ChainBridge,
+		IgnoreChecker:       lfn.Some(b.cfg.IgnoreChecker),
 	}
 }

--- a/tapgarden/custodian.go
+++ b/tapgarden/custodian.go
@@ -19,6 +19,7 @@ import (
 	"github.com/lightninglabs/taproot-assets/fn"
 	"github.com/lightninglabs/taproot-assets/internal/ecies"
 	"github.com/lightninglabs/taproot-assets/proof"
+	lfn "github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/lightningnetwork/lnd/lnrpc"
 )
@@ -151,6 +152,10 @@ type CustodianConfig struct {
 	// ProofWatcher is used to watch new proofs for their anchor transaction
 	// to be confirmed safely with a minimum number of confirmations.
 	ProofWatcher proof.Watcher
+
+	// IgnoreChecker is an optional function that can be used to check if
+	// a proof should be ignored.
+	IgnoreChecker proof.IgnoreChecker
 
 	// ErrChan is the main error channel the custodian will report back
 	// critical errors to the main server.
@@ -1609,5 +1614,6 @@ func (c *Custodian) verifierCtx(ctx context.Context) proof.VerifierCtx {
 		MerkleVerifier: merkleVerifier,
 		GroupVerifier:  c.cfg.GroupVerifier,
 		ChainLookupGen: c.cfg.ChainBridge,
+		IgnoreChecker:  lfn.Some(c.cfg.IgnoreChecker),
 	}
 }

--- a/tapgarden/planter.go
+++ b/tapgarden/planter.go
@@ -81,6 +81,10 @@ type GardenKit struct {
 	// UniversePushBatchSize is the number of minted items to push to the
 	// local universe in a single batch.
 	UniversePushBatchSize int
+
+	// IgnoreChecker is an optional function that can be used to check if
+	// a proof should be ignored.
+	IgnoreChecker proof.IgnoreChecker
 }
 
 // PlanterConfig is the main config for the ChainPlanter.
@@ -3145,6 +3149,7 @@ func (c *ChainPlanter) verifierCtx(ctx context.Context) proof.VerifierCtx {
 		MerkleVerifier: merkleVerifier,
 		GroupVerifier:  groupVerifier,
 		ChainLookupGen: c.cfg.ChainBridge,
+		IgnoreChecker:  lfn.Some(c.cfg.IgnoreChecker),
 	}
 }
 

--- a/tapgarden/re-org_watcher.go
+++ b/tapgarden/re-org_watcher.go
@@ -13,6 +13,7 @@ import (
 	"github.com/lightninglabs/taproot-assets/fn"
 	"github.com/lightninglabs/taproot-assets/proof"
 	"github.com/lightningnetwork/lnd/chainntnfs"
+	lfn "github.com/lightningnetwork/lnd/fn/v2"
 )
 
 // proofRegistration is a struct that holds all proofs that need to be watched
@@ -69,6 +70,10 @@ type ReOrgWatcherConfig struct {
 	// ProofArchive is the storage backend for proofs to which we store
 	// updated proofs.
 	ProofArchive proof.Archiver
+
+	// IgnoreChecker is an optional function that can be used to check if
+	// a proof should be ignored.
+	IgnoreChecker proof.IgnoreChecker
 
 	// NonBuriedAssetFetcher is a function that returns all assets that are
 	// not yet sufficiently deep buried.
@@ -587,6 +592,7 @@ func (w *ReOrgWatcher) DefaultUpdateCallback() proof.UpdateCallback {
 			MerkleVerifier: proof.DefaultMerkleVerifier,
 			GroupVerifier:  w.cfg.GroupVerifier,
 			ChainLookupGen: w.cfg.ChainBridge,
+			IgnoreChecker:  lfn.Some(w.cfg.IgnoreChecker),
 		}
 		for idx := range proofs {
 			err := proof.ReplaceProofInBlob(

--- a/universe/archive.go
+++ b/universe/archive.go
@@ -14,6 +14,7 @@ import (
 	"github.com/lightninglabs/taproot-assets/fn"
 	"github.com/lightninglabs/taproot-assets/mssmt"
 	"github.com/lightninglabs/taproot-assets/proof"
+	lfn "github.com/lightningnetwork/lnd/fn/v2"
 )
 
 // ArchiveConfig is the main config for the archive. This includes all the items
@@ -47,6 +48,10 @@ type ArchiveConfig struct {
 	// ChainLookupGenerator is the main interface for generating a chain
 	// lookup interface that is required to validate proofs.
 	ChainLookupGenerator proof.ChainLookupGenerator
+
+	// IgnoreChecker is an optional function that can be used to check if
+	// a proof should be ignored.
+	IgnoreChecker proof.IgnoreChecker
 
 	// TODO(roasbeef): query re genesis asset known?
 
@@ -354,6 +359,7 @@ func (a *Archive) verifyIssuanceProof(ctx context.Context, id Identifier,
 		MerkleVerifier: a.cfg.MerkleVerifier,
 		GroupVerifier:  a.cfg.GroupVerifier,
 		ChainLookupGen: a.cfg.ChainLookupGenerator,
+		IgnoreChecker:  lfn.Some(a.cfg.IgnoreChecker),
 	}
 
 	lookup, err := a.cfg.ChainLookupGenerator.GenProofChainLookup(newProof)


### PR DESCRIPTION
Fixes https://github.com/lightninglabs/taproot-assets/issues/1684.

Implements and hooks up a caching ignore tree checker.

Opening as draft because some of the caching isn't fully finished yet (mainly the negative case LRU cache).