### PR TITLE
tapfreighter: verify passive asset proofs before archiving

### DIFF
--- a/tapfreighter/chain_porter.go
+++ b/tapfreighter/chain_porter.go
@@ -528,6 +528,20 @@ func (p *ChainPorter) storeProofs(sendPkg *sendPackage) error {
 		IgnoreChecker:  p.cfg.IgnoreChecker,
 	}
 
+	// Before we import passive proofs into the archive, validate them.
+	verifier := &proof.BaseVerifier{}
+	for idx := range passiveAssetProofFiles {
+		passiveProof := passiveAssetProofFiles[idx]
+
+		_, err := verifier.Verify(
+			ctx, bytes.NewReader(passiveProof.Blob), vCtx,
+		)
+		if err != nil {
+			return fmt.Errorf("verifying passive asset proof %d: "+
+				"%w", idx, err)
+		}
+	}
+
 	log.Infof("Importing %d passive asset proofs into local Proof "+
 		"Archive", len(passiveAssetProofFiles))
 	err := p.cfg.ProofWriter.ImportProofs(


### PR DESCRIPTION
Related to https://github.com/lightninglabs/taproot-assets/issues/1835

---

EDIT: we may not want this PR if we're happy with https://github.com/lightninglabs/taproot-assets/pull/1974

---

Passive proofs were previously archived without verification, since `FileArchiver.ImportProofs` does not perform any checks. This adds an explicit verification step in `ChainPorter.storeProofs` to validate passive proofs using `BaseVerifier` and the existing `VerifierCtx` before importing.

This brings passive proof handling in line with active output proofs, improving correctness without altering storage backends or archive behavior.