### PR TITLE
authmailbox: bump timeout to decrease flake incidence

### DIFF
--- a/authmailbox/mock.go
+++ b/authmailbox/mock.go
@@ -20,7 +20,7 @@ import (
 )
 
 var (
-	testTimeout            = time.Second
+	testTimeout            = 5 * time.Second
 	testMinBackoff         = time.Millisecond * 20
 	testMaxBackoff         = time.Millisecond * 100
 	testMaxConnectAttempts = uint32(200)


### PR DESCRIPTION
The one-second testTimeout here seemed to cause a flake in [this CI job](https://github.com/lightninglabs/taproot-assets/actions/runs/23746732592/job/69177257065). I'm not sure I've ever seen this flake before, so it must be rare at 1s; bumping to 5s should make it significantly more rare.