### PR TITLE
github: pass tag to docker via build-args

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -58,6 +58,8 @@ jobs:
           push: true
           platforms: linux/amd64,linux/arm64
           tags: "${{ env.DOCKER_REPO }}/${{ env.DOCKER_IMAGE }}:${{ env.RELEASE_VERSION }}"
+          build-args: |
+            checkout=${{ env.RELEASE_VERSION }}
 
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}


### PR DESCRIPTION
PR #1956 added a 'checkout' step to the Docker workflow that checked out the appropriate ref before building the image. This works for the validation step in that workflow, but fails to build an image at the correct tag, since the Dockerfile performs its own checkout in order to build the image.

The fix here is to additionally pass 'checkout' to Docker via 'build-args'.