### PR TITLE
itest: add test case for chain re-org with V2 addresses

### DIFF
--- a/itest/addrs_v2_test.go
+++ b/itest/addrs_v2_test.go
@@ -319,8 +319,9 @@ func testAddressV2WithGroupKey(t *harnessTest) {
 		WithNumUtxos(2),
 	)
 
-	// We now make sure we can send to the same address twice, using
-	// different amounts, in the same transaction.
+	// We now make sure we can send to two different addresses of the same
+	// group at the same time, using different amounts, in the same
+	// transaction.
 	groupAddrAlice1, _ := NewAddrWithEventStream(
 		t.t, t.tapd, &taprpc.NewAddrRequest{
 			AddressVersion: addrV2,

--- a/itest/test_list_on_test.go
+++ b/itest/test_list_on_test.go
@@ -77,6 +77,10 @@ var allTestCases = []*testCase{
 		test: testReOrgSend,
 	},
 	{
+		name: "re-org send v2 address",
+		test: testReOrgSendV2Address,
+	},
+	{
 		name: "re-org mint and send",
 		test: testReOrgMintAndSend,
 	},


### PR DESCRIPTION
Some questions by @ZZiigguurraatt made me realize we didn't previously test the new addresses in a chain re-org scenario.