### PR TITLE
build: bump version to v0.7.0

### DIFF
--- a/version.go
+++ b/version.go
@@ -52,7 +52,7 @@ const (
 
 	// AppPreRelease defines the pre-release version of this binary.
 	// It MUST only contain characters from the semantic versioning spec.
-	AppPreRelease = "rc2"
+	AppPreRelease = ""
 
 	// GitTagIncludeStatus indicates whether the status should be included
 	// in the git tag name.


### PR DESCRIPTION
Final prerequisite before creating `v0.7.0` release tag.

Once this PR is merged a tag can be added using command: `make release-tag`.