### PR TITLE
tapfreighter: pre-broadcast guard for split root witnesses

### DIFF
--- a/tapfreighter/chain_porter_test.go
+++ b/tapfreighter/chain_porter_test.go
@@ -6,7 +6,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btclog/v2"
+	"github.com/lightninglabs/taproot-assets/asset"
+	"github.com/lightninglabs/taproot-assets/tappsbt"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRunChainPorter(t *testing.T) {
@@ -18,4 +22,89 @@ func init() {
 
 	logger := btclog.NewSLogger(btclog.NewDefaultHandler(os.Stdout))
 	UseLogger(logger.SubSystem(Subsystem))
+}
+
+// TestVerifySplitCommitmentWitnesses exercises the split witness verifier with
+// table-driven vPacket fixtures.
+func TestVerifySplitCommitmentWitnesses(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name        string
+		vPkt        func() tappsbt.VPacket
+		expectError bool
+	}{
+		{
+			name: "split leaf with root witness passes",
+			vPkt: func() tappsbt.VPacket {
+				root := asset.Asset{
+					PrevWitnesses: []asset.Witness{{
+						PrevID:    &asset.ZeroPrevID,
+						TxWitness: wire.TxWitness{{1}},
+					}},
+				}
+
+				prevWitnesses := []asset.Witness{{
+					PrevID: &asset.ZeroPrevID,
+					SplitCommitment: &asset.SplitCommitment{
+						RootAsset: root,
+					},
+				}}
+				splitLeaf := &asset.Asset{
+					PrevWitnesses: prevWitnesses,
+				}
+
+				return tappsbt.VPacket{
+					Outputs: []*tappsbt.VOutput{{
+						Asset: splitLeaf,
+					}},
+				}
+			},
+			expectError: false,
+		},
+		{
+			name: "split leaf missing root witness fails",
+			vPkt: func() tappsbt.VPacket {
+				root := asset.Asset{
+					PrevWitnesses: []asset.Witness{{
+						PrevID:    &asset.ZeroPrevID,
+						TxWitness: wire.TxWitness{},
+					}},
+				}
+
+				prevWitnesses := []asset.Witness{{
+					PrevID: &asset.ZeroPrevID,
+					SplitCommitment: &asset.SplitCommitment{
+						RootAsset: root,
+					},
+				}}
+				splitLeaf := &asset.Asset{
+					PrevWitnesses: prevWitnesses,
+				}
+
+				return tappsbt.VPacket{
+					Outputs: []*tappsbt.VOutput{{
+						Asset: splitLeaf,
+					}},
+				}
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := verifySplitCommitmentWitnesses(tc.vPkt())
+			if tc.expectError {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
 }


### PR DESCRIPTION
This PR adds `ChainPorter` hardening following from this bug: https://github.com/lightninglabs/taproot-assets/pull/1897

Add a pre-broadcast verification step to ensure split leaf outputs embed a split root that carries a populated TxWitness, preventing invalid split commitments from being broadcast.