### PR TITLE
tapgarden: reduce flakiness in TestBatchedAssetIssuance

### DIFF
--- a/tapgarden/planter_test.go
+++ b/tapgarden/planter_test.go
@@ -2040,10 +2040,10 @@ func TestBatchedAssetIssuance(t *testing.T) {
 	t.Helper()
 
 	for _, testCase := range testCases {
-		mintingStore := newMintingStore(t)
 		testCase := testCase
 
 		t.Run(testCase.name, func(t *testing.T) {
+			mintingStore := newMintingStore(t)
 			mintTest := newMintingTestHarness(t, mintingStore)
 			testCase.testFunc(mintTest)
 		})


### PR DESCRIPTION
Assign a separate minting store to each test case to avoid shared state and improve test reliability.

I think I've noticed this unit test flake a few times in CI.