### PR TITLE
build: bump version to v0.7.0-rc2

### DIFF
--- a/version.go
+++ b/version.go
@@ -52,7 +52,7 @@ const (
 
 	// AppPreRelease defines the pre-release version of this binary.
 	// It MUST only contain characters from the semantic versioning spec.
-	AppPreRelease = "rc1"
+	AppPreRelease = "rc2"
 
 	// GitTagIncludeStatus indicates whether the status should be included
 	// in the git tag name.


### PR DESCRIPTION
Bumps to rc2 in version.go.