### PR TITLE
itest: avoid dns lookup in rfq tests

### DIFF
--- a/itest/rfq_forwards_test.go
+++ b/itest/rfq_forwards_test.go
@@ -33,7 +33,7 @@ import (
 //  6. We query Bob's forwarding history and verify the event was recorded.
 //  7. We test query filters (timestamp, peer, asset_id) and pagination.
 func testForwardingEventHistory(t *harnessTest) {
-	oracleAddr := fmt.Sprintf("localhost:%d", port.NextAvailablePort())
+	oracleAddr := fmt.Sprintf("127.0.0.1:%d", port.NextAvailablePort())
 	oracle := newOracleHarness(oracleAddr)
 	oracle.start(t.t)
 	t.t.Cleanup(oracle.stop)

--- a/itest/rfq_test.go
+++ b/itest/rfq_test.go
@@ -54,7 +54,7 @@ var (
 // the tap asset to Carol's node.
 func testRfqAssetBuyHtlcIntercept(t *harnessTest) {
 	// For this test we'll use an actual oracle RPC server harness.
-	oracleAddr := fmt.Sprintf("localhost:%d", port.NextAvailablePort())
+	oracleAddr := fmt.Sprintf("127.0.0.1:%d", port.NextAvailablePort())
 	oracle := newOracleHarness(oracleAddr)
 	oracle.start(t.t)
 	t.t.Cleanup(oracle.stop)
@@ -336,7 +336,7 @@ func testRfqAssetBuyHtlcIntercept(t *harnessTest) {
 // sell request.
 func testRfqAssetSellHtlcIntercept(t *harnessTest) {
 	// For this test we'll use an actual oracle RPC server harness.
-	oracleAddr := fmt.Sprintf("localhost:%d", port.NextAvailablePort())
+	oracleAddr := fmt.Sprintf("127.0.0.1:%d", port.NextAvailablePort())
 	oracle := newOracleHarness(oracleAddr)
 	oracle.start(t.t)
 	t.t.Cleanup(oracle.stop)
@@ -612,7 +612,7 @@ func testRfqAssetSellHtlcIntercept(t *harnessTest) {
 // quotes based on a specifier that only uses a group key.
 func testRfqNegotiationGroupKey(t *harnessTest) {
 	// For this test we'll use an actual oracle RPC server harness.
-	oracleAddr := fmt.Sprintf("localhost:%d", port.NextAvailablePort())
+	oracleAddr := fmt.Sprintf("127.0.0.1:%d", port.NextAvailablePort())
 	oracle := newOracleHarness(oracleAddr)
 	oracle.start(t.t)
 	t.t.Cleanup(oracle.stop)
@@ -747,13 +747,13 @@ func testRfqNegotiationGroupKey(t *harnessTest) {
 // server.
 func testRfqPortfolioPilotRpc(t *harnessTest) {
 	// Start a mock price oracle RPC server.
-	oracleAddr := fmt.Sprintf("localhost:%d", port.NextAvailablePort())
+	oracleAddr := fmt.Sprintf("127.0.0.1:%d", port.NextAvailablePort())
 	oracle := newOracleHarness(oracleAddr)
 	oracle.start(t.t)
 	t.t.Cleanup(oracle.stop)
 
 	// Start a portfolio pilot RPC server.
-	pilotAddr := fmt.Sprintf("localhost:%d", port.NextAvailablePort())
+	pilotAddr := fmt.Sprintf("127.0.0.1:%d", port.NextAvailablePort())
 	pilot := newPortfolioPilotHarness(pilotAddr)
 	pilot.start(t.t)
 	t.t.Cleanup(pilot.stop)


### PR DESCRIPTION
(This is unrelated to the changes in #1988, but might be worth bringing in along with them. I discovered this while reviewing that PR.)

Using "localhost" in these tests can cause issues with gRPC if it resolves to an ipv6 link-local address, which is commonly the case on macOS (some of the tests fail at present on macOS, for example). Using 127.0.0.1 bypasses DNS entirely.

See commit 4aa5d221a55, which made a similar change.