### PR TITLE
tapgarden: deep copy seedlings

### DIFF
--- a/tapgarden/planter_test.go
+++ b/tapgarden/planter_test.go
@@ -591,6 +591,11 @@ func (t *mintingTestHarness) finalizeBatchAssertFrozen(
 	t.finalizeBatch(&wg, respChan, nil)
 
 	if noBatch {
+		// Wait for the FinalizeBatch goroutine to complete before
+		// returning. This prevents a race where the goroutine's
+		// stateReqs message could interleave with subsequent seedling
+		// requests, potentially corrupting batch state.
+		wg.Wait()
 		t.assertNoPendingBatch()
 		return nil
 	}


### PR DESCRIPTION
Probably resolves #1882.

These commits add a deep Copy() method for Seedling values, as well as the same for values of other complex types that Seedling depends on. MintingBatch's Copy() method is then tweaked to use this deep copy on seedling types.

Also included are a bunch of basic unit and mutation tests that check that copies are as deep as expected.