### PR TITLE
tapgarden: wait for finalizebatch to complete

### DIFF
--- a/tapgarden/planter_test.go
+++ b/tapgarden/planter_test.go
@@ -591,6 +591,11 @@ func (t *mintingTestHarness) finalizeBatchAssertFrozen(
 	t.finalizeBatch(&wg, respChan, nil)
 
 	if noBatch {
+		// Wait for the FinalizeBatch goroutine to complete before
+		// returning. This prevents a race where the goroutine's
+		// stateReqs message could interleave with subsequent seedling
+		// requests, potentially corrupting batch state.
+		wg.Wait()
 		t.assertNoPendingBatch()
 		return nil
 	}


### PR DESCRIPTION
This should resolve #1882.

Previously we didn't wait for the FinalizeBatch goroutine to complete in the planter tests' finalizeBatchAssertFrozen. Now we do. 

I ran CI a bunch of times on #1916 to check if I could trigger the minting_with_cancellation flake, and I couldn't, so hopefully CI won't prove me wrong on this one..