### PR TITLE
docs/debug-handbook: create new debug run books for developers to help pattern match common issues and knowledge

### DIFF
--- a/docs/debug-handbook/README.md
+++ b/docs/debug-handbook/README.md
@@ -1,0 +1,168 @@
+# Debug Handbook
+
+This directory contains debugging guides for common issues encountered in taproot-assets development. Each guide provides pattern recognition techniques, debugging flowcharts, and proven resolution strategies.
+
+## Available Guides
+
+### [PSBT Finalization Failures](./psbt-finalization-failures.md)
+Comprehensive guide for debugging PSBT signing and finalization issues, particularly those involving:
+- BIP32 key derivation mismatches
+- Missing tapscript merkle roots
+- Supply commitment key storage problems
+
+## How to Use This Handbook
+
+1. **Identify symptoms** - Match error messages or behaviors to guide titles
+2. **Follow the flowchart** - Each guide has a decision tree for systematic debugging
+3. **Check common causes** - Most issues follow predictable patterns
+4. **Apply the fix pattern** - Use provided code examples as templates
+5. **Verify resolution** - Run the suggested verification steps
+
+## Contributing New Guides
+
+When you solve a difficult debugging problem, consider adding a guide:
+
+### Guide Template
+
+```markdown
+# [Issue Name] - Debug Handbook
+
+## Quick Identification
+- List symptoms
+- Common error messages
+- Affected components
+
+## Debug Flow Chart
+- Mermaid flowchart showing decision points
+- Clear paths to root causes
+
+## Detailed Debugging Steps
+- Step-by-step investigation process
+- Where to look in code
+- What to check in logs
+
+## Common Pitfalls
+- Things that often trip people up
+- Non-obvious failure modes
+
+## Prevention Strategies
+- How to avoid this issue in the future
+- Best practices
+
+## External References
+- Links to relevant documentation
+- Related specifications or RFCs
+
+## Quick Checklist
+- [ ] Actionable debugging steps
+```
+
+### Good Guide Characteristics
+
+1. **Symptom-focused** - Start with what developers will see
+2. **Systematic approach** - Provide clear debugging methodology
+3. **Code examples** - Show both wrong and right patterns
+4. **Tool commands** - Include exact commands to run
+5. **Cross-references** - Link to relevant code and docs
+6. **Battle-tested** - Based on actual debugging experience
+
+## General Debugging Tips
+
+### Enable Comprehensive Logging
+```bash
+# Maximum verbosity for all components
+export TAPD_DEBUG_LEVEL=debug
+export LND_DEBUG_LEVEL=debug
+export BTCD_DEBUG_LEVEL=debug
+```
+
+### Useful Log Grep Patterns
+```bash
+# Find errors across all logs
+grep -i "error\|fail\|skip\|warn" itest/regtest/*.log
+
+# Track RPC calls
+grep "interceptor.go.*requested" *.log
+
+# Find state transitions
+grep -i "state.*transition\|ProcessEvent" *.log
+
+# Database operations
+grep -i "insert\|update\|upsert" *.log
+```
+
+### Component Interaction Points
+
+Key interfaces where issues often occur:
+- **tapd ↔ lnd**: PSBT signing, wallet operations
+- **tapd ↔ btcd**: Transaction broadcast, block notifications
+- **tapd ↔ universe**: Proof synchronization, supply commits
+- **Database layer**: Key storage, state persistence
+
+### Testing Strategies
+
+1. **Isolate the failure**
+   - Run single test case: `make itest icase=specific_test`
+   - Use unit tests when possible: `go test -v -run TestSpecific`
+
+2. **Simplify the scenario**
+   - Reduce to minimum inputs
+   - Remove unnecessary components
+   - Test with regtest before testnet/mainnet
+
+3. **Add strategic logging**
+   ```go
+   log.Debugf("Key details: family=%d, index=%d, pubkey=%x", 
+       key.Family, key.Index, key.PubKey.SerializeCompressed())
+   ```
+
+4. **Verify assumptions**
+   - Check database state matches expectations
+   - Verify RPC responses contain expected fields
+   - Ensure configuration is correct
+
+## Debugging Tools
+
+### Database Inspection
+```bash
+# SQLite database inspection
+sqlite3 ~/.tapd/data/regtest/tapd.db
+
+# Common queries
+.tables  # List all tables
+.schema supply_commitments  # Show table structure
+SELECT * FROM internal_keys WHERE key_index != 0;  # Find non-zero indices
+```
+
+### PSBT Decoding
+```bash
+# Decode PSBT to human-readable format
+bitcoin-cli decodepsbt "cHNidP8B..."
+
+# Using btcdecode tool
+echo "cHNidP8B..." | btcdecode -psbt
+```
+
+### Transaction Analysis
+```bash
+# Decode raw transaction
+bitcoin-cli decoderawtransaction "0200000001..."
+
+# Get transaction details
+bitcoin-cli getrawtransaction "txid" true
+```
+
+## Common Abbreviations
+
+- **PSBT**: Partially Signed Bitcoin Transaction
+- **BIP32**: Hierarchical Deterministic key derivation
+- **SMT/MSSMT**: Sparse Merkle Tree / Merkle Sum Sparse Merkle Tree
+- **tapd**: Taproot Assets Daemon
+- **lnd**: Lightning Network Daemon
+
+## Learning Resources
+
+- [Bitcoin Optech](https://bitcoinops.org/) - Bitcoin technology explained
+- [BIPs Repository](https://github.com/bitcoin/bips) - Bitcoin Improvement Proposals
+- [Taproot Assets Docs](https://docs.lightning.engineering/the-lightning-network/taproot-assets) - Official documentation
+- [lnd Developer Docs](https://dev.lightning.community/) - Lightning Network development

--- a/docs/debug-handbook/psbt-finalization-failures.md
+++ b/docs/debug-handbook/psbt-finalization-failures.md
@@ -1,0 +1,258 @@
+# PSBT Finalization Failures - Debug Handbook
+
+## Quick Identification
+
+**Symptoms:**
+- Error message: "PSBT failed to finalize" or similar
+- Integration tests fail during supply commitment operations
+- Transactions involving taproot outputs fail to broadcast
+- Key signing operations silently skip inputs
+
+**Common Error Patterns:**
+```
+ERR RPCS interceptor.go:279: [/walletrpc.WalletKit/FinalizePsbt]: could not finalize PSBT
+WRN BTWL psbt.go:224: SignPsbt: Skipping input X, derived public key XXX does not match bip32 derivation info public key YYY
+```
+
+## Debug Flow Chart
+
+```mermaid
+flowchart TD
+    A[PSBT Finalization Failure] --> B{Check lnd logs}
+    B --> C[Look for 'SignPsbt' errors]
+    C --> D{Input being skipped?}
+    D -->|Yes| E[Check error reason]
+    D -->|No| F[Check PSBT structure]
+    
+    E --> G{BIP32 mismatch?}
+    E --> H{Missing tapscript root?}
+    
+    G -->|Yes| I[Key derivation issue]
+    H -->|Yes| J[Script path spend issue]
+    
+    I --> K[Check KeyDescriptor storage]
+    J --> L[Check TapscriptMerkleRoot field]
+    
+    K --> M[Verify Family/Index preserved]
+    L --> N[Verify PSBT input fields]
+    
+    F --> O[Check witness/script data]
+    O --> P[Verify all required fields present]
+```
+
+## Detailed Debugging Steps
+
+### Step 1: Enable Detailed Logging
+
+First, ensure you have debug-level logging enabled:
+```bash
+# For lnd
+lnd --debuglevel=debug
+
+# For tapd
+tapd --debuglevel=debug
+```
+
+### Step 2: Identify the Failure Point
+
+Look for these key indicators in the logs:
+
+1. **PSBT Finalization Error**
+   ```
+   [/walletrpc.WalletKit/FinalizePsbt]: could not finalize PSBT
+   ```
+   This is the high-level error - dig deeper for root cause.
+
+2. **Input Skipping Warnings**
+   ```
+   SignPsbt: Skipping input 1, derived public key XXX does not match bip32 derivation info public key YYY
+   ```
+   This indicates a key derivation mismatch.
+
+3. **Missing Tapscript Root**
+   ```
+   SignPsbt: Skipping input X, script path spend without tapscript merkle root
+   ```
+   This indicates missing PSBT fields for taproot script spends.
+
+### Step 3: Diagnose Root Cause
+
+#### A. BIP32 Key Derivation Mismatch
+
+**What's happening:** The wallet cannot derive the correct private key because the derivation path is wrong.
+
+**Common causes:**
+1. KeyFamily or KeyIndex not preserved when storing keys
+2. Using raw public key bytes instead of full KeyDescriptor
+3. Defaulting to Family=0, Index=0 when values should be preserved
+
+**Where to check:**
+- Database storage code: Look for `UpsertInternalKey` calls
+- Key retrieval code: Look for `parseInternalKey` or similar
+- PSBT construction: Look for `Bip32DerivationFromKeyDesc`
+
+**Relevant code locations:**
+- tapd: `tapdb/supply_commit.go` - `InsertSignedCommitTx` method
+- tapd: `tapdb/assets_common.go` - `parseInternalKey` function
+- tapd: `tappsbt/interface.go` - `Bip32DerivationFromKeyDesc` function
+- lnd: [`lnwallet/btcwallet/psbt.go`](https://github.com/lightningnetwork/lnd/blob/master/lnwallet/btcwallet/psbt.go#L200-L250)
+
+**Fix pattern:**
+```go
+// WRONG - loses derivation info
+internalKeyID, err := db.UpsertInternalKey(ctx, InternalKey{
+    RawKey: internalKey.SerializeCompressed(),
+})
+
+// CORRECT - preserves full key info
+internalKeyID, err := db.UpsertInternalKey(ctx, InternalKey{
+    RawKey:    internalKey.PubKey.SerializeCompressed(),
+    KeyFamily: int32(internalKey.Family),
+    KeyIndex:  int32(internalKey.Index),
+})
+```
+
+#### B. Missing Tapscript Merkle Root
+
+**What's happening:** For taproot script path spends, the PSBT needs the merkle root to verify the script.
+
+**Common causes:**
+1. Not setting `TaprootMerkleRoot` in PSBT input
+2. Incorrect witness construction for taproot spends
+3. Missing control block information
+
+**Where to check:**
+- PSBT creation code: Look for `psbt.PInput` field assignments
+- Taproot output construction: Look for `TapscriptRoot` calculations
+
+**Relevant code locations:**
+- btcd: [`btcutil/psbt` package](https://github.com/btcsuite/btcd/tree/master/btcutil/psbt)
+- tapd: `universe/supplycommit/transitions.go` - PSBT construction
+
+**Fix pattern:**
+```go
+// For script path spends, ensure merkle root is set
+psbtInput := &psbt.PInput{
+    WitnessUtxo:       prevOut,
+    TaprootMerkleRoot: merkleRootBytes,  // MUST be set for script spends
+    // ... other fields
+}
+```
+
+### Step 4: Verify the Fix
+
+After implementing fixes, verify:
+
+1. **Check logs for successful signing:**
+   ```
+   DBG RPCS interceptor.go:775: [/walletrpc.WalletKit/SignPsbt] requested
+   # No "Skipping input" warnings should follow
+   ```
+
+2. **Run unit tests:**
+   ```bash
+   go test -v -run "TestSupplyCommit" ./tapdb/...
+   ```
+
+3. **Run integration tests:**
+   ```bash
+   make itest icase=supply_commit
+   ```
+
+## Common Pitfalls
+
+### 1. Struct Field Changes
+When modifying structs that contain keys, ensure all uses are updated:
+```go
+// If changing from:
+type SupplyCommitTxn struct {
+    InternalKey *btcec.PublicKey
+}
+
+// To:
+type SupplyCommitTxn struct {
+    InternalKey keychain.KeyDescriptor
+}
+
+// Must update ALL creation sites and test code
+```
+
+### 2. Database Migrations
+When key storage format changes, consider if existing data needs migration.
+
+### 3. Test Key Generation
+Test code often uses simplified key generation - ensure it matches production:
+```go
+// Test code should use:
+internalKey, _ := test.RandKeyDesc(t)  // Full descriptor
+
+// Not:
+internalKey := test.RandPubKey(t)  // Just public key
+```
+
+## Prevention Strategies
+
+1. **Always use KeyDescriptor** when passing keys that need signing
+2. **Preserve all key metadata** through the entire lifecycle
+3. **Add validation** to check required PSBT fields before finalization
+4. **Use structured logging** to trace key derivation paths
+5. **Write tests** that verify PSBT signing works end-to-end
+
+## External References
+
+- [BIP 174 - PSBT Specification](https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki)
+- [BIP 371 - Taproot PSBT Fields](https://github.com/bitcoin/bips/blob/master/bip-0371.mediawiki)
+- [lnd PSBT Implementation](https://github.com/lightningnetwork/lnd/blob/master/lnwallet/btcwallet/psbt.go)
+- [btcd PSBT Package Docs](https://pkg.go.dev/github.com/btcsuite/btcd/btcutil/psbt)
+- [Taproot Asset PSBT Utils](https://github.com/lightninglabs/taproot-assets/tree/main/tappsbt)
+
+## Related Issues
+
+- Supply commitment key storage
+- Taproot witness construction
+- Multi-signature coordination
+- Hardware wallet integration
+
+## Quick Checklist
+
+When debugging PSBT finalization issues:
+
+- [ ] Check lnd debug logs for specific error messages
+- [ ] Identify which input(s) are failing
+- [ ] Verify BIP32 derivation paths match
+- [ ] Check KeyFamily and KeyIndex are preserved
+- [ ] Verify tapscript merkle root for script spends
+- [ ] Ensure all required PSBT fields are populated
+- [ ] Test with simplified single-input transaction first
+- [ ] Verify database stores complete key information
+- [ ] Check for version mismatches between components
+
+## Example Debug Session
+
+```bash
+# 1. See test failure
+make itest icase=supply_commit
+# Error: PSBT failed to finalize
+
+# 2. Check lnd logs
+grep -i "SignPsbt\|Skipping" itest/regtest/*.log
+# Found: Skipping input 1, derived public key mismatch
+
+# 3. Check key storage
+grep -A5 "UpsertInternalKey" tapdb/supply_commit.go
+# Found: Only storing RawKey, not Family/Index
+
+# 4. Fix key storage to preserve full descriptor
+# 5. Update struct definitions if needed
+# 6. Fix test code to use KeyDescriptor
+# 7. Re-run tests to verify fix
+```
+
+## Contact & Escalation
+
+If you encounter PSBT issues not covered here:
+1. Check recent commits affecting key management
+2. Review taproot-assets and lnd release notes
+3. Search GitHub issues for similar problems
+4. Ask in #taproot-assets Slack channel
+5. File detailed bug report with logs and PSBT hex

--- a/docs/debug-handbook/psbt-quick-reference.md
+++ b/docs/debug-handbook/psbt-quick-reference.md
@@ -1,0 +1,169 @@
+# PSBT Debugging Quick Reference Card
+
+## Error → Root Cause → Fix Mapping
+
+| Error Message | Likely Cause | Quick Fix |
+|--------------|--------------|-----------|
+| `Skipping input X, derived public key XXX does not match YYY` | BIP32 path mismatch | Check KeyFamily/KeyIndex storage |
+| `script path spend without tapscript merkle root` | Missing PSBT field | Set `TaprootMerkleRoot` in PInput |
+| `could not finalize PSBT` | Multiple possible causes | Check lnd debug logs for specifics |
+| `witness program invalid version` | Wrong address type | Verify taproot vs segwit usage |
+| `non-mandatory-script-verify-flag` | Script execution failed | Check witness stack construction |
+
+## Critical Code Locations
+
+### Supply Commitment Keys
+```go
+// tapdb/supply_commit.go:905
+// MUST preserve full key descriptor:
+internalKeyID, err := db.UpsertInternalKey(ctx, InternalKey{
+    RawKey:    internalKeyDesc.PubKey.SerializeCompressed(),
+    KeyFamily: int32(internalKeyDesc.Family),  // ← CRITICAL
+    KeyIndex:  int32(internalKeyDesc.Index),   // ← CRITICAL
+})
+```
+
+### PSBT Input Construction
+```go
+// universe/supplycommit/transitions.go:464
+// BIP32 derivation must match stored key:
+bip32Derivation, trBip32Derivation := 
+    tappsbt.Bip32DerivationFromKeyDesc(
+        r.InternalKey,  // Must be full KeyDescriptor
+        chainParams.HDCoinType,
+    )
+```
+
+### Tapscript Root for Script Spends
+```go
+// For script path spends:
+psbtInput.TaprootMerkleRoot = merkleRootBytes  // REQUIRED
+psbtInput.TaprootLeafScript = []psbt.TaprootTapLeafScript{
+    {
+        ControlBlock: controlBlock,
+        Script:       leafScript,
+        LeafVersion:  tapscript.BaseLeafVersion,
+    },
+}
+```
+
+## Debug Commands
+
+```bash
+# Find signing errors in lnd logs
+grep -n "SignPsbt.*Skipping" ~/.lnd/logs/bitcoin/regtest/lnd.log
+
+# Check key storage in database
+sqlite3 ~/.tapd/data/regtest/tapd.db \
+  "SELECT key_family, key_index, hex(raw_key) FROM internal_keys;"
+
+# Decode PSBT to check fields
+echo "cHNidP8B..." | base64 -d | xxd  # Raw view
+bitcoin-cli decodepsbt "cHNidP8B..."  # Structured view
+
+# Track supply commit operations
+grep -E "SupplyCommit|InsertSignedCommitTx|UpsertInternalKey" *.log
+```
+
+## Key Data Structures
+
+### KeyDescriptor (ALWAYS use for signing keys)
+```go
+type KeyDescriptor struct {
+    PubKey *btcec.PublicKey
+    Family KeyFamily  // MUST preserve
+    Index  uint32     // MUST preserve
+}
+```
+
+### PSBT Input Fields for Taproot
+```go
+type PInput struct {
+    WitnessUtxo       *wire.TxOut           // Required
+    TaprootBip32Path  []Bip32Derivation     // For key path
+    TaprootMerkleRoot []byte                // For script path
+    TaprootLeafScript []TaprootTapLeafScript // Script details
+}
+```
+
+## Verification Checklist
+
+**Before PSBT Signing:**
+- [ ] All inputs have WitnessUtxo set
+- [ ] BIP32 derivation paths are correct
+- [ ] For taproot: merkle root set if script spend
+- [ ] Internal keys have Family/Index preserved
+
+**After Fixing Issues:**
+- [ ] No "Skipping input" warnings in logs
+- [ ] PSBT finalizes successfully
+- [ ] Transaction broadcasts without errors
+- [ ] Unit tests pass: `go test ./tapdb/...`
+- [ ] Integration tests pass: `make itest`
+
+## Common Mistakes
+
+1. **Using raw pubkey instead of KeyDescriptor**
+   ```go
+   // WRONG
+   type CommitTxn struct {
+       InternalKey *btcec.PublicKey
+   }
+   
+   // CORRECT
+   type CommitTxn struct {
+       InternalKey keychain.KeyDescriptor
+   }
+   ```
+
+2. **Not preserving key metadata in storage**
+   ```go
+   // WRONG - loses derivation info
+   UpsertInternalKey(ctx, InternalKey{
+       RawKey: key.SerializeCompressed(),
+   })
+   
+   // CORRECT - preserves everything
+   UpsertInternalKey(ctx, InternalKey{
+       RawKey:    key.PubKey.SerializeCompressed(),
+       KeyFamily: int32(key.Family),
+       KeyIndex:  int32(key.Index),
+   })
+   ```
+
+3. **Missing tapscript fields for script spends**
+   ```go
+   // Script path spends need:
+   psbtInput.TaprootMerkleRoot = root  // MANDATORY
+   psbtInput.TaprootLeafScript = [...]  // Script details
+   ```
+
+## Emergency Fixes
+
+### Force Key Recovery
+```sql
+-- If keys lost Family/Index, try common values:
+UPDATE internal_keys 
+SET key_family = 300,  -- TaprootAssetsKeyFamily 
+    key_index = 0 
+WHERE key_family = 0 AND key_index = 0;
+```
+
+### PSBT Field Addition
+```go
+// Quick fix to add missing merkle root:
+if isScriptSpend && psbtIn.TaprootMerkleRoot == nil {
+    tree := txscript.AssembleTaprootScriptTree(tapLeaf)
+    root := tree.RootNode.TapHash()
+    psbtIn.TaprootMerkleRoot = root[:]
+}
+```
+
+## Related Files to Check
+
+- `tapdb/supply_commit.go` - Supply commitment storage
+- `tapdb/assets_common.go` - Key parsing functions  
+- `universe/supplycommit/transitions.go` - PSBT creation
+- `universe/supplycommit/env.go` - Data structures
+- `tappsbt/interface.go` - BIP32 derivation helpers
+- `lnwallet/btcwallet/psbt.go` (lnd) - PSBT signing logic


### PR DESCRIPTION
In this PR, we add a README for a new area of documentation intended
for active developers of the project. The goal of this new set of docs
is to capture all the hard earned wisdom that devs gain while debugging
a non-trivial issue. It's meant to serve as a run book to allow for
rapid pattern matching to identify a routine issue, along with a guided
path to aide in debugging.

This should also be great for agents as well, since they can use them to
locate issues that they would otherwise need some prodding to figure
out.

The first one added is intended to devs find PSBT signing related issues more quickly. I ran into this during the dev of https://github.com/lightninglabs/taproot-assets/pull/1675 to get the itests working properly. It relies on some deeper knowledge of: PSBTs, the way lnd signs them, where the code lives, the logs to watch for, etc. So I figured I'd document it. 

I also made a [sub-agent](https://github.com/Roasbeef/claude-files?tab=readme-ov-file#debug-chronicler) that can be useful for such tasks. 