### PR TITLE
Extract supply pre-commits from mint leaves during supply verifier sync

### DIFF
--- a/docs/release-notes/release-notes-0.7.0.md
+++ b/docs/release-notes/release-notes-0.7.0.md
@@ -78,6 +78,7 @@
    - https://github.com/lightninglabs/taproot-assets/pull/1797
    - https://github.com/lightninglabs/taproot-assets/pull/1823
    - https://github.com/lightninglabs/taproot-assets/pull/1822
+   - https://github.com/lightninglabs/taproot-assets/pull/1820
 
 - A new [address version 2 was introduced that supports grouped assets and
   custom (sender-defined)

--- a/itest/supply_commit_test.go
+++ b/itest/supply_commit_test.go
@@ -1042,6 +1042,9 @@ func testSupplyCommitMintBurn(t *harnessTest) {
 //  5. Ignores the asset outpoint sent to the secondary node.
 //  6. Publishes the second supply commitment and mines it.
 //  7. Verifies the secondary node can fetch the updated supply commitment.
+//  8. Primary node mints another asset into the group and publishes the
+//     third supply commitment.
+//  9. Verifies the secondary node can fetch the third supply commitment.
 func testSupplyVerifyPeerNode(t *harnessTest) {
 	ctxb := context.Background()
 
@@ -1049,11 +1052,11 @@ func testSupplyVerifyPeerNode(t *harnessTest) {
 		"commitments enabled")
 
 	// Create a mint request for a grouped asset with supply commitments.
-	mintReq := CopyRequest(issuableAssets[0])
-	mintReq.Asset.Amount = 5000
+	firstMintReq := CopyRequest(issuableAssets[0])
+	firstMintReq.Asset.Amount = 5000
 
 	rpcFirstAsset, _ := MintAssetWithSupplyCommit(
-		t, mintReq, fn.None[btcec.PublicKey](),
+		t, firstMintReq, fn.None[btcec.PublicKey](),
 	)
 
 	// Parse out the group key from the minted asset.
@@ -1077,7 +1080,7 @@ func testSupplyVerifyPeerNode(t *harnessTest) {
 	// Verify the issuance subtree root exists and has the correct amount.
 	require.NotNil(t.t, fetchResp.IssuanceSubtreeRoot)
 	require.Equal(
-		t.t, int64(mintReq.Asset.Amount),
+		t.t, int64(firstMintReq.Asset.Amount),
 		fetchResp.IssuanceSubtreeRoot.RootNode.RootSum,
 	)
 
@@ -1125,7 +1128,7 @@ func testSupplyVerifyPeerNode(t *harnessTest) {
 	)
 
 	require.Equal(
-		t.t, int64(mintReq.Asset.Amount),
+		t.t, int64(firstMintReq.Asset.Amount),
 		peerFetchResp.IssuanceSubtreeRoot.RootNode.RootSum,
 	)
 
@@ -1160,7 +1163,7 @@ func testSupplyVerifyPeerNode(t *harnessTest) {
 
 	t.Log("Verifying retrieval of second supply commitment from primary " +
 		"node")
-	fetchResp, _ = WaitForSupplyCommit(
+	fetchResp, supplyOutpoint = WaitForSupplyCommit(
 		t.t, ctxb, t.tapd, groupKeyBytes, fn.Some(supplyOutpoint),
 		func(resp *unirpc.FetchSupplyCommitResponse) bool {
 			ignoreRoot := resp.IgnoreSubtreeRoot
@@ -1265,4 +1268,92 @@ func testSupplyVerifyPeerNode(t *harnessTest) {
 	// Verify that the secondary node's supply commitment matches the
 	// primary's.
 	assertFetchCommitResponse(t, fetchResp, peerFetchResp2)
+
+	// Step 8: Primary node mints another asset into the group and publishes
+	// the third supply commitment.
+	t.Log("Minting second asset into the same asset group")
+
+	secondMintReq := &mintrpc.MintAssetRequest{
+		Asset: &mintrpc.MintAsset{
+			AssetType: taprpc.AssetType_NORMAL,
+			Name:      "itestbuxx-supply-commit-tranche-2",
+			AssetMeta: &taprpc.AssetMeta{
+				Data: []byte("second tranche metadata"),
+			},
+			Amount:          2000,
+			AssetVersion:    taprpc.AssetVersion_ASSET_VERSION_V1,
+			NewGroupedAsset: false,
+			GroupedAsset:    true,
+			GroupKey:        groupKeyBytes,
+
+			EnableSupplyCommitments: true,
+		},
+	}
+
+	MintAssetWithSupplyCommit(
+		t, secondMintReq, fn.None[btcec.PublicKey](),
+	)
+
+	t.Log("Updating supply commitment after second mint (creating third " +
+		"supply commitment)")
+	UpdateAndMineSupplyCommit(
+		t.t, ctxb, t.tapd, t.lndHarness.Miner().Client,
+		groupKeyBytes, 1,
+	)
+
+	// Wait for the third supply commitment to be available.
+	expectedTotalAfterSecondMint := int64(
+		firstMintReq.Asset.Amount + secondMintReq.Asset.Amount,
+	)
+	var thirdSupplyCommitResp *unirpc.FetchSupplyCommitResponse
+	thirdSupplyCommitResp, _ = WaitForSupplyCommit(
+		t.t, ctxb, t.tapd, groupKeyBytes, fn.Some(supplyOutpoint),
+		func(resp *unirpc.FetchSupplyCommitResponse) bool {
+			actualRootSum :=
+				resp.IssuanceSubtreeRoot.RootNode.RootSum
+
+			return resp.IssuanceSubtreeRoot != nil &&
+				actualRootSum == expectedTotalAfterSecondMint
+		},
+	)
+
+	// Step 9: Verify the secondary node can fetch the third supply
+	// commitment.
+	t.Log("Verifying secondary node can fetch third supply commitment")
+
+	// Verify the secondary node can fetch the third supply commitment.
+	peerFetchPred3 := func(resp *unirpc.FetchSupplyCommitResponse) error {
+		if resp.IssuanceSubtreeRoot == nil {
+			return fmt.Errorf("expected issuance subtree root")
+		}
+
+		// Check if the supply commitment includes the second mint.
+		if resp.IssuanceSubtreeRoot.RootNode.RootSum !=
+			expectedTotalAfterSecondMint {
+
+			return fmt.Errorf("expected RootSum %d, got %d",
+				expectedTotalAfterSecondMint,
+				resp.IssuanceSubtreeRoot.RootNode.RootSum)
+		}
+
+		return nil
+	}
+
+	// nolint: lll
+	req = unirpc.FetchSupplyCommitRequest{
+		GroupKey: &unirpc.FetchSupplyCommitRequest_GroupKeyBytes{
+			GroupKeyBytes: groupKeyBytes,
+		},
+		Locator: &unirpc.FetchSupplyCommitRequest_SpentCommitOutpoint{
+			SpentCommitOutpoint: thirdSupplyCommitResp.SpentCommitmentOutpoint,
+		},
+	}
+
+	peerFetchResp3 := rpcassert.FetchSupplyCommitRPC(
+		t.t, ctxb, secondTapd, peerFetchPred3, &req,
+	)
+
+	// Verify that the secondary node's third supply commitment matches the
+	// primary's.
+	assertFetchCommitResponse(t, thirdSupplyCommitResp, peerFetchResp3)
 }

--- a/tapdb/supply_commit.go
+++ b/tapdb/supply_commit.go
@@ -1151,6 +1151,12 @@ func (s *SupplyCommitMachine) InsertSupplyCommit(ctx context.Context,
 					"pre-commit outpoint: %w", err)
 			}
 
+			err = upsertSupplyPreCommit(ctx, db, preCommit)
+			if err != nil {
+				return fmt.Errorf("failed to upsert "+
+					"pre-commit: %w", err)
+			}
+
 			markParams := sqlc.MarkPreCommitSpentByOutpointParams{
 				SpentByCommitID: sqlInt64(newCommitmentID),
 				Outpoint:        outpointBytes,

--- a/tapdb/universe.go
+++ b/tapdb/universe.go
@@ -16,7 +16,7 @@ import (
 	"github.com/lightninglabs/taproot-assets/proof"
 	"github.com/lightninglabs/taproot-assets/tapdb/sqlc"
 	"github.com/lightninglabs/taproot-assets/universe"
-	"github.com/lightninglabs/taproot-assets/universe/supplyverifier"
+	"github.com/lightninglabs/taproot-assets/universe/supplycommit"
 	lfn "github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/lightningnetwork/lnd/keychain"
 )
@@ -628,7 +628,7 @@ func maybeUpsertSupplyPreCommit(ctx context.Context, dbTx UpsertAssetStore,
 		return err
 	}
 
-	preCommitOutput, err := supplyverifier.ExtractPreCommitOutput(
+	preCommitOutput, err := supplycommit.NewPreCommitFromProof(
 		issuanceProof, delegationKey,
 	)
 	if err != nil {

--- a/universe/supplycommit/env.go
+++ b/universe/supplycommit/env.go
@@ -365,6 +365,57 @@ type PreCommitment struct {
 	GroupPubKey btcec.PublicKey
 }
 
+// NewPreCommitFromProof extracts and returns the supply pre-commitment from the
+// given issuance proof and delegation key.
+func NewPreCommitFromProof(issuanceProof proof.Proof,
+	delegationKey btcec.PublicKey) (PreCommitment, error) {
+
+	var zero PreCommitment
+
+	// Identify txOut in mint anchor transaction which corresponds to the
+	// supply pre-commitment output.
+	//
+	// Construct the expected pre-commit tx out.
+	expectedTxOut, err := tapgarden.PreCommitTxOut(delegationKey)
+	if err != nil {
+		return zero, fmt.Errorf("unable to derive expected pre-commit "+
+			"txout: %w", err)
+	}
+
+	var preCommitTxOutIndex int32 = -1
+	for idx := range issuanceProof.AnchorTx.TxOut {
+		txOut := *issuanceProof.AnchorTx.TxOut[idx]
+
+		// Compare txOut to the expected pre-commit tx out.
+		isValueEqual := txOut.Value == expectedTxOut.Value
+		isPkScriptEqual := bytes.Equal(
+			txOut.PkScript, expectedTxOut.PkScript,
+		)
+
+		if isValueEqual && isPkScriptEqual {
+			preCommitTxOutIndex = int32(idx)
+			break
+		}
+	}
+
+	// If we didn't find the pre-commit tx out, then return an error.
+	if preCommitTxOutIndex == -1 {
+		return zero, fmt.Errorf("unable to find pre-commit tx out in " +
+			"issuance anchor tx")
+	}
+
+	// Calculate the outpoint of the supply pre-commitment.
+	return PreCommitment{
+		BlockHeight: issuanceProof.BlockHeight,
+		MintingTxn:  &issuanceProof.AnchorTx,
+		OutIdx:      uint32(preCommitTxOutIndex),
+		InternalKey: keychain.KeyDescriptor{
+			PubKey: &delegationKey,
+		},
+		GroupPubKey: issuanceProof.Asset.GroupKey.GroupPubKey,
+	}, nil
+}
+
 // TxIn returns the transaction input that corresponds to the pre-commitment.
 func (p *PreCommitment) TxIn() *wire.TxIn {
 	return &wire.TxIn{

--- a/universe/supplycommit/env.go
+++ b/universe/supplycommit/env.go
@@ -416,6 +416,25 @@ func NewPreCommitFromProof(issuanceProof proof.Proof,
 	}, nil
 }
 
+// NewPreCommitFromMintEvent extracts and returns the supply pre-commitment
+// from the given mint event.
+func NewPreCommitFromMintEvent(issuanceEntry NewMintEvent,
+	delegationKey btcec.PublicKey) (PreCommitment, error) {
+
+	var zero PreCommitment
+
+	issuanceLeaf := issuanceEntry.IssuanceProof
+
+	var issuanceProof proof.Proof
+	err := issuanceProof.Decode(bytes.NewReader(issuanceLeaf.RawProof))
+	if err != nil {
+		return zero, fmt.Errorf("unable to decode issuance proof: %w",
+			err)
+	}
+
+	return NewPreCommitFromProof(issuanceProof, delegationKey)
+}
+
 // TxIn returns the transaction input that corresponds to the pre-commitment.
 func (p *PreCommitment) TxIn() *wire.TxIn {
 	return &wire.TxIn{

--- a/universe/supplycommit/mock.go
+++ b/universe/supplycommit/mock.go
@@ -59,13 +59,13 @@ func (m *mockSupplyTreeView) FetchSupplyLeavesByHeight(_ context.Context,
 	return args.Get(0).(lfn.Result[SupplyLeaves])
 }
 
-// mockCommitmentTracker is a mock implementation of the CommitmentTracker
+// MockCommitmentTracker is a mock implementation of the CommitmentTracker
 // interface.
-type mockCommitmentTracker struct {
+type MockCommitmentTracker struct {
 	mock.Mock
 }
 
-func (m *mockCommitmentTracker) UnspentPrecommits(ctx context.Context,
+func (m *MockCommitmentTracker) UnspentPrecommits(ctx context.Context,
 	assetSpec asset.Specifier,
 	localIssuerOnly bool) lfn.Result[PreCommits] {
 
@@ -73,7 +73,7 @@ func (m *mockCommitmentTracker) UnspentPrecommits(ctx context.Context,
 	return args.Get(0).(lfn.Result[PreCommits])
 }
 
-func (m *mockCommitmentTracker) SupplyCommit(ctx context.Context,
+func (m *MockCommitmentTracker) SupplyCommit(ctx context.Context,
 	assetSpec asset.Specifier) RootCommitResp {
 
 	args := m.Called(ctx, assetSpec)
@@ -432,12 +432,12 @@ func (c *mockIgnoreCheckerCache) InvalidateCache(groupKey btcec.PublicKey) {
 	c.Called(groupKey)
 }
 
-// mockAssetLookup is a mock implementation of the AssetLookup interface.
-type mockAssetLookup struct {
+// MockAssetLookup is a mock implementation of the AssetLookup interface.
+type MockAssetLookup struct {
 	mock.Mock
 }
 
-func (m *mockAssetLookup) FetchSupplyCommitAssets(ctx context.Context,
+func (m *MockAssetLookup) FetchSupplyCommitAssets(ctx context.Context,
 	localControlled bool) ([]btcec.PublicKey, error) {
 
 	args := m.Called(ctx, localControlled)
@@ -447,7 +447,7 @@ func (m *mockAssetLookup) FetchSupplyCommitAssets(ctx context.Context,
 	return args.Get(0).([]btcec.PublicKey), args.Error(1)
 }
 
-func (m *mockAssetLookup) QueryAssetGroupByID(ctx context.Context,
+func (m *MockAssetLookup) QueryAssetGroupByID(ctx context.Context,
 	assetID asset.ID) (*asset.AssetGroup, error) {
 
 	args := m.Called(ctx, assetID)
@@ -457,7 +457,7 @@ func (m *mockAssetLookup) QueryAssetGroupByID(ctx context.Context,
 	return args.Get(0).(*asset.AssetGroup), args.Error(1)
 }
 
-func (m *mockAssetLookup) QueryAssetGroupByGroupKey(ctx context.Context,
+func (m *MockAssetLookup) QueryAssetGroupByGroupKey(ctx context.Context,
 	groupKey *btcec.PublicKey) (*asset.AssetGroup, error) {
 
 	args := m.Called(ctx, groupKey)
@@ -467,7 +467,7 @@ func (m *mockAssetLookup) QueryAssetGroupByGroupKey(ctx context.Context,
 	return args.Get(0).(*asset.AssetGroup), args.Error(1)
 }
 
-func (m *mockAssetLookup) FetchAssetMetaForAsset(ctx context.Context,
+func (m *MockAssetLookup) FetchAssetMetaForAsset(ctx context.Context,
 	assetID asset.ID) (*proof.MetaReveal, error) {
 
 	args := m.Called(ctx, assetID)
@@ -477,7 +477,7 @@ func (m *mockAssetLookup) FetchAssetMetaForAsset(ctx context.Context,
 	return args.Get(0).(*proof.MetaReveal), args.Error(1)
 }
 
-func (m *mockAssetLookup) FetchInternalKeyLocator(ctx context.Context,
+func (m *MockAssetLookup) FetchInternalKeyLocator(ctx context.Context,
 	rawKey *btcec.PublicKey) (keychain.KeyLocator, error) {
 
 	args := m.Called(ctx, rawKey)

--- a/universe/supplycommit/state_machine_test.go
+++ b/universe/supplycommit/state_machine_test.go
@@ -121,7 +121,7 @@ type supplyCommitTestHarness struct {
 	env          *Environment
 
 	mockTreeView     *mockSupplyTreeView
-	mockCommits      *mockCommitmentTracker
+	mockCommits      *MockCommitmentTracker
 	mockWallet       *mockWallet
 	mockKeyRing      *mockKeyRing
 	mockChain        *mockChainBridge
@@ -129,7 +129,7 @@ type supplyCommitTestHarness struct {
 	mockCache        *mockIgnoreCheckerCache
 	mockDaemon       *mockDaemonAdapters
 	mockErrReporter  *mockErrorReporter
-	mockAssetLookup  *mockAssetLookup
+	MockAssetLookup  *MockAssetLookup
 	mockSupplySyncer *mockSupplySyncer
 
 	stateSub protofsm.StateSubscriber[Event, *Environment]
@@ -139,7 +139,7 @@ func newSupplyCommitTestHarness(t *testing.T,
 	cfg *harnessCfg) *supplyCommitTestHarness {
 
 	mTreeView := &mockSupplyTreeView{}
-	mCommits := &mockCommitmentTracker{}
+	mCommits := &MockCommitmentTracker{}
 	mWallet := &mockWallet{}
 	mKey := &mockKeyRing{}
 	mChain := &mockChainBridge{}
@@ -147,7 +147,7 @@ func newSupplyCommitTestHarness(t *testing.T,
 	mDaemon := newMockDaemonAdapters()
 	mErrReporter := &mockErrorReporter{}
 	mCache := &mockIgnoreCheckerCache{}
-	mAssetLookup := &mockAssetLookup{}
+	mAssetLookup := &MockAssetLookup{}
 	mSupplySyncer := &mockSupplySyncer{}
 
 	env := &Environment{
@@ -190,7 +190,7 @@ func newSupplyCommitTestHarness(t *testing.T,
 		mockCache:        mCache,
 		mockDaemon:       mDaemon,
 		mockErrReporter:  mErrReporter,
-		mockAssetLookup:  mAssetLookup,
+		MockAssetLookup:  mAssetLookup,
 		mockSupplySyncer: mSupplySyncer,
 	}
 
@@ -552,7 +552,7 @@ func (h *supplyCommitTestHarness) expectAssetLookup() {
 		},
 	}
 
-	h.mockAssetLookup.On(
+	h.MockAssetLookup.On(
 		"QueryAssetGroupByGroupKey", mock.Anything, mock.Anything,
 	).Return(dummyAssetGroup, nil).Maybe()
 
@@ -562,7 +562,7 @@ func (h *supplyCommitTestHarness) expectAssetLookup() {
 		Type: proof.MetaOpaque,
 	}
 
-	h.mockAssetLookup.On(
+	h.MockAssetLookup.On(
 		"FetchAssetMetaForAsset", mock.Anything, mock.Anything,
 	).Return(dummyMetaReveal, nil).Maybe()
 }

--- a/universe/supplyverifier/manager.go
+++ b/universe/supplyverifier/manager.go
@@ -551,13 +551,12 @@ func (m *Manager) InsertSupplyCommit(ctx context.Context,
 		commitment.CommitPoint().String())
 
 	// Fetch all known unspent pre-commitment outputs for the asset group.
-	unspentPreCommits, err :=
-		m.cfg.SupplyCommitView.UnspentPrecommits(
-			ctx, assetSpec, false,
-		).Unpack()
+	preCommits, err := FetchPreCommits(ctx,
+		m.cfg.AssetLookup, m.cfg.SupplyCommitView, assetSpec,
+		commitment, leaves.IssuanceLeafEntries,
+	)
 	if err != nil {
-		return fmt.Errorf("unable to fetch unspent pre-commitments: %w",
-			err)
+		return fmt.Errorf("unable to fetch pre-commitments: %w", err)
 	}
 
 	// First, we verify the supply commitment to ensure it is valid and
@@ -578,7 +577,7 @@ func (m *Manager) InsertSupplyCommit(ctx context.Context,
 	}
 
 	err = verifier.VerifyCommit(
-		ctx, assetSpec, commitment, leaves, unspentPreCommits,
+		ctx, assetSpec, commitment, leaves, preCommits,
 	)
 	if err != nil {
 		return fmt.Errorf("supply commitment verification failed: %w",
@@ -586,7 +585,7 @@ func (m *Manager) InsertSupplyCommit(ctx context.Context,
 	}
 
 	return m.cfg.SupplyCommitView.InsertSupplyCommit(
-		ctx, assetSpec, commitment, leaves, unspentPreCommits,
+		ctx, assetSpec, commitment, leaves, preCommits,
 	)
 }
 

--- a/universe/supplyverifier/mock.go
+++ b/universe/supplyverifier/mock.go
@@ -1,0 +1,76 @@
+package supplyverifier
+
+import (
+	"context"
+
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/taproot-assets/asset"
+	"github.com/lightninglabs/taproot-assets/universe/supplycommit"
+	lfn "github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/stretchr/testify/mock"
+)
+
+// MockSupplyCommitView is a mock implementation of the SupplyCommitView
+// interface.
+type MockSupplyCommitView struct {
+	mock.Mock
+}
+
+func (m *MockSupplyCommitView) UnspentPrecommits(ctx context.Context,
+	assetSpec asset.Specifier,
+	localIssuerOnly bool) lfn.Result[supplycommit.PreCommits] {
+
+	args := m.Called(ctx, assetSpec, localIssuerOnly)
+	return args.Get(0).(lfn.Result[supplycommit.PreCommits])
+}
+
+func (m *MockSupplyCommitView) FetchStartingCommitment(ctx context.Context,
+	assetSpec asset.Specifier) (*supplycommit.RootCommitment, error) {
+
+	args := m.Called(ctx, assetSpec)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*supplycommit.RootCommitment), args.Error(1)
+}
+
+func (m *MockSupplyCommitView) FetchLatestCommitment(ctx context.Context,
+	assetSpec asset.Specifier) (*supplycommit.RootCommitment, error) {
+
+	args := m.Called(ctx, assetSpec)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*supplycommit.RootCommitment), args.Error(1)
+}
+
+func (m *MockSupplyCommitView) FetchCommitmentByOutpoint(ctx context.Context,
+	assetSpec asset.Specifier,
+	outpoint wire.OutPoint) (*supplycommit.RootCommitment, error) {
+
+	args := m.Called(ctx, assetSpec, outpoint)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*supplycommit.RootCommitment), args.Error(1)
+}
+
+func (m *MockSupplyCommitView) FetchCommitmentBySpentOutpoint(
+	ctx context.Context, assetSpec asset.Specifier,
+	spentOutpoint wire.OutPoint) (*supplycommit.RootCommitment, error) {
+
+	args := m.Called(ctx, assetSpec, spentOutpoint)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*supplycommit.RootCommitment), args.Error(1)
+}
+
+func (m *MockSupplyCommitView) InsertSupplyCommit(ctx context.Context,
+	assetSpec asset.Specifier, commit supplycommit.RootCommitment,
+	leaves supplycommit.SupplyLeaves,
+	unspentPreCommits supplycommit.PreCommits) error {
+
+	args := m.Called(ctx, assetSpec, commit, leaves, unspentPreCommits)
+	return args.Error(0)
+}

--- a/universe/supplyverifier/util.go
+++ b/universe/supplyverifier/util.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/lightninglabs/taproot-assets/asset"
+	"github.com/lightninglabs/taproot-assets/fn"
 	"github.com/lightninglabs/taproot-assets/universe/supplycommit"
 )
 
@@ -32,4 +33,95 @@ func FetchDelegationKey(ctx context.Context,
 	}
 
 	return delegationKey, nil
+}
+
+// FetchPreCommits returns all pre-commitment outputs expected to be spent by
+// the anchoring transaction of the specified supply commitment.
+func FetchPreCommits(ctx context.Context,
+	assetLookup supplycommit.AssetLookup, supplyCommitView SupplyCommitView,
+	assetSpec asset.Specifier, supplyCommit supplycommit.RootCommitment,
+	mintEvents []supplycommit.NewMintEvent) ([]supplycommit.PreCommitment,
+	error) {
+
+	// Get supply commit block height. This will be used to filter out any
+	// pre-commitments that are above the supply commitment height.
+	chainCommit, err := supplyCommit.CommitmentBlock.UnwrapOrErr(
+		fmt.Errorf("commitment block missing"),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("unable to extract supply commitment "+
+			"chain block: %w", err)
+	}
+	supplyCommitBlockHeight := chainCommit.Height
+
+	// Fetch all known unspent pre-commitment outputs for the asset
+	// group.
+	preCommits, err := supplyCommitView.UnspentPrecommits(
+		ctx, assetSpec, false,
+	).Unpack()
+	if err != nil {
+		return nil, fmt.Errorf("unable to fetch unspent "+
+			"pre-commitments: %w", err)
+	}
+
+	// Filter out any pre-commitments that are above the supply commitment
+	// height. These can't be spent by the current supply commitment.
+	filteredPreCommits := make(
+		[]supplycommit.PreCommitment, 0, len(preCommits),
+	)
+	for _, pc := range preCommits {
+		if pc.BlockHeight <= supplyCommitBlockHeight {
+			filteredPreCommits = append(filteredPreCommits, pc)
+		}
+	}
+	preCommits = filteredPreCommits
+
+	// If there are no mint events, then we can return early here because
+	// there won't be any new pre-commitments to consider.
+	if len(mintEvents) == 0 {
+		return preCommits, nil
+	}
+
+	// We'll need the delegation key to extract any new pre-commitments from
+	// the mint events.
+	delegationKey, err := FetchDelegationKey(
+		ctx, assetLookup, assetSpec,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("unable to fetch delegation key: %w",
+			err)
+	}
+
+	// Create a set of outpoints from all known pre-commits. This will be
+	// used to prevent duplicates when adding new pre-commits from the mint
+	// events.
+	preCommitOutPoints := fn.NewSet(fn.Map(
+		preCommits, func(preCommit supplycommit.PreCommitment) string {
+			return preCommit.OutPoint().String()
+		},
+	)...)
+
+	// Collect pre-commitments from the mint events that we haven't already
+	// seen.
+	for idx := range mintEvents {
+		mintEvent := mintEvents[idx]
+
+		preCommit, err := supplycommit.NewPreCommitFromMintEvent(
+			mintEvent, delegationKey,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("unable to extract "+
+				"pre-commitment from mint event: %w", err)
+		}
+
+		// If we already have this pre-commitment, then skip it.
+		op := preCommit.OutPoint()
+		if preCommitOutPoints.Contains(op.String()) {
+			continue
+		}
+
+		preCommits = append(preCommits, preCommit)
+	}
+
+	return preCommits, nil
 }

--- a/universe/supplyverifier/util.go
+++ b/universe/supplyverifier/util.go
@@ -1,0 +1,35 @@
+package supplyverifier
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/lightninglabs/taproot-assets/asset"
+	"github.com/lightninglabs/taproot-assets/universe/supplycommit"
+)
+
+// FetchDelegationKey fetches the delegation key for the given asset specifier.
+func FetchDelegationKey(ctx context.Context,
+	assetLookup supplycommit.AssetLookup,
+	assetSpec asset.Specifier) (btcec.PublicKey, error) {
+
+	var zero btcec.PublicKey
+
+	metaReveal, err := supplycommit.FetchLatestAssetMetadata(
+		ctx, assetLookup, assetSpec,
+	)
+	if err != nil {
+		return zero, fmt.Errorf("unable to fetch asset "+
+			"metadata: %w", err)
+	}
+
+	delegationKey, err := metaReveal.DelegationKey.UnwrapOrErr(
+		fmt.Errorf("missing delegation key in asset metadata"),
+	)
+	if err != nil {
+		return zero, err
+	}
+
+	return delegationKey, nil
+}

--- a/universe/supplyverifier/util_test.go
+++ b/universe/supplyverifier/util_test.go
@@ -1,0 +1,779 @@
+package supplyverifier
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/taproot-assets/asset"
+	"github.com/lightninglabs/taproot-assets/fn"
+	"github.com/lightninglabs/taproot-assets/proof"
+	"github.com/lightninglabs/taproot-assets/tapgarden"
+	"github.com/lightninglabs/taproot-assets/universe"
+	"github.com/lightninglabs/taproot-assets/universe/supplycommit"
+	lfn "github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/lightningnetwork/lnd/keychain"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// createTestPreCommitment creates a test pre-commitment for testing.
+func createTestPreCommitment(t *testing.T, blockHeight uint32, txIndex uint32,
+	outIdx uint32) supplycommit.PreCommitment {
+
+	t.Helper()
+
+	tx := &wire.MsgTx{
+		Version: 2,
+		TxIn: []*wire.TxIn{{
+			PreviousOutPoint: wire.OutPoint{
+				Hash:  chainhash.Hash{},
+				Index: 0,
+			},
+		}},
+		TxOut: []*wire.TxOut{{
+			Value:    1000,
+			PkScript: []byte{0x51},
+		}},
+	}
+
+	privKey, err := btcec.NewPrivateKey()
+	if err != nil {
+		t.Fatalf("failed to create private key: %v", err)
+	}
+	internalKey := keychain.KeyDescriptor{
+		PubKey: privKey.PubKey(),
+		KeyLocator: keychain.KeyLocator{
+			Family: keychain.KeyFamily(1),
+			Index:  txIndex,
+		},
+	}
+
+	groupPrivKey, err := btcec.NewPrivateKey()
+	if err != nil {
+		t.Fatalf("failed to create group private key: %v", err)
+	}
+
+	return supplycommit.PreCommitment{
+		BlockHeight: blockHeight,
+		MintingTxn:  tx,
+		OutIdx:      outIdx,
+		InternalKey: internalKey,
+		GroupPubKey: *groupPrivKey.PubKey(),
+	}
+}
+
+// createTestRootCommitment creates a test root commitment for testing.
+func createTestRootCommitment(t *testing.T,
+	blockHeight uint32) supplycommit.RootCommitment {
+
+	t.Helper()
+
+	tx := &wire.MsgTx{
+		Version: 2,
+		TxIn: []*wire.TxIn{{
+			PreviousOutPoint: wire.OutPoint{
+				Hash:  chainhash.Hash{},
+				Index: 0,
+			},
+		}},
+		TxOut: []*wire.TxOut{{
+			Value:    1000,
+			PkScript: []byte{0x51},
+		}},
+	}
+
+	privKey, err := btcec.NewPrivateKey()
+	if err != nil {
+		t.Fatalf("failed to create private key: %v", err)
+	}
+	internalKey := keychain.KeyDescriptor{
+		PubKey: privKey.PubKey(),
+		KeyLocator: keychain.KeyLocator{
+			Family: keychain.KeyFamily(1),
+			Index:  0,
+		},
+	}
+
+	commitmentBlock := supplycommit.CommitmentBlock{
+		Height:    blockHeight,
+		Hash:      chainhash.Hash{},
+		TxIndex:   0,
+		ChainFees: 1000,
+	}
+
+	return supplycommit.RootCommitment{
+		Txn:             tx,
+		TxOutIdx:        0,
+		InternalKey:     internalKey,
+		OutputKey:       privKey.PubKey(),
+		CommitmentBlock: fn.Some(commitmentBlock),
+		SpentCommitment: fn.None[wire.OutPoint](),
+	}
+}
+
+// createTestAssetSpec creates a test asset specifier for testing.
+func createTestAssetSpec(t *testing.T) asset.Specifier {
+	t.Helper()
+
+	privKey, err := btcec.NewPrivateKey()
+	if err != nil {
+		t.Fatalf("failed to create private key: %v", err)
+	}
+
+	return asset.NewSpecifierFromGroupKey(*privKey.PubKey())
+}
+
+// createTestDelegationKey creates a test delegation key for testing.
+func createTestDelegationKey(t *testing.T) btcec.PublicKey {
+	t.Helper()
+
+	privKey, err := btcec.NewPrivateKey()
+	if err != nil {
+		t.Fatalf("failed to create private key: %v", err)
+	}
+	return *privKey.PubKey()
+}
+
+// createTestMetaReveal creates a test meta reveal with delegation key for
+// testing.
+func createTestMetaReveal(t *testing.T) *proof.MetaReveal {
+	t.Helper()
+
+	delegationKey := createTestDelegationKey(t)
+	return &proof.MetaReveal{
+		Data:          []byte("test-metadata"),
+		Type:          proof.MetaOpaque,
+		DelegationKey: fn.Some(delegationKey),
+	}
+}
+
+// createTestMetaRevealWithKey creates a test MetaReveal with a specific
+// delegation key.
+func createTestMetaRevealWithKey(t *testing.T,
+	delegationKey *btcec.PublicKey) *proof.MetaReveal {
+
+	t.Helper()
+
+	return &proof.MetaReveal{
+		Data:          []byte("test-metadata"),
+		Type:          proof.MetaOpaque,
+		DelegationKey: fn.Some(*delegationKey),
+	}
+}
+
+// createTestMintEvent creates a test mint event for testing.
+// Note: This creates a minimal mint event that will fail processing due to
+// missing RawProof, which is useful for testing error conditions.
+func createTestMintEvent(t *testing.T,
+	blockHeight uint32) supplycommit.NewMintEvent {
+
+	t.Helper()
+
+	privKey, err := btcec.NewPrivateKey()
+	if err != nil {
+		t.Fatalf("failed to create private key: %v", err)
+	}
+	scriptKey := privKey.PubKey()
+
+	outpoint := wire.OutPoint{
+		Hash:  chainhash.Hash{1, 2, 3},
+		Index: 0,
+	}
+
+	assetGenesis := asset.Genesis{
+		FirstPrevOut: wire.OutPoint{
+			Hash:  chainhash.Hash{},
+			Index: 0,
+		},
+		Tag:         "test-asset",
+		OutputIndex: 0,
+		Type:        asset.Normal,
+	}
+
+	assetID := assetGenesis.ID()
+	testAsset := &asset.Asset{
+		Version:   asset.V0,
+		Genesis:   assetGenesis,
+		Amount:    1000,
+		ScriptKey: asset.NewScriptKey(scriptKey),
+		GroupKey:  nil,
+	}
+
+	// Create the issuance proof (without RawProof, so it will fail
+	// processing).
+	issuanceProof := universe.Leaf{
+		GenesisWithGroup: universe.GenesisWithGroup{
+			Genesis: assetGenesis,
+		},
+		Asset: testAsset,
+		Amt:   testAsset.Amount,
+		// RawProof is intentionally omitted to test error handling.
+	}
+
+	leafKey := universe.AssetLeafKey{
+		BaseLeafKey: universe.BaseLeafKey{
+			OutPoint:  outpoint,
+			ScriptKey: &asset.ScriptKey{PubKey: scriptKey},
+		},
+		AssetID: assetID,
+	}
+
+	return supplycommit.NewMintEvent{
+		LeafKey:       leafKey,
+		IssuanceProof: issuanceProof,
+		MintHeight:    blockHeight,
+	}
+}
+
+// createTestValidMintEvent creates a valid mint event.
+func createTestValidMintEvent(t *testing.T, blockHeight uint32,
+	delegationKey *btcec.PublicKey) supplycommit.NewMintEvent {
+
+	t.Helper()
+
+	privKey, err := btcec.NewPrivateKey()
+	if err != nil {
+		t.Fatalf("failed to create private key: %v", err)
+	}
+	scriptKey := privKey.PubKey()
+
+	outpoint := wire.OutPoint{
+		Hash:  chainhash.Hash{1, 2, 3},
+		Index: 0,
+	}
+
+	assetGenesis := asset.Genesis{
+		FirstPrevOut: wire.OutPoint{
+			Hash:  chainhash.Hash{},
+			Index: 0,
+		},
+		Tag:         "test-asset",
+		OutputIndex: 0,
+		Type:        asset.Normal,
+	}
+
+	// Create the pre-commitment output that matches what
+	// tapgarden.PreCommitTxOut would create.
+	preCommitTxOut, err := tapgarden.PreCommitTxOut(*delegationKey)
+	if err != nil {
+		t.Fatalf("failed to create pre-commit tx out: %v", err)
+	}
+
+	// Create an anchor transaction that includes the pre-commitment output.
+	anchorTx := &wire.MsgTx{
+		Version: 2,
+		TxIn: []*wire.TxIn{{
+			PreviousOutPoint: wire.OutPoint{
+				Hash:  chainhash.Hash{},
+				Index: 0,
+			},
+		}},
+		TxOut: []*wire.TxOut{
+			// First output: the pre-commitment output that matches
+			// the delegation key.
+			&preCommitTxOut,
+			// Second output: a dummy output for the asset.
+			{
+				Value:    1000,
+				PkScript: []byte{0x51},
+			},
+		},
+	}
+
+	block := wire.MsgBlock{
+		Header: wire.BlockHeader{
+			Version:    1,
+			PrevBlock:  chainhash.Hash{},
+			MerkleRoot: chainhash.Hash{},
+			Timestamp:  time.Unix(1234567890, 0),
+			Bits:       0x207fffff,
+		},
+		Transactions: []*wire.MsgTx{anchorTx},
+	}
+
+	// Create a valid proof using proof.RandProof, but we need to modify
+	// the anchor transaction to have the correct structure.
+	validProof := proof.RandProof(t, assetGenesis, scriptKey, block, 0, 1)
+
+	// Replace the anchor transaction in the proof with our custom one
+	// that has the correct pre-commitment output.
+	validProof.AnchorTx = *anchorTx
+
+	var proofBuf bytes.Buffer
+	err = validProof.Encode(&proofBuf)
+	if err != nil {
+		t.Fatalf("failed to encode proof: %v", err)
+	}
+
+	assetID := assetGenesis.ID()
+	testAsset := &asset.Asset{
+		Version:   asset.V0,
+		Genesis:   assetGenesis,
+		Amount:    1000,
+		ScriptKey: asset.NewScriptKey(scriptKey),
+		GroupKey:  nil,
+	}
+
+	issuanceProof := universe.Leaf{
+		GenesisWithGroup: universe.GenesisWithGroup{
+			Genesis: assetGenesis,
+		},
+		Asset:    testAsset,
+		Amt:      testAsset.Amount,
+		RawProof: proofBuf.Bytes(),
+	}
+
+	leafKey := universe.AssetLeafKey{
+		BaseLeafKey: universe.BaseLeafKey{
+			OutPoint:  outpoint,
+			ScriptKey: &asset.ScriptKey{PubKey: scriptKey},
+		},
+		AssetID: assetID,
+	}
+
+	return supplycommit.NewMintEvent{
+		LeafKey:       leafKey,
+		IssuanceProof: issuanceProof,
+		MintHeight:    blockHeight,
+	}
+}
+
+// TestFetchPreCommits tests the FetchPreCommits function with various
+// scenarios.
+func TestFetchPreCommits(t *testing.T) {
+	ctx := context.Background()
+	assetSpec := createTestAssetSpec(t)
+
+	// Create a single delegation key to use consistently throughout test
+	// cases.
+	delegationKey := createTestDelegationKey(t)
+
+	tests := []struct {
+		name       string
+		setupMocks func(
+			*supplycommit.MockAssetLookup,
+			*MockSupplyCommitView,
+		)
+		supplyCommit supplycommit.RootCommitment
+		mintEvents   []supplycommit.NewMintEvent
+		expectedLen  int
+		expectError  bool
+	}{
+		{
+			name: "successful fetch with no mint events",
+			setupMocks: func(
+				assetLookup *supplycommit.MockAssetLookup,
+				commitView *MockSupplyCommitView,
+			) {
+
+				// Create test pre-commitments.
+				preCommit1 := createTestPreCommitment(
+					t, 100, 0, 0,
+				)
+				preCommit2 := createTestPreCommitment(
+					t, 150, 1, 0,
+				)
+				preCommits := []supplycommit.PreCommitment{
+					preCommit1, preCommit2,
+				}
+
+				commitView.On(
+					"UnspentPrecommits", ctx, assetSpec,
+					false,
+				).Return(lfn.Ok(preCommits))
+			},
+			supplyCommit: createTestRootCommitment(t, 200),
+			mintEvents:   []supplycommit.NewMintEvent{},
+			expectedLen:  2,
+			expectError:  false,
+		},
+		{
+			name: "filter pre-commitments above supply commit " +
+				"height",
+			setupMocks: func(
+				assetLookup *supplycommit.MockAssetLookup,
+				commitView *MockSupplyCommitView,
+			) {
+
+				// Create test pre-commitments with mixed
+				// heights.
+				//
+				// Below height.
+				preCommit1 := createTestPreCommitment(
+					t, 100, 0, 0,
+				)
+
+				// Above height.
+				preCommit2 := createTestPreCommitment(
+					t, 250, 1, 0,
+				)
+
+				// Below height.
+				preCommit3 := createTestPreCommitment(
+					t, 150, 2, 0,
+				)
+
+				preCommits := []supplycommit.PreCommitment{
+					preCommit1, preCommit2, preCommit3,
+				}
+
+				commitView.On(
+					"UnspentPrecommits", ctx, assetSpec,
+					false,
+				).Return(lfn.Ok(preCommits))
+			},
+			supplyCommit: createTestRootCommitment(t, 200),
+			mintEvents:   []supplycommit.NewMintEvent{},
+			// Only preCommit1 and preCommit3 should remain.
+			expectedLen: 2,
+			expectError: false,
+		},
+		{
+			name: "supply commitment missing commitment block",
+			setupMocks: func(
+				assetLookup *supplycommit.MockAssetLookup,
+				commitView *MockSupplyCommitView) {
+
+				// No mocks needed as this should fail early
+			},
+			supplyCommit: func() supplycommit.RootCommitment {
+				commit := createTestRootCommitment(t, 200)
+				commit.CommitmentBlock =
+					fn.None[supplycommit.CommitmentBlock]()
+				return commit
+			}(),
+			mintEvents:  []supplycommit.NewMintEvent{},
+			expectedLen: 0,
+			expectError: true,
+		},
+		{
+			name: "unspent pre-commitments fetch error",
+			setupMocks: func(
+				assetLookup *supplycommit.MockAssetLookup,
+				commitView *MockSupplyCommitView,
+			) {
+
+				commitView.On(
+					"UnspentPrecommits", ctx, assetSpec,
+					false,
+				).Return(lfn.Err[supplycommit.PreCommits](
+					ErrCommitmentNotFound))
+			},
+			supplyCommit: createTestRootCommitment(t, 200),
+			mintEvents:   []supplycommit.NewMintEvent{},
+			expectedLen:  0,
+			expectError:  true,
+		},
+		{
+			name: "successful fetch with mint events",
+			setupMocks: func(
+				assetLookup *supplycommit.MockAssetLookup,
+				commitView *MockSupplyCommitView,
+			) {
+
+				// Create test pre-commitments.
+				preCommit1 := createTestPreCommitment(
+					t, 100, 0, 0,
+				)
+				preCommits := []supplycommit.PreCommitment{
+					preCommit1,
+				}
+
+				commitView.On(
+					"UnspentPrecommits", ctx, assetSpec,
+					false,
+				).Return(lfn.Ok(preCommits))
+
+				// Mock asset group fetch (needed by
+				// FetchLatestAssetMetadata).
+				dummyAssetGroup := &asset.AssetGroup{
+					Genesis: &asset.Genesis{
+						FirstPrevOut: wire.OutPoint{
+							Hash:  chainhash.Hash{},
+							Index: 0,
+						},
+						Tag:         "test-asset",
+						OutputIndex: 0,
+						Type:        asset.Normal,
+					},
+				}
+				assetLookup.On(
+					"QueryAssetGroupByGroupKey", ctx,
+					mock.Anything,
+				).Return(dummyAssetGroup, nil)
+
+				// Mock successful asset metadata fetch for
+				// delegation key. Use the same delegation key
+				// as in the mint event.
+				metaReveal := createTestMetaRevealWithKey(
+					t, &delegationKey,
+				)
+				assetLookup.On(
+					"FetchAssetMetaForAsset", ctx,
+					mock.AnythingOfType("asset.ID"),
+				).Return(metaReveal, nil)
+			},
+			supplyCommit: createTestRootCommitment(t, 200),
+			mintEvents: []supplycommit.NewMintEvent{
+				// This mint event has the correct anchor
+				// transaction structure with a pre-commitment
+				// output that matches the delegation key,
+				// allowing successful processing.
+				createTestValidMintEvent(
+					t, 150, &delegationKey,
+				),
+			},
+			// Original pre-commitment + new pre-commitment from
+			// successfully processed mint event.
+			expectedLen: 2,
+			expectError: false,
+		},
+		{
+			name: "mint event processing error",
+			setupMocks: func(
+				assetLookup *supplycommit.MockAssetLookup,
+				commitView *MockSupplyCommitView) {
+
+				// Create test pre-commitments.
+				preCommit1 := createTestPreCommitment(
+					t, 100, 0, 0,
+				)
+				preCommits := []supplycommit.PreCommitment{
+					preCommit1,
+				}
+
+				commitView.On(
+					"UnspentPrecommits", ctx, assetSpec,
+					false,
+				).Return(lfn.Ok(preCommits))
+
+				// Mock asset group fetch (needed by
+				// FetchLatestAssetMetadata).
+				dummyAssetGroup := &asset.AssetGroup{
+					Genesis: &asset.Genesis{
+						FirstPrevOut: wire.OutPoint{
+							Hash:  chainhash.Hash{},
+							Index: 0,
+						},
+						Tag:         "test-asset",
+						OutputIndex: 0,
+						Type:        asset.Normal,
+					},
+				}
+				assetLookup.On(
+					"QueryAssetGroupByGroupKey", ctx,
+					mock.Anything,
+				).Return(dummyAssetGroup, nil)
+
+				// Mock asset metadata fetch for delegation key.
+				metaReveal := createTestMetaReveal(t)
+				assetLookup.On(
+					"FetchAssetMetaForAsset", ctx,
+					mock.AnythingOfType("asset.ID"),
+				).Return(metaReveal, nil)
+			},
+			supplyCommit: createTestRootCommitment(t, 200),
+			mintEvents: []supplycommit.NewMintEvent{
+				// Below supply commit height.
+				createTestMintEvent(t, 150),
+			},
+			// Error in processing mint event.
+			expectedLen: 0,
+			expectError: true,
+		},
+		{
+			name: "delegation key fetch error with mint events",
+			setupMocks: func(
+				assetLookup *supplycommit.MockAssetLookup,
+				commitView *MockSupplyCommitView) {
+
+				// Create test pre-commitments.
+				preCommit1 := createTestPreCommitment(
+					t, 100, 0, 0,
+				)
+				preCommits := []supplycommit.PreCommitment{
+					preCommit1,
+				}
+
+				commitView.On("UnspentPrecommits", ctx,
+					assetSpec, false,
+				).Return(lfn.Ok(preCommits))
+
+				// Mock asset group fetch (needed by
+				// FetchLatestAssetMetadata).
+				assetLookup.On("QueryAssetGroupByGroupKey", ctx,
+					mock.Anything,
+				).Return(
+					(*asset.AssetGroup)(nil),
+					ErrCommitmentNotFound,
+				)
+			},
+			supplyCommit: createTestRootCommitment(t, 200),
+			mintEvents: []supplycommit.NewMintEvent{
+				// Below supply commit height.
+				createTestMintEvent(t, 150),
+			},
+			expectedLen: 0,
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create mocks.
+			mockAssetLookup := &supplycommit.MockAssetLookup{}
+			mockCommitView := &MockSupplyCommitView{}
+
+			// Setup mocks.
+			tt.setupMocks(mockAssetLookup, mockCommitView)
+
+			// Call the function under test.
+			result, err := FetchPreCommits(
+				ctx, mockAssetLookup, mockCommitView, assetSpec,
+				tt.supplyCommit, tt.mintEvents,
+			)
+
+			// Check error expectation.
+			if tt.expectError {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Len(t, result, tt.expectedLen)
+
+			// Verify all mock expectations were met.
+			mockAssetLookup.AssertExpectations(t)
+			mockCommitView.AssertExpectations(t)
+		})
+	}
+}
+
+// TestFetchDelegationKey tests the FetchDelegationKey function.
+func TestFetchDelegationKey(t *testing.T) {
+	ctx := context.Background()
+	assetSpec := createTestAssetSpec(t)
+
+	tests := []struct {
+		name        string
+		setupMocks  func(*supplycommit.MockAssetLookup)
+		expectError bool
+	}{
+		{
+			name: "successful delegation key fetch",
+			setupMocks: func(
+				assetLookup *supplycommit.MockAssetLookup,
+			) {
+
+				// Mock asset group fetch (needed by
+				// FetchLatestAssetMetadata).
+				dummyAssetGroup := &asset.AssetGroup{
+					Genesis: &asset.Genesis{
+						FirstPrevOut: wire.OutPoint{
+							Hash:  chainhash.Hash{},
+							Index: 0,
+						},
+						Tag:         "test-asset",
+						OutputIndex: 0,
+						Type:        asset.Normal,
+					},
+				}
+				assetLookup.On("QueryAssetGroupByGroupKey", ctx,
+					mock.Anything,
+				).Return(dummyAssetGroup, nil)
+
+				metaReveal := createTestMetaReveal(t)
+				assetLookup.On(
+					"FetchAssetMetaForAsset", ctx,
+					mock.AnythingOfType("asset.ID"),
+				).Return(metaReveal, nil)
+			},
+			expectError: false,
+		},
+		{
+			name: "asset metadata fetch error",
+			setupMocks: func(
+				assetLookup *supplycommit.MockAssetLookup,
+			) {
+
+				assetLookup.On(
+					"QueryAssetGroupByGroupKey", ctx,
+					mock.Anything,
+				).Return(
+					(*asset.AssetGroup)(nil),
+					ErrCommitmentNotFound,
+				)
+			},
+			expectError: true,
+		},
+		{
+			name: "missing delegation key",
+			setupMocks: func(
+				assetLookup *supplycommit.MockAssetLookup,
+			) {
+
+				// Mock asset group fetch (needed by
+				// FetchLatestAssetMetadata).
+				dummyAssetGroup := &asset.AssetGroup{
+					Genesis: &asset.Genesis{
+						FirstPrevOut: wire.OutPoint{
+							Hash:  chainhash.Hash{},
+							Index: 0,
+						},
+						Tag:         "test-asset",
+						OutputIndex: 0,
+						Type:        asset.Normal,
+					},
+				}
+				assetLookup.On(
+					"QueryAssetGroupByGroupKey", ctx,
+					mock.Anything,
+				).Return(dummyAssetGroup, nil)
+
+				pk := fn.None[btcec.PublicKey]()
+				metaReveal := &proof.MetaReveal{
+					Data:          []byte("test-metadata"),
+					Type:          proof.MetaOpaque,
+					DelegationKey: pk,
+				}
+				assetLookup.On(
+					"FetchAssetMetaForAsset", ctx,
+					mock.AnythingOfType("asset.ID"),
+				).Return(metaReveal, nil)
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create mock.
+			mockAssetLookup := &supplycommit.MockAssetLookup{}
+
+			// Setup mock.
+			tt.setupMocks(mockAssetLookup)
+
+			// Call the function under test.
+			result, err := FetchDelegationKey(
+				ctx, mockAssetLookup, assetSpec,
+			)
+
+			// Check error expectation.
+			if tt.expectError {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, result)
+
+			// Verify all mock expectations were met.
+			mockAssetLookup.AssertExpectations(t)
+		})
+	}
+}

--- a/universe/supplyverifier/verifier.go
+++ b/universe/supplyverifier/verifier.go
@@ -727,30 +727,6 @@ func (v *Verifier) verifySupplyLeaves(ctx context.Context,
 	return nil
 }
 
-// fetchDelegationKey fetches the delegation key for the given asset specifier.
-func (v *Verifier) fetchDelegationKey(ctx context.Context,
-	assetSpec asset.Specifier) (btcec.PublicKey, error) {
-
-	var zero btcec.PublicKey
-
-	metaReveal, err := supplycommit.FetchLatestAssetMetadata(
-		ctx, v.cfg.AssetLookup, assetSpec,
-	)
-	if err != nil {
-		return zero, fmt.Errorf("unable to fetch asset "+
-			"metadata: %w", err)
-	}
-
-	delegationKey, err := metaReveal.DelegationKey.UnwrapOrErr(
-		fmt.Errorf("missing delegation key in asset metadata"),
-	)
-	if err != nil {
-		return zero, err
-	}
-
-	return delegationKey, nil
-}
-
 // VerifyCommit verifies a supply commitment for a given asset group.
 // Verification succeeds only if all previous supply commitment dependencies
 // are known and verified. The dependency chain must be traceable back to the
@@ -801,7 +777,9 @@ func (v *Verifier) VerifyCommit(ctx context.Context,
 			"commitment with given outpoint: %w", err)
 	}
 
-	delegationKey, err := v.fetchDelegationKey(ctx, assetSpec)
+	delegationKey, err := FetchDelegationKey(
+		ctx, v.cfg.AssetLookup, assetSpec,
+	)
 	if err != nil {
 		return fmt.Errorf("unable to fetch delegation key: %w", err)
 	}

--- a/universe/supplyverifier/verifier.go
+++ b/universe/supplyverifier/verifier.go
@@ -813,6 +813,15 @@ func (v *Verifier) VerifyCommit(ctx context.Context,
 			"group when verifying supply commitment: %w", err)
 	}
 
+	// Verify that we have at least as many supply pre-commitments as
+	// new issuance leaves. Each issuance leaf must correspond to a
+	// pre-commitment output created at the time of asset issuance.
+	if len(unspentPreCommits) < len(leaves.IssuanceLeafEntries) {
+		return fmt.Errorf("not enough unspent supply pre-commitment "+
+			"outputs for issuance leaves: have %d, need %d",
+			len(unspentPreCommits), len(leaves.IssuanceLeafEntries))
+	}
+
 	// Perform validation of the provided supply leaves.
 	err = v.verifySupplyLeaves(ctx, assetSpec, delegationKey, leaves)
 	if err != nil {


### PR DESCRIPTION
Closes: https://github.com/lightninglabs/taproot-assets/issues/1811

This PR adds functionality to extract supply pre-commits directly from the mint leaves retrieved by the supply verifier during a sync pull of a supply commitment.

Previously, the supply verifier relied on the universe issuance syncer to obtain the full set of pre-commitments. This change removes that dependency, reducing the risk of a race condition where supply commitments were synced before the associated pre-commitments were available.