### PR TITLE
fix: rename sweep-orphan-utxos to disable-sweep-orphan-utxos

### DIFF
--- a/docs/release-notes/release-notes-0.8.0.md
+++ b/docs/release-notes/release-notes-0.8.0.md
@@ -124,8 +124,8 @@
 - [Garbage collection of orphaned UTXOs](https://github.com/lightninglabs/taproot-assets/pull/1832)
   by sweeping tombstones and burn outputs when executing onchain transactions.
   Garbage collection will be executed on every burn, transfer or call to
-  `AnchorVirtualPsbts`. A new configuration is available to control the sweeping
-  via the flag `wallet.sweep-orphan-utxos`.
+  `AnchorVirtualPsbts`. Sweeping is enabled by default and can be disabled via
+  the flag `wallet.disable-sweep-orphan-utxos`.
 - [PR](https://github.com/lightninglabs/taproot-assets/pull/1899) tapd now
   treats HTLC interceptor setup failures as fatal during RFQ subsystem startup.
   If the RFQ subsystem cannot install its interceptor, tapd shuts down instead
@@ -194,9 +194,9 @@
   human-readable values such as `64MB`.
 
 - [Enable orphan UTXO sweeping by default](https://github.com/lightninglabs/taproot-assets/pull/1905):
-  The `wallet.sweep-orphan-utxos` configuration option is now enabled by
-  default. This automatically sweeps tombstone and burn outputs when executing
-  on-chain transactions. Set to `false` to disable.
+  Orphan UTXO sweeping is now enabled by default. This automatically sweeps
+  tombstone and burn outputs when executing on-chain transactions. Set
+  `wallet.disable-sweep-orphan-utxos` to disable.
 
 ## Breaking Changes
 

--- a/itest/tapd_harness.go
+++ b/itest/tapd_harness.go
@@ -149,15 +149,19 @@ type harnessOpts struct {
 	// not via on-chain spend detection.
 	disableSupplyVerifierChainWatch bool
 
-	// sweepOrphanUtxos indicates whether orphaned anchor UTXOs should be
-	// swept into anchor transactions.
-	sweepOrphanUtxos bool
+	// disableSweepOrphanUtxos indicates whether sweeping of orphaned anchor
+	// UTXOs into anchor transactions should be disabled.
+	disableSweepOrphanUtxos bool
 }
 
 type harnessOption func(*harnessOpts)
 
 func defaultHarnessOpts() *harnessOpts {
-	return &harnessOpts{}
+	return &harnessOpts{
+		// Disable orphan UTXO sweeping in tests by default to avoid
+		// interference with test assertions.
+		disableSweepOrphanUtxos: true,
+	}
 }
 
 // withOracleAddress is a functional option that sets the oracle address option
@@ -271,11 +275,11 @@ func newTapdHarness(t *testing.T, ht *harnessTest, cfg tapdConfig,
 	// nolint: lll
 	tapCfg.Universe.DisableSupplyVerifierChainWatch = opts.disableSupplyVerifierChainWatch
 
-	// Pass through the sweep orphan UTXOs flag. If the option was not set,
-	// this will be false. Note: The production default is true, but we
-	// disable it by default in tests to avoid interference with test
-	// assertions unless explicitly enabled via WithSweepOrphanUtxos().
-	tapCfg.Wallet.SweepOrphanUtxos = opts.sweepOrphanUtxos
+	// Pass through the disable sweep orphan UTXOs flag. In tests, sweeping
+	// is disabled by default (defaultHarnessOpts sets
+	// disableSweepOrphanUtxos=true) to avoid interference with test
+	// assertions. Use WithSweepOrphanUtxos() to re-enable sweeping.
+	tapCfg.Wallet.DisableSweepOrphanUtxos = opts.disableSweepOrphanUtxos
 
 	if tapCfg.Experimental == nil {
 		tapCfg.Experimental = &tapcfg.ExperimentalConfig{}

--- a/itest/test_harness.go
+++ b/itest/test_harness.go
@@ -373,8 +373,8 @@ type tapdHarnessParams struct {
 	// the local oracle to the counterparty when requesting a quote.
 	sendPriceHint bool
 
-	// sweepOrphanUtxos indicates whether orphaned UTXOs should be swept
-	// into anchor transactions.
+	// sweepOrphanUtxos indicates whether orphan UTXO sweeping should be
+	// enabled (overriding the test default of disabled).
 	sweepOrphanUtxos bool
 }
 
@@ -419,7 +419,8 @@ func WithSendPriceHint() Option {
 }
 
 // WithSweepOrphanUtxos enables sweeping zero-value anchor UTXOs for
-// the tapd harness created with this option.
+// the tapd harness created with this option. Tests disable sweeping by
+// default; this option re-enables it.
 func WithSweepOrphanUtxos() Option {
 	return func(th *tapdHarnessParams) {
 		th.sweepOrphanUtxos = true
@@ -461,7 +462,7 @@ func setupTapdHarness(t *testing.T, ht *harnessTest,
 		ho.oracleServerAddress = params.oracleServerAddress
 		ho.portfolioPilotAddress = params.portfolioPilotAddress
 		ho.sendPriceHint = params.sendPriceHint
-		ho.sweepOrphanUtxos = params.sweepOrphanUtxos
+		ho.disableSweepOrphanUtxos = !params.sweepOrphanUtxos
 	}
 
 	tapdCfg := tapdConfig{

--- a/itest/zero_value_anchor_test.go
+++ b/itest/zero_value_anchor_test.go
@@ -21,7 +21,7 @@ func testZeroValueAnchorSweep(t *harnessTest) {
 
 	// Restart Alice's node with sweeping enabled.
 	require.NoError(t.t, t.tapd.stop(false))
-	t.tapd.clientCfg.Wallet.SweepOrphanUtxos = true
+	t.tapd.clientCfg.Wallet.DisableSweepOrphanUtxos = false
 	require.NoError(t.t, t.tapd.start(false))
 
 	// First, mint some simple asset.
@@ -313,7 +313,7 @@ func testZeroValueAnchorAccumulation(t *harnessTest) {
 	require.NoError(t.t, t.tapd.stop(false))
 
 	// Enable sweeping in the config.
-	t.tapd.clientCfg.Wallet.SweepOrphanUtxos = true
+	t.tapd.clientCfg.Wallet.DisableSweepOrphanUtxos = false
 
 	// Restart with the modified config.
 	require.NoError(t.t, t.tapd.start(false))

--- a/rpcserver/rpcserver.go
+++ b/rpcserver/rpcserver.go
@@ -2787,7 +2787,7 @@ func (r *RPCServer) AnchorVirtualPsbts(ctx context.Context,
 		zeroValueInputs []*tapfreighter.ZeroValueInput
 		err             error
 	)
-	if r.cfg.SweepOrphanUtxos {
+	if !r.cfg.DisableSweepOrphanUtxos {
 		zeroValueInputs, err = r.cfg.AssetStore.FetchOrphanUTXOs(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("unable to fetch zero-value "+

--- a/sample-tapd.conf
+++ b/sample-tapd.conf
@@ -418,9 +418,9 @@
 ; Value must be a valid float ranging from 0.00 to 1.00.
 ; wallet.psbt-max-fee-ratio=0.75
 
-; Sweep orphaned UTXOs into send and burn anchor transactions.
-; Disabled by default.
-; wallet.sweep-orphan-utxos=false
+; Disable sweeping orphaned UTXOs into send and burn anchor transactions.
+; Sweeping is enabled by default; set to true to disable.
+; wallet.disable-sweep-orphan-utxos=false
 
 [address]
 

--- a/tapcfg/config.go
+++ b/tapcfg/config.go
@@ -323,9 +323,10 @@ type WalletConfig struct {
 	// amount. The allowed values for this argument range from 0.00 to 1.00.
 	PsbtMaxFeeRatio float64 `long:"psbt-max-fee-ratio" description:"The maximum fees to total output amount ratio to use when funding PSBTs for asset transfers. Value must be between 0.00 and 1.00"`
 
-	// SweepOrphanUtxos, when true, sweeps orphaned UTXOs into anchor
-	// transactions created during sends and burns.
-	SweepOrphanUtxos bool `long:"sweep-orphan-utxos" description:"Sweep orphaned UTXOs into anchor transactions created during sends and burns. Enabled by default."`
+	// DisableSweepOrphanUtxos, when true, disables sweeping of orphaned
+	// UTXOs into anchor transactions created during sends and burns.
+	// Sweeping is enabled by default.
+	DisableSweepOrphanUtxos bool `long:"disable-sweep-orphan-utxos" description:"Disable sweeping orphaned UTXOs into anchor transactions created during sends and burns. Sweeping is enabled by default."`
 }
 
 // UniverseConfig is the config that houses any Universe related config
@@ -532,8 +533,7 @@ func DefaultConfig() Config {
 			DisableSupplyVerifierChainWatch: false,
 		},
 		Wallet: &WalletConfig{
-			PsbtMaxFeeRatio:  DefaultPsbtMaxFeeRatio,
-			SweepOrphanUtxos: true,
+			PsbtMaxFeeRatio: DefaultPsbtMaxFeeRatio,
 		},
 		AddrBook: &AddrBookConfig{
 			DisableSyncer: false,

--- a/tapcfg/server.go
+++ b/tapcfg/server.go
@@ -477,7 +477,7 @@ func genServerConfig(cfg *Config, cfgLogger btclog.Logger,
 		IgnoreChecker:    ignoreCheckerOpt,
 		Wallet:           walletAnchor,
 		ChainParams:      &tapChainParams,
-		SweepOrphanUtxos: cfg.Wallet.SweepOrphanUtxos,
+		DisableSweepOrphanUtxos: cfg.Wallet.DisableSweepOrphanUtxos,
 	})
 
 	// Addresses can have different proof couriers configured, but both
@@ -819,7 +819,7 @@ func genServerConfig(cfg *Config, cfgLogger btclog.Logger,
 		AssetWallet:              assetWallet,
 		CoinSelect:               coinSelect,
 		ChainPorter:              chainPorter,
-		SweepOrphanUtxos:         cfg.Wallet.SweepOrphanUtxos,
+		DisableSweepOrphanUtxos:  cfg.Wallet.DisableSweepOrphanUtxos,
 		FsmDaemonAdapters:        lndFsmDaemonAdapters,
 		SupplyCommitManager:      supplyCommitManager,
 		IgnoreChecker:            ignoreChecker,

--- a/tapconfig/config.go
+++ b/tapconfig/config.go
@@ -204,9 +204,9 @@ type Config struct {
 
 	ChainPorter tapfreighter.Porter
 
-	// SweepOrphanUtxos toggles sweeping orphaned UTXOs into anchor
-	// transactions for sends and burns.
-	SweepOrphanUtxos bool
+	// DisableSweepOrphanUtxos disables sweeping orphaned UTXOs into
+	// anchor transactions for sends and burns.
+	DisableSweepOrphanUtxos bool
 
 	// FsmDaemonAdapters is a set of adapters that allow a state machine to
 	// interact with external daemons.

--- a/tapfreighter/wallet.go
+++ b/tapfreighter/wallet.go
@@ -227,9 +227,9 @@ type WalletConfig struct {
 	// ChainParams is the chain params of the chain we operate on.
 	ChainParams *address.ChainParams
 
-	// SweepOrphanUtxos specifies whether orphaned UTXOs should be swept
-	// into send and burn anchor transactions.
-	SweepOrphanUtxos bool
+	// DisableSweepOrphanUtxos specifies whether sweeping of orphaned UTXOs
+	// into send and burn anchor transactions should be disabled.
+	DisableSweepOrphanUtxos bool
 }
 
 // AssetWallet is an implementation of the Wallet interface that can create
@@ -700,7 +700,7 @@ func (f *AssetWallet) FundPacket(ctx context.Context,
 		}
 	}()
 
-	if f.cfg.SweepOrphanUtxos {
+	if !f.cfg.DisableSweepOrphanUtxos {
 		zeroValueInputs, err = f.cfg.CoinSelector.SelectOrphanCoins(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("unable to select zero-value "+
@@ -777,7 +777,7 @@ func (f *AssetWallet) FundBurn(ctx context.Context,
 		}
 	}()
 
-	if f.cfg.SweepOrphanUtxos {
+	if !f.cfg.DisableSweepOrphanUtxos {
 		zeroValueInputs, err = f.cfg.CoinSelector.SelectOrphanCoins(
 			ctx,
 		)


### PR DESCRIPTION
The `wallet.sweep-orphan-utxos` flag defaults to `true` (enabled), but go-flags doesn't support `--flag=false` for boolean options, making it impossible to disable sweeping via CLI.