### PR TITLE
chore: fix docker workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -37,6 +37,19 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
+          fetch-depth: 0
+
+      - name: Validate release tag ${{ env.RELEASE_VERSION }}
+        run: |
+          expected_tag=$(./scripts/get-git-tag-name.sh version.go)
+          actual_tag=${{ env.RELEASE_VERSION }}
+
+          if [ "$actual_tag" = "$expected_tag" ]; then
+            echo "git tag matches version.go: $actual_tag"
+          else
+            echo "Error: Versions are not equal. Actual: $actual_tag, Expected: $expected_tag"
+            exit 1
+          fi
 
       - name: Build and push default image
         id: docker_build


### PR DESCRIPTION
The Docker workflow didn't include an actions/checkout step, so whilst it was only kicked off on push of a release tag, it actually grabbed the code from 'main' when executing. The result was that for any release that wasn't included in 'main', e.g. v0.7.1-rc1, the Docker image was built with the wrong code.

Adds a checkout step at the appropriate ref as a fix, plus the tag validation sanity check already used in the release workflow.