### PR TITLE
Chaos test STXO proof gen: swap `EmptyGenesisID` for `spentAsset.TapCommitmentKey()`

### DIFF
--- a/proof/append.go
+++ b/proof/append.go
@@ -221,7 +221,7 @@ func CreateTransitionProof(prevOut wire.OutPoint, params *TransitionParams,
 			// Generate an STXO inclusion proof for each prev
 			// witness.
 			_, stxoProof, err := params.TaprootAssetRoot.Proof(
-				asset.EmptyGenesisID,
+				spentAsset.TapCommitmentKey(),
 				spentAsset.AssetCommitmentKey(),
 			)
 			if err != nil {


### PR DESCRIPTION
This PR replaces the tap commitment key used in STXO proof generation from `EmptyGenesisID` (which should be correct) to `spentAsset.TapCommitmentKey()` (which should be incorrect).

### Purpose

The change is intentionally experimental — to test whether this substitution causes any failures in unit or integration tests.

### Notes

* Not intended for merge.
