### PR TITLE
proof+tapsend: sanity-check STXO proof structure at creation time

### DIFF
--- a/tapsend/proof_test.go
+++ b/tapsend/proof_test.go
@@ -37,10 +37,9 @@ func TestCreateProofSuffix(t *testing.T) {
 			stxoProof: true,
 		},
 		{
-			name:      "No stxo proof",
-			stxoProof: false,
-			expectedErr: "error verifying STXO proof: missing " +
-				"asset proof",
+			name:        "No stxo proof",
+			stxoProof:   false,
+			expectedErr: "no alt leaves for transfer root asset",
 		},
 	}
 	for _, tc := range testCases {
@@ -125,7 +124,14 @@ func createProofSuffix(t *testing.T, stxoProof bool, expectedErr string) {
 				outputCommitments, outIdx, testPackets,
 				proof.WithVersion(proof.TransitionV1),
 			)
-			require.NoError(t, err)
+			switch {
+			case err != nil:
+				require.Nil(t, proofSuffix)
+				require.ErrorContains(t, err, expectedErr)
+				continue
+			default:
+				require.NoError(t, err)
+			}
 
 			ctx := context.Background()
 			prev := &proof.AssetSnapshot{


### PR DESCRIPTION
Related to https://github.com/lightninglabs/taproot-assets/issues/1809

---

Add a sanity check to ensure STXO inclusion proofs are well-formed at the time of creation, rather than relying solely on validation later. This hardens the transition proof generation logic.