### PR TITLE
build: bump version to v0.7.99-alpha

### DIFF
--- a/version.go
+++ b/version.go
@@ -45,7 +45,7 @@ const (
 	AppMinor uint = 7
 
 	// AppPatch defines the application patch for this binary.
-	AppPatch uint = 0
+	AppPatch uint = 99
 
 	// AppStatus defines the release status of this binary (e.g. beta).
 	AppStatus = "alpha"


### PR DESCRIPTION
Bump version to v0.7.99-alpha so that master builds are distinguishable from release builds.