### PR TITLE
chore: use --match 'v*' in git describe to ignore submodule tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ MIGRATE_BIN := $(GO_BIN)/migrate
 # VERSION_GO_FILE is the golang file which defines the current project version.
 VERSION_GO_FILE := "version.go"
 
-COMMIT := $(shell git describe --tags --dirty --always)
+COMMIT := $(shell git describe --tags --match 'v*' --dirty --always)
 
 GOBUILD := go build -v
 GOINSTALL := go install -v

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -100,7 +100,7 @@ function check_tag_correct() {
   fi
 
   # If a tag is specified, ensure that that tag is present and checked out.
-  if [[ $tag != $(git describe --tags) ]]; then
+  if [[ $tag != $(git describe --tags --match 'v*') ]]; then
     red "tag $tag not checked out"
     exit 1
   else


### PR DESCRIPTION
When a commit has both a release tag (e.g. v0.7.0) and a Go submodule tag (e.g. taprpc/v1.0.13), git describe --tags may return the submodule tag, causing 1) the submodule tag to be baked as the version string into any locally-built binary (e.g. taprpc/v1.0.13-445-g4f622253), and 2) the release build to fail with the "tag not checked out" error.

The use of "--match 'v*'" fixes the issue by ensuring that 'git describe' only hits an actual release tag (so we get e.g. v0.7.0-445-g4f622253 instead, and the release build works).