### PR TITLE
tapchannel: align to latest LND version

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -21,7 +21,7 @@ env:
 
   GO_VERSION: '1.25.2'
 
-  LITD_BRANCH: 'master'
+  LITD_BRANCH: 'chore/lnd-latest'
 
   # Number of parallel itest jobs in the matrix and tranches per job.
   # Total tranches = NUM_ITEST_JOBS * ITEST_PARALLELISM.

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.24.11
 
 require (
 	github.com/btcsuite/btcd v0.24.3-0.20250318170759-4f4ea81776d6
-	github.com/btcsuite/btcd/btcec/v2 v2.3.4
+	github.com/btcsuite/btcd/btcec/v2 v2.3.6
 	github.com/btcsuite/btcd/btcutil v1.1.5
 	github.com/btcsuite/btcd/btcutil/psbt v1.1.10
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.1.0
@@ -31,7 +31,7 @@ require (
 	github.com/lightninglabs/lndclient v0.20.0-6
 	github.com/lightninglabs/neutrino/cache v1.1.3
 	github.com/lightninglabs/taproot-assets/taprpc v1.0.9
-	github.com/lightningnetwork/lnd v0.20.0-beta.rc4.0.20251127014118-f8b5cb0e8918
+	github.com/lightningnetwork/lnd v0.20.0-beta.rc4.0.20260205225502-14b90a27cfc3
 	github.com/lightningnetwork/lnd/cert v1.2.2
 	github.com/lightningnetwork/lnd/clock v1.1.1
 	github.com/lightningnetwork/lnd/fn/v2 v2.0.9
@@ -133,7 +133,7 @@ require (
 	github.com/lightningnetwork/lnd/healthcheck v1.2.6 // indirect
 	github.com/lightningnetwork/lnd/kvdb v1.4.16 // indirect
 	github.com/lightningnetwork/lnd/queue v1.1.1 // indirect
-	github.com/lightningnetwork/lnd/sqldb v1.0.11 // indirect
+	github.com/lightningnetwork/lnd/sqldb v1.0.13-0.20260113150738-e26a114cdcf0 // indirect
 	github.com/lightningnetwork/lnd/ticker v1.1.1 // indirect
 	github.com/ltcsuite/ltcd v0.0.0-20190101042124-f37f8bf35796 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect

--- a/go.sum
+++ b/go.sum
@@ -651,8 +651,8 @@ github.com/btcsuite/btcd v0.24.3-0.20250318170759-4f4ea81776d6 h1:8n9k3I7e8DkpdQ
 github.com/btcsuite/btcd v0.24.3-0.20250318170759-4f4ea81776d6/go.mod h1:OmM4kFtB0klaG/ZqT86rQiyw/1iyXlJgc3UHClPhhbs=
 github.com/btcsuite/btcd/btcec/v2 v2.1.0/go.mod h1:2VzYrv4Gm4apmbVVsSq5bqf1Ec8v56E48Vt0Y/umPgA=
 github.com/btcsuite/btcd/btcec/v2 v2.1.3/go.mod h1:ctjw4H1kknNJmRN4iP1R7bTQ+v3GJkZBd6mui8ZsAZE=
-github.com/btcsuite/btcd/btcec/v2 v2.3.4 h1:3EJjcN70HCu/mwqlUsGK8GcNVyLVxFDlWurTXGPFfiQ=
-github.com/btcsuite/btcd/btcec/v2 v2.3.4/go.mod h1:zYzJ8etWJQIv1Ogk7OzpWjowwOdXY1W/17j2MW85J04=
+github.com/btcsuite/btcd/btcec/v2 v2.3.6 h1:IzlsEr9olcSRKB/n7c4351F3xHKxS2lma+1UFGCYd4E=
+github.com/btcsuite/btcd/btcec/v2 v2.3.6/go.mod h1:m22FrOAiuxl/tht9wIqAoGHcbnCCaPWyauO8y2LGGtQ=
 github.com/btcsuite/btcd/btcutil v1.0.0/go.mod h1:Uoxwv0pqYWhD//tfTiipkxNfdhG9UrLwaeswfjfdF0A=
 github.com/btcsuite/btcd/btcutil v1.1.0/go.mod h1:5OapHB7A2hBBWLm48mmw4MOHNJCcUBTwmWH/0Jn8VHE=
 github.com/btcsuite/btcd/btcutil v1.1.5 h1:+wER79R5670vs/ZusMTF1yTcRYE5GUsFbdjdisflzM8=
@@ -1132,8 +1132,8 @@ github.com/lightninglabs/protobuf-go-hex-display v1.34.2-hex-display h1:w7FM5LH9
 github.com/lightninglabs/protobuf-go-hex-display v1.34.2-hex-display/go.mod h1:qYOHts0dSfpeUzUFpOMr/WGzszTmLH+DiWniOlNbLDw=
 github.com/lightningnetwork/lightning-onion v1.2.1-0.20240815225420-8b40adf04ab9 h1:6D3LrdagJweLLdFm1JNodZsBk6iU4TTsBBFLQ4yiXfI=
 github.com/lightningnetwork/lightning-onion v1.2.1-0.20240815225420-8b40adf04ab9/go.mod h1:EDqJ3MuZIbMq0QI1czTIKDJ/GS8S14RXPwapHw8cw6w=
-github.com/lightningnetwork/lnd v0.20.0-beta.rc4.0.20251127014118-f8b5cb0e8918 h1:FoCUqt9QVJW7LOQHocOBF6kbiybaNyQrbbsx5/FsmWY=
-github.com/lightningnetwork/lnd v0.20.0-beta.rc4.0.20251127014118-f8b5cb0e8918/go.mod h1:8hc55AnE3mMSJ/UAEJZgmhgNCcH0yWaPg0olpxhhp4M=
+github.com/lightningnetwork/lnd v0.20.0-beta.rc4.0.20260205225502-14b90a27cfc3 h1:+IEcAFiRmeNc+rwPWM9+Y5z9NUHTJYPnQPL1bX91Lrs=
+github.com/lightningnetwork/lnd v0.20.0-beta.rc4.0.20260205225502-14b90a27cfc3/go.mod h1:964P7ZTy5dOkw+0/f/VZIXCRgChqOp912P8iEzk0JVY=
 github.com/lightningnetwork/lnd/cert v1.2.2 h1:71YK6hogeJtxSxw2teq3eGeuy4rHGKcFf0d0Uy4qBjI=
 github.com/lightningnetwork/lnd/cert v1.2.2/go.mod h1:jQmFn/Ez4zhDgq2hnYSw8r35bqGVxViXhX6Cd7HXM6U=
 github.com/lightningnetwork/lnd/clock v1.1.1 h1:OfR3/zcJd2RhH0RU+zX/77c0ZiOnIMsDIBjgjWdZgA0=
@@ -1146,8 +1146,8 @@ github.com/lightningnetwork/lnd/kvdb v1.4.16 h1:9BZgWdDfjmHRHLS97cz39bVuBAqMc4/p
 github.com/lightningnetwork/lnd/kvdb v1.4.16/go.mod h1:HW+bvwkxNaopkz3oIgBV6NEnV4jCEZCACFUcNg4xSjM=
 github.com/lightningnetwork/lnd/queue v1.1.1 h1:99ovBlpM9B0FRCGYJo6RSFDlt8/vOkQQZznVb18iNMI=
 github.com/lightningnetwork/lnd/queue v1.1.1/go.mod h1:7A6nC1Qrm32FHuhx/mi1cieAiBZo5O6l8IBIoQxvkz4=
-github.com/lightningnetwork/lnd/sqldb v1.0.11 h1:X8J3OvdIhJVniQG78Qsp3niErl1zdGMTPvzgiLMWOOo=
-github.com/lightningnetwork/lnd/sqldb v1.0.11/go.mod h1:oOdZ7vjmAUmI9He+aFHTunnxKVefHZAfJttZdz16hSg=
+github.com/lightningnetwork/lnd/sqldb v1.0.13-0.20260113150738-e26a114cdcf0 h1:7R7NP7FVzl4XWfBrX4rmxcp/7tRmj/15ZlU5HI//RFU=
+github.com/lightningnetwork/lnd/sqldb v1.0.13-0.20260113150738-e26a114cdcf0/go.mod h1:zfcfU7cx/mLkkuCgwSesndk6A3mAOHtFfb+y3tyme/k=
 github.com/lightningnetwork/lnd/ticker v1.1.1 h1:J/b6N2hibFtC7JLV77ULQp++QLtCwT6ijJlbdiZFbSM=
 github.com/lightningnetwork/lnd/ticker v1.1.1/go.mod h1:waPTRAAcwtu7Ji3+3k+u/xH5GHovTsCoSVpho0KDvdA=
 github.com/lightningnetwork/lnd/tlv v1.3.2 h1:MO4FCk7F4k5xPMqVZF6Nb/kOpxlwPrUQpYjmyKny5s0=

--- a/server.go
+++ b/server.go
@@ -37,6 +37,7 @@ import (
 	"github.com/lightningnetwork/lnd/lnwallet"
 	lnwl "github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwallet/chancloser"
+	"github.com/lightningnetwork/lnd/lnwallet/types"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/macaroons"
 	"github.com/lightningnetwork/lnd/msgmux"
@@ -1207,9 +1208,9 @@ func (s *Server) IsCustomHTLC(htlcRecords lnwire.CustomRecords) bool {
 // attempt. We'll add some extra outputs to the co-op close transaction, and
 // also give the caller a custom sorting routine.
 //
-// NOTE: This method is part of the chancloser.AuxChanCloser interface.
+// NOTE: This method is part of the types.AuxChanCloser interface.
 func (s *Server) AuxCloseOutputs(
-	desc chancloser.AuxCloseDesc) (lfn.Option[chancloser.AuxCloseOutputs],
+	desc types.AuxCloseDesc) (lfn.Option[chancloser.AuxCloseOutputs],
 	error) {
 
 	srvrLog.Tracef("AuxCloseOutputs called, desc=%v",
@@ -1225,9 +1226,9 @@ func (s *Server) AuxCloseOutputs(
 // ShutdownBlob returns the set of custom records that should be included in
 // the shutdown message.
 //
-// NOTE: This method is part of the chancloser.AuxChanCloser interface.
+// NOTE: This method is part of the types.AuxChanCloser interface.
 func (s *Server) ShutdownBlob(
-	req chancloser.AuxShutdownReq) (lfn.Option[lnwire.CustomRecords],
+	req types.AuxShutdownReq) (lfn.Option[lnwire.CustomRecords],
 	error) {
 
 	srvrLog.Tracef("ShutdownBlob called, req=%v",
@@ -1244,8 +1245,8 @@ func (s *Server) ShutdownBlob(
 // upon. We'll finalize the exclusion proofs, then send things off to the
 // custodian or porter to finish sending/receiving the proofs.
 //
-// NOTE: This method is part of the chancloser.AuxChanCloser interface.
-func (s *Server) FinalizeClose(desc chancloser.AuxCloseDesc,
+// NOTE: This method is part of the types.AuxChanCloser interface.
+func (s *Server) FinalizeClose(desc types.AuxCloseDesc,
 	closeTx *wire.MsgTx) error {
 
 	srvrLog.Tracef("FinalizeClose called, desc=%v, closeTx=%v",

--- a/tapchannel/aux_closer.go
+++ b/tapchannel/aux_closer.go
@@ -25,6 +25,7 @@ import (
 	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwallet/chancloser"
+	"github.com/lightningnetwork/lnd/lnwallet/types"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/tlv"
 )
@@ -227,7 +228,7 @@ func signCommitVirtualPackets(ctx context.Context,
 //
 // NOTE: This method is part of the chancloser.AuxChanCloser interface.
 func (a *AuxChanCloser) AuxCloseOutputs(
-	desc chancloser.AuxCloseDesc) (lfn.Option[chancloser.AuxCloseOutputs],
+	desc types.AuxCloseDesc) (lfn.Option[chancloser.AuxCloseOutputs],
 	error) {
 
 	a.Lock()
@@ -282,7 +283,7 @@ func (a *AuxChanCloser) AuxCloseOutputs(
 	// information (delivery script keys, etc.).
 	var localShutdown, remoteShutdown tapchannelmsg.AuxShutdownMsg
 	err = lfn.MapOptionZ(
-		desc.LocalCloseOutput, func(o chancloser.CloseOutput) error {
+		desc.LocalCloseOutput, func(o types.CloseOutput) error {
 			blob, err := o.ShutdownRecords.Serialize()
 			if err != nil {
 				return err
@@ -295,7 +296,7 @@ func (a *AuxChanCloser) AuxCloseOutputs(
 		return none, err
 	}
 	err = lfn.MapOptionZ(
-		desc.RemoteCloseOutput, func(o chancloser.CloseOutput) error {
+		desc.RemoteCloseOutput, func(o types.CloseOutput) error {
 			blob, err := o.ShutdownRecords.Serialize()
 			if err != nil {
 				return err
@@ -352,7 +353,7 @@ func (a *AuxChanCloser) AuxCloseOutputs(
 
 	// Next, we'll create allocations for the (up to) two settled outputs
 	// in the co-op close transaction.
-	desc.LocalCloseOutput.WhenSome(func(o chancloser.CloseOutput) {
+	desc.LocalCloseOutput.WhenSome(func(o types.CloseOutput) {
 		btcAmt := o.Amt
 		if desc.Initiator {
 			btcAmt += desc.CommitFee
@@ -381,7 +382,7 @@ func (a *AuxChanCloser) AuxCloseOutputs(
 			InternalKey:         localShutdown.BtcInternalKey.Val,
 		})
 	})
-	desc.RemoteCloseOutput.WhenSome(func(o chancloser.CloseOutput) {
+	desc.RemoteCloseOutput.WhenSome(func(o types.CloseOutput) {
 		btcAmt := o.Amt
 		if !desc.Initiator {
 			btcAmt += desc.CommitFee
@@ -547,7 +548,7 @@ func (a *AuxChanCloser) AuxCloseOutputs(
 //
 // NOTE: This method is part of the chancloser.AuxChanCloser interface.
 func (a *AuxChanCloser) ShutdownBlob(
-	req chancloser.AuxShutdownReq) (lfn.Option[lnwire.CustomRecords],
+	req types.AuxShutdownReq) (lfn.Option[lnwire.CustomRecords],
 	error) {
 
 	a.Lock()
@@ -693,8 +694,8 @@ func shipChannelTxn(txSender tapfreighter.Porter, chanTx *wire.MsgTx,
 // upon. We'll finalize the exclusion proofs, then send things off to the
 // custodian or porter to finish sending/receiving the proofs.
 //
-// NOTE: This method is part of the chancloser.AuxChanCloser interface.
-func (a *AuxChanCloser) FinalizeClose(desc chancloser.AuxCloseDesc,
+// NOTE: This method is part of the types.AuxChanCloser interface.
+func (a *AuxChanCloser) FinalizeClose(desc types.AuxCloseDesc,
 	closeTx *wire.MsgTx) error {
 
 	a.Lock()


### PR DESCRIPTION
Bumps `lnd` to latest version to align `aux_closer.go` with types that have moved from `lnwallet/chancloser` to `lnwallet/types`.