### PR TITLE
tapdb: fix flaky `TestQueryMessages` due to close timestamps

### DIFF
--- a/tapdb/authmailbox_test.go
+++ b/tapdb/authmailbox_test.go
@@ -69,14 +69,17 @@ func TestQueryMessages(t *testing.T) {
 	mailboxStore, _ := newMailboxStore(t)
 	ctx := context.Background()
 
+	// Use a fixed base timestamp to avoid flaky tests.
+	baseTime := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+
 	const numMessages = 5
 	for i := 0; i < numMessages; i++ {
 		txProof := proof.MockTxProof(t)
 		msg := &authmailbox.Message{
 			ReceiverKey:      *receiverKey,
 			EncryptedPayload: []byte("payload"),
-			ArrivalTimestamp: time.Now().Add(
-				time.Duration(i) * time.Second,
+			ArrivalTimestamp: baseTime.Add(
+				time.Duration(i) * time.Hour,
 			),
 		}
 
@@ -84,10 +87,11 @@ func TestQueryMessages(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	// Query messages created after the second message.
+	// Query messages created after the second message (after 1 hour from
+	// base time).
 	filter := authmailbox.MessageFilter{
 		ReceiverKey: *receiverKey,
-		After:       time.Now().Add(time.Second),
+		After:       baseTime.Add(time.Hour),
 	}
 	messages, err := mailboxStore.QueryMessages(ctx, filter)
 	require.NoError(t, err)


### PR DESCRIPTION
Fixed a flake in the `TestQueryMessages` unit test caused by message arrival timestamps being only seconds apart. This led to inconsistent test results depending on execution timing.

```
--- FAIL: TestQueryMessages (5.43s)
    test_sqlite.go:11: Creating new SQLite DB handle for testing: /tmp/TestQueryMessages561491793/001/tmp.db
    authmailbox_test.go:94: 
        	Error Trace:	/home/runner/work/taproot-assets/taproot-assets/tapdb/authmailbox_test.go:94
        	Error:      	"[0xc000116510 0xc0001165a0]" should have 3 item(s), but has 2
        	Test:       	TestQueryMessages
```

As seen in this CI run: https://github.com/lightninglabs/taproot-assets/actions/runs/17980772557/job/51145950670