### PR TITLE
ci: fix itest log zipping and unhide log directories

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -429,7 +429,7 @@ jobs:
 
       - name: Zip log files on failure
         if: ${{ failure() }}
-        run: 7z a logs-itest-${{ matrix.tranche }}.zip itest/regtest/.logs-tranche*/*.log itest/regtest/.logs-tranche*/output.log
+        run: 7z a logs-itest-${{ matrix.tranche }}.zip itest/regtest/logs-tranche*/*.log
 
       - name: Upload log files on failure
         uses: actions/upload-artifact@v7
@@ -521,7 +521,7 @@ jobs:
 
       - name: Zip log files on failure
         if: ${{ failure() }}
-        run: 7z a logs-itest-postgres-${{ matrix.tranche }}.zip itest/regtest/.logs-tranche*/*.log itest/regtest/.logs-tranche*/output.log
+        run: 7z a logs-itest-postgres-${{ matrix.tranche }}.zip itest/regtest/logs-tranche*/*.log
 
       - name: Upload log files on failure
         uses: actions/upload-artifact@v7

--- a/scripts/itest_part.sh
+++ b/scripts/itest_part.sh
@@ -26,7 +26,7 @@ done
 # that here if necessary.
 EXEC="$WORKDIR"/itest.test
 BTCD_EXEC="$WORKDIR"/btcd-itest
-LOG_DIR="$WORKDIR/regtest/.logs-tranche$TRANCHE"
+LOG_DIR="$WORKDIR/regtest/logs-tranche$TRANCHE"
 export GOCOVERDIR="$WORKDIR/regtest/cover"
 COVERFILE="$GOCOVERDIR/coverage-tranche$TRANCHE.txt"
 mkdir -p "$GOCOVERDIR"


### PR DESCRIPTION
When an integration test tranche fails, the "Zip log files on failure" step itself was failing with a `Duplicate filename on disk` error (example: [run #23148778068](https://github.com/lightninglabs/taproot-assets/actions/runs/23148778068/job/67244943986?pr=2020)), preventing log artifacts from being uploaded.

Additionally, `itest_part.sh` was writing logs to a hidden directory (`.logs-tranche*`) while the custom-channels equivalent (`itest_cc_part.sh`) uses a non-hidden `logs-tranche* `directory. This inconsistency was unnecessary.