### PR TITLE
internal/test: don't use dns for mock servers

### DIFF
--- a/internal/test/grpc.go
+++ b/internal/test/grpc.go
@@ -18,7 +18,7 @@ import (
 var (
 	// ListenAddrTemplate is the template for the address the mock server
 	// listens on.
-	ListenAddrTemplate = "localhost:%d"
+	ListenAddrTemplate = "127.0.0.1:%d"
 
 	// StartupWaitTime is the time we wait for the server to start up.
 	StartupWaitTime = 50 * time.Millisecond


### PR DESCRIPTION
Fixes an issue observed in the authmailbox unit tests when running on macOS.

If 'localhost' resolved to an ipv6 link-local address, as is (apparently) commonly the case on macOS, then the following query would return a "dns: error parsing A record IP address" error:

```
		// Try connecting by querying a "cheap" RPC that the server can
		// answer from memory only.
		_, err = s.client.MailboxInfo(
			ctx, &mboxrpc.MailboxInfoRequest{},
		)
```

The result for at least the authmailbox tests was that they would hang indefinitely as the test clients tried to connect to the mock server forever, failing on each DNS resolution attempt. The fix hard-codes the listen address template to "127.0.0.1:%d", which bypasses DNS entirely.