### PR TITLE
taprpc+scripts: detect Podman wrapper and preserve Docker UID mapping

### DIFF
--- a/make/release_flags.mk
+++ b/make/release_flags.mk
@@ -8,9 +8,19 @@ VERSION_TAG = $(tag)
 VERSION_CHECK = ./scripts/release.sh check-tag "$(VERSION_TAG)" "$(VERSION_GO_FILE)"
 endif
 
-DOCKER_RELEASE_HELPER = docker run \
+# Use DOCKER/IS_PODMAN from Makefile.
+
+# For Podman rootless, use --user=0:0 to avoid permission issues.
+# For Docker, use current user to ensure generated files are user-owned.
+ifeq ($(IS_PODMAN),1)
+USER_ARGS = --user=0:0
+else
+USER_ARGS = --user $(shell id -u):$(shell id -g)
+endif
+
+DOCKER_RELEASE_HELPER = $(DOCKER) run \
   --rm \
-  --user $(shell id -u):$(shell id -g) \
+  $(USER_ARGS) \
   -v $(shell pwd):/tmp/build/taproot-assets \
   -v $(shell bash -c "go env GOCACHE || (mkdir -p /tmp/go-cache; echo /tmp/go-cache)"):/tmp/build/.cache \
   -v $(shell bash -c "go env GOMODCACHE || (mkdir -p /tmp/go-modcache; echo /tmp/go-modcache)"):/tmp/build/.modcache \

--- a/scripts/docker_helpers.sh
+++ b/scripts/docker_helpers.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# docker_helpers.sh: Common Docker/Podman detection and configuration
+#
+# This script should be sourced by other scripts that need to run Docker or
+# Podman commands. It sets up the DOCKER variable and user_args array based
+# on whether Docker or Podman is being used.
+#
+# Usage:
+#   source scripts/docker_helpers.sh
+#   "$DOCKER" run "${user_args[@]}" ...
+
+# Use docker by default; allow overrides and detect podman wrapper.
+DOCKER=${DOCKER:-docker}
+user_args=(--user "$UID:$(id -g)")
+if "$DOCKER" --version 2>/dev/null | grep -qi podman; then
+	user_args=(--user=0:0)
+fi

--- a/scripts/gen_sqlc_docker.sh
+++ b/scripts/gen_sqlc_docker.sh
@@ -2,6 +2,12 @@
 
 set -e
 
+# Directory of the script file, independent of where it's called from.
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Source Docker/Podman detection helper.
+source "$DIR/docker_helpers.sh"
+
 # restore_files is a function to restore original schema files.
 restore_files() {
 	echo "Restoring SQLite bigint patch..."
@@ -13,9 +19,6 @@ restore_files() {
 # Set trap to call restore_files on script exit. This makes sure the old files
 # are always restored.
 trap restore_files EXIT
-
-# Directory of the script file, independent of where it's called from.
-DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Use the user's cache directories.
 GOCACHE=$(go env GOCACHE)
@@ -40,9 +43,9 @@ echo "Generating sql models and queries in go..."
 
 # Run the script to generate the new generated code. Once the script exits, we
 # use `trap` to make sure all files are restored.
-docker run \
+"$DOCKER" run \
 	--rm \
-	--user "$UID:$(id -g)" \
+	"${user_args[@]}" \
 	-e UID=$UID \
 	-v "$DIR/../:/build" \
 	-w /build \

--- a/taprpc/gen_protos_docker.sh
+++ b/taprpc/gen_protos_docker.sh
@@ -5,21 +5,24 @@ set -e
 # Directory of the script file, independent of where it's called from.
 DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
 
+# Source Docker/Podman detection helper.
+source "$DIR/../scripts/docker_helpers.sh"
+
 PROTOBUF_VERSION=$(go list -f '{{.Version}}' -m google.golang.org/protobuf)
 GRPC_GATEWAY_VERSION=$(go list -f '{{.Version}}' -m github.com/grpc-ecosystem/grpc-gateway/v2)
 LND_VERSION=$(go list -f '{{.Version}}' -m github.com/lightningnetwork/lnd)
 
 echo "Building protobuf compiler docker image..."
-docker build -t taproot-assets-protobuf-builder \
+"$DOCKER" build -t taproot-assets-protobuf-builder \
   --build-arg PROTOBUF_VERSION="$PROTOBUF_VERSION" \
   --build-arg GRPC_GATEWAY_VERSION="$GRPC_GATEWAY_VERSION" \
   --build-arg LND_VERSION="$LND_VERSION" \
   .
 
 echo "Compiling and formatting *.proto files..."
-docker run \
+"$DOCKER" run \
   --rm \
-  --user "$UID:$(id -g)" \
+  "${user_args[@]}" \
   -e UID=$UID \
   -e COMPILE_MOBILE \
   -e SUBSERVER_PREFIX \


### PR DESCRIPTION
Detect Podman by checking "$DOCKER --version", allowing overrides via the DOCKER environment variable. Retain `--user $UID:$(id -g)` for Docker/CI to ensure generated files are user-owned. For Podman, switch to "--user=0:0" to avoid EACCES errors caused by rootless subuid/subgid remapping on bind mounts.

- scripts/gen_sqlc_docker.sh: add runtime user selection; use $DOCKER for run
- taprpc/gen_protos_docker.sh: same detection logic; use $DOCKER for build/run

Fixes "Permission denied" errors with rootless Podman, while maintaining existing Docker behavior.