### PR TITLE
tapdb: introduce sqlTime helper

### DIFF
--- a/tapdb/addrs.go
+++ b/tapdb/addrs.go
@@ -761,10 +761,7 @@ func (t *TapAddressBook) SetAddrManaged(ctx context.Context,
 	var writeTxOpts AddrBookTxOptions
 	return t.db.ExecTx(ctx, &writeTxOpts, func(db AddrBook) error {
 		return db.SetAddrManaged(ctx, AddrManaged{
-			ManagedFrom: sql.NullTime{
-				Time:  managedFrom.UTC(),
-				Valid: true,
-			},
+			ManagedFrom: sqlTime(managedFrom.UTC()),
 			TaprootOutputKey: schnorr.SerializePubKey(
 				&addr.TaprootOutputKey,
 			),

--- a/tapdb/post_migration_checks.go
+++ b/tapdb/post_migration_checks.go
@@ -111,10 +111,7 @@ func determineAndAssignScriptKeyType(ctx context.Context,
 	// a list of the burn keys from the assets (because burn keys can only
 	// be calculated from the asset's witness).
 	assetFilter := QueryAssetFilters{
-		Now: sql.NullTime{
-			Time:  defaultClock.Now().UTC(),
-			Valid: true,
-		},
+		Now: sqlTime(defaultClock.Now().UTC()),
 	}
 	dbAssets, assetWitnesses, err := fetchAssetsWithWitness(
 		ctx, q, assetFilter,
@@ -235,10 +232,7 @@ func insertAssetBurns(ctx context.Context, q sqlc.Querier) error {
 	// a list of the burn keys from the assets (because burn keys can only
 	// be calculated from the asset's witness).
 	assetFilter := QueryAssetFilters{
-		Now: sql.NullTime{
-			Time:  defaultClock.Now().UTC(),
-			Valid: true,
-		},
+		Now: sqlTime(defaultClock.Now().UTC()),
 	}
 	dbAssets, assetWitnesses, err := fetchAssetsWithWitness(
 		ctx, q, assetFilter,

--- a/tapdb/sqlutils.go
+++ b/tapdb/sqlutils.go
@@ -97,6 +97,15 @@ func sqlStr(s string) sql.NullString {
 	}
 }
 
+// sqlTime turns a time.Time into the NullTime that sql/sqlc
+// uses when a time field can be permitted to be NULL.
+func sqlTime(t time.Time) sql.NullTime {
+	return sql.NullTime{
+		Time:  t,
+		Valid: true,
+	}
+}
+
 // SparseDecodeBlockHeight sparse decodes a proof to extract the block height.
 func SparseDecodeBlockHeight(rawProof []byte) (lfn.Option[uint32], error) {
 	var blockHeightVal uint32


### PR DESCRIPTION
Replace boilerplate code using sql.NullTime with helper sqlTime, reproducing pattern used with `sqlInt16`, `sqlBool`, etc.