### PR TITLE
itest: remove more shared timeout context across test files

### DIFF
--- a/itest/collectible_split_test.go
+++ b/itest/collectible_split_test.go
@@ -360,12 +360,9 @@ func testCollectibleGroupSend(t *harnessTest) {
 	t.Logf("Running send test, sending %d asset(s) of type %v %d times",
 		numAssets, sendType, numSends)
 
-	ctxt, cancel := context.WithTimeout(ctxb, defaultWaitTimeout*numSends)
-	defer cancel()
-
 	for i := 1; i <= numSends; i++ {
 		send, receive, ok := pickSendNode(
-			t.t, ctxt, numAssets, sendType, t.tapd, secondTapd,
+			t.t, ctxb, numAssets, sendType, t.tapd, secondTapd,
 		)
 		if !ok {
 			t.Fatalf("Aborting send test at attempt %d of %d as "+
@@ -376,7 +373,7 @@ func testCollectibleGroupSend(t *harnessTest) {
 		}
 
 		sendAssets(
-			t.t, ctxt, numAssets, sendType, send, receive,
+			t.t, ctxb, numAssets, sendType, send, receive,
 			t.lndHarness.Miner().Client,
 		)
 

--- a/itest/multi_asset_group_test.go
+++ b/itest/multi_asset_group_test.go
@@ -272,11 +272,7 @@ func testMintMultiAssetGroupErrors(t *harnessTest) {
 // testMultiAssetGroupSend tests that we can randomly send assets from a group
 // of collectibles one after another from one node to the other.
 func testMultiAssetGroupSend(t *harnessTest) {
-	// We use a hashmail proof courier for this test, which takes a bit
-	// longer to send proofs. So we use a longer timeout.
-	ctxb := context.Background()
-	ctxt, cancel := context.WithTimeout(ctxb, defaultWaitTimeout*3)
-	defer cancel()
+	ctx := context.Background()
 
 	// First, we'll build a batch to mint.
 	issuableAsset := CopyRequest(simpleAssets[1])
@@ -299,7 +295,7 @@ func testMultiAssetGroupSend(t *harnessTest) {
 	groupCount := 1
 	AssertNumGroups(t.t, t.tapd, groupCount)
 	balancesResp, err := t.tapd.ListBalances(
-		ctxt, &taprpc.ListBalancesRequest{
+		ctx, &taprpc.ListBalancesRequest{
 			GroupBy: &taprpc.ListBalancesRequest_GroupKey{
 				GroupKey: true,
 			},
@@ -351,7 +347,7 @@ func testMultiAssetGroupSend(t *harnessTest) {
 		t.Logf("Attempt %d: Sending %d asset(s) with ID %x from "+
 			"alice to bob", i+1, numUnits, genInfo.AssetId)
 
-		addr, err := secondTapd.NewAddr(ctxt, &taprpc.NewAddrRequest{
+		addr, err := secondTapd.NewAddr(ctx, &taprpc.NewAddrRequest{
 			AssetId: genInfo.AssetId,
 			Amt:     numUnits,
 		})

--- a/itest/test_harness.go
+++ b/itest/test_harness.go
@@ -232,12 +232,8 @@ func (h *harnessTest) newLndClient(
 func (h *harnessTest) syncUniverseState(target, syncer *tapdHarness,
 	numExpectedAssets int) {
 
-	ctxt, cancel := context.WithTimeout(
-		context.Background(), defaultWaitTimeout,
-	)
-	defer cancel()
-
-	syncDiff, err := syncer.SyncUniverse(ctxt, &unirpc.SyncRequest{
+	ctx := context.Background()
+	syncDiff, err := syncer.SyncUniverse(ctx, &unirpc.SyncRequest{
 		UniverseHost: target.rpcHost(),
 		SyncMode:     unirpc.UniverseSyncMode_SYNC_ISSUANCE_ONLY,
 	})


### PR DESCRIPTION
Should finally close: https://github.com/lightninglabs/taproot-assets/issues/1946

Replaced shared timeout contexts with locally created background contexts in multiple tests for consistency and simplicity.