### PR TITLE
rfq+rfqmsg: relay errors received from price oracle

### DIFF
--- a/docs/release-notes/release-notes-0.7.0.md
+++ b/docs/release-notes/release-notes-0.7.0.md
@@ -147,6 +147,10 @@
   [PR](https://github.com/lightninglabs/taproot-assets/pull/1640) addresses the
   issue.
 
+- Errors received from a price oracle [are now relayed to a requesting
+  peer](https://github.com/lightninglabs/taproot-assets/pull/1751) in
+  the reject message sent to them, instead of being ignored.
+
 ## RPC Updates
 
 ## tapcli Updates
@@ -217,5 +221,6 @@
 
 - ffranr
 - George Tsagkarelis
+- Jared Tobin
 - Olaoluwa Osuntokun
 - Oliver Gugger

--- a/rfq/negotiator.go
+++ b/rfq/negotiator.go
@@ -346,7 +346,7 @@ func (n *Negotiator) HandleIncomingBuyRequest(
 			// Send a reject message to the peer.
 			msg := rfqmsg.NewReject(
 				request.Peer, request.ID,
-				rfqmsg.ErrUnknownReject,
+				rfqmsg.ErrUnknownRejectWithCustomMsg(err.Error()),
 			)
 			sendOutgoingMsg(msg)
 
@@ -441,7 +441,7 @@ func (n *Negotiator) HandleIncomingSellRequest(
 			// Send a reject message to the peer.
 			msg := rfqmsg.NewReject(
 				request.Peer, request.ID,
-				rfqmsg.ErrUnknownReject,
+				rfqmsg.ErrUnknownRejectWithCustomMsg(err.Error()),
 			)
 			sendOutgoingMsg(msg)
 

--- a/rfqmsg/reject.go
+++ b/rfqmsg/reject.go
@@ -92,6 +92,15 @@ var (
 	}
 )
 
+// ErrUnknownRejectWithCustomMsg produces the "unknown" error code, but
+// pairs it with a custom error message
+func ErrUnknownRejectWithCustomMsg(msg string) RejectErr {
+	return RejectErr{
+		Code: 0,
+		Msg:  msg,
+	}
+}
+
 const (
 	// latestRejectVersion is the latest supported reject wire message data
 	// field version.


### PR DESCRIPTION
Forwards errors received from a price oracle back to the requesting peer in the 'Reject' message that it is sent. An error is simply rendered as a string and included in the 'msg' field of the RejectErr, which seems sufficient.

Resolves #1326.
