### PR TITLE
itest: add test for invalid input proof rejection

### DIFF
--- a/itest/test_list_on_test.go
+++ b/itest/test_list_on_test.go
@@ -242,6 +242,10 @@ var allTestCases = []*testCase{
 		test: testPsbtRelativeLockTimeSendProofFail,
 	},
 	{
+		name: "psbt invalid input proof rejection",
+		test: testPsbtInvalidInputProofRejection,
+	},
+	{
 		name: "psbt normal interactive split send",
 		test: testPsbtNormalInteractiveSplitSend,
 	},


### PR DESCRIPTION
(N.b., I cribbed this one together while reviewing #1884 -- might be worth adding?)

Add a new icase, 'testPsbtInvalidInputProofRejection', that tests that pre-anchored send packages with corrupted input proofs are rejected as expected during the SendStateVerifyPreBroadcast state.