### PR TITLE
rfq+server: properly configure gRPC keep alive settings for client+server

### DIFF
--- a/rfq/oracle.go
+++ b/rfq/oracle.go
@@ -18,6 +18,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/keepalive"
 )
 
 // PriceQueryIntent is an enum that represents the intent of a price rate
@@ -196,6 +197,21 @@ func serverDialOpts() ([]grpc.DialOption, error) {
 	transportCredentials := credentials.NewTLS(&tlsConfig)
 	opts = append(opts, grpc.WithTransportCredentials(transportCredentials))
 
+	// Configure client-side keepalive parameters. These settings ensure
+	// the client actively probes the connection health and prevents idle
+	// connections from being silently closed by intermediaries or the
+	// server.
+	opts = append(opts, grpc.WithKeepaliveParams(keepalive.ClientParameters{
+		// Ping server after 30 seconds of inactivity.
+		Time: 30 * time.Second,
+		// Wait 20 seconds for ping response.
+		Timeout: 20 * time.Second,
+		// Permit keepalive pings even when there are no active
+		// streams. This is critical for long-lived connections with
+		// infrequent RFQ requests.
+		PermitWithoutStream: true,
+	}))
+
 	return opts, nil
 }
 
@@ -208,6 +224,21 @@ func insecureServerDialOpts() ([]grpc.DialOption, error) {
 	opts = append(opts, grpc.WithTransportCredentials(
 		insecure.NewCredentials(),
 	))
+
+	// Configure client-side keepalive parameters. These settings ensure
+	// the client actively probes the connection health and prevents idle
+	// connections from being silently closed by intermediaries or the
+	// server.
+	opts = append(opts, grpc.WithKeepaliveParams(keepalive.ClientParameters{
+		// Ping server after 30 seconds of inactivity.
+		Time: 30 * time.Second,
+		// Wait 20 seconds for ping response.
+		Timeout: 20 * time.Second,
+		// Permit keepalive pings even when there are no active
+		// streams. This is critical for long-lived connections with
+		// infrequent RFQ requests.
+		PermitWithoutStream: true,
+	}))
 
 	return opts, nil
 }


### PR DESCRIPTION
## Problem

Users were experiencing "connection reset by peer" errors when using the RFQ system with price oracle servers (issue #1814). The core problem manifested when:

1. An edge node establishes a connection to a price oracle server
2. The connection sits idle between RFQ price queries (potentially for minutes or hours)
3. The network layer silently closes the idle connection without sending a proper GOAWAY frame
4. The client remains unaware of the broken connection
5. The next RFQ request fails immediately with "connection reset by peer"
6. A retry succeeds because it establishes a fresh connection

This created a poor user experience where the first payment attempt after an idle period would always fail, requiring manual retries.

## Root Cause

The issue had two contributing factors:

**Missing Client-Side Keepalive**: The RFQ price oracle client (`rfq/oracle.go`) had **no keepalive configuration at all**. Without active health probing, the client couldn't detect when connections were broken and wouldn't prevent intermediaries (NATs, load balancers, firewalls) from timing out idle connections.

**Aggressive Server-Side Timeout**: The tapd gRPC server only configured `MaxConnectionIdle: 2 minutes`, which would aggressively close any connection idle for more than 2 minutes. This is far too short for RFQ operations where price queries may be infrequent.

## Solution

We implemented comprehensive bidirectional keepalive configuration following the same pattern used by lnd:

### Client-Side Configuration (`rfq/oracle.go`)

Added to both `serverDialOpts()` and `insecureServerDialOpts()`:

```go
grpc.WithKeepaliveParams(keepalive.ClientParameters{
    Time:                30 * time.Second,  // Ping every 30s when idle
    Timeout:             20 * time.Second,  // Wait 20s for ping response
    PermitWithoutStream: true,              // Ping even without active RPCs
})
```

**Key Settings:**
- `Time: 30s` - Client sends a ping after 30 seconds of inactivity. This is frequent enough to keep connections alive through most intermediaries while being conservative with network resources.
- `Timeout: 20s` - If the server doesn't respond to a ping within 20 seconds, the connection is considered dead. This allows prompt detection of network issues.
- `PermitWithoutStream: true` - **Critical setting**. Allows pings even when no RPC calls are active. Without this, the client wouldn't send pings during idle periods, defeating the entire purpose.

### Server-Side Configuration (`server.go`)

Enhanced the existing minimal configuration with comprehensive settings:

```go
serverKeepalive := keepalive.ServerParameters{
    Time:              time.Minute,      // Ping clients every 1min when idle
    Timeout:           20 * time.Second, // Wait 20s for ping response
    MaxConnectionIdle: time.Hour * 24,   // Allow 24h of idle time
}

clientKeepalive := keepalive.EnforcementPolicy{
    MinTime:             5 * time.Second, // Min time between client pings
    PermitWithoutStream: true,            // Accept client pings without active RPCs
}
```

**Key Settings:**
- `Time: 1min` - Server actively pings clients every minute when idle. This provides server-initiated health checking.
- `Timeout: 20s` - Server waits 20 seconds for ping responses before considering the connection dead.
- `MaxConnectionIdle: 24h` - Extended from 2 minutes to 24 hours. Allows long-lived connections that are crucial for RFQ operations. The active pinging mechanism (via `Time` parameter) handles health checking, so we don't need aggressive idle timeouts.
- **EnforcementPolicy.PermitWithoutStream: true** - **Critical setting**. Tells the server to accept keepalive pings from clients even when there are no active RPC calls. Without this, the server would reject client pings on idle connections with a GOAWAY, breaking the client-side keepalive mechanism.
- `MinTime: 5s` - Prevents abusive clients from sending pings too frequently (DoS protection).

## How It Works

With these settings in place:

1. **During Idle Periods**: Both client and server send periodic pings (client every 30s, server every 1min) to verify the connection is still alive
2. **Network Issue Detection**: If a ping doesn't get a response within 20s, the connection is immediately closed and the application is notified
3. **Intermediary Keepalive**: The regular pings prevent NATs, load balancers, and firewalls from timing out the connection
4. **No Silent Failures**: Connections are never silently broken - either they work or they fail fast with proper notification



Fixes #1814
