### PR TITLE
tapdb: error on dirty database versions

### DIFF
--- a/docs/release-notes/release-notes-0.7.0.md
+++ b/docs/release-notes/release-notes-0.7.0.md
@@ -53,6 +53,16 @@
   requiring a fully initialized AuxSweeper, allowing sweep operations to proceed
   during server startup.
 
+- [Ensure that tapd won't start if the latest db migration errors and sets the
+  db to a dirty state for sqlite database
+  backends](https://github.com/lightninglabs/taproot-assets/pull/1826).
+  If the latest migration errors and sets the db to a dirty state, startup of
+  tapd will now be prevented for all database backend types. Previously, this
+  safeguard did not work correctly for SQLite backends if the most recent
+  migration failed. Tapd could then still start even though the database was
+  dirty. This issue has been resolved, and the behavior is now consistent across
+  all database backend types.
+
 # New Features
 
 ## Functional Enhancements

--- a/tapdb/migrations.go
+++ b/tapdb/migrations.go
@@ -166,10 +166,18 @@ func applyMigrations(fs fs.FS, driver database.Driver, path, dbName string,
 		return err
 	}
 
-	migrationVersion, _, err := sqlMigrate.Version()
+	migrationVersion, dirty, err := sqlMigrate.Version()
 	if err != nil && !errors.Is(err, migrate.ErrNilVersion) {
 		return fmt.Errorf("unable to determine current migration "+
 			"version: %w", err)
+	}
+
+	// If the migration version is dirty, we should not proceed with further
+	// migrations, as this indicates that a previous migration did not
+	// complete successfully and requires manual intervention.
+	if dirty {
+		return fmt.Errorf("database is in a dirty state at version "+
+			"%v, manual intervention required", migrationVersion)
 	}
 
 	// As the down migrations may end up *dropping* data, we want to

--- a/tapdb/migrations.go
+++ b/tapdb/migrations.go
@@ -166,7 +166,11 @@ func applyMigrations(fs fs.FS, driver database.Driver, path, dbName string,
 		return err
 	}
 
-	migrationVersion, _, _ := sqlMigrate.Version()
+	migrationVersion, _, err := sqlMigrate.Version()
+	if err != nil && !errors.Is(err, migrate.ErrNilVersion) {
+		return fmt.Errorf("unable to determine current migration "+
+			"version: %w", err)
+	}
 
 	// As the down migrations may end up *dropping* data, we want to
 	// prevent that without explicit accounting.


### PR DESCRIPTION
This PR fixes 2 issues in the current handling of database migrations in `tapdb`:

1. The main issue resolved is that we add a check during startup to ensure that the database version is not dirty (i.e., the last migration did not complete successfully). If it is dirty, the application will now always exit with an error.
This is done to resolve a bug that would occur when the migration with the  **latest** migration version failed. In that scenario, the database version would correctly be marked as dirty and exit with an error. However, under `sqlite` database backends, when `tapd` was restarted, the dirty database version would never be checked and `tapd` would start up normally, despite the database being in a dirty state. This is due to the check here: https://github.com/lightninglabs/taproot-assets/blob/0ddb08670f59e41e7edb2925a49df18d2124598e/tapdb/sqlite.go#L206-L213 In that scenario, since no migration is needed the migrate library is never called to perform any potential migration. And since the dirty check is normally done in the migrate library during a migration, it is never performed in that scenario.

2. Secondly, we add checking of an error that was previously unchecked.