### PR TITLE
multi: increase commitment v0/v1/v2 unit test coverage

### DIFF
--- a/commitment/commitment_test.go
+++ b/commitment/commitment_test.go
@@ -3,6 +3,7 @@ package commitment
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"encoding/hex"
 	"math/rand"
 	"testing"
@@ -1483,7 +1484,9 @@ func TestIsTaprootAssetCommitmentScript(t *testing.T) {
 	t.Parallel()
 
 	require.True(t, IsTaprootAssetCommitmentScript(testTapCommitmentScript))
-	require.False(t, IsTaprootAssetCommitmentScript(TaprootAssetsMarker[:]))
+
+	tag := sha256.Sum256(markerV2)
+	require.False(t, IsTaprootAssetCommitmentScript(tag[:]))
 }
 
 // TestAssetCommitmentNoWitness tests that an asset commitment of a v1 asset is

--- a/commitment/tap_test.go
+++ b/commitment/tap_test.go
@@ -1,0 +1,79 @@
+package commitment
+
+import (
+	"crypto/sha256"
+	"testing"
+
+	"github.com/lightninglabs/taproot-assets/asset"
+	"github.com/lightninglabs/taproot-assets/fn"
+	"github.com/lightninglabs/taproot-assets/internal/test"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	// markerV2 is the marker tag for Taproot Assets used in V2 commitments.
+	markerV2 = []byte(taprootAssetsMarkerTag + ":194243")
+)
+
+// randTapCommitment generates a random Taproot commitment for the given
+// assetVersion.
+func randTapCommitment(t *testing.T, commitVersion *TapCommitmentVersion,
+	assetVersion asset.Version) *TapCommitment {
+
+	t.Helper()
+	randAssetType := test.RandFlip(asset.Normal, asset.Collectible)
+	randGenesis := asset.RandGenesis(t, randAssetType)
+	randAsset := randAsset(t, randGenesis, nil)
+
+	randAsset.Version = assetVersion
+
+	tapCommitment, err := FromAssets(commitVersion, randAsset)
+	require.NoError(t, err)
+
+	return tapCommitment
+}
+
+// TestTaprootAssetsMarkerV0 tests if it can find the TaprootAssetsMarker V0 at
+// the correct spot according to the legacy MarkerV0 digest with assetVersion 0
+// and 1.
+func TestTaprootAssetsMarkerV0(t *testing.T) {
+	t.Parallel()
+
+	assetVersions := []asset.Version{asset.V0, asset.V1}
+	for _, assetVersion := range assetVersions {
+		// Create a random Taproot commitment, and extract the tapLeaf
+		// script.
+		randTapCommitment := randTapCommitment(t, nil, assetVersion)
+		tapLeaf := randTapCommitment.TapLeaf()
+		script := tapLeaf.Script
+
+		require.Equal(t, byte(assetVersion), script[0])
+		require.Equal(t, TaprootAssetsMarker[:], script[1:33])
+	}
+}
+
+// TestTaprootAssetsMarkerV1 tests if it can find the TaprootAssetsMarker V2 at
+// the correct spot according to the MarkerV1 digest with assetVersion 0 and 1.
+func TestTaprootAssetsMarkerV1(t *testing.T) {
+	t.Parallel()
+
+	assetVersions := []asset.Version{asset.V0, asset.V1}
+	for _, assetVersion := range assetVersions {
+		// Create a random Taproot commitment, and extract the tapLeaf
+		// script.
+		randTapCommitment := randTapCommitment(
+			t, fn.Ptr(TapCommitmentV2), assetVersion,
+		)
+
+		// Check if MarkerVersion is set to MarkerV2, which should be
+		// the default.
+		require.Equal(t, randTapCommitment.Version, TapCommitmentV2)
+
+		tapLeaf := randTapCommitment.TapLeaf()
+		script := tapLeaf.Script
+
+		tag := sha256.Sum256(markerV2)
+		require.Equal(t, tag[:], script[:32])
+		require.Equal(t, byte(TapCommitmentV2), script[32])
+	}
+}

--- a/itest/multisig.go
+++ b/itest/multisig.go
@@ -501,6 +501,9 @@ type publishAndLogTransferOptions struct {
 
 	// label is the label to use for the transfer.
 	label string
+
+	// expectedErr is the expected error when calling PublishAndLogTransfer.
+	expectedErr string
 }
 
 // defaultPublishAndLogTransferOptions returns the default options for
@@ -522,6 +525,14 @@ func withSkipAnchorTxBroadcast() PublishAndLogTransferOption {
 func withLabel(label string) PublishAndLogTransferOption {
 	return func(opts *publishAndLogTransferOptions) {
 		opts.label = label
+	}
+}
+
+// withExpectedErr is an option for PublishAndLogTransfer that sets the
+// expected error.
+func withExpectedErr(expectedErr string) PublishAndLogTransferOption {
+	return func(opts *publishAndLogTransferOptions) {
+		opts.expectedErr = expectedErr
 	}
 }
 
@@ -572,7 +583,15 @@ func PublishAndLogTransfer(t *testing.T, tapd commands.RpcClientsBundle,
 	}
 
 	resp, err := tapd.PublishAndLogTransfer(ctxt, request)
-	require.NoError(t, err)
+
+	if options.expectedErr != "" {
+		require.Error(t, err)
+		require.Contains(t, err.Error(), options.expectedErr,
+			"unexpected error: %v", err)
+		return nil
+	} else {
+		require.NoError(t, err)
+	}
 
 	return resp
 }

--- a/itest/test_list_on_test.go
+++ b/itest/test_list_on_test.go
@@ -218,6 +218,10 @@ var allTestCases = []*testCase{
 		test: testPsbtMultiVersionSend,
 	},
 	{
+		name: "psbt markerv0 mixed versions",
+		test: testPsbtMarkerV0MixedVersions,
+	},
+	{
 		name: "psbt grouped interactive full value send",
 		test: testPsbtGroupedInteractiveFullValueSend,
 	},

--- a/tapgarden/planter_test.go
+++ b/tapgarden/planter_test.go
@@ -3,6 +3,7 @@ package tapgarden_test
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"database/sql"
 	"encoding/binary"
 	"encoding/hex"
@@ -1579,9 +1580,11 @@ func testFinalizeWithTapscriptTree(t *mintingTestHarness) {
 	// to one TapCommitment.
 	var dummyRootSum [8]byte
 	binary.BigEndian.PutUint64(dummyRootSum[:], test.RandInt[uint64]())
+
+	tag := sha256.Sum256([]byte("taproot-assets:194243"))
 	dummyRootHashParts := [][]byte{
-		{byte(asset.V0)}, commitment.TaprootAssetsMarker[:],
-		fn.ByteSlice(test.RandHash()), dummyRootSum[:],
+		tag[:], {byte(asset.V0)}, fn.ByteSlice(test.RandHash()),
+		dummyRootSum[:],
 	}
 	dummyTapCommitmentRootHash := bytes.Join(dummyRootHashParts, nil)
 	dummyTapLeaf := txscript.NewBaseTapLeaf(dummyTapCommitmentRootHash)

--- a/tapsend/proof_test.go
+++ b/tapsend/proof_test.go
@@ -113,6 +113,10 @@ func createProofSuffix(t *testing.T, stxoProof bool, expectedErr string) {
 	)
 	addBip86Output(t, anchorTx.FundedPsbt.Pkt)
 
+	// Change on outputCommitment to the legacy marker.
+	outputCommitments[2], err = outputCommitments[2].Downgrade()
+	require.NoError(t, err)
+
 	// Create a proof suffix for all 4 packets now and validate it.
 	for _, vPkt := range testPackets {
 		for outIdx := range vPkt.Outputs {


### PR DESCRIPTION
Adds more unit tests around the commitment v0/v1/v2 formats.