### PR TITLE
Refactor `FederationEnvoy.AddServer` connection logic and add unit tests

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -7402,24 +7402,9 @@ func (r *rpcServer) AddFederationServer(ctx context.Context,
 ) (*unirpc.AddFederationServerResponse, error) {
 
 	serversToAdd := fn.Map(req.Servers, unmarshalUniverseServer)
-
-	for idx := range serversToAdd {
-		server := serversToAdd[idx]
-
-		// Before we add the server as a federation member, we check
-		// that we can actually connect to it and that it isn't
-		// ourselves.
-		err := CheckFederationServer(
-			r.cfg.RuntimeID, universe.DefaultTimeout, server,
-		)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	err := r.cfg.UniverseFederation.AddServer(serversToAdd...)
+	_, err := r.cfg.UniverseFederation.AddServer(ctx, true, serversToAdd...)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to add server: %w", err)
 	}
 
 	return &unirpc.AddFederationServerResponse{}, nil

--- a/tapdb/sqlc/querier.go
+++ b/tapdb/sqlc/querier.go
@@ -151,7 +151,6 @@ type Querier interface {
 	InsertSupplySyncerPushLog(ctx context.Context, arg InsertSupplySyncerPushLogParams) error
 	InsertSupplyUpdateEvent(ctx context.Context, arg InsertSupplyUpdateEventParams) error
 	InsertTxProof(ctx context.Context, arg InsertTxProofParams) error
-	InsertUniverseServer(ctx context.Context, arg InsertUniverseServerParams) error
 	LinkDanglingSupplyUpdateEvents(ctx context.Context, arg LinkDanglingSupplyUpdateEventsParams) error
 	LogProofTransferAttempt(ctx context.Context, arg LogProofTransferAttemptParams) error
 	LogServerSync(ctx context.Context, arg LogServerSyncParams) error
@@ -264,6 +263,9 @@ type Querier interface {
 	UpsertTapscriptTreeRootHash(ctx context.Context, arg UpsertTapscriptTreeRootHashParams) (int64, error)
 	UpsertUniverseLeaf(ctx context.Context, arg UpsertUniverseLeafParams) error
 	UpsertUniverseRoot(ctx context.Context, arg UpsertUniverseRootParams) (int64, error)
+	// Upserts a universe server by inserting or updating the last sync time for a
+	// given server host.
+	UpsertUniverseServer(ctx context.Context, arg UpsertUniverseServerParams) error
 	UpsertUniverseSupplyLeaf(ctx context.Context, arg UpsertUniverseSupplyLeafParams) (int64, error)
 	UpsertUniverseSupplyRoot(ctx context.Context, arg UpsertUniverseSupplyRootParams) (int64, error)
 }

--- a/tapdb/sqlc/queries/universe.sql
+++ b/tapdb/sqlc/queries/universe.sql
@@ -99,12 +99,16 @@ ORDER BY
     CASE WHEN sqlc.narg('sort_direction') = 1 THEN universe_roots.id END DESC
 LIMIT @num_limit OFFSET @num_offset;
 
--- name: InsertUniverseServer :exec
+-- name: UpsertUniverseServer :exec
+-- Upserts a universe server by inserting or updating the last sync time for a
+-- given server host.
 INSERT INTO universe_servers(
     server_host, last_sync_time
 ) VALUES (
-    @server_host, @last_sync_time
-);
+     @server_host, @last_sync_time
+ )
+ON CONFLICT(server_host)
+    DO UPDATE SET last_sync_time = EXCLUDED.last_sync_time;
 
 -- name: DeleteUniverseServer :exec
 DELETE FROM universe_servers

--- a/tapdb/universe_federation_test.go
+++ b/tapdb/universe_federation_test.go
@@ -50,10 +50,10 @@ func TestUniverseFederationCRUD(t *testing.T) {
 	// Next, we'll try to add a new series of servers to the DB.
 	addrs := db.AddRandomServerAddrs(t, 10)
 
-	// If we try to insert them all again, then we should get an error as
-	// we ensure the host names are unique.
+	// Re-inserting the same addresses should not cause an error, since they
+	// are expected to be upserted.
 	err = fedDB.AddServers(ctx, addrs...)
-	require.ErrorIs(t, err, universe.ErrDuplicateUniverse)
+	require.NoError(t, err)
 
 	// Next, we should be able to fetch all the active hosts.
 	dbAddrs, err := fedDB.UniverseServers(ctx)

--- a/universe/federation_test.go
+++ b/universe/federation_test.go
@@ -1,0 +1,231 @@
+package universe
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/lightninglabs/taproot-assets/fn"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// TestFederationEnvoyAddServer tests the AddServer method of FederationEnvoy.
+func TestFederationEnvoyAddServer(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	t.Run("successfully add new servers", func(t *testing.T) {
+		t.Parallel()
+
+		mockDB := &MockFederationDB{}
+		mockSyncer := &MockSyncer{}
+
+		// Set up expectations
+		mockDB.On("UniverseServers", mock.Anything).Return(
+			[]ServerAddr{}, nil)
+
+		expectedAddrs := []ServerAddr{
+			NewServerAddrFromStr("server1.example.com"),
+			NewServerAddrFromStr("server2.example.com"),
+		}
+		mockDB.On("AddServers", mock.Anything,
+			expectedAddrs).Return(nil)
+
+		// Mock the QueryFederationSyncConfigs call used by SyncServers
+		mockDB.On("QueryFederationSyncConfigs", mock.Anything).Return(
+			[]*FedGlobalSyncConfig(nil), []*FedUniSyncConfig(nil),
+			nil,
+		)
+
+		mockSyncer.On("SyncUniverse", mock.Anything, mock.Anything,
+			mock.Anything, mock.Anything, mock.Anything).Return(
+			[]AssetSyncDiff(nil), nil)
+
+		successfulServerChecker := func(addr ServerAddr) error {
+			// Simulate successful connection check.
+			return nil
+		}
+
+		envoy := &FederationEnvoy{
+			cfg: FederationConfig{
+				FederationDB:   mockDB,
+				UniverseSyncer: mockSyncer,
+				ServerChecker:  successfulServerChecker,
+			},
+			ContextGuard: &fn.ContextGuard{
+				DefaultTimeout: DefaultTimeout,
+				Quit:           make(chan struct{}),
+			},
+		}
+
+		addrs := []ServerAddr{
+			NewServerAddrFromStr("server1.example.com"),
+			NewServerAddrFromStr("server2.example.com"),
+		}
+
+		reports, err := envoy.AddServer(ctx, true, addrs...)
+		require.NoError(t, err)
+		require.Len(t, reports, 2)
+
+		// Verify the reports.
+		for _, report := range reports {
+			require.Equal(
+				t, fn.Some(true), report.ConnectionSuccess,
+			)
+			require.False(t, report.KnownServer)
+			require.NoError(t, report.Error)
+		}
+
+		// Verify all expectations were met
+		mockDB.AssertExpectations(t)
+		mockSyncer.AssertExpectations(t)
+	})
+
+	t.Run("connection check disabled", func(t *testing.T) {
+		t.Parallel()
+
+		mockDB := &MockFederationDB{}
+		mockSyncer := &MockSyncer{}
+
+		// Set up expectations
+		mockDB.On("UniverseServers", mock.Anything).Return(
+			[]ServerAddr{}, nil)
+
+		expectedAddr := NewServerAddrFromStr("server.example.com")
+		mockDB.On("AddServers", mock.Anything,
+			[]ServerAddr{expectedAddr}).Return(nil)
+
+		// Mock the QueryFederationSyncConfigs call used by SyncServers
+		mockDB.On("QueryFederationSyncConfigs", mock.Anything).Return(
+			[]*FedGlobalSyncConfig(nil), []*FedUniSyncConfig(nil),
+			nil,
+		)
+
+		mockSyncer.On("SyncUniverse", mock.Anything, mock.Anything,
+			mock.Anything, mock.Anything, mock.Anything).Return(
+			[]AssetSyncDiff(nil), nil)
+
+		shouldNotBeCalledServerChecker := func(addr ServerAddr) error {
+			t.Fatal("ServerChecker should not be called when " +
+				"connection check is disabled")
+			return nil
+		}
+
+		envoy := &FederationEnvoy{
+			cfg: FederationConfig{
+				FederationDB:   mockDB,
+				UniverseSyncer: mockSyncer,
+				ServerChecker:  shouldNotBeCalledServerChecker,
+			},
+			ContextGuard: &fn.ContextGuard{
+				DefaultTimeout: DefaultTimeout,
+				Quit:           make(chan struct{}),
+			},
+		}
+
+		reports, err := envoy.AddServer(ctx, false, expectedAddr)
+		require.NoError(t, err)
+		require.Len(t, reports, 1)
+
+		// Verify the report when connection check is disabled.
+		report := reports[0]
+		require.Equal(t, fn.None[bool](), report.ConnectionSuccess)
+		require.False(t, report.KnownServer)
+		require.NoError(t, report.Error)
+
+		// Verify all expectations were met
+		mockDB.AssertExpectations(t)
+		mockSyncer.AssertExpectations(t)
+	})
+
+	t.Run("connection check fails", func(t *testing.T) {
+		t.Parallel()
+
+		mockDB := &MockFederationDB{}
+		mockSyncer := &MockSyncer{}
+
+		// Set up expectations - only UniverseServers should be called
+		mockDB.On("UniverseServers", mock.Anything).Return(
+			[]ServerAddr{}, nil)
+		// AddServers and SyncUniverse should NOT be called
+
+		failingServerChecker := func(addr ServerAddr) error {
+			return errors.New("connection failed")
+		}
+
+		envoy := &FederationEnvoy{
+			cfg: FederationConfig{
+				FederationDB:   mockDB,
+				UniverseSyncer: mockSyncer,
+				ServerChecker:  failingServerChecker,
+			},
+			ContextGuard: &fn.ContextGuard{
+				DefaultTimeout: DefaultTimeout,
+				Quit:           make(chan struct{}),
+			},
+		}
+
+		addr := NewServerAddrFromStr("unreachable.example.com")
+		reports, err := envoy.AddServer(ctx, true, addr)
+		require.NoError(t, err)
+		require.Len(t, reports, 1)
+
+		// Verify the report when connection check fails.
+		report := reports[0]
+		require.Equal(t, fn.Some(false), report.ConnectionSuccess)
+		require.False(t, report.KnownServer)
+		require.Error(t, report.Error)
+		require.ErrorIs(t, report.Error, ErrUniConnFailed)
+
+		// Verify expectations were met
+		mockDB.AssertExpectations(t)
+		mockSyncer.AssertExpectations(t)
+	})
+
+	t.Run("skip known servers", func(t *testing.T) {
+		t.Parallel()
+
+		existingServer := NewServerAddrFromStr("existing.example.com")
+
+		mockDB := &MockFederationDB{}
+		mockSyncer := &MockSyncer{}
+
+		// Set up expectations - only UniverseServers should be called
+		mockDB.On("UniverseServers", mock.Anything).Return(
+			[]ServerAddr{existingServer}, nil)
+		// AddServers and SyncUniverse should NOT be called for known
+		// servers
+
+		successfulServerChecker := func(addr ServerAddr) error {
+			return nil
+		}
+
+		envoy := &FederationEnvoy{
+			cfg: FederationConfig{
+				FederationDB:   mockDB,
+				UniverseSyncer: mockSyncer,
+				ServerChecker:  successfulServerChecker,
+			},
+			ContextGuard: &fn.ContextGuard{
+				DefaultTimeout: DefaultTimeout,
+				Quit:           make(chan struct{}),
+			},
+		}
+
+		reports, err := envoy.AddServer(ctx, true, existingServer)
+		require.NoError(t, err)
+		require.Len(t, reports, 1)
+
+		// Verify the report for known server.
+		report := reports[0]
+		require.Equal(t, fn.Some(true), report.ConnectionSuccess)
+		require.True(t, report.KnownServer)
+		require.NoError(t, report.Error)
+
+		// Verify expectations were met
+		mockDB.AssertExpectations(t)
+		mockSyncer.AssertExpectations(t)
+	})
+}

--- a/universe/mock.go
+++ b/universe/mock.go
@@ -1,0 +1,107 @@
+package universe
+
+import (
+	"context"
+
+	"github.com/stretchr/testify/mock"
+)
+
+// MockFederationDB is a mock implementation of the FederationDB interface
+// for testing.
+type MockFederationDB struct {
+	mock.Mock
+}
+
+func (m *MockFederationDB) UniverseServers(ctx context.Context) (
+	[]ServerAddr, error) {
+
+	args := m.Called(ctx)
+	return args.Get(0).([]ServerAddr), args.Error(1)
+}
+
+func (m *MockFederationDB) AddServers(ctx context.Context,
+	addrs ...ServerAddr) error {
+
+	args := m.Called(ctx, addrs)
+	return args.Error(0)
+}
+
+func (m *MockFederationDB) RemoveServers(ctx context.Context,
+	addrs ...ServerAddr) error {
+
+	args := m.Called(ctx, addrs)
+	return args.Error(0)
+}
+
+func (m *MockFederationDB) LogNewSyncs(ctx context.Context,
+	addrs ...ServerAddr) error {
+
+	args := m.Called(ctx, addrs)
+	return args.Error(0)
+}
+
+func (m *MockFederationDB) QueryFederationSyncConfigs(
+	ctx context.Context) ([]*FedGlobalSyncConfig, []*FedUniSyncConfig,
+	error) {
+
+	args := m.Called(ctx)
+	return args.Get(0).([]*FedGlobalSyncConfig),
+		args.Get(1).([]*FedUniSyncConfig), args.Error(2)
+}
+
+func (m *MockFederationDB) UpsertFederationSyncConfig(
+	ctx context.Context, globalSyncConfigs []*FedGlobalSyncConfig,
+	uniSyncConfigs []*FedUniSyncConfig) error {
+
+	args := m.Called(ctx, globalSyncConfigs, uniSyncConfigs)
+	return args.Error(0)
+}
+
+func (m *MockFederationDB) UpsertFederationProofSyncLog(
+	ctx context.Context, uniID Identifier, leafKey LeafKey,
+	addr ServerAddr, syncDirection SyncDirection,
+	syncStatus ProofSyncStatus,
+	bumpSyncAttemptCounter bool) (int64, error) {
+
+	args := m.Called(ctx, uniID, leafKey, addr, syncDirection,
+		syncStatus, bumpSyncAttemptCounter)
+	return args.Get(0).(int64), args.Error(1)
+}
+
+func (m *MockFederationDB) QueryFederationProofSyncLog(
+	ctx context.Context, uniID Identifier, leafKey LeafKey,
+	syncDirection SyncDirection,
+	syncStatus ProofSyncStatus) ([]*ProofSyncLogEntry, error) {
+
+	args := m.Called(ctx, uniID, leafKey, syncDirection, syncStatus)
+	return args.Get(0).([]*ProofSyncLogEntry), args.Error(1)
+}
+
+func (m *MockFederationDB) FetchPendingProofsSyncLog(
+	ctx context.Context,
+	syncDirection *SyncDirection) ([]*ProofSyncLogEntry, error) {
+
+	args := m.Called(ctx, syncDirection)
+	return args.Get(0).([]*ProofSyncLogEntry), args.Error(1)
+}
+
+func (m *MockFederationDB) DeleteProofsSyncLogEntries(
+	ctx context.Context, servers ...ServerAddr) error {
+
+	args := m.Called(ctx, servers)
+	return args.Error(0)
+}
+
+// MockSyncer is a mock implementation of the Syncer interface for testing.
+type MockSyncer struct {
+	mock.Mock
+}
+
+// SyncUniverse implements the Syncer interface.
+func (m *MockSyncer) SyncUniverse(ctx context.Context, host ServerAddr,
+	syncType SyncType, syncConfigs SyncConfigs,
+	idsToSync ...Identifier) ([]AssetSyncDiff, error) {
+
+	args := m.Called(ctx, host, syncType, syncConfigs, idsToSync)
+	return args.Get(0).([]AssetSyncDiff), args.Error(1)
+}


### PR DESCRIPTION
This PR improves the `FederationEnvoy.AddServer` method by:

* Moving the server connection check into `AddServer`, simplifying logic at two call sites.
* Introducing a `ServerAddReport` struct that provides detailed feedback on each server addition attempt (e.g., whether it was already known and the result of the connection check).
* Adding initial unit tests and mocks to provide unit test coverage for `AddServer`, which previously had none.

Also includes:

* A supporting change to use `UpsertUniverseServer` in place of `InsertUniverseServer`, avoiding unique constraint errors when adding known servers.