### PR TITLE
githubci: update Litd itest branch

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -21,7 +21,7 @@ env:
 
   GO_VERSION: '1.24.6'
   
-  LITD_ITEST_BRANCH: 'tapd-main-branch'
+  LITD_ITEST_BRANCH: 'master'
 
 jobs:
   #######################


### PR DESCRIPTION
### Description

With https://github.com/lightninglabs/lightning-terminal/pull/1155 merged we can now point our LiT itest CI back to the `master` branch of lightning-terminal.