### PR TITLE
server: fix UniverseFederation.Start() called during shutdown

### DIFF
--- a/server.go
+++ b/server.go
@@ -838,7 +838,7 @@ func (s *Server) Stop() error {
 		return err
 	}
 
-	if err := s.cfg.UniverseFederation.Start(); err != nil {
+	if err := s.cfg.UniverseFederation.Stop(); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
The server's Stop() method was incorrectly calling Start() on the UniverseFederation instead of Stop(), causing it to restart during shutdown. This likely caused tapd to hang during graceful shutdown.