### PR TITLE
make: use Docker named volumes for ~10x faster local linting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,11 +51,28 @@ ifneq ($(workers),)
 LINT_WORKERS = --concurrency=$(workers)
 endif
 
+# Docker cache mounting strategy:
+# - CI (GitHub Actions): Use bind mounts to host paths that GA caches persist.
+# - Local: Use Docker named volumes (much faster on macOS/Windows due to
+#   avoiding slow host-syncing overhead).
+# Paths inside container must match GOCACHE/GOMODCACHE in tools/Dockerfile.
+ifdef CI
+# CI mode: bind mount to host paths that GitHub Actions caches.
 DOCKER_TOOLS = docker run \
-  -v $(shell bash -c "go env GOCACHE || (mkdir -p /tmp/go-cache; echo /tmp/go-cache)"):/tmp/build/.cache \
-  -v $(shell bash -c "go env GOMODCACHE || (mkdir -p /tmp/go-modcache; echo /tmp/go-modcache)"):/tmp/build/.modcache \
-  -v $(shell bash -c "mkdir -p /tmp/go-lint-cache; echo /tmp/go-lint-cache"):/root/.cache/golangci-lint \
+  --rm \
+  -v $${HOME}/.cache/go-build:/tmp/build/.cache \
+  -v $${HOME}/go/pkg/mod:/tmp/build/.modcache \
+  -v $${HOME}/.cache/golangci-lint:/root/.cache/golangci-lint \
   -v $$(pwd):/build taproot-assets-tools
+else
+# Local mode: Docker named volumes for fast macOS/Windows performance.
+DOCKER_TOOLS = docker run \
+  --rm \
+  -v tapd-go-build-cache:/tmp/build/.cache \
+  -v tapd-go-mod-cache:/tmp/build/.modcache \
+  -v tapd-go-lint-cache:/root/.cache/golangci-lint \
+  -v $$(pwd):/build taproot-assets-tools
+endif
 
 GO_VERSION = 1.24.9
 


### PR DESCRIPTION
This commit optimizes Docker cache mounting for the linter with a CI-aware strategy:

**Local development (macOS/Windows)**: Uses Docker named volumes which keep data inside Docker's native Linux filesystem, avoiding the slow host-syncing overhead of bind mounts. This yields ~10x faster linting on warm cache.

**CI (GitHub Actions)**: Uses bind mounts to host paths (`~/.cache/go-build`, `~/go/pkg/mod`) that GitHub Actions already caches via the setup-go action. This ensures CI benefits from cached dependencies across runs.

The Makefile detects CI mode via the `CI` environment variable that GitHub Actions sets automatically (since April 2020).

Local benchmark results:
- Baseline (old config): ~2m 21s
- Warm run (cached): ~14s (~10x faster)

Key improvements in warm runs:
- Go packages loading: 1m 35s → 10s
- Linters execution: 13.4s → 1.8s
- Total execution: 1m 49s → 12s