### PR TITLE
rfq+rfqmsg: add fill quantity negotiation and constraint validation

### DIFF
--- a/docs/release-notes/release-notes-0.8.0.md
+++ b/docs/release-notes/release-notes-0.8.0.md
@@ -130,6 +130,12 @@
   with a new `FOK_NOT_VIABLE` reject code. New fields are optional and
   backward-compatible.
 
+- [Fill Quantity Negotiation](https://github.com/lightninglabs/taproot-assets/pull/2050):
+  RFQ accept messages now carry an optional fill quantity, allowing
+  the responder to signal the maximum amount it is willing to fill.
+  The negotiated fill caps HTLC policies so forwarding never exceeds
+  the agreed amount.
+
 ## Functional Enhancements
 
 - [Wallet Backup/Restore](https://github.com/lightninglabs/taproot-assets/pull/1980):
@@ -187,6 +193,13 @@
   `EXECUTION_POLICY_FOK`) to `AddAssetBuyOrder` and `AddAssetSellOrder`
   requests, and to `PortfolioPilot.ResolveRequest` for constraint
   forwarding. Add `FOK_NOT_VIABLE` to `QuoteRespStatus`.
+
+- [PR#2050](https://github.com/lightninglabs/taproot-assets/pull/2050):
+  Add `max_in_asset` to `PeerAcceptedBuyQuote` and
+  `PeerAcceptedSellQuote` in both the RFQ and PortfolioPilot
+  services, exposing the negotiated fill quantity to RPC clients.
+  Add `fill_amount` to `PortfolioPilot.ResolveResponse` for
+  responder-side fill signalling.
 
 ## tapcli Additions
 
@@ -398,6 +411,10 @@
 - [PR#2023](https://github.com/lightninglabs/taproot-assets/pull/2023)
   Add `DeleteUniverseLeaf` SQL query for single-leaf deletion from a
   universe.
+
+- [PR#2050](https://github.com/lightninglabs/taproot-assets/pull/2050)
+  Add `accepted_max_amount` column to the `rfq_policies` table to
+  persist the negotiated fill quantity alongside HTLC policies.
 
 ## Code Health
 

--- a/itest/custom_channels/limit_constraints_test.go
+++ b/itest/custom_channels/limit_constraints_test.go
@@ -300,6 +300,62 @@ func testCustomChannelsLimitConstraints(_ context.Context,
 	logBalance(t.t, nodes, assetID, "after FOK payment")
 	t.Logf("FOK payment completed: %d units sent", numUnitsFOK)
 
+	// -----------------------------------------------------------------
+	// Negotiate a sell order with explicit IOC policy.
+	// This mirrors the implicit-IOC block above but sets the
+	// execution policy explicitly to prove the RPC surface
+	// accepts and correctly handles the value end-to-end.
+	// -----------------------------------------------------------------
+	t.Logf("Negotiating sell order with explicit IOC policy...")
+
+	sellRespIOC, err := asTapd(charlie).RfqClient.AddAssetSellOrder(
+		ctxb, &rfqrpc.AddAssetSellOrderRequest{
+			AssetSpecifier: &rfqrpc.AssetSpecifier{
+				Id: &rfqrpc.AssetSpecifier_AssetId{
+					AssetId: assetID,
+				},
+			},
+			PaymentMaxAmt: 180_000_000,
+			PaymentMinAmt: 1000,
+			AssetRateLimit: &rfqrpc.FixedPoint{
+				Coefficient: "100000000000000",
+				Scale:       2,
+			},
+			ExecutionPolicy: rfqrpc.ExecutionPolicy_EXECUTION_POLICY_IOC,
+			Expiry:          uint64(inOneHour.Unix()),
+			PeerPubKey:      dave.PubKey[:],
+			TimeoutSeconds:  10,
+		},
+	)
+	require.NoError(t.t, err, "sell order with explicit IOC")
+
+	acceptedIOC := sellRespIOC.GetAcceptedQuote()
+	require.NotNil(
+		t.t, acceptedIOC,
+		"expected accepted IOC sell quote",
+	)
+	t.Logf("IOC sell quote accepted: scid=%d", acceptedIOC.Scid)
+
+	// Pay using the IOC quote with a regular BTC invoice.
+	invoiceRespIOC, err := erin.LightningClient.AddInvoice(
+		ctxb, &lnrpc.Invoice{
+			ValueMsat: invoiceMsat,
+		},
+	)
+	require.NoError(t.t, err)
+
+	var quoteIDIOC rfqmsg.ID
+	copy(quoteIDIOC[:], acceptedIOC.Id)
+
+	numUnitsIOC, _ := payInvoiceWithAssets(
+		t.t, charlie, dave, invoiceRespIOC.PaymentRequest,
+		assetID, withRFQ(quoteIDIOC),
+	)
+	require.Greater(t.t, numUnitsIOC, uint64(0))
+
+	logBalance(t.t, nodes, assetID, "after explicit IOC payment")
+	t.Logf("IOC payment completed: %d units sent", numUnitsIOC)
+
 	// Close channels.
 	closeAssetChannelAndAssert(
 		t, net, charlie, dave, chanPointCD,

--- a/itest/portfolio_pilot_harness.go
+++ b/itest/portfolio_pilot_harness.go
@@ -54,6 +54,10 @@ type portfolioPilotHarness struct {
 
 	// verifyStatus is the quote verification status returned by the server.
 	verifyStatus pilotrpc.QuoteRespStatus
+
+	// fillAmount is the optional fill cap returned in
+	// ResolveRequestResponse. 0 means no cap.
+	fillAmount uint64
 }
 
 // newPortfolioPilotHarness returns a new portfolio pilot harness instance that
@@ -116,6 +120,15 @@ func (p *portfolioPilotHarness) callCounts() (resolve, verify, query int) {
 	return p.resolveCalls, p.verifyCalls, p.queryCalls
 }
 
+// SetFillAmount sets the fill cap returned in ResolveRequest
+// responses. 0 means no cap.
+func (p *portfolioPilotHarness) SetFillAmount(amt uint64) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	p.fillAmount = amt
+}
+
 // defaultAssetRate returns a default asset rate in RPC form.
 func (p *portfolioPilotHarness) defaultAssetRate() (*pilotrpc.AssetRate,
 	error) {
@@ -140,6 +153,7 @@ func (p *portfolioPilotHarness) ResolveRequest(_ context.Context,
 	p.mu.Lock()
 	p.resolveCalls++
 	p.lastResolve = req
+	fa := p.fillAmount
 	p.mu.Unlock()
 
 	if req == nil {
@@ -182,6 +196,7 @@ func (p *portfolioPilotHarness) ResolveRequest(_ context.Context,
 		Result: &pilotrpc.ResolveRequestResponse_Accept{
 			Accept: hint,
 		},
+		AcceptedMaxAmount: fa,
 	}, nil
 }
 

--- a/itest/rfq_test.go
+++ b/itest/rfq_test.go
@@ -842,6 +842,221 @@ func testRfqPortfolioPilotRpc(t *harnessTest) {
 		return resolveCalls > 0 && verifyCalls > 0 &&
 			queryCalls > 0
 	}, rfqTimeout, 50*time.Millisecond)
+
+	err = carolEventNtfns.CloseSend()
+	require.NoError(t.t, err)
+
+	// -----------------------------------------------------------------
+	// Sub-test: Buy order with fill cap.
+	//
+	// Set pilot fill amount to 3. Submit a buy order with
+	// AssetMaxAmt = 6. The accepted quote should report
+	// AcceptedMaxAmount = 3.
+	// -----------------------------------------------------------------
+	t.Log("Sub-test: buy order with fill cap")
+
+	pilot.SetFillAmount(3)
+
+	carolEvents2, err := ts.CarolTapd.SubscribeRfqEventNtfns(
+		ctx, &rfqrpc.SubscribeRfqEventNtfnsRequest{},
+	)
+	require.NoError(t.t, err)
+
+	buyReq2 := &rfqrpc.AddAssetBuyOrderRequest{
+		AssetSpecifier: &rfqrpc.AssetSpecifier{
+			Id: &rfqrpc.AssetSpecifier_AssetId{
+				AssetId: mintedAssetId,
+			},
+		},
+		AssetMaxAmt: 6,
+		Expiry:      buyOrderExpiry,
+		PeerPubKey:  ts.BobLnd.PubKey[:],
+		TimeoutSeconds: uint32(
+			rfqTimeout.Seconds(),
+		),
+		SkipAssetChannelCheck: true,
+	}
+	_, err = ts.CarolTapd.AddAssetBuyOrder(ctx, buyReq2)
+	require.NoError(t.t, err, "buy order with fill cap")
+
+	var buyCapQuoteID []byte
+	BeforeTimeout(t.t, func() {
+		event, err := carolEvents2.Recv()
+		require.NoError(t.t, err)
+
+		e, ok := event.Event.(*rfqrpc.RfqEvent_PeerAcceptedBuyQuote)
+		require.True(t.t, ok, "unexpected event: %v", event)
+
+		buyCapQuoteID = e.PeerAcceptedBuyQuote.
+			PeerAcceptedBuyQuote.Id
+	}, rfqTimeout)
+
+	acceptedQuotes, err := ts.CarolTapd.QueryPeerAcceptedQuotes(
+		ctx, &rfqrpc.QueryPeerAcceptedQuotesRequest{},
+	)
+	require.NoError(t.t, err)
+
+	var matchedBuy *rfqrpc.PeerAcceptedBuyQuote
+	for _, q := range acceptedQuotes.BuyQuotes {
+		if bytes.Equal(q.Id, buyCapQuoteID) {
+			matchedBuy = q
+			break
+		}
+	}
+	require.NotNil(t.t, matchedBuy, "quote not found by ID")
+	require.Equal(
+		t.t, uint64(3), matchedBuy.AcceptedMaxAmount,
+		"expected fill cap of 3",
+	)
+
+	err = carolEvents2.CloseSend()
+	require.NoError(t.t, err)
+
+	// -----------------------------------------------------------------
+	// Sub-test: Buy order without fill cap.
+	//
+	// Set pilot fill amount to 0 (no cap). The accepted quote
+	// should report AcceptedMaxAmount = 0.
+	// -----------------------------------------------------------------
+	t.Log("Sub-test: buy order without fill cap")
+
+	pilot.SetFillAmount(0)
+
+	carolEvents3, err := ts.CarolTapd.SubscribeRfqEventNtfns(
+		ctx, &rfqrpc.SubscribeRfqEventNtfnsRequest{},
+	)
+	require.NoError(t.t, err)
+
+	buyReq3 := &rfqrpc.AddAssetBuyOrderRequest{
+		AssetSpecifier: &rfqrpc.AssetSpecifier{
+			Id: &rfqrpc.AssetSpecifier_AssetId{
+				AssetId: mintedAssetId,
+			},
+		},
+		AssetMaxAmt: 6,
+		Expiry:      buyOrderExpiry,
+		PeerPubKey:  ts.BobLnd.PubKey[:],
+		TimeoutSeconds: uint32(
+			rfqTimeout.Seconds(),
+		),
+		SkipAssetChannelCheck: true,
+	}
+	_, err = ts.CarolTapd.AddAssetBuyOrder(ctx, buyReq3)
+	require.NoError(t.t, err, "buy order without fill cap")
+
+	var buyNoCapQuoteID []byte
+	BeforeTimeout(t.t, func() {
+		event, err := carolEvents3.Recv()
+		require.NoError(t.t, err)
+
+		e, ok := event.Event.(*rfqrpc.RfqEvent_PeerAcceptedBuyQuote)
+		require.True(t.t, ok, "unexpected event: %v", event)
+
+		buyNoCapQuoteID = e.PeerAcceptedBuyQuote.
+			PeerAcceptedBuyQuote.Id
+	}, rfqTimeout)
+
+	acceptedQuotes, err = ts.CarolTapd.QueryPeerAcceptedQuotes(
+		ctx, &rfqrpc.QueryPeerAcceptedQuotesRequest{},
+	)
+	require.NoError(t.t, err)
+
+	var matchedBuyNoCap *rfqrpc.PeerAcceptedBuyQuote
+	for _, q := range acceptedQuotes.BuyQuotes {
+		if bytes.Equal(q.Id, buyNoCapQuoteID) {
+			matchedBuyNoCap = q
+			break
+		}
+	}
+	require.NotNil(t.t, matchedBuyNoCap, "quote not found by ID")
+	require.Equal(
+		t.t, uint64(0), matchedBuyNoCap.AcceptedMaxAmount,
+		"expected no fill cap",
+	)
+
+	err = carolEvents3.CloseSend()
+	require.NoError(t.t, err)
+
+	// -----------------------------------------------------------------
+	// Sub-test: Sell order with fill cap.
+	//
+	// Register a buy offer on Bob so Alice can sell. Set pilot
+	// fill amount to 20000. Submit a sell order from Alice and
+	// verify AcceptedMaxAmount = 20000.
+	// -----------------------------------------------------------------
+	t.Log("Sub-test: sell order with fill cap")
+
+	_, err = ts.BobTapd.AddAssetBuyOffer(
+		ctx, &rfqrpc.AddAssetBuyOfferRequest{
+			AssetSpecifier: &rfqrpc.AssetSpecifier{
+				Id: &rfqrpc.AssetSpecifier_AssetId{
+					AssetId: mintedAssetId,
+				},
+			},
+			MaxUnits: 1000,
+		},
+	)
+	require.NoError(t.t, err)
+
+	pilot.SetFillAmount(20000)
+
+	aliceEvents, err := ts.AliceTapd.SubscribeRfqEventNtfns(
+		ctx, &rfqrpc.SubscribeRfqEventNtfnsRequest{},
+	)
+	require.NoError(t.t, err)
+
+	sellOrderExpiry := uint64(
+		time.Now().Add(24 * time.Hour).Unix(),
+	)
+	sellReq := &rfqrpc.AddAssetSellOrderRequest{
+		AssetSpecifier: &rfqrpc.AssetSpecifier{
+			Id: &rfqrpc.AssetSpecifier_AssetId{
+				AssetId: mintedAssetId,
+			},
+		},
+		PaymentMaxAmt: 42000,
+		Expiry:        sellOrderExpiry,
+		PeerPubKey:    ts.BobLnd.PubKey[:],
+		TimeoutSeconds: uint32(
+			rfqTimeout.Seconds(),
+		),
+		SkipAssetChannelCheck: true,
+	}
+	_, err = ts.AliceTapd.AddAssetSellOrder(ctx, sellReq)
+	require.NoError(t.t, err, "sell order with fill cap")
+
+	var sellCapQuoteID []byte
+	BeforeTimeout(t.t, func() {
+		event, err := aliceEvents.Recv()
+		require.NoError(t.t, err)
+
+		e, ok := event.Event.(*rfqrpc.RfqEvent_PeerAcceptedSellQuote)
+		require.True(t.t, ok, "unexpected event: %v", event)
+
+		sellCapQuoteID = e.PeerAcceptedSellQuote.
+			PeerAcceptedSellQuote.Id
+	}, rfqTimeout)
+
+	acceptedQuotes, err = ts.AliceTapd.QueryPeerAcceptedQuotes(
+		ctx, &rfqrpc.QueryPeerAcceptedQuotesRequest{},
+	)
+	require.NoError(t.t, err)
+
+	var matchedSell *rfqrpc.PeerAcceptedSellQuote
+	for _, q := range acceptedQuotes.SellQuotes {
+		if bytes.Equal(q.Id, sellCapQuoteID) {
+			matchedSell = q
+			break
+		}
+	}
+	require.NotNil(t.t, matchedSell, "quote not found by ID")
+	require.Equal(
+		t.t, uint64(20000), matchedSell.AcceptedMaxAmount,
+		"expected fill cap of 20000",
+	)
+
+	err = aliceEvents.CloseSend()
+	require.NoError(t.t, err)
 }
 
 // testRfqLimitConstraints tests that RFQ negotiation correctly enforces
@@ -986,6 +1201,8 @@ func testRfqLimitConstraints(t *harnessTest) {
 	//
 	// Oracle rate = 1000. Alice sets rate limit = 2000 (ceiling
 	// for sell). Since 1000 <= 2000, the constraint passes.
+	// Payment amounts must be large enough to convert to non-zero
+	// asset units at this rate (1 unit = 10^8 msat).
 	// -----------------------------------------------------------------
 	t.Log("Sub-test 3: sell with satisfied constraints")
 
@@ -1000,7 +1217,8 @@ func testRfqLimitConstraints(t *harnessTest) {
 				AssetId: mintedAssetId,
 			},
 		},
-		PaymentMaxAmt: 42000,
+		PaymentMaxAmt: 200_000_000,
+		PaymentMinAmt: 100_000_000,
 		AssetRateLimit: &rfqrpc.FixedPoint{
 			Coefficient: "2000000",
 			Scale:       3,
@@ -1039,7 +1257,7 @@ func testRfqLimitConstraints(t *harnessTest) {
 				AssetId: mintedAssetId,
 			},
 		},
-		PaymentMaxAmt: 42000,
+		PaymentMaxAmt: 200_000_000,
 		AssetRateLimit: &rfqrpc.FixedPoint{
 			Coefficient: "500000",
 			Scale:       3,
@@ -1082,6 +1300,242 @@ func testRfqLimitConstraints(t *harnessTest) {
 		t.t, err, "exceeds max amount",
 		"expected immediate min > max rejection",
 	)
+
+	// -----------------------------------------------------------------
+	// Sub-test 6: Buy FOK — rate supports full amount.
+	//
+	// Oracle rate = 1000. Carol sets FOK on a max of 6 units.
+	// At 1000 units/BTC, 6 units = 6e-3 BTC = 6M msat, which
+	// is non-zero. FOK is satisfied.
+	// -----------------------------------------------------------------
+	t.Log("Sub-test 6: buy FOK accepted")
+
+	carolEvents2, err := ts.CarolTapd.SubscribeRfqEventNtfns(
+		ctx, &rfqrpc.SubscribeRfqEventNtfnsRequest{},
+	)
+	require.NoError(t.t, err)
+
+	buyReqFOK := &rfqrpc.AddAssetBuyOrderRequest{
+		AssetSpecifier: &rfqrpc.AssetSpecifier{
+			Id: &rfqrpc.AssetSpecifier_AssetId{
+				AssetId: mintedAssetId,
+			},
+		},
+		AssetMaxAmt:           6,
+		ExecutionPolicy:       rfqrpc.ExecutionPolicy_EXECUTION_POLICY_FOK, //nolint:lll
+		Expiry:                expiry,
+		PeerPubKey:            ts.BobLnd.PubKey[:],
+		TimeoutSeconds:        uint32(rfqTimeout.Seconds()),
+		SkipAssetChannelCheck: true,
+	}
+	_, err = ts.CarolTapd.AddAssetBuyOrder(ctx, buyReqFOK)
+	require.NoError(t.t, err, "buy FOK with viable rate")
+
+	BeforeTimeout(t.t, func() {
+		event, err := carolEvents2.Recv()
+		require.NoError(t.t, err)
+
+		_, ok := event.Event.(*rfqrpc.RfqEvent_PeerAcceptedBuyQuote)
+		require.True(t.t, ok, "expected PeerAcceptedBuyQuote, "+
+			"got: %v", event)
+	}, rfqTimeout)
+
+	err = carolEvents2.CloseSend()
+	require.NoError(t.t, err)
+
+	// -----------------------------------------------------------------
+	// Sub-test 7: Sell FOK — rate supports full amount.
+	//
+	// Oracle rate = 1000. Alice sets FOK on a max of 200M msat.
+	// At 1000 units/BTC, 200M msat = 2 units, which is non-zero.
+	// FOK is satisfied.
+	// -----------------------------------------------------------------
+	t.Log("Sub-test 7: sell FOK accepted")
+
+	aliceEvents2, err := ts.AliceTapd.SubscribeRfqEventNtfns(
+		ctx, &rfqrpc.SubscribeRfqEventNtfnsRequest{},
+	)
+	require.NoError(t.t, err)
+
+	sellReqFOK := &rfqrpc.AddAssetSellOrderRequest{
+		AssetSpecifier: &rfqrpc.AssetSpecifier{
+			Id: &rfqrpc.AssetSpecifier_AssetId{
+				AssetId: mintedAssetId,
+			},
+		},
+		PaymentMaxAmt:         200_000_000,
+		ExecutionPolicy:       rfqrpc.ExecutionPolicy_EXECUTION_POLICY_FOK, //nolint:lll
+		Expiry:                expiry,
+		PeerPubKey:            ts.BobLnd.PubKey[:],
+		TimeoutSeconds:        uint32(rfqTimeout.Seconds()),
+		SkipAssetChannelCheck: true,
+	}
+	_, err = ts.AliceTapd.AddAssetSellOrder(ctx, sellReqFOK)
+	require.NoError(t.t, err, "sell FOK with viable rate")
+
+	BeforeTimeout(t.t, func() {
+		event, err := aliceEvents2.Recv()
+		require.NoError(t.t, err)
+
+		_, ok := event.Event.(*rfqrpc.RfqEvent_PeerAcceptedSellQuote)
+		require.True(t.t, ok, "expected PeerAcceptedSellQuote, "+
+			"got: %v", event)
+	}, rfqTimeout)
+
+	err = aliceEvents2.CloseSend()
+	require.NoError(t.t, err)
+
+	// -----------------------------------------------------------------
+	// Sub-test 8: Buy FOK — rate cannot support full amount.
+	//
+	// Set oracle to a very high rate (1e12 units/BTC), then FOK
+	// with max = 1 unit. 1 unit at 1e12 rate = ~0 msat. FOK
+	// fails.
+	// -----------------------------------------------------------------
+	t.Log("Sub-test 8: buy FOK rejected")
+
+	hugeRate := rfqmath.NewBigIntFixedPoint(
+		1_000_000_000_000, 0,
+	)
+	oracle.SetPrice(specifier, hugeRate, hugeRate)
+
+	buyReqFOKFail := &rfqrpc.AddAssetBuyOrderRequest{
+		AssetSpecifier: &rfqrpc.AssetSpecifier{
+			Id: &rfqrpc.AssetSpecifier_AssetId{
+				AssetId: mintedAssetId,
+			},
+		},
+		AssetMaxAmt:           1,
+		ExecutionPolicy:       rfqrpc.ExecutionPolicy_EXECUTION_POLICY_FOK, //nolint:lll
+		Expiry:                expiry,
+		PeerPubKey:            ts.BobLnd.PubKey[:],
+		TimeoutSeconds:        uint32(rfqTimeout.Seconds()),
+		SkipAssetChannelCheck: true,
+	}
+	_, err = ts.CarolTapd.AddAssetBuyOrder(ctx, buyReqFOKFail)
+	require.ErrorContains(
+		t.t, err, "rejected quote",
+		"expected FOK rejection for buy order",
+	)
+
+	// -----------------------------------------------------------------
+	// Sub-test 9: IOC (default) — same extreme rate, no rejection.
+	//
+	// Same huge rate but without FOK. IOC doesn't enforce the
+	// full-amount conversion, so the quote is accepted.
+	// -----------------------------------------------------------------
+	t.Log("Sub-test 9: IOC default accepted with extreme rate")
+
+	carolEvents3, err := ts.CarolTapd.SubscribeRfqEventNtfns(
+		ctx, &rfqrpc.SubscribeRfqEventNtfnsRequest{},
+	)
+	require.NoError(t.t, err)
+
+	buyReqIOC := &rfqrpc.AddAssetBuyOrderRequest{
+		AssetSpecifier: &rfqrpc.AssetSpecifier{
+			Id: &rfqrpc.AssetSpecifier_AssetId{
+				AssetId: mintedAssetId,
+			},
+		},
+		AssetMaxAmt:           1,
+		Expiry:                expiry,
+		PeerPubKey:            ts.BobLnd.PubKey[:],
+		TimeoutSeconds:        uint32(rfqTimeout.Seconds()),
+		SkipAssetChannelCheck: true,
+	}
+	_, err = ts.CarolTapd.AddAssetBuyOrder(ctx, buyReqIOC)
+	require.NoError(t.t, err, "IOC should not reject")
+
+	BeforeTimeout(t.t, func() {
+		event, err := carolEvents3.Recv()
+		require.NoError(t.t, err)
+
+		_, ok := event.Event.(*rfqrpc.RfqEvent_PeerAcceptedBuyQuote)
+		require.True(t.t, ok, "expected PeerAcceptedBuyQuote, "+
+			"got: %v", event)
+	}, rfqTimeout)
+
+	err = carolEvents3.CloseSend()
+	require.NoError(t.t, err)
+
+	// -----------------------------------------------------------------
+	// Sub-test 10: Sell FOK — rate cannot support full amount.
+	//
+	// Set oracle to a tiny rate (1 unit/BTC). With
+	// PaymentMaxAmt = 1 msat, MilliSatoshiToUnits(1, 1) ≈ 0
+	// asset units — FOK viability check fails.
+	//
+	// Note: the hugeRate from sub-test 8 does NOT work here
+	// because sell-side converts msat→units (not units→msat),
+	// and 1 msat * 1e12 ≈ 10 units (non-zero).
+	// -----------------------------------------------------------------
+	t.Log("Sub-test 10: sell FOK rejected")
+
+	tinyRate := rfqmath.NewBigIntFixedPoint(1, 0)
+	oracle.SetPrice(specifier, tinyRate, tinyRate)
+
+	sellReqFOKFail := &rfqrpc.AddAssetSellOrderRequest{
+		AssetSpecifier: &rfqrpc.AssetSpecifier{
+			Id: &rfqrpc.AssetSpecifier_AssetId{
+				AssetId: mintedAssetId,
+			},
+		},
+		PaymentMaxAmt:   1,
+		ExecutionPolicy: rfqrpc.ExecutionPolicy_EXECUTION_POLICY_FOK,
+		Expiry:          expiry,
+		PeerPubKey:      ts.BobLnd.PubKey[:],
+		TimeoutSeconds: uint32(
+			rfqTimeout.Seconds(),
+		),
+		SkipAssetChannelCheck: true,
+	}
+	_, err = ts.AliceTapd.AddAssetSellOrder(ctx, sellReqFOKFail)
+	require.ErrorContains(
+		t.t, err, "rejected quote",
+		"expected FOK rejection for sell order",
+	)
+
+	// -----------------------------------------------------------------
+	// Sub-test 11: Sell IOC — same tiny rate, no rejection.
+	//
+	// Same tinyRate but without FOK (default IOC). IOC doesn't
+	// enforce full-amount conversion, so the quote is accepted.
+	// -----------------------------------------------------------------
+	t.Log("Sub-test 11: sell IOC accepted with tiny rate")
+
+	aliceEvents3, err := ts.AliceTapd.SubscribeRfqEventNtfns(
+		ctx, &rfqrpc.SubscribeRfqEventNtfnsRequest{},
+	)
+	require.NoError(t.t, err)
+
+	sellReqIOC := &rfqrpc.AddAssetSellOrderRequest{
+		AssetSpecifier: &rfqrpc.AssetSpecifier{
+			Id: &rfqrpc.AssetSpecifier_AssetId{
+				AssetId: mintedAssetId,
+			},
+		},
+		PaymentMaxAmt: 1,
+		Expiry:        expiry,
+		PeerPubKey:    ts.BobLnd.PubKey[:],
+		TimeoutSeconds: uint32(
+			rfqTimeout.Seconds(),
+		),
+		SkipAssetChannelCheck: true,
+	}
+	_, err = ts.AliceTapd.AddAssetSellOrder(ctx, sellReqIOC)
+	require.NoError(t.t, err, "sell IOC should not reject")
+
+	BeforeTimeout(t.t, func() {
+		event, err := aliceEvents3.Recv()
+		require.NoError(t.t, err)
+
+		_, ok := event.Event.(*rfqrpc.RfqEvent_PeerAcceptedSellQuote)
+		require.True(t.t, ok, "expected PeerAcceptedSellQuote, "+
+			"got: %v", event)
+	}, rfqTimeout)
+
+	err = aliceEvents3.CloseSend()
+	require.NoError(t.t, err)
 }
 
 // rfqTestScenario is a struct which holds test scenario helper infra.

--- a/rfq/manager.go
+++ b/rfq/manager.go
@@ -1452,6 +1452,10 @@ const (
 	// FOKNotViableQuoteRespStatus indicates that the FOK execution
 	// policy could not be satisfied at the accepted rate.
 	FOKNotViableQuoteRespStatus QuoteRespStatus = 7
+
+	// FillExceedsMaxQuoteRespStatus indicates that the negotiated
+	// fill amount exceeds the requester's maximum.
+	FillExceedsMaxQuoteRespStatus QuoteRespStatus = 8
 )
 
 // InvalidQuoteRespEvent is an event that is broadcast when the RFQ manager

--- a/rfq/marshal.go
+++ b/rfq/marshal.go
@@ -49,6 +49,7 @@ func MarshalAcceptedSellQuote(
 		AssetAmount:          numAssetUnits.ScaleTo(0).ToUint64(),
 		MinTransportableMsat: uint64(minTransportableMSat),
 		PriceOracleMetadata:  accept.Request.PriceOracleMetadata,
+		AcceptedMaxAmount:    accept.AcceptedMaxAmount.UnwrapOr(0),
 	}
 
 	// Populate asset ID and/or group key based on the asset specifier.
@@ -96,6 +97,7 @@ func MarshalAcceptedBuyQuote(q rfqmsg.BuyAccept) *rfqrpc.PeerAcceptedBuyQuote {
 		Expiry:                uint64(q.AssetRate.Expiry.Unix()),
 		MinTransportableUnits: minTransportableUnits,
 		PriceOracleMetadata:   q.Request.PriceOracleMetadata,
+		AcceptedMaxAmount:     q.AcceptedMaxAmount.UnwrapOr(0),
 	}
 
 	// Populate asset ID and/or group key based on the asset specifier.

--- a/rfq/negotiator.go
+++ b/rfq/negotiator.go
@@ -314,9 +314,10 @@ func (n *Negotiator) HandleIncomingQuoteRequest(ctx context.Context,
 		}
 
 		var acceptErr error
+		fillAmount := resp.FillAmount()
 		resp.WhenAccept(func(assetRate rfqmsg.AssetRate) {
 			msg, err := rfqmsg.NewQuoteAcceptFromRequest(
-				request, assetRate,
+				request, assetRate, fillAmount,
 			)
 			if err != nil {
 				acceptErr = fmt.Errorf("create quote accept "+

--- a/rfq/order.go
+++ b/rfq/order.go
@@ -206,10 +206,17 @@ func NewAssetSalePolicy(quote rfqmsg.BuyAccept, noop bool,
 
 	htlcToAmtMap := make(map[models.CircuitKey]lnwire.MilliSatoshi)
 
+	maxAmt := quote.Request.AssetMaxAmt
+	quote.AcceptedMaxAmount.WhenSome(func(fill uint64) {
+		if fill < maxAmt {
+			maxAmt = fill
+		}
+	})
+
 	return &AssetSalePolicy{
 		AssetSpecifier:         quote.Request.AssetSpecifier,
 		AcceptedQuoteId:        quote.ID,
-		MaxOutboundAssetAmount: quote.Request.AssetMaxAmt,
+		MaxOutboundAssetAmount: maxAmt,
 		AskAssetRate:           quote.AssetRate.Rate,
 		expiry:                 uint64(quote.AssetRate.Expiry.Unix()),
 		htlcToAmt:              htlcToAmtMap,
@@ -444,12 +451,20 @@ type AssetPurchasePolicy struct {
 func NewAssetPurchasePolicy(quote rfqmsg.SellAccept) *AssetPurchasePolicy {
 	htlcToAmtMap := make(map[models.CircuitKey]lnwire.MilliSatoshi)
 
+	payMax := quote.Request.PaymentMaxAmt
+	quote.AcceptedMaxAmount.WhenSome(func(fill uint64) {
+		fillMsat := lnwire.MilliSatoshi(fill)
+		if fillMsat < payMax {
+			payMax = fillMsat
+		}
+	})
+
 	return &AssetPurchasePolicy{
 		scid:            quote.ShortChannelId(),
 		AssetSpecifier:  quote.Request.AssetSpecifier,
 		AcceptedQuoteId: quote.ID,
 		BidAssetRate:    quote.AssetRate.Rate,
-		PaymentMaxAmt:   quote.Request.PaymentMaxAmt,
+		PaymentMaxAmt:   payMax,
 		expiry:          uint64(quote.AssetRate.Expiry.Unix()),
 		htlcToAmt:       htlcToAmtMap,
 		ExecutionPolicy: quote.Request.ExecutionPolicy,

--- a/rfq/order_test.go
+++ b/rfq/order_test.go
@@ -1,0 +1,155 @@
+package rfq
+
+import (
+	"testing"
+	"time"
+
+	"github.com/lightninglabs/taproot-assets/asset"
+	"github.com/lightninglabs/taproot-assets/fn"
+	"github.com/lightninglabs/taproot-assets/rfqmath"
+	"github.com/lightninglabs/taproot-assets/rfqmsg"
+	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/lightningnetwork/lnd/routing/route"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNewAssetSalePolicyFillCap tests that NewAssetSalePolicy caps
+// MaxOutboundAssetAmount when a fill quantity is present.
+func TestNewAssetSalePolicyFillCap(t *testing.T) {
+	t.Parallel()
+
+	spec := asset.NewSpecifierFromId(asset.ID{0x01})
+	peer := route.Vertex{0x0A}
+	rate := rfqmsg.NewAssetRate(
+		rfqmath.NewBigIntFixedPoint(100, 0),
+		time.Now().Add(time.Hour),
+	)
+
+	tests := []struct {
+		name      string
+		maxAmt    uint64
+		fill      fn.Option[uint64]
+		expectMax uint64
+	}{
+		{
+			name:      "no fill uses request max",
+			maxAmt:    100,
+			fill:      fn.None[uint64](),
+			expectMax: 100,
+		},
+		{
+			name:      "fill < max caps to fill",
+			maxAmt:    100,
+			fill:      fn.Some[uint64](60),
+			expectMax: 60,
+		},
+		{
+			name:      "fill > max uses request max",
+			maxAmt:    100,
+			fill:      fn.Some[uint64](200),
+			expectMax: 100,
+		},
+		{
+			name:      "fill == max uses request max",
+			maxAmt:    100,
+			fill:      fn.Some[uint64](100),
+			expectMax: 100,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			buyReq := &rfqmsg.BuyRequest{
+				Peer:           peer,
+				AssetSpecifier: spec,
+				AssetMaxAmt:    tc.maxAmt,
+			}
+
+			accept := rfqmsg.BuyAccept{
+				Peer:              peer,
+				Request:           *buyReq,
+				AssetRate:         rate,
+				AcceptedMaxAmount: tc.fill,
+			}
+
+			policy := NewAssetSalePolicy(
+				accept, false, nil,
+			)
+			require.Equal(
+				t, tc.expectMax,
+				policy.MaxOutboundAssetAmount,
+			)
+		})
+	}
+}
+
+// TestNewAssetPurchasePolicyFillCap tests that NewAssetPurchasePolicy
+// caps PaymentMaxAmt when a fill quantity is present.
+func TestNewAssetPurchasePolicyFillCap(t *testing.T) {
+	t.Parallel()
+
+	spec := asset.NewSpecifierFromId(asset.ID{0x01})
+	peer := route.Vertex{0x0A}
+	rate := rfqmsg.NewAssetRate(
+		rfqmath.NewBigIntFixedPoint(100, 0),
+		time.Now().Add(time.Hour),
+	)
+
+	tests := []struct {
+		name      string
+		maxAmt    lnwire.MilliSatoshi
+		fill      fn.Option[uint64]
+		expectMax lnwire.MilliSatoshi
+	}{
+		{
+			name:      "no fill uses request max",
+			maxAmt:    1000,
+			fill:      fn.None[uint64](),
+			expectMax: 1000,
+		},
+		{
+			name:      "fill < max caps to fill",
+			maxAmt:    1000,
+			fill:      fn.Some[uint64](600),
+			expectMax: 600,
+		},
+		{
+			name:      "fill > max uses request max",
+			maxAmt:    1000,
+			fill:      fn.Some[uint64](2000),
+			expectMax: 1000,
+		},
+		{
+			name:      "fill == max uses request max",
+			maxAmt:    1000,
+			fill:      fn.Some[uint64](1000),
+			expectMax: 1000,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			sellReq := &rfqmsg.SellRequest{
+				Peer:           peer,
+				AssetSpecifier: spec,
+				PaymentMaxAmt:  tc.maxAmt,
+			}
+
+			accept := rfqmsg.SellAccept{
+				Peer:              peer,
+				Request:           *sellReq,
+				AssetRate:         rate,
+				AcceptedMaxAmount: tc.fill,
+			}
+
+			policy := NewAssetPurchasePolicy(accept)
+			require.Equal(
+				t, tc.expectMax, policy.PaymentMaxAmt,
+			)
+		})
+	}
+}

--- a/rfq/portfolio_pilot.go
+++ b/rfq/portfolio_pilot.go
@@ -90,21 +90,29 @@ type AssetRateQuery struct {
 	Expiry fn.Option[time.Time]
 }
 
-// ResolveResp captures the portfolio pilot's resolution decision for an RFQ. It
-// carries either an accepted asset rate quote or a structured rejection reason.
+// ResolveResp captures the portfolio pilot's resolution decision for an
+// RFQ. It carries either an accepted asset rate quote or a structured
+// rejection reason, plus an optional fill amount.
 type ResolveResp struct {
-	// outcome holds either the accepted asset rate (left) or the rejection
-	// error (right).
+	// outcome holds either the accepted asset rate (left) or the
+	// rejection error (right).
 	outcome fn.Either[rfqmsg.AssetRate, rfqmsg.RejectErr]
+
+	// fillAmount is an optional fill quantity that caps the amount
+	// the responder is willing to accept.
+	fillAmount fn.Option[uint64]
 }
 
-// NewAcceptResolveResp builds an acceptance response with the provided asset
-// rate quote.
-func NewAcceptResolveResp(assetRate rfqmsg.AssetRate) ResolveResp {
+// NewAcceptResolveResp builds an acceptance response with the provided
+// asset rate quote and optional fill amount.
+func NewAcceptResolveResp(assetRate rfqmsg.AssetRate,
+	fillAmount fn.Option[uint64]) ResolveResp {
+
 	return ResolveResp{
 		outcome: fn.NewLeft[rfqmsg.AssetRate, rfqmsg.RejectErr](
 			assetRate,
 		),
+		fillAmount: fillAmount,
 	}
 }
 
@@ -116,6 +124,11 @@ func NewRejectResolveResp(rejectErr rfqmsg.RejectErr) ResolveResp {
 			rejectErr,
 		),
 	}
+}
+
+// FillAmount returns the optional fill quantity.
+func (r *ResolveResp) FillAmount() fn.Option[uint64] {
+	return r.fillAmount
 }
 
 // IsAccept reports whether the response contains an accepted asset rate.
@@ -275,7 +288,20 @@ func (p *InternalPortfolioPilot) ResolveRequest(ctx context.Context,
 			resp.Err)
 	}
 
-	return NewAcceptResolveResp(resp.AssetRate), nil
+	// Enforce the requester's constraints on the responder side
+	// to avoid wasted round-trips.
+	status := checkAllConstraints(
+		request, resp.AssetRate.Rate, fn.None[uint64](),
+	)
+	if status != ValidAcceptQuoteRespStatus {
+		return NewRejectResolveResp(
+			rejectForStatus(status),
+		), nil
+	}
+
+	return NewAcceptResolveResp(
+		resp.AssetRate, fn.None[uint64](),
+	), nil
 }
 
 // VerifyAcceptQuote verifies that an accepted quote from a peer meets
@@ -363,20 +389,11 @@ func (p *InternalPortfolioPilot) VerifyAcceptQuote(ctx context.Context,
 		return InvalidAssetRatesQuoteRespStatus, nil
 	}
 
-	// Enforce the requester's rate bound constraint if set.
-	status := checkRateBound(req, counterRate.Rate)
-	if status != ValidAcceptQuoteRespStatus {
-		return status, nil
-	}
-
-	// Enforce the requester's min fill constraint if set.
-	status = checkMinFill(req, counterRate.Rate)
-	if status != ValidAcceptQuoteRespStatus {
-		return status, nil
-	}
-
-	// Enforce FOK execution policy if set.
-	status = checkFOK(req, counterRate.Rate)
+	// Enforce all limit-order constraints (rate bound, min fill,
+	// FOK, and fill-vs-constraint compatibility).
+	status := checkAllConstraints(
+		req, counterRate.Rate, accept.AcceptedFillAmount(),
+	)
 	if status != ValidAcceptQuoteRespStatus {
 		return status, nil
 	}
@@ -462,42 +479,57 @@ func (p *InternalPortfolioPilot) Close() error {
 	return nil
 }
 
-// checkRateBound verifies that the accepted rate satisfies the
-// requester's rate limit constraint. For a buy request, the accepted
-// rate must be >= the limit (buyer's floor). For a sell request, the
-// accepted rate must be <= the limit (seller's ceiling).
-func checkRateBound(req rfqmsg.Request,
-	acceptedRate rfqmath.BigIntFixedPoint) QuoteRespStatus {
+// checkAllConstraints runs every limit-order constraint check
+// against the given request, rate, and optional fill amount.
+// It returns the first non-valid status, or ValidAcceptQuoteRespStatus
+// if all checks pass.
+func checkAllConstraints(req rfqmsg.Request,
+	rate rfqmath.BigIntFixedPoint,
+	fill fn.Option[uint64]) QuoteRespStatus {
 
-	switch r := req.(type) {
-	case *rfqmsg.BuyRequest:
-		miss := fn.MapOptionZ(
-			r.AssetRateLimit,
-			func(limit rfqmath.BigIntFixedPoint) bool {
-				return acceptedRate.Cmp(limit) < 0
-			},
-		)
-		if miss {
-			return RateBoundMissQuoteRespStatus
+	for _, check := range []func() QuoteRespStatus{
+		func() QuoteRespStatus {
+			return checkRateBound(req, rate)
+		},
+		func() QuoteRespStatus {
+			return checkMinFill(req, rate)
+		},
+		func() QuoteRespStatus {
+			return checkFOK(req, rate)
+		},
+		func() QuoteRespStatus {
+			return checkFillConstraints(req, fill)
+		},
+	} {
+		if s := check(); s != ValidAcceptQuoteRespStatus {
+			return s
 		}
-
-	case *rfqmsg.SellRequest:
-		miss := fn.MapOptionZ(
-			r.AssetRateLimit,
-			func(limit rfqmath.BigIntFixedPoint) bool {
-				return acceptedRate.Cmp(limit) > 0
-			},
-		)
-		if miss {
-			return RateBoundMissQuoteRespStatus
-		}
-
-	default:
-		log.Warnf("checkRateBound: unhandled request type %T",
-			req)
 	}
 
 	return ValidAcceptQuoteRespStatus
+}
+
+// amountIsTransportable returns true if the given amount converts to
+// a non-zero result at the given rate. For buy requests (RateBoundCmp
+// == -1), the amount is in asset units and converts to msat. For sell
+// requests (RateBoundCmp == +1), the amount is in msat and converts
+// to asset units.
+func amountIsTransportable(amt uint64,
+	rate rfqmath.BigIntFixedPoint, rateBoundCmp int) bool {
+
+	if rateBoundCmp < 0 {
+		// Buy: asset units → msat.
+		units := rfqmath.NewBigIntFixedPoint(amt, 0)
+		return rfqmath.UnitsToMilliSatoshi(units, rate) != 0
+	}
+
+	// Sell: msat → asset units.
+	units := rfqmath.MilliSatoshiToUnits(
+		lnwire.MilliSatoshi(amt), rate,
+	)
+	zero := rfqmath.NewBigIntFromUint64(0)
+
+	return !units.Coefficient.Equals(zero)
 }
 
 // isFOK returns true if the execution policy is Fill-Or-Kill.
@@ -507,93 +539,126 @@ func isFOK(p fn.Option[rfqmsg.ExecutionPolicy]) bool {
 	})
 }
 
+// checkRateBound verifies that the accepted rate satisfies the
+// requester's rate limit constraint. For a buy request the accepted
+// rate must be >= the limit (floor); for a sell request it must be
+// <= the limit (ceiling). The comparison direction is encoded in
+// RequestConstraints.RateBoundCmp.
+func checkRateBound(req rfqmsg.Request,
+	acceptedRate rfqmath.BigIntFixedPoint) QuoteRespStatus {
+
+	c := req.Constraints()
+	miss := fn.MapOptionZ(
+		c.RateLimit,
+		func(limit rfqmath.BigIntFixedPoint) bool {
+			// RateBoundCmp is -1 for buy (floor) and +1
+			// for sell (ceiling). A miss occurs when the
+			// accepted rate falls on the wrong side:
+			//   buy:  accepted < limit  → Cmp returns -1
+			//   sell: accepted > limit  → Cmp returns +1
+			return acceptedRate.Cmp(limit) == c.RateBoundCmp
+		},
+	)
+	if miss {
+		return RateBoundMissQuoteRespStatus
+	}
+
+	return ValidAcceptQuoteRespStatus
+}
+
 // checkFOK verifies that the full max amount is transportable at the
-// accepted rate when the execution policy is FOK. For a buy request,
-// the max asset amount must convert to non-zero msat. For a sell
-// request, the max payment amount must convert to non-zero asset units.
+// accepted rate when the execution policy is FOK.
 func checkFOK(req rfqmsg.Request,
 	acceptedRate rfqmath.BigIntFixedPoint) QuoteRespStatus {
 
-	switch r := req.(type) {
-	case *rfqmsg.BuyRequest:
-		if !isFOK(r.ExecutionPolicy) {
-			return ValidAcceptQuoteRespStatus
-		}
+	c := req.Constraints()
+	if !isFOK(c.ExecutionPolicy) {
+		return ValidAcceptQuoteRespStatus
+	}
 
-		units := rfqmath.NewBigIntFixedPoint(
-			r.AssetMaxAmt, 0,
-		)
-		msat := rfqmath.UnitsToMilliSatoshi(
-			units, acceptedRate,
-		)
-		if msat == 0 {
-			return FOKNotViableQuoteRespStatus
-		}
+	if !amountIsTransportable(
+		c.MaxAmount, acceptedRate, c.RateBoundCmp,
+	) {
 
-	case *rfqmsg.SellRequest:
-		if !isFOK(r.ExecutionPolicy) {
-			return ValidAcceptQuoteRespStatus
-		}
-
-		units := rfqmath.MilliSatoshiToUnits(
-			r.PaymentMaxAmt, acceptedRate,
-		)
-		zero := rfqmath.NewBigIntFromUint64(0)
-		if units.Coefficient.Equals(zero) {
-			return FOKNotViableQuoteRespStatus
-		}
-
-	default:
-		log.Warnf("checkFOK: unhandled request type %T", req)
+		return FOKNotViableQuoteRespStatus
 	}
 
 	return ValidAcceptQuoteRespStatus
 }
 
 // checkMinFill verifies that the requester's minimum fill amount is
-// transportable at the accepted rate. For a buy request, the min asset
-// amount must convert to a non-zero msat value. For a sell request,
-// the min payment amount must convert to non-zero asset units.
+// transportable at the accepted rate.
 func checkMinFill(req rfqmsg.Request,
 	acceptedRate rfqmath.BigIntFixedPoint) QuoteRespStatus {
 
-	switch r := req.(type) {
-	case *rfqmsg.BuyRequest:
-		notMet := fn.MapOptionZ(
-			r.AssetMinAmt,
-			func(minAmt uint64) bool {
-				units := rfqmath.NewBigIntFixedPoint(
-					minAmt, 0,
-				)
-				msat := rfqmath.UnitsToMilliSatoshi(
-					units, acceptedRate,
-				)
-				return msat == 0
-			},
-		)
-		if notMet {
-			return MinFillNotMetQuoteRespStatus
-		}
-
-	case *rfqmsg.SellRequest:
-		notMet := fn.MapOptionZ(
-			r.PaymentMinAmt,
-			func(minAmt lnwire.MilliSatoshi) bool {
-				units := rfqmath.MilliSatoshiToUnits(
-					minAmt, acceptedRate,
-				)
-				zero := rfqmath.NewBigIntFromUint64(0)
-				return units.Coefficient.Equals(zero)
-			},
-		)
-		if notMet {
-			return MinFillNotMetQuoteRespStatus
-		}
-
-	default:
-		log.Warnf("checkMinFill: unhandled request type %T",
-			req)
+	c := req.Constraints()
+	notMet := fn.MapOptionZ(
+		c.MinAmount,
+		func(minAmt uint64) bool {
+			return !amountIsTransportable(
+				minAmt, acceptedRate, c.RateBoundCmp,
+			)
+		},
+	)
+	if notMet {
+		return MinFillNotMetQuoteRespStatus
 	}
 
 	return ValidAcceptQuoteRespStatus
+}
+
+// checkFillConstraints verifies that the negotiated fill amount (if
+// present) is compatible with the requester's min-fill and FOK
+// constraints.
+func checkFillConstraints(req rfqmsg.Request,
+	fill fn.Option[uint64]) QuoteRespStatus {
+
+	if fill.IsNone() {
+		// No fill → full request max implied; nothing to
+		// check.
+		return ValidAcceptQuoteRespStatus
+	}
+
+	fillAmt := fill.UnwrapOr(0)
+	c := req.Constraints()
+
+	// Fill must not exceed the request max.
+	if fillAmt > c.MaxAmount {
+		return FillExceedsMaxQuoteRespStatus
+	}
+
+	// Fill must be >= min fill when set.
+	tooSmall := fn.MapOptionZ(
+		c.MinAmount,
+		func(minAmt uint64) bool {
+			return fillAmt < minAmt
+		},
+	)
+	if tooSmall {
+		return MinFillNotMetQuoteRespStatus
+	}
+
+	// FOK requires the full max to be fillable.
+	if isFOK(c.ExecutionPolicy) && fillAmt < c.MaxAmount {
+		return FOKNotViableQuoteRespStatus
+	}
+
+	return ValidAcceptQuoteRespStatus
+}
+
+// rejectForStatus maps a constraint-violation QuoteRespStatus to the
+// corresponding RejectErr.
+func rejectForStatus(status QuoteRespStatus) rfqmsg.RejectErr {
+	switch status {
+	case RateBoundMissQuoteRespStatus:
+		return rfqmsg.ErrPriceBoundMiss
+	case MinFillNotMetQuoteRespStatus:
+		return rfqmsg.ErrMinFillNotMet
+	case FOKNotViableQuoteRespStatus:
+		return rfqmsg.ErrFOKNotViable
+	case FillExceedsMaxQuoteRespStatus:
+		return rfqmsg.ErrFillExceedsMax
+	default:
+		return rfqmsg.ErrUnknownReject
+	}
 }

--- a/rfq/portfolio_pilot_rpc.go
+++ b/rfq/portfolio_pilot_rpc.go
@@ -165,7 +165,12 @@ func (r *RpcPortfolioPilot) ResolveRequest(ctx context.Context,
 				err)
 		}
 
-		return NewAcceptResolveResp(*assetRate), nil
+		fillAmount := fn.None[uint64]()
+		if resp.AcceptedMaxAmount > 0 {
+			fillAmount = fn.Some(resp.AcceptedMaxAmount)
+		}
+
+		return NewAcceptResolveResp(*assetRate, fillAmount), nil
 
 	case *pilotrpc.ResolveRequestResponse_Reject:
 		if result.Reject == nil {
@@ -314,9 +319,10 @@ func rpcMarshalVerifyAcceptQuoteRequest(
 		}
 		return &pilotrpc.VerifyAcceptQuoteRequest{
 			Accept: &pilotrpc.AcceptedQuote{
-				PeerId:       peer[:],
-				AcceptedRate: rpcAcceptedRate,
-				Request:      requestWrapper,
+				PeerId:            peer[:],
+				AcceptedRate:      rpcAcceptedRate,
+				Request:           requestWrapper,
+				AcceptedMaxAmount: msg.AcceptedMaxAmount.UnwrapOr(0), //nolint:lll
 			},
 		}, nil
 
@@ -339,9 +345,10 @@ func rpcMarshalVerifyAcceptQuoteRequest(
 		}
 		return &pilotrpc.VerifyAcceptQuoteRequest{
 			Accept: &pilotrpc.AcceptedQuote{
-				PeerId:       peer[:],
-				AcceptedRate: rpcAcceptedRate,
-				Request:      requestWrapper,
+				PeerId:            peer[:],
+				AcceptedRate:      rpcAcceptedRate,
+				Request:           requestWrapper,
+				AcceptedMaxAmount: msg.AcceptedMaxAmount.UnwrapOr(0), //nolint:lll
 			},
 		}, nil
 
@@ -641,6 +648,8 @@ func rpcUnmarshalQuoteRespStatus(
 		return RateBoundMissQuoteRespStatus, nil
 	case pilotrpc.QuoteRespStatus_FOK_NOT_VIABLE:
 		return FOKNotViableQuoteRespStatus, nil
+	case pilotrpc.QuoteRespStatus_FILL_EXCEEDS_MAX:
+		return FillExceedsMaxQuoteRespStatus, nil
 	default:
 		return 0, fmt.Errorf("unknown quote response status: %v",
 			status)
@@ -662,6 +671,8 @@ func rpcUnmarshalRejectCode(
 		return rfqmsg.PriceBoundMissRejectCode
 	case pilotrpc.RejectCode_REJECT_CODE_FOK_NOT_VIABLE:
 		return rfqmsg.FOKNotViableRejectCode
+	case pilotrpc.RejectCode_REJECT_CODE_FILL_EXCEEDS_MAX:
+		return rfqmsg.FillExceedsMaxRejectCode
 	default:
 		return rfqmsg.PriceOracleUnspecifiedRejectCode
 	}

--- a/rfq/portfolio_pilot_test.go
+++ b/rfq/portfolio_pilot_test.go
@@ -185,6 +185,10 @@ func TestResolveRequest(t *testing.T) {
 		// error.
 		expectErr string
 
+		// expectReject, if true, means we expect a reject response
+		// (not an error, but a valid reject).
+		expectReject bool
+
 		// assertFn performs per-case assertions.
 		assertFn func(
 			t *testing.T, resp ResolveResp, req rfqmsg.Request,
@@ -457,6 +461,320 @@ func TestResolveRequest(t *testing.T) {
 				)
 			},
 		},
+
+		// --- Responder-side constraint enforcement ---
+
+		{
+			name:         "buy: rate bound reject",
+			expectReject: true,
+			makeReq: func(t *testing.T) rfqmsg.Request {
+				// Rate limit of 200 means the
+				// oracle's 125 is below bound.
+				req, err := rfqmsg.NewBuyRequest(
+					route.Vertex{0x01, 0x02, 0x03},
+					asset.NewSpecifierFromId(
+						asset.ID{0xA0},
+					),
+					100,
+					fn.None[uint64](),
+					fn.Some(
+						rfqmath.NewBigIntFixedPoint(
+							200, 0,
+						),
+					),
+					fn.None[rfqmsg.AssetRate](),
+					"metadata",
+					fn.None[rfqmsg.ExecutionPolicy](),
+				)
+				require.NoError(t, err)
+				return req
+			},
+			setupOracle: func(o *MockPriceOracle) {
+				expectQuerySellPrice(
+					o, &OracleResponse{
+						AssetRate: expectedBuyRate,
+					}, nil,
+				)
+			},
+			assertFn: func(
+				t *testing.T, resp ResolveResp,
+				_ rfqmsg.Request,
+				_ *MockPriceOracle,
+			) {
+
+				require.True(t, resp.IsReject())
+				resp.WhenReject(
+					func(e rfqmsg.RejectErr) {
+						require.Equal(
+							t,
+							rfqmsg.PriceBoundMissRejectCode, //nolint:lll
+							e.Code,
+						)
+					},
+				)
+			},
+		},
+		{
+			name:         "buy: min fill reject",
+			expectReject: true,
+			makeReq: func(t *testing.T) rfqmsg.Request {
+				// Huge rate: 1 unit → ~0 msat,
+				// so min of 1 is untransportable.
+				req, err := rfqmsg.NewBuyRequest(
+					route.Vertex{0x01, 0x02, 0x03},
+					asset.NewSpecifierFromId(
+						asset.ID{0xA1},
+					),
+					1,
+					fn.Some[uint64](1),
+					fn.None[rfqmath.BigIntFixedPoint](),
+					fn.None[rfqmsg.AssetRate](),
+					"metadata",
+					fn.None[rfqmsg.ExecutionPolicy](),
+				)
+				require.NoError(t, err)
+				return req
+			},
+			setupOracle: func(o *MockPriceOracle) {
+				hugeRate := rfqmsg.NewAssetRate(
+					rfqmath.NewBigIntFixedPoint(
+						1_000_000_000_000, 0,
+					),
+					buyResponseExpiry,
+				)
+				expectQuerySellPrice(
+					o, &OracleResponse{
+						AssetRate: hugeRate,
+					}, nil,
+				)
+			},
+			assertFn: func(
+				t *testing.T, resp ResolveResp,
+				_ rfqmsg.Request,
+				_ *MockPriceOracle,
+			) {
+
+				require.True(t, resp.IsReject())
+				resp.WhenReject(
+					func(e rfqmsg.RejectErr) {
+						require.Equal(
+							t,
+							rfqmsg.MinFillNotMetRejectCode, //nolint:lll
+							e.Code,
+						)
+					},
+				)
+			},
+		},
+		{
+			name:         "buy: FOK reject",
+			expectReject: true,
+			makeReq: func(t *testing.T) rfqmsg.Request {
+				// Huge rate: 1 unit → ~0 msat.
+				req, err := rfqmsg.NewBuyRequest(
+					route.Vertex{0x01, 0x02, 0x03},
+					asset.NewSpecifierFromId(
+						asset.ID{0xA2},
+					),
+					1,
+					fn.None[uint64](),
+					fn.None[rfqmath.BigIntFixedPoint](),
+					fn.None[rfqmsg.AssetRate](),
+					"metadata",
+					fn.Some(
+						rfqmsg.ExecutionPolicyFOK,
+					),
+				)
+				require.NoError(t, err)
+				return req
+			},
+			setupOracle: func(o *MockPriceOracle) {
+				hugeRate := rfqmsg.NewAssetRate(
+					rfqmath.NewBigIntFixedPoint(
+						1_000_000_000_000, 0,
+					),
+					buyResponseExpiry,
+				)
+				expectQuerySellPrice(
+					o, &OracleResponse{
+						AssetRate: hugeRate,
+					}, nil,
+				)
+			},
+			assertFn: func(
+				t *testing.T, resp ResolveResp,
+				_ rfqmsg.Request,
+				_ *MockPriceOracle,
+			) {
+
+				require.True(t, resp.IsReject())
+				resp.WhenReject(
+					func(e rfqmsg.RejectErr) {
+						require.Equal(
+							t,
+							rfqmsg.FOKNotViableRejectCode, //nolint:lll
+							e.Code,
+						)
+					},
+				)
+			},
+		},
+		{
+			name:         "sell: rate bound reject",
+			expectReject: true,
+			makeReq: func(t *testing.T) rfqmsg.Request {
+				// Rate limit of 50: oracle's 200 is
+				// above the sell upper bound.
+				req, err := rfqmsg.NewSellRequest(
+					route.Vertex{0x0A, 0x0B, 0x0C},
+					asset.NewSpecifierFromId(
+						asset.ID{0xB0},
+					),
+					lnwire.MilliSatoshi(10000),
+					fn.None[lnwire.MilliSatoshi](),
+					fn.Some(
+						rfqmath.NewBigIntFixedPoint(
+							50, 0,
+						),
+					),
+					fn.None[rfqmsg.AssetRate](),
+					"metadata",
+					fn.None[rfqmsg.ExecutionPolicy](),
+				)
+				require.NoError(t, err)
+				return req
+			},
+			setupOracle: func(o *MockPriceOracle) {
+				expectQueryBuyPrice(
+					o, &OracleResponse{
+						AssetRate: expectedSellRate,
+					}, nil,
+				)
+			},
+			assertFn: func(
+				t *testing.T, resp ResolveResp,
+				_ rfqmsg.Request,
+				_ *MockPriceOracle,
+			) {
+
+				require.True(t, resp.IsReject())
+				resp.WhenReject(
+					func(e rfqmsg.RejectErr) {
+						require.Equal(
+							t,
+							rfqmsg.PriceBoundMissRejectCode, //nolint:lll
+							e.Code,
+						)
+					},
+				)
+			},
+		},
+		{
+			name:         "sell: min fill reject",
+			expectReject: true,
+			makeReq: func(t *testing.T) rfqmsg.Request {
+				// Low rate (1 unit/BTC): 1 msat
+				// converts to 0 units.
+				req, err := rfqmsg.NewSellRequest(
+					route.Vertex{0x0A, 0x0B, 0x0C},
+					asset.NewSpecifierFromId(
+						asset.ID{0xB1},
+					),
+					lnwire.MilliSatoshi(1),
+					fn.Some(lnwire.MilliSatoshi(1)),
+					fn.None[rfqmath.BigIntFixedPoint](),
+					fn.None[rfqmsg.AssetRate](),
+					"metadata",
+					fn.None[rfqmsg.ExecutionPolicy](),
+				)
+				require.NoError(t, err)
+				return req
+			},
+			setupOracle: func(o *MockPriceOracle) {
+				lowRate := rfqmsg.NewAssetRate(
+					rfqmath.NewBigIntFixedPoint(
+						1, 0,
+					),
+					sellResponseExpiry,
+				)
+				expectQueryBuyPrice(
+					o, &OracleResponse{
+						AssetRate: lowRate,
+					}, nil,
+				)
+			},
+			assertFn: func(
+				t *testing.T, resp ResolveResp,
+				_ rfqmsg.Request,
+				_ *MockPriceOracle,
+			) {
+
+				require.True(t, resp.IsReject())
+				resp.WhenReject(
+					func(e rfqmsg.RejectErr) {
+						require.Equal(
+							t,
+							rfqmsg.MinFillNotMetRejectCode, //nolint:lll
+							e.Code,
+						)
+					},
+				)
+			},
+		},
+		{
+			name:         "sell: FOK reject",
+			expectReject: true,
+			makeReq: func(t *testing.T) rfqmsg.Request {
+				// Low rate (1 unit/BTC): 1 msat
+				// converts to 0 units.
+				req, err := rfqmsg.NewSellRequest(
+					route.Vertex{0x0A, 0x0B, 0x0C},
+					asset.NewSpecifierFromId(
+						asset.ID{0xB2},
+					),
+					lnwire.MilliSatoshi(1),
+					fn.None[lnwire.MilliSatoshi](),
+					fn.None[rfqmath.BigIntFixedPoint](),
+					fn.None[rfqmsg.AssetRate](),
+					"metadata",
+					fn.Some(
+						rfqmsg.ExecutionPolicyFOK,
+					),
+				)
+				require.NoError(t, err)
+				return req
+			},
+			setupOracle: func(o *MockPriceOracle) {
+				lowRate := rfqmsg.NewAssetRate(
+					rfqmath.NewBigIntFixedPoint(
+						1, 0,
+					),
+					sellResponseExpiry,
+				)
+				expectQueryBuyPrice(
+					o, &OracleResponse{
+						AssetRate: lowRate,
+					}, nil,
+				)
+			},
+			assertFn: func(
+				t *testing.T, resp ResolveResp,
+				_ rfqmsg.Request,
+				_ *MockPriceOracle,
+			) {
+
+				require.True(t, resp.IsReject())
+				resp.WhenReject(
+					func(e rfqmsg.RejectErr) {
+						require.Equal(
+							t,
+							rfqmsg.FOKNotViableRejectCode, //nolint:lll
+							e.Code,
+						)
+					},
+				)
+			},
+		},
 	}
 
 	for _, tc := range tests {
@@ -483,6 +801,11 @@ func TestResolveRequest(t *testing.T) {
 				require.ErrorContains(t, err, tc.expectErr)
 				require.False(t, resp.IsAccept())
 				require.False(t, resp.IsReject())
+
+			case tc.expectReject:
+				require.NoError(t, err)
+				require.True(t, resp.IsReject())
+				require.False(t, resp.IsAccept())
 
 			default:
 				require.NoError(t, err)
@@ -1255,6 +1578,257 @@ func TestVerifyAcceptQuote(t *testing.T) {
 			expectStatus: FOKNotViableQuoteRespStatus,
 			expectErr:    false,
 		},
+
+		// --- Fill constraint cases ---
+
+		{
+			name: "buy accept: fill < min fill",
+			makeAccept: func(t *testing.T) rfqmsg.Accept {
+				buyReq, err := rfqmsg.NewBuyRequest(
+					peerID, assetSpec, 100,
+					fn.Some[uint64](50),
+					fn.None[rfqmath.BigIntFixedPoint](),
+					fn.None[rfqmsg.AssetRate](),
+					"metadata",
+					fn.None[rfqmsg.ExecutionPolicy](),
+				)
+				require.NoError(t, err)
+
+				return &rfqmsg.BuyAccept{
+					Peer:              peerID,
+					Request:           *buyReq,
+					AssetRate:         peerRate,
+					AcceptedMaxAmount: fn.Some[uint64](30),
+				}
+			},
+			setupOracle: func(p *MockPriceOracle) {
+				expectQueryBuyPrice(
+					p, &OracleResponse{
+						AssetRate: oracleRateMatch,
+					}, nil,
+				)
+			},
+			expectStatus: MinFillNotMetQuoteRespStatus,
+			expectErr:    false,
+		},
+		{
+			name: "buy accept: FOK fill < max",
+			makeAccept: func(t *testing.T) rfqmsg.Accept {
+				buyReq, err := rfqmsg.NewBuyRequest(
+					peerID, assetSpec, 100,
+					fn.None[uint64](),
+					fn.None[rfqmath.BigIntFixedPoint](),
+					fn.None[rfqmsg.AssetRate](),
+					"metadata",
+					fn.Some(
+						rfqmsg.ExecutionPolicyFOK,
+					),
+				)
+				require.NoError(t, err)
+
+				return &rfqmsg.BuyAccept{
+					Peer:              peerID,
+					Request:           *buyReq,
+					AssetRate:         peerRate,
+					AcceptedMaxAmount: fn.Some[uint64](80),
+				}
+			},
+			setupOracle: func(p *MockPriceOracle) {
+				expectQueryBuyPrice(
+					p, &OracleResponse{
+						AssetRate: oracleRateMatch,
+					}, nil,
+				)
+			},
+			expectStatus: FOKNotViableQuoteRespStatus,
+			expectErr:    false,
+		},
+		{
+			name: "buy accept: IOC partial fill accepted",
+			makeAccept: func(t *testing.T) rfqmsg.Accept {
+				buyReq, err := rfqmsg.NewBuyRequest(
+					peerID, assetSpec, 100,
+					fn.None[uint64](),
+					fn.None[rfqmath.BigIntFixedPoint](),
+					fn.None[rfqmsg.AssetRate](),
+					"metadata",
+					fn.Some(
+						rfqmsg.ExecutionPolicyIOC,
+					),
+				)
+				require.NoError(t, err)
+
+				return &rfqmsg.BuyAccept{
+					Peer:              peerID,
+					Request:           *buyReq,
+					AssetRate:         peerRate,
+					AcceptedMaxAmount: fn.Some[uint64](60),
+				}
+			},
+			setupOracle: func(p *MockPriceOracle) {
+				expectQueryBuyPrice(
+					p, &OracleResponse{
+						AssetRate: oracleRateMatch,
+					}, nil,
+				)
+			},
+			expectStatus: ValidAcceptQuoteRespStatus,
+			expectErr:    false,
+		},
+		{
+			name: "sell accept: fill < min fill",
+			makeAccept: func(t *testing.T) rfqmsg.Accept {
+				sellReq, err := rfqmsg.NewSellRequest(
+					peerID, assetSpec,
+					lnwire.MilliSatoshi(1000),
+					fn.Some(
+						lnwire.MilliSatoshi(500),
+					),
+					fn.None[rfqmath.BigIntFixedPoint](),
+					fn.None[rfqmsg.AssetRate](),
+					"metadata",
+					fn.None[rfqmsg.ExecutionPolicy](),
+				)
+				require.NoError(t, err)
+
+				return &rfqmsg.SellAccept{
+					Peer:              peerID,
+					Request:           *sellReq,
+					AssetRate:         peerRate,
+					AcceptedMaxAmount: fn.Some[uint64](300),
+				}
+			},
+			setupOracle: func(p *MockPriceOracle) {
+				resp := OracleResponse{
+					AssetRate: oracleRateMatch,
+				}
+				expectQuerySellPrice(p, &resp, nil)
+			},
+			expectStatus: MinFillNotMetQuoteRespStatus,
+			expectErr:    false,
+		},
+		{
+			name: "sell accept: FOK fill < max",
+			makeAccept: func(t *testing.T) rfqmsg.Accept {
+				sellReq, err := rfqmsg.NewSellRequest(
+					peerID, assetSpec,
+					lnwire.MilliSatoshi(1000),
+					fn.None[lnwire.MilliSatoshi](),
+					fn.None[rfqmath.BigIntFixedPoint](),
+					fn.None[rfqmsg.AssetRate](),
+					"metadata",
+					fn.Some(
+						rfqmsg.ExecutionPolicyFOK,
+					),
+				)
+				require.NoError(t, err)
+
+				return &rfqmsg.SellAccept{
+					Peer:              peerID,
+					Request:           *sellReq,
+					AssetRate:         peerRate,
+					AcceptedMaxAmount: fn.Some[uint64](800),
+				}
+			},
+			setupOracle: func(p *MockPriceOracle) {
+				resp := OracleResponse{
+					AssetRate: oracleRateMatch,
+				}
+				expectQuerySellPrice(p, &resp, nil)
+			},
+			expectStatus: FOKNotViableQuoteRespStatus,
+			expectErr:    false,
+		},
+		{
+			name: "buy accept: fill > max",
+			makeAccept: func(t *testing.T) rfqmsg.Accept {
+				buyReq, err := rfqmsg.NewBuyRequest(
+					peerID, assetSpec, 100,
+					fn.None[uint64](),
+					fn.None[rfqmath.BigIntFixedPoint](),
+					fn.None[rfqmsg.AssetRate](),
+					"metadata",
+					fn.None[rfqmsg.ExecutionPolicy](),
+				)
+				require.NoError(t, err)
+
+				return &rfqmsg.BuyAccept{
+					Peer:              peerID,
+					Request:           *buyReq,
+					AssetRate:         peerRate,
+					AcceptedMaxAmount: fn.Some[uint64](150),
+				}
+			},
+			setupOracle: func(p *MockPriceOracle) {
+				expectQueryBuyPrice(
+					p, &OracleResponse{
+						AssetRate: oracleRateMatch,
+					}, nil,
+				)
+			},
+			expectStatus: FillExceedsMaxQuoteRespStatus,
+			expectErr:    false,
+		},
+		{
+			name: "sell accept: fill > max",
+			makeAccept: func(t *testing.T) rfqmsg.Accept {
+				sellReq, err := rfqmsg.NewSellRequest(
+					peerID, assetSpec,
+					lnwire.MilliSatoshi(1000),
+					fn.None[lnwire.MilliSatoshi](),
+					fn.None[rfqmath.BigIntFixedPoint](),
+					fn.None[rfqmsg.AssetRate](),
+					"metadata",
+					fn.None[rfqmsg.ExecutionPolicy](),
+				)
+				require.NoError(t, err)
+
+				return &rfqmsg.SellAccept{
+					Peer:              peerID,
+					Request:           *sellReq,
+					AssetRate:         peerRate,
+					AcceptedMaxAmount: fn.Some[uint64](1500), //nolint:lll
+				}
+			},
+			setupOracle: func(p *MockPriceOracle) {
+				resp := OracleResponse{
+					AssetRate: oracleRateMatch,
+				}
+				expectQuerySellPrice(p, &resp, nil)
+			},
+			expectStatus: FillExceedsMaxQuoteRespStatus,
+			expectErr:    false,
+		},
+		{
+			name: "buy accept: fill >= min (passes)",
+			makeAccept: func(t *testing.T) rfqmsg.Accept {
+				buyReq, err := rfqmsg.NewBuyRequest(
+					peerID, assetSpec, 100,
+					fn.Some[uint64](50),
+					fn.None[rfqmath.BigIntFixedPoint](),
+					fn.None[rfqmsg.AssetRate](),
+					"metadata",
+					fn.None[rfqmsg.ExecutionPolicy](),
+				)
+				require.NoError(t, err)
+
+				return &rfqmsg.BuyAccept{
+					Peer:              peerID,
+					Request:           *buyReq,
+					AssetRate:         peerRate,
+					AcceptedMaxAmount: fn.Some[uint64](60),
+				}
+			},
+			setupOracle: func(p *MockPriceOracle) {
+				expectQueryBuyPrice(
+					p, &OracleResponse{
+						AssetRate: oracleRateMatch,
+					}, nil,
+				)
+			},
+			expectStatus: ValidAcceptQuoteRespStatus,
+			expectErr:    false,
+		},
 	}
 
 	for _, tc := range tests {
@@ -1695,6 +2269,189 @@ func TestCheckFOK(t *testing.T) {
 			t.Parallel()
 
 			status := checkFOK(tc.req, tc.rate)
+			require.Equal(t, tc.expect, status)
+		})
+	}
+}
+
+// TestCheckFillConstraints exercises the checkFillConstraints helper
+// directly.
+func TestCheckFillConstraints(t *testing.T) {
+	t.Parallel()
+
+	spec := asset.NewSpecifierFromId(asset.ID{0x01})
+
+	tests := []struct {
+		name   string
+		req    rfqmsg.Request
+		fill   fn.Option[uint64]
+		expect QuoteRespStatus
+	}{
+		{
+			name: "buy: no fill",
+			req: &rfqmsg.BuyRequest{
+				AssetSpecifier: spec,
+				AssetMaxAmt:    100,
+				AssetMinAmt:    fn.Some[uint64](50),
+			},
+			fill:   fn.None[uint64](),
+			expect: ValidAcceptQuoteRespStatus,
+		},
+		{
+			name: "buy: fill >= min",
+			req: &rfqmsg.BuyRequest{
+				AssetSpecifier: spec,
+				AssetMaxAmt:    100,
+				AssetMinAmt:    fn.Some[uint64](50),
+			},
+			fill:   fn.Some[uint64](60),
+			expect: ValidAcceptQuoteRespStatus,
+		},
+		{
+			name: "buy: fill < min",
+			req: &rfqmsg.BuyRequest{
+				AssetSpecifier: spec,
+				AssetMaxAmt:    100,
+				AssetMinAmt:    fn.Some[uint64](50),
+			},
+			fill:   fn.Some[uint64](30),
+			expect: MinFillNotMetQuoteRespStatus,
+		},
+		{
+			name: "buy: FOK fill == max",
+			req: &rfqmsg.BuyRequest{
+				AssetSpecifier: spec,
+				AssetMaxAmt:    100,
+				ExecutionPolicy: fn.Some(
+					rfqmsg.ExecutionPolicyFOK,
+				),
+			},
+			fill:   fn.Some[uint64](100),
+			expect: ValidAcceptQuoteRespStatus,
+		},
+		{
+			name: "buy: FOK fill < max",
+			req: &rfqmsg.BuyRequest{
+				AssetSpecifier: spec,
+				AssetMaxAmt:    100,
+				ExecutionPolicy: fn.Some(
+					rfqmsg.ExecutionPolicyFOK,
+				),
+			},
+			fill:   fn.Some[uint64](80),
+			expect: FOKNotViableQuoteRespStatus,
+		},
+		{
+			name: "sell: no fill",
+			req: &rfqmsg.SellRequest{
+				AssetSpecifier: spec,
+				PaymentMaxAmt:  1000,
+				PaymentMinAmt: fn.Some(
+					lnwire.MilliSatoshi(500),
+				),
+			},
+			fill:   fn.None[uint64](),
+			expect: ValidAcceptQuoteRespStatus,
+		},
+		{
+			name: "sell: fill >= min",
+			req: &rfqmsg.SellRequest{
+				AssetSpecifier: spec,
+				PaymentMaxAmt:  1000,
+				PaymentMinAmt: fn.Some(
+					lnwire.MilliSatoshi(500),
+				),
+			},
+			fill:   fn.Some[uint64](600),
+			expect: ValidAcceptQuoteRespStatus,
+		},
+		{
+			name: "sell: fill < min",
+			req: &rfqmsg.SellRequest{
+				AssetSpecifier: spec,
+				PaymentMaxAmt:  1000,
+				PaymentMinAmt: fn.Some(
+					lnwire.MilliSatoshi(500),
+				),
+			},
+			fill:   fn.Some[uint64](300),
+			expect: MinFillNotMetQuoteRespStatus,
+		},
+		{
+			name: "sell: FOK fill == max",
+			req: &rfqmsg.SellRequest{
+				AssetSpecifier: spec,
+				PaymentMaxAmt:  1000,
+				ExecutionPolicy: fn.Some(
+					rfqmsg.ExecutionPolicyFOK,
+				),
+			},
+			fill:   fn.Some[uint64](1000),
+			expect: ValidAcceptQuoteRespStatus,
+		},
+		{
+			name: "sell: FOK fill < max",
+			req: &rfqmsg.SellRequest{
+				AssetSpecifier: spec,
+				PaymentMaxAmt:  1000,
+				ExecutionPolicy: fn.Some(
+					rfqmsg.ExecutionPolicyFOK,
+				),
+			},
+			fill:   fn.Some[uint64](800),
+			expect: FOKNotViableQuoteRespStatus,
+		},
+		{
+			name: "buy: fill > max",
+			req: &rfqmsg.BuyRequest{
+				AssetSpecifier: spec,
+				AssetMaxAmt:    100,
+			},
+			fill:   fn.Some[uint64](150),
+			expect: FillExceedsMaxQuoteRespStatus,
+		},
+		{
+			name: "sell: fill > max",
+			req: &rfqmsg.SellRequest{
+				AssetSpecifier: spec,
+				PaymentMaxAmt:  1000,
+			},
+			fill:   fn.Some[uint64](1500),
+			expect: FillExceedsMaxQuoteRespStatus,
+		},
+		{
+			name: "buy: IOC fill < max (partial fill ok)",
+			req: &rfqmsg.BuyRequest{
+				AssetSpecifier: spec,
+				AssetMaxAmt:    100,
+				ExecutionPolicy: fn.Some(
+					rfqmsg.ExecutionPolicyIOC,
+				),
+			},
+			fill:   fn.Some[uint64](60),
+			expect: ValidAcceptQuoteRespStatus,
+		},
+		{
+			name: "sell: IOC fill < max (partial fill ok)",
+			req: &rfqmsg.SellRequest{
+				AssetSpecifier: spec,
+				PaymentMaxAmt:  1000,
+				ExecutionPolicy: fn.Some(
+					rfqmsg.ExecutionPolicyIOC,
+				),
+			},
+			fill:   fn.Some[uint64](600),
+			expect: ValidAcceptQuoteRespStatus,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			status := checkFillConstraints(
+				tc.req, tc.fill,
+			)
 			require.Equal(t, tc.expect, status)
 		})
 	}

--- a/rfqmsg/accept.go
+++ b/rfqmsg/accept.go
@@ -6,7 +6,17 @@ import (
 	"io"
 	"time"
 
+	"github.com/lightninglabs/taproot-assets/fn"
 	"github.com/lightningnetwork/lnd/tlv"
+)
+
+type (
+	// acceptMaxInAsset is a type alias for a record that represents
+	// an optional maximum in-asset amount (fill quantity) in the
+	// accept message.
+	acceptMaxInAsset = tlv.OptionalRecordT[
+		tlv.TlvType11, uint64,
+	]
 )
 
 const (
@@ -36,6 +46,10 @@ type acceptWireMsgData struct {
 
 	// OutAssetRate is the out-asset to BTC rate.
 	OutAssetRate tlv.RecordT[tlv.TlvType10, TlvFixedPoint]
+
+	// MaxInAsset is an optional maximum in-asset amount (fill
+	// quantity) that the responder is willing to accept.
+	MaxInAsset acceptMaxInAsset
 }
 
 // newAcceptWireMsgDataFromBuy creates a new acceptWireMsgData from a buy
@@ -60,6 +74,14 @@ func newAcceptWireMsgDataFromBuy(q BuyAccept) (acceptWireMsgData, error) {
 		NewTlvFixedPointFromBigInt(MilliSatPerBtc),
 	)
 
+	// Set optional max in-asset fill quantity.
+	var maxInAsset acceptMaxInAsset
+	q.AcceptedMaxAmount.WhenSome(func(amt uint64) {
+		maxInAsset = tlv.SomeRecordT[tlv.TlvType11](
+			tlv.NewPrimitiveRecord[tlv.TlvType11](amt),
+		)
+	})
+
 	// Encode message data component as TLV bytes.
 	return acceptWireMsgData{
 		Version:      version,
@@ -68,6 +90,7 @@ func newAcceptWireMsgDataFromBuy(q BuyAccept) (acceptWireMsgData, error) {
 		Sig:          sig,
 		InAssetRate:  inAssetRate,
 		OutAssetRate: outAssetRate,
+		MaxInAsset:   maxInAsset,
 	}, nil
 }
 
@@ -93,6 +116,14 @@ func newAcceptWireMsgDataFromSell(q SellAccept) (acceptWireMsgData, error) {
 	rate := NewTlvFixedPointFromBigInt(q.AssetRate.Rate)
 	outAssetRate := tlv.NewRecordT[tlv.TlvType10](rate)
 
+	// Set optional max in-asset fill quantity.
+	var maxInAsset acceptMaxInAsset
+	q.AcceptedMaxAmount.WhenSome(func(amt uint64) {
+		maxInAsset = tlv.SomeRecordT[tlv.TlvType11](
+			tlv.NewPrimitiveRecord[tlv.TlvType11](amt),
+		)
+	})
+
 	// Encode message data component as TLV bytes.
 	return acceptWireMsgData{
 		Version:      version,
@@ -101,6 +132,7 @@ func newAcceptWireMsgDataFromSell(q SellAccept) (acceptWireMsgData, error) {
 		Sig:          sig,
 		InAssetRate:  inAssetRate,
 		OutAssetRate: outAssetRate,
+		MaxInAsset:   maxInAsset,
 	}, nil
 }
 
@@ -137,6 +169,12 @@ func (m *acceptWireMsgData) Encode(w io.Writer) error {
 		m.OutAssetRate.Record(),
 	}
 
+	m.MaxInAsset.WhenSome(
+		func(r tlv.RecordT[tlv.TlvType11, uint64]) {
+			records = append(records, r.Record())
+		},
+	)
+
 	tlv.SortRecords(records)
 
 	// Create the tlv stream.
@@ -150,6 +188,8 @@ func (m *acceptWireMsgData) Encode(w io.Writer) error {
 
 // Decode deserializes the acceptWireMsgData from the given io.Reader.
 func (m *acceptWireMsgData) Decode(r io.Reader) error {
+	maxInAsset := m.MaxInAsset.Zero()
+
 	// Create a tlv stream with all the fields.
 	tlvStream, err := tlv.NewStream(
 		m.Version.Record(),
@@ -158,15 +198,25 @@ func (m *acceptWireMsgData) Decode(r io.Reader) error {
 		m.Sig.Record(),
 		m.InAssetRate.Record(),
 		m.OutAssetRate.Record(),
+		maxInAsset.Record(),
 	)
 	if err != nil {
 		return err
 	}
 
 	// Decode the reader's contents into the tlv stream.
-	_, err = tlvStream.DecodeWithParsedTypes(r)
+	tlvMap, err := tlvStream.DecodeWithParsedTypes(r)
 	if err != nil {
 		return err
+	}
+
+	if _, ok := tlvMap[maxInAsset.TlvType()]; ok {
+		// Normalize 0 to None: a zero fill is semantically
+		// "unset" (full request max) and must not cap the
+		// policy at zero.
+		if maxInAsset.Val > 0 {
+			m.MaxInAsset = tlv.SomeRecordT(maxInAsset)
+		}
 	}
 
 	return nil
@@ -251,6 +301,10 @@ type Accept interface {
 	// message responds to.
 	OriginalRequest() Request
 
+	// AcceptedFillAmount returns the optional negotiated fill
+	// quantity. When None the full request max is implied.
+	AcceptedFillAmount() fn.Option[uint64]
+
 	// acceptMarker is an unexported marker method that ensures only rfqmsg
 	// package types may satisfy this interface.
 	acceptMarker()
@@ -258,14 +312,18 @@ type Accept interface {
 
 // NewQuoteAcceptFromRequest creates a new instance of a quote accept message
 // given a quote request message.
-func NewQuoteAcceptFromRequest(request Request, assetRate AssetRate) (Accept,
-	error) {
+func NewQuoteAcceptFromRequest(request Request, assetRate AssetRate,
+	fillAmount fn.Option[uint64]) (Accept, error) {
 
 	switch req := request.(type) {
 	case *BuyRequest:
-		return NewBuyAcceptFromRequest(*req, assetRate), nil
+		return NewBuyAcceptFromRequest(
+			*req, assetRate, fillAmount,
+		), nil
 	case *SellRequest:
-		return NewSellAcceptFromRequest(*req, assetRate), nil
+		return NewSellAcceptFromRequest(
+			*req, assetRate, fillAmount,
+		), nil
 	default:
 		return nil, fmt.Errorf("unknown request type: %T", request)
 	}

--- a/rfqmsg/accept_test.go
+++ b/rfqmsg/accept_test.go
@@ -21,6 +21,7 @@ type acceptEncodeDecodeTC struct {
 	sig          [64]byte
 	inAssetRate  TlvFixedPoint
 	outAssetRate TlvFixedPoint
+	maxInAsset   acceptMaxInAsset
 }
 
 // MsgData generates a acceptWireMsgData instance from the test case.
@@ -39,6 +40,7 @@ func (tc acceptEncodeDecodeTC) MsgData() acceptWireMsgData {
 		Sig:          sig,
 		InAssetRate:  inAssetRate,
 		OutAssetRate: outAssetRate,
+		MaxInAsset:   tc.maxInAsset,
 	}
 }
 
@@ -83,6 +85,29 @@ func TestAcceptMsgDataEncodeDecode(t *testing.T) {
 			inAssetRate:  inAssetRate,
 			outAssetRate: outAssetRate,
 		},
+		{
+			testName:     "with max in-asset fill",
+			version:      V1,
+			id:           id,
+			expiry:       expiry,
+			sig:          randSig,
+			inAssetRate:  inAssetRate,
+			outAssetRate: outAssetRate,
+			maxInAsset: tlv.SomeRecordT(
+				tlv.NewPrimitiveRecord[tlv.TlvType11](
+					uint64(500),
+				),
+			),
+		},
+		{
+			testName:     "no max in-asset fill",
+			version:      V1,
+			id:           id,
+			expiry:       expiry,
+			sig:          randSig,
+			inAssetRate:  inAssetRate,
+			outAssetRate: outAssetRate,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -105,4 +130,34 @@ func TestAcceptMsgDataEncodeDecode(t *testing.T) {
 			require.Equal(tt, msgData, decodedMsgData)
 		})
 	}
+
+	// Verify that a zero fill value on the wire is normalised to
+	// None during decode.
+	t.Run("zero max in-asset normalised to None", func(tt *testing.T) {
+		zeroFill := acceptEncodeDecodeTC{
+			testName:     "zero fill",
+			version:      V1,
+			id:           id,
+			expiry:       expiry,
+			sig:          randSig,
+			inAssetRate:  inAssetRate,
+			outAssetRate: outAssetRate,
+			maxInAsset: tlv.SomeRecordT(
+				tlv.NewPrimitiveRecord[tlv.TlvType11](
+					uint64(0),
+				),
+			),
+		}
+		msgData := zeroFill.MsgData()
+
+		msgDataBytes, err := msgData.Bytes()
+		require.NoError(tt, err)
+
+		var decoded acceptWireMsgData
+		err = decoded.Decode(bytes.NewReader(msgDataBytes))
+		require.NoError(tt, err)
+
+		// Zero should have been normalised away.
+		require.True(tt, decoded.MaxInAsset.IsNone())
+	})
 }

--- a/rfqmsg/buy_accept.go
+++ b/rfqmsg/buy_accept.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/lightninglabs/taproot-assets/fn"
 	"github.com/lightningnetwork/lnd/routing/route"
+	"github.com/lightningnetwork/lnd/tlv"
 )
 
 const (
@@ -32,6 +34,11 @@ type BuyAccept struct {
 	// AssetRate is the accepted asset to BTC rate.
 	AssetRate AssetRate
 
+	// AcceptedMaxAmount is an optional fill quantity that caps the
+	// amount the responder is willing to accept. When None the full
+	// request max is implied.
+	AcceptedMaxAmount fn.Option[uint64]
+
 	// sig is a signature over the serialized contents of the message.
 	sig [64]byte
 
@@ -46,15 +53,17 @@ type BuyAccept struct {
 // AgreedAt value (e.g., when reconstructing from storage), they should
 // manually construct the BuyAccept.
 func NewBuyAcceptFromRequest(request BuyRequest,
-	assetRate AssetRate) *BuyAccept {
+	assetRate AssetRate,
+	fillAmount fn.Option[uint64]) *BuyAccept {
 
 	return &BuyAccept{
-		Peer:      request.Peer,
-		Request:   request,
-		Version:   latestBuyAcceptVersion,
-		ID:        request.ID,
-		AssetRate: assetRate,
-		AgreedAt:  time.Now().UTC(),
+		Peer:              request.Peer,
+		Request:           request,
+		Version:           latestBuyAcceptVersion,
+		ID:                request.ID,
+		AssetRate:         assetRate,
+		AcceptedMaxAmount: fillAmount,
+		AgreedAt:          time.Now().UTC(),
 	}
 }
 
@@ -75,14 +84,23 @@ func newBuyAcceptFromWireMsg(wireMsg WireMessage,
 	// Convert the unix timestamp in seconds to a time.Time.
 	expiry := time.Unix(int64(msgData.Expiry.Val), 0).UTC()
 
+	// Extract the optional fill quantity.
+	var acceptedMax fn.Option[uint64]
+	msgData.MaxInAsset.WhenSome(
+		func(r tlv.RecordT[tlv.TlvType11, uint64]) {
+			acceptedMax = fn.Some(r.Val)
+		},
+	)
+
 	return &BuyAccept{
-		Peer:      wireMsg.Peer,
-		Request:   request,
-		Version:   msgData.Version.Val,
-		ID:        msgData.ID.Val,
-		AssetRate: NewAssetRate(assetRate, expiry),
-		sig:       msgData.Sig.Val,
-		AgreedAt:  time.Now().UTC(),
+		Peer:              wireMsg.Peer,
+		Request:           request,
+		Version:           msgData.Version.Val,
+		ID:                msgData.ID.Val,
+		AssetRate:         NewAssetRate(assetRate, expiry),
+		AcceptedMaxAmount: acceptedMax,
+		sig:               msgData.Sig.Val,
+		AgreedAt:          time.Now().UTC(),
 	}, nil
 }
 
@@ -142,14 +160,28 @@ func (q *BuyAccept) OriginalRequest() Request {
 	return &q.Request
 }
 
+// AcceptedFillAmount returns the optional negotiated fill quantity.
+func (q *BuyAccept) AcceptedFillAmount() fn.Option[uint64] {
+	return q.AcceptedMaxAmount
+}
+
 // acceptMarker makes BuyAccept satisfy the Accept interface while keeping
 // implementations local to this package.
 func (q *BuyAccept) acceptMarker() {}
 
 // String returns a human-readable string representation of the message.
 func (q *BuyAccept) String() string {
-	return fmt.Sprintf("BuyAccept(peer=%x, id=%x, asset_rate=%s, scid=%d)",
-		q.Peer[:], q.ID[:], q.AssetRate.String(), q.ShortChannelId())
+	fillStr := ""
+	q.AcceptedMaxAmount.WhenSome(func(amt uint64) {
+		fillStr = fmt.Sprintf(", fill=%d", amt)
+	})
+
+	return fmt.Sprintf(
+		"BuyAccept(peer=%x, id=%x, asset_rate=%s, "+
+			"scid=%d%s)",
+		q.Peer[:], q.ID[:], q.AssetRate.String(),
+		q.ShortChannelId(), fillStr,
+	)
 }
 
 // Ensure that the message type implements the OutgoingMsg interface.

--- a/rfqmsg/buy_request.go
+++ b/rfqmsg/buy_request.go
@@ -267,33 +267,14 @@ func (q *BuyRequest) Validate() error {
 	}
 
 	// Ensure rate limit is strictly positive when set.
-	err = fn.MapOptionZ(
-		q.AssetRateLimit,
-		func(limit rfqmath.BigIntFixedPoint) error {
-			zero := rfqmath.NewBigIntFromUint64(0)
-			if !limit.Coefficient.Gt(zero) {
-				return fmt.Errorf("asset rate limit " +
-					"coefficient must be positive")
-			}
-			return nil
-		},
-	)
-	if err != nil {
+	if err := validateRateLimit(q.AssetRateLimit); err != nil {
 		return err
 	}
 
 	// Ensure execution policy is valid when set.
-	err = fn.MapOptionZ(
+	if err := validateExecutionPolicy(
 		q.ExecutionPolicy,
-		func(p ExecutionPolicy) error {
-			if p > ExecutionPolicyFOK {
-				return fmt.Errorf("invalid execution "+
-					"policy: %d", p)
-			}
-			return nil
-		},
-	)
-	if err != nil {
+	); err != nil {
 		return err
 	}
 
@@ -346,6 +327,18 @@ func (q *BuyRequest) MsgPeer() route.Vertex {
 // MsgID returns the quote request session ID.
 func (q *BuyRequest) MsgID() ID {
 	return q.ID
+}
+
+// Constraints returns the normalised limit-order constraints for
+// this buy request.
+func (q *BuyRequest) Constraints() RequestConstraints {
+	return RequestConstraints{
+		MaxAmount:       q.AssetMaxAmt,
+		MinAmount:       q.AssetMinAmt,
+		RateLimit:       q.AssetRateLimit,
+		RateBoundCmp:    -1,
+		ExecutionPolicy: q.ExecutionPolicy,
+	}
 }
 
 // requestMarker makes BuyRequest satisfy the Request interface while keeping

--- a/rfqmsg/reject.go
+++ b/rfqmsg/reject.go
@@ -100,9 +100,6 @@ const (
 
 	// FOKNotViableRejectCode indicates that the FOK execution
 	// policy could not be satisfied at the accepted rate.
-	//
-	// NOTE: Currently unused. Reserved for workstream D where the
-	// responder may reject via wire Reject message.
 	FOKNotViableRejectCode RejectCode = 4
 )
 
@@ -137,9 +134,6 @@ var (
 
 	// ErrFOKNotViable is the error for when the FOK execution
 	// policy cannot be satisfied at the accepted rate.
-	//
-	// NOTE: Currently unused. Reserved for workstream D where the
-	// responder may reject via wire Reject message.
 	ErrFOKNotViable = RejectErr{
 		Code: FOKNotViableRejectCode,
 		Msg:  "FOK not viable at accepted rate",

--- a/rfqmsg/reject.go
+++ b/rfqmsg/reject.go
@@ -101,6 +101,10 @@ const (
 	// FOKNotViableRejectCode indicates that the FOK execution
 	// policy could not be satisfied at the accepted rate.
 	FOKNotViableRejectCode RejectCode = 4
+
+	// FillExceedsMaxRejectCode indicates that the negotiated
+	// fill amount exceeds the requester's maximum.
+	FillExceedsMaxRejectCode RejectCode = 5
 )
 
 var (
@@ -137,6 +141,13 @@ var (
 	ErrFOKNotViable = RejectErr{
 		Code: FOKNotViableRejectCode,
 		Msg:  "FOK not viable at accepted rate",
+	}
+
+	// ErrFillExceedsMax is the error for when the negotiated
+	// fill amount exceeds the requester's maximum.
+	ErrFillExceedsMax = RejectErr{
+		Code: FillExceedsMaxRejectCode,
+		Msg:  "fill exceeds max amount",
 	}
 )
 

--- a/rfqmsg/request.go
+++ b/rfqmsg/request.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/lightninglabs/taproot-assets/asset"
+	"github.com/lightninglabs/taproot-assets/fn"
 	"github.com/lightninglabs/taproot-assets/rfqmath"
 	lfn "github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/lightningnetwork/lnd/lnwire"
@@ -89,6 +90,41 @@ const (
 	// to support the full max amount or the quote is rejected.
 	ExecutionPolicyFOK ExecutionPolicy = 1
 )
+
+// validateRateLimit checks that an optional rate limit has a strictly
+// positive coefficient. Shared by BuyRequest and SellRequest.
+func validateRateLimit(
+	limit fn.Option[rfqmath.BigIntFixedPoint]) error {
+
+	return fn.MapOptionZ(
+		limit,
+		func(fp rfqmath.BigIntFixedPoint) error {
+			zero := rfqmath.NewBigIntFromUint64(0)
+			if !fp.Coefficient.Gt(zero) {
+				return fmt.Errorf("asset rate limit " +
+					"coefficient must be positive")
+			}
+			return nil
+		},
+	)
+}
+
+// validateExecutionPolicy checks that an optional execution policy
+// is a known value. Shared by BuyRequest and SellRequest.
+func validateExecutionPolicy(
+	p fn.Option[ExecutionPolicy]) error {
+
+	return fn.MapOptionZ(
+		p,
+		func(ep ExecutionPolicy) error {
+			if ep > ExecutionPolicyFOK {
+				return fmt.Errorf("invalid execution "+
+					"policy: %d", ep)
+			}
+			return nil
+		},
+	)
+}
 
 // requestWireMsgData is a struct that represents the message data field for
 // a quote request wire message.
@@ -701,10 +737,38 @@ func NewIncomingRequestFromWire(wireMsg WireMessage) (IncomingMsg, error) {
 	}
 }
 
+// RequestConstraints is a normalised view of the limit-order
+// constraint fields that BuyRequest and SellRequest share. It lets
+// validation and enforcement code operate generically without
+// type-switching on the concrete request type.
+type RequestConstraints struct {
+	// MaxAmount is the maximum amount for the quote (asset units
+	// for buy, msat for sell).
+	MaxAmount uint64
+
+	// MinAmount is an optional minimum amount for the quote.
+	MinAmount fn.Option[uint64]
+
+	// RateLimit is an optional rate bound constraint.
+	RateLimit fn.Option[rfqmath.BigIntFixedPoint]
+
+	// RateBoundCmp defines how the accepted rate is compared to
+	// the limit. A buy request uses -1 (floor: accepted >= limit),
+	// a sell request uses +1 (ceiling: accepted <= limit).
+	RateBoundCmp int
+
+	// ExecutionPolicy is the optional execution policy.
+	ExecutionPolicy fn.Option[ExecutionPolicy]
+}
+
 // Request represents an RFQ quote request.
 type Request interface {
 	IncomingMsg
 	OutgoingMsg
+
+	// Constraints returns a normalised view of the limit-order
+	// constraint fields for this request.
+	Constraints() RequestConstraints
 
 	// requestMarker is an unexported marker method that ensures only rfqmsg
 	// package types may satisfy this interface.

--- a/rfqmsg/request_property_test.go
+++ b/rfqmsg/request_property_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 // optionalUint64Gen draws an fn.Option[uint64] that is None half the
-// time and Some(v) otherwise, where v is drawn from [0, bound].
+// time and Some(v) otherwise, where v is drawn from [1, bound].
 func optionalUint64Gen(bound uint64) *rapid.Generator[fn.Option[uint64]] {
 	return rapid.Custom(func(t *rapid.T) fn.Option[uint64] {
 		if rapid.Bool().Draw(t, "present") {
@@ -69,12 +69,10 @@ func fixedPointGen() *rapid.Generator[rfqmath.BigIntFixedPoint] {
 	)
 }
 
-// optFP is a short alias used in test generators to stay
-// within the 80-character line limit.
+// optionalFixedPointGen draws an optional BigIntFixedPoint, None half
+// the time.
 type optFP = fn.Option[rfqmath.BigIntFixedPoint]
 
-// optionalFixedPointGen draws an optional BigIntFixedPoint,
-// None half the time.
 func optionalFixedPointGen() *rapid.Generator[optFP] {
 	return rapid.Custom(
 		func(t *rapid.T) fn.Option[rfqmath.BigIntFixedPoint] {
@@ -84,6 +82,27 @@ func optionalFixedPointGen() *rapid.Generator[optFP] {
 				)
 			}
 			return fn.None[rfqmath.BigIntFixedPoint]()
+		},
+	)
+}
+
+// optionalExecutionPolicyGen draws an
+// fn.Option[ExecutionPolicy] that is None one-third of the time,
+// IOC one-third, and FOK one-third.
+func optionalExecutionPolicyGen() *rapid.Generator[fn.Option[ExecutionPolicy]] {
+	return rapid.Custom(
+		func(t *rapid.T) fn.Option[ExecutionPolicy] {
+			v := rapid.IntRange(0, 2).Draw(
+				t, "execPolicy",
+			)
+			switch v {
+			case 0:
+				return fn.None[ExecutionPolicy]()
+			case 1:
+				return fn.Some(ExecutionPolicyIOC)
+			default:
+				return fn.Some(ExecutionPolicyFOK)
+			}
 		},
 	)
 }
@@ -129,12 +148,14 @@ func TestBuyRequestWireRoundtripProperty(t *testing.T) {
 		rateLimit := optionalFixedPointGen().Draw(
 			t, "rateLimit",
 		)
+		execPolicy := optionalExecutionPolicyGen().Draw(
+			t, "execPolicy",
+		)
 
-		noPolicy := fn.None[ExecutionPolicy]()
 		req, err := NewBuyRequest(
 			peer, spec, maxAmt, minAmt,
-			rateLimit, fn.None[AssetRate](),
-			"", noPolicy,
+			rateLimit, fn.None[AssetRate](), "",
+			execPolicy,
 		)
 		require.NoError(t, err)
 
@@ -162,6 +183,9 @@ func TestBuyRequestWireRoundtripProperty(t *testing.T) {
 		requireOptFpEq(
 			t, rateLimit, decoded.AssetRateLimit,
 		)
+		requireOptExecPolicyEq(
+			t, execPolicy, decoded.ExecutionPolicy,
+		)
 	})
 }
 
@@ -184,13 +208,15 @@ func TestSellRequestWireRoundtripProperty(t *testing.T) {
 		rateLimit := optionalFixedPointGen().Draw(
 			t, "rateLimit",
 		)
+		execPolicy := optionalExecutionPolicyGen().Draw(
+			t, "execPolicy",
+		)
 
-		noPolicy := fn.None[ExecutionPolicy]()
 		req, err := NewSellRequest(
 			peer, spec,
 			lnwire.MilliSatoshi(maxAmt), minAmt,
-			rateLimit, fn.None[AssetRate](),
-			"", noPolicy,
+			rateLimit, fn.None[AssetRate](), "",
+			execPolicy,
 		)
 		require.NoError(t, err)
 
@@ -219,6 +245,9 @@ func TestSellRequestWireRoundtripProperty(t *testing.T) {
 
 		requireOptFpEq(
 			t, rateLimit, decoded.AssetRateLimit,
+		)
+		requireOptExecPolicyEq(
+			t, execPolicy, decoded.ExecutionPolicy,
 		)
 	})
 }
@@ -428,13 +457,12 @@ func TestRateBoundEnforcementProperty(t *testing.T) {
 				Draw(t, "maxAmt")
 			limit := fixedPointGen().Draw(t, "limit")
 
-			noExec := fn.None[ExecutionPolicy]()
 			req, err := NewBuyRequest(
 				peer, spec, maxAmt,
 				fn.None[uint64](),
 				fn.Some(limit),
-				fn.None[AssetRate](),
-				"", noExec,
+				fn.None[AssetRate](), "",
+				fn.None[ExecutionPolicy](),
 			)
 			require.NoError(t, err)
 
@@ -483,14 +511,13 @@ func TestRateBoundEnforcementProperty(t *testing.T) {
 			).Draw(t, "maxAmt")
 			limit := fixedPointGen().Draw(t, "limit")
 
-			noExec := fn.None[ExecutionPolicy]()
 			req, err := NewSellRequest(
 				peer, spec,
 				lnwire.MilliSatoshi(maxAmt),
 				fn.None[lnwire.MilliSatoshi](),
 				fn.Some(limit),
-				fn.None[AssetRate](),
-				"", noExec,
+				fn.None[AssetRate](), "",
+				fn.None[ExecutionPolicy](),
 			)
 			require.NoError(t, err)
 
@@ -556,10 +583,14 @@ func TestBuyRequestRoundtripWithHintProperty(t *testing.T) {
 		fp := fixedPointGen().Draw(t, "hintRate")
 		hint := fn.Some(NewAssetRate(fp, expiry))
 
-		noPolicy := fn.None[ExecutionPolicy]()
+		execPolicy := optionalExecutionPolicyGen().Draw(
+			t, "execPolicy",
+		)
+
 		req, err := NewBuyRequest(
 			peer, spec, maxAmt, minAmt,
-			rateLimit, hint, "", noPolicy,
+			rateLimit, hint, "",
+			execPolicy,
 		)
 		require.NoError(t, err)
 
@@ -583,6 +614,9 @@ func TestBuyRequestRoundtripWithHintProperty(t *testing.T) {
 			t, rateLimit, decoded.AssetRateLimit,
 		)
 		require.True(t, decoded.AssetRateHint.IsSome())
+		requireOptExecPolicyEq(
+			t, execPolicy, decoded.ExecutionPolicy,
+		)
 	})
 }
 
@@ -644,4 +678,21 @@ func requireOptFpEq(t require.TestingT,
 		rfqmath.NewBigIntFixedPoint(0, 0),
 	)
 	require.Equal(t, 0, gotVal.Cmp(wantVal))
+}
+
+// requireOptExecPolicyEq asserts two optional ExecutionPolicy
+// values are equal.
+func requireOptExecPolicyEq(t require.TestingT,
+	want, got fn.Option[ExecutionPolicy]) {
+
+	if want.IsNone() {
+		require.True(t, got.IsNone())
+		return
+	}
+
+	require.True(t, got.IsSome())
+
+	wantVal := want.UnwrapOr(ExecutionPolicyIOC)
+	gotVal := got.UnwrapOr(ExecutionPolicyIOC)
+	require.Equal(t, wantVal, gotVal)
 }

--- a/rfqmsg/sell_accept.go
+++ b/rfqmsg/sell_accept.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/lightninglabs/taproot-assets/fn"
 	"github.com/lightningnetwork/lnd/routing/route"
+	"github.com/lightningnetwork/lnd/tlv"
 )
 
 const (
@@ -32,6 +34,11 @@ type SellAccept struct {
 	// AssetRate is the accepted asset to BTC rate.
 	AssetRate AssetRate
 
+	// AcceptedMaxAmount is an optional fill quantity that caps the
+	// amount the responder is willing to accept. When None the full
+	// request max is implied.
+	AcceptedMaxAmount fn.Option[uint64]
+
 	// sig is a signature over the serialized contents of the message.
 	sig [64]byte
 
@@ -44,17 +51,19 @@ type SellAccept struct {
 // message given an asset sell quote request message. Note that this function
 // sets the AgreedAt timestamp to the current time. If callers need to preserve
 // an existing AgreedAt value (e.g., when reconstructing from storage),
-// they should manually construct the BuyAccept.
+// they should manually construct the SellAccept.
 func NewSellAcceptFromRequest(request SellRequest,
-	assetRate AssetRate) *SellAccept {
+	assetRate AssetRate,
+	fillAmount fn.Option[uint64]) *SellAccept {
 
 	return &SellAccept{
-		Peer:      request.Peer,
-		Request:   request,
-		Version:   latestSellAcceptVersion,
-		ID:        request.ID,
-		AssetRate: assetRate,
-		AgreedAt:  time.Now().UTC(),
+		Peer:              request.Peer,
+		Request:           request,
+		Version:           latestSellAcceptVersion,
+		ID:                request.ID,
+		AssetRate:         assetRate,
+		AcceptedMaxAmount: fillAmount,
+		AgreedAt:          time.Now().UTC(),
 	}
 }
 
@@ -77,16 +86,25 @@ func newSellAcceptFromWireMsg(wireMsg WireMessage,
 	// Convert the unix timestamp in seconds to a time.Time.
 	expiry := time.Unix(int64(msgData.Expiry.Val), 0).UTC()
 
+	// Extract the optional fill quantity.
+	var acceptedMax fn.Option[uint64]
+	msgData.MaxInAsset.WhenSome(
+		func(r tlv.RecordT[tlv.TlvType11, uint64]) {
+			acceptedMax = fn.Some(r.Val)
+		},
+	)
+
 	// Note that the `Request` field is populated later in the RFQ stream
 	// service.
 	return &SellAccept{
-		Peer:      wireMsg.Peer,
-		Request:   request,
-		Version:   msgData.Version.Val,
-		ID:        msgData.ID.Val,
-		AssetRate: NewAssetRate(assetRate, expiry),
-		sig:       msgData.Sig.Val,
-		AgreedAt:  time.Now().UTC(),
+		Peer:              wireMsg.Peer,
+		Request:           request,
+		Version:           msgData.Version.Val,
+		ID:                msgData.ID.Val,
+		AssetRate:         NewAssetRate(assetRate, expiry),
+		AcceptedMaxAmount: acceptedMax,
+		sig:               msgData.Sig.Val,
+		AgreedAt:          time.Now().UTC(),
 	}, nil
 }
 
@@ -147,15 +165,28 @@ func (q *SellAccept) OriginalRequest() Request {
 	return &q.Request
 }
 
+// AcceptedFillAmount returns the optional negotiated fill quantity.
+func (q *SellAccept) AcceptedFillAmount() fn.Option[uint64] {
+	return q.AcceptedMaxAmount
+}
+
 // acceptMarker makes SellAccept satisfy the Accept interface while keeping
 // implementations local to this package.
 func (q *SellAccept) acceptMarker() {}
 
 // String returns a human-readable string representation of the message.
 func (q *SellAccept) String() string {
-	return fmt.Sprintf("SellAccept(peer=%x, id=%x, asset_rate=%s, "+
-		"scid=%d)", q.Peer[:], q.ID[:], q.AssetRate.String(),
-		q.ShortChannelId())
+	fillStr := ""
+	q.AcceptedMaxAmount.WhenSome(func(amt uint64) {
+		fillStr = fmt.Sprintf(", fill=%d", amt)
+	})
+
+	return fmt.Sprintf(
+		"SellAccept(peer=%x, id=%x, asset_rate=%s, "+
+			"scid=%d%s)",
+		q.Peer[:], q.ID[:], q.AssetRate.String(),
+		q.ShortChannelId(), fillStr,
+	)
 }
 
 // Ensure that the message type implements the OutgoingMsg interface.

--- a/rfqmsg/sell_request.go
+++ b/rfqmsg/sell_request.go
@@ -270,33 +270,14 @@ func (q *SellRequest) Validate() error {
 	}
 
 	// Ensure execution policy is valid when set.
-	err = fn.MapOptionZ(
+	if err := validateExecutionPolicy(
 		q.ExecutionPolicy,
-		func(p ExecutionPolicy) error {
-			if p > ExecutionPolicyFOK {
-				return fmt.Errorf("invalid execution "+
-					"policy: %d", p)
-			}
-			return nil
-		},
-	)
-	if err != nil {
+	); err != nil {
 		return err
 	}
 
 	// Ensure rate limit is strictly positive when set.
-	err = fn.MapOptionZ(
-		q.AssetRateLimit,
-		func(limit rfqmath.BigIntFixedPoint) error {
-			zero := rfqmath.NewBigIntFromUint64(0)
-			if !limit.Coefficient.Gt(zero) {
-				return fmt.Errorf("asset rate limit " +
-					"coefficient must be positive")
-			}
-			return nil
-		},
-	)
-	if err != nil {
+	if err := validateRateLimit(q.AssetRateLimit); err != nil {
 		return err
 	}
 
@@ -338,6 +319,22 @@ func (q *SellRequest) MsgPeer() route.Vertex {
 // MsgID returns the quote request session ID.
 func (q *SellRequest) MsgID() ID {
 	return q.ID
+}
+
+// Constraints returns the normalised limit-order constraints for
+// this sell request.
+func (q *SellRequest) Constraints() RequestConstraints {
+	return RequestConstraints{
+		MaxAmount: uint64(q.PaymentMaxAmt),
+		MinAmount: fn.MapOption(
+			func(v lnwire.MilliSatoshi) uint64 {
+				return uint64(v)
+			},
+		)(q.PaymentMinAmt),
+		RateLimit:       q.AssetRateLimit,
+		RateBoundCmp:    1,
+		ExecutionPolicy: q.ExecutionPolicy,
+	}
 }
 
 // requestMarker makes SellRequest satisfy the Request interface while keeping

--- a/rpcserver/rpcserver.go
+++ b/rpcserver/rpcserver.go
@@ -8587,6 +8587,7 @@ func (r *RPCServer) AddAssetBuyOrder(ctx context.Context,
 	type (
 		targetEventType = *rfq.PeerAcceptedBuyQuoteEvent
 		rejectEventType = *rfq.InvalidQuoteRespEvent
+		peerRejectType  = *rfq.IncomingRejectQuoteEvent
 	)
 
 	for {
@@ -8599,6 +8600,16 @@ func (r *RPCServer) AddAssetBuyOrder(ctx context.Context,
 						"rejected quote %v",
 						peer.String(),
 						e.QuoteResponse.String())
+				}
+
+			case peerRejectType:
+				if e.MsgID() == id {
+					return nil, fmt.Errorf(
+						"peer %s rejected "+
+							"quote %v",
+						peer.String(),
+						e.String(),
+					)
 				}
 
 			case targetEventType:
@@ -8833,6 +8844,7 @@ func (r *RPCServer) AddAssetSellOrder(ctx context.Context,
 	type (
 		targetEventType = *rfq.PeerAcceptedSellQuoteEvent
 		rejectEventType = *rfq.InvalidQuoteRespEvent
+		peerRejectType  = *rfq.IncomingRejectQuoteEvent
 	)
 
 	for {
@@ -8845,6 +8857,16 @@ func (r *RPCServer) AddAssetSellOrder(ctx context.Context,
 						"rejected quote %v",
 						peer.String(),
 						e.QuoteResponse.String())
+				}
+
+			case peerRejectType:
+				if e.MsgID() == id {
+					return nil, fmt.Errorf(
+						"peer %s rejected "+
+							"quote %v",
+						peer.String(),
+						e.String(),
+					)
 				}
 
 			case targetEventType:

--- a/tapdb/migrations.go
+++ b/tapdb/migrations.go
@@ -24,7 +24,7 @@ const (
 	// daemon.
 	//
 	// NOTE: This MUST be updated when a new migration is added.
-	LatestMigrationVersion = 55
+	LatestMigrationVersion = 56
 )
 
 // DatabaseBackend is an interface that contains all methods our different

--- a/tapdb/migrations.go
+++ b/tapdb/migrations.go
@@ -24,7 +24,7 @@ const (
 	// daemon.
 	//
 	// NOTE: This MUST be updated when a new migration is added.
-	LatestMigrationVersion = 54
+	LatestMigrationVersion = 55
 )
 
 // DatabaseBackend is an interface that contains all methods our different

--- a/tapdb/rfq_policies.go
+++ b/tapdb/rfq_policies.go
@@ -64,6 +64,11 @@ type rfqPolicy struct {
 	// RequestVersion is the version of the RFQ request.
 	RequestVersion *uint32
 
+	// AcceptedMaxAmount is the optional fill cap from the accept
+	// message. For sales it is asset units; for purchases it is
+	// msat. NULL means the full request max applies.
+	AcceptedMaxAmount *uint64
+
 	// AgreedAt is the timestamp when the policy was agreed upon.
 	AgreedAt time.Time
 }
@@ -109,6 +114,11 @@ func (s *PersistedPolicyStore) StoreSalePolicy(ctx context.Context,
 	rateBytes := coefficientBytes(acpt.AssetRate.Rate)
 	expiry := acpt.AssetRate.Expiry.UTC()
 
+	var acceptedMax *uint64
+	acpt.AcceptedMaxAmount.WhenSome(func(v uint64) {
+		acceptedMax = fn.Ptr(v)
+	})
+
 	record := rfqPolicy{
 		PolicyType:          rfq.RfqPolicyTypeAssetSale,
 		Scid:                uint64(acpt.ShortChannelId()),
@@ -121,6 +131,7 @@ func (s *PersistedPolicyStore) StoreSalePolicy(ctx context.Context,
 		ExpiryUnix:          uint64(expiry.Unix()),
 		MaxOutAssetAmt:      fn.Ptr(acpt.Request.AssetMaxAmt),
 		RequestAssetMaxAmt:  fn.Ptr(acpt.Request.AssetMaxAmt),
+		AcceptedMaxAmount:   acceptedMax,
 		PriceOracleMetadata: acpt.Request.PriceOracleMetadata,
 		RequestVersion:      fn.Ptr(uint32(acpt.Request.Version)),
 		AgreedAt:            acpt.AgreedAt.UTC(),
@@ -138,6 +149,11 @@ func (s *PersistedPolicyStore) StorePurchasePolicy(ctx context.Context,
 	expiry := acpt.AssetRate.Expiry.UTC()
 	paymentMax := int64(acpt.Request.PaymentMaxAmt)
 
+	var acceptedMax *uint64
+	acpt.AcceptedMaxAmount.WhenSome(func(v uint64) {
+		acceptedMax = fn.Ptr(v)
+	})
+
 	record := rfqPolicy{
 		PolicyType:            rfq.RfqPolicyTypeAssetPurchase,
 		Scid:                  uint64(acpt.ShortChannelId()),
@@ -150,6 +166,7 @@ func (s *PersistedPolicyStore) StorePurchasePolicy(ctx context.Context,
 		ExpiryUnix:            uint64(expiry.Unix()),
 		PaymentMaxMsat:        fn.Ptr(paymentMax),
 		RequestPaymentMaxMsat: fn.Ptr(paymentMax),
+		AcceptedMaxAmount:     acceptedMax,
 		PriceOracleMetadata:   acpt.Request.PriceOracleMetadata,
 		RequestVersion:        fn.Ptr(uint32(acpt.Request.Version)),
 		AgreedAt:              acpt.AgreedAt.UTC(),
@@ -247,6 +264,11 @@ func (s *PersistedPolicyStore) StorePeerAcceptedBuyQuote(ctx context.Context,
 	rateBytes := coefficientBytes(acpt.AssetRate.Rate)
 	expiry := acpt.AssetRate.Expiry.UTC()
 
+	var acceptedMax *uint64
+	acpt.AcceptedMaxAmount.WhenSome(func(v uint64) {
+		acceptedMax = fn.Ptr(v)
+	})
+
 	record := rfqPolicy{
 		PolicyType:          rfq.RfqPolicyTypeAssetPeerAcceptedBuy,
 		Scid:                uint64(acpt.ShortChannelId()),
@@ -259,6 +281,7 @@ func (s *PersistedPolicyStore) StorePeerAcceptedBuyQuote(ctx context.Context,
 		ExpiryUnix:          uint64(expiry.Unix()),
 		MaxOutAssetAmt:      fn.Ptr(acpt.Request.AssetMaxAmt),
 		RequestAssetMaxAmt:  fn.Ptr(acpt.Request.AssetMaxAmt),
+		AcceptedMaxAmount:   acceptedMax,
 		PriceOracleMetadata: acpt.Request.PriceOracleMetadata,
 		RequestVersion:      fn.Ptr(uint32(acpt.Request.Version)),
 		AgreedAt:            acpt.AgreedAt.UTC(),
@@ -347,6 +370,7 @@ func newInsertParams(policy rfqPolicy) sqlc.InsertRfqPolicyParams {
 
 	params.PriceOracleMetadata = sqlStr(policy.PriceOracleMetadata)
 	params.RequestVersion = sqlPtrInt32(policy.RequestVersion)
+	params.AcceptedMaxAmount = sqlPtrInt64(policy.AcceptedMaxAmount)
 
 	return params
 }
@@ -399,6 +423,9 @@ func policyFromRow(row sqlc.RfqPolicy) rfqPolicy {
 	)
 	policy.RequestPaymentMaxMsat = extractSqlInt64Ptr[int64](
 		row.RequestPaymentMaxMsat,
+	)
+	policy.AcceptedMaxAmount = extractSqlInt64Ptr[uint64](
+		row.AcceptedMaxAmount,
 	)
 
 	return policy
@@ -482,13 +509,19 @@ func buyAcceptFromStored(row rfqPolicy) (rfqmsg.BuyAccept, error) {
 		PriceOracleMetadata: row.PriceOracleMetadata,
 	}
 
+	var fillOpt fn.Option[uint64]
+	if row.AcceptedMaxAmount != nil {
+		fillOpt = fn.Some(*row.AcceptedMaxAmount)
+	}
+
 	return rfqmsg.BuyAccept{
-		Peer:      vertex,
-		Request:   request,
-		Version:   rfqmsg.V1,
-		ID:        id,
-		AssetRate: rfqmsg.NewAssetRate(rate, expiry),
-		AgreedAt:  row.AgreedAt,
+		Peer:              vertex,
+		Request:           request,
+		Version:           rfqmsg.V1,
+		ID:                id,
+		AssetRate:         rfqmsg.NewAssetRate(rate, expiry),
+		AcceptedMaxAmount: fillOpt,
+		AgreedAt:          row.AgreedAt,
 	}, nil
 }
 
@@ -526,13 +559,19 @@ func sellAcceptFromStored(row rfqPolicy) (rfqmsg.SellAccept, error) {
 		PriceOracleMetadata: row.PriceOracleMetadata,
 	}
 
+	var fillOpt fn.Option[uint64]
+	if row.AcceptedMaxAmount != nil {
+		fillOpt = fn.Some(*row.AcceptedMaxAmount)
+	}
+
 	return rfqmsg.SellAccept{
-		Peer:      vertex,
-		Request:   request,
-		Version:   rfqmsg.V1,
-		ID:        id,
-		AssetRate: rfqmsg.NewAssetRate(rate, expiry),
-		AgreedAt:  row.AgreedAt,
+		Peer:              vertex,
+		Request:           request,
+		Version:           rfqmsg.V1,
+		ID:                id,
+		AssetRate:         rfqmsg.NewAssetRate(rate, expiry),
+		AcceptedMaxAmount: fillOpt,
+		AgreedAt:          row.AgreedAt,
 	}, nil
 }
 

--- a/tapdb/rfq_policies.go
+++ b/tapdb/rfq_policies.go
@@ -69,6 +69,10 @@ type rfqPolicy struct {
 	// msat. NULL means the full request max applies.
 	AcceptedMaxAmount *uint64
 
+	// ExecutionPolicy is the optional execution policy from
+	// the original request (IOC or FOK).
+	ExecutionPolicy *uint8
+
 	// AgreedAt is the timestamp when the policy was agreed upon.
 	AgreedAt time.Time
 }
@@ -119,6 +123,14 @@ func (s *PersistedPolicyStore) StoreSalePolicy(ctx context.Context,
 		acceptedMax = fn.Ptr(v)
 	})
 
+	var execPolicy *uint8
+	acpt.Request.ExecutionPolicy.WhenSome(
+		func(ep rfqmsg.ExecutionPolicy) {
+			v := uint8(ep)
+			execPolicy = &v
+		},
+	)
+
 	record := rfqPolicy{
 		PolicyType:          rfq.RfqPolicyTypeAssetSale,
 		Scid:                uint64(acpt.ShortChannelId()),
@@ -132,6 +144,7 @@ func (s *PersistedPolicyStore) StoreSalePolicy(ctx context.Context,
 		MaxOutAssetAmt:      fn.Ptr(acpt.Request.AssetMaxAmt),
 		RequestAssetMaxAmt:  fn.Ptr(acpt.Request.AssetMaxAmt),
 		AcceptedMaxAmount:   acceptedMax,
+		ExecutionPolicy:     execPolicy,
 		PriceOracleMetadata: acpt.Request.PriceOracleMetadata,
 		RequestVersion:      fn.Ptr(uint32(acpt.Request.Version)),
 		AgreedAt:            acpt.AgreedAt.UTC(),
@@ -154,6 +167,14 @@ func (s *PersistedPolicyStore) StorePurchasePolicy(ctx context.Context,
 		acceptedMax = fn.Ptr(v)
 	})
 
+	var execPolicy *uint8
+	acpt.Request.ExecutionPolicy.WhenSome(
+		func(ep rfqmsg.ExecutionPolicy) {
+			v := uint8(ep)
+			execPolicy = &v
+		},
+	)
+
 	record := rfqPolicy{
 		PolicyType:            rfq.RfqPolicyTypeAssetPurchase,
 		Scid:                  uint64(acpt.ShortChannelId()),
@@ -167,6 +188,7 @@ func (s *PersistedPolicyStore) StorePurchasePolicy(ctx context.Context,
 		PaymentMaxMsat:        fn.Ptr(paymentMax),
 		RequestPaymentMaxMsat: fn.Ptr(paymentMax),
 		AcceptedMaxAmount:     acceptedMax,
+		ExecutionPolicy:       execPolicy,
 		PriceOracleMetadata:   acpt.Request.PriceOracleMetadata,
 		RequestVersion:        fn.Ptr(uint32(acpt.Request.Version)),
 		AgreedAt:              acpt.AgreedAt.UTC(),
@@ -269,6 +291,14 @@ func (s *PersistedPolicyStore) StorePeerAcceptedBuyQuote(ctx context.Context,
 		acceptedMax = fn.Ptr(v)
 	})
 
+	var execPolicy *uint8
+	acpt.Request.ExecutionPolicy.WhenSome(
+		func(ep rfqmsg.ExecutionPolicy) {
+			v := uint8(ep)
+			execPolicy = &v
+		},
+	)
+
 	record := rfqPolicy{
 		PolicyType:          rfq.RfqPolicyTypeAssetPeerAcceptedBuy,
 		Scid:                uint64(acpt.ShortChannelId()),
@@ -282,6 +312,7 @@ func (s *PersistedPolicyStore) StorePeerAcceptedBuyQuote(ctx context.Context,
 		MaxOutAssetAmt:      fn.Ptr(acpt.Request.AssetMaxAmt),
 		RequestAssetMaxAmt:  fn.Ptr(acpt.Request.AssetMaxAmt),
 		AcceptedMaxAmount:   acceptedMax,
+		ExecutionPolicy:     execPolicy,
 		PriceOracleMetadata: acpt.Request.PriceOracleMetadata,
 		RequestVersion:      fn.Ptr(uint32(acpt.Request.Version)),
 		AgreedAt:            acpt.AgreedAt.UTC(),
@@ -371,6 +402,7 @@ func newInsertParams(policy rfqPolicy) sqlc.InsertRfqPolicyParams {
 	params.PriceOracleMetadata = sqlStr(policy.PriceOracleMetadata)
 	params.RequestVersion = sqlPtrInt32(policy.RequestVersion)
 	params.AcceptedMaxAmount = sqlPtrInt64(policy.AcceptedMaxAmount)
+	params.ExecutionPolicy = sqlPtrInt32(policy.ExecutionPolicy)
 
 	return params
 }
@@ -426,6 +458,9 @@ func policyFromRow(row sqlc.RfqPolicy) rfqPolicy {
 	)
 	policy.AcceptedMaxAmount = extractSqlInt64Ptr[uint64](
 		row.AcceptedMaxAmount,
+	)
+	policy.ExecutionPolicy = extractSqlInt32Ptr[uint8](
+		row.ExecutionPolicy,
 	)
 
 	return policy
@@ -499,6 +534,13 @@ func buyAcceptFromStored(row rfqPolicy) (rfqmsg.BuyAccept, error) {
 
 	expiry := time.Unix(int64(row.ExpiryUnix), 0).UTC()
 
+	var execPolicy fn.Option[rfqmsg.ExecutionPolicy]
+	if row.ExecutionPolicy != nil {
+		execPolicy = fn.Some(
+			rfqmsg.ExecutionPolicy(*row.ExecutionPolicy),
+		)
+	}
+
 	request := rfqmsg.BuyRequest{
 		Peer:                vertex,
 		Version:             version,
@@ -507,6 +549,7 @@ func buyAcceptFromStored(row rfqPolicy) (rfqmsg.BuyAccept, error) {
 		AssetMaxAmt:         *assetMax,
 		AssetRateHint:       fn.None[rfqmsg.AssetRate](),
 		PriceOracleMetadata: row.PriceOracleMetadata,
+		ExecutionPolicy:     execPolicy,
 	}
 
 	var fillOpt fn.Option[uint64]
@@ -549,6 +592,13 @@ func sellAcceptFromStored(row rfqPolicy) (rfqmsg.SellAccept, error) {
 
 	expiry := time.Unix(int64(row.ExpiryUnix), 0).UTC()
 
+	var execPolicy fn.Option[rfqmsg.ExecutionPolicy]
+	if row.ExecutionPolicy != nil {
+		execPolicy = fn.Some(
+			rfqmsg.ExecutionPolicy(*row.ExecutionPolicy),
+		)
+	}
+
 	request := rfqmsg.SellRequest{
 		Peer:                vertex,
 		Version:             version,
@@ -557,6 +607,7 @@ func sellAcceptFromStored(row rfqPolicy) (rfqmsg.SellAccept, error) {
 		PaymentMaxAmt:       lnwire.MilliSatoshi(*paymentPtr),
 		AssetRateHint:       fn.None[rfqmsg.AssetRate](),
 		PriceOracleMetadata: row.PriceOracleMetadata,
+		ExecutionPolicy:     execPolicy,
 	}
 
 	var fillOpt fn.Option[uint64]

--- a/tapdb/rfq_policies_test.go
+++ b/tapdb/rfq_policies_test.go
@@ -252,6 +252,65 @@ func TestFetchAcceptedQuotesAllThreeTypes(t *testing.T) {
 	require.Equal(t, peerBuy.ID, peerBuys[0].ID)
 }
 
+// TestAcceptedMaxAmountRoundTrip verifies that the AcceptedMaxAmount
+// field survives a store-then-fetch cycle for all three policy types.
+func TestAcceptedMaxAmountRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := newPolicyStore(t)
+
+	// Sale policy with a fill cap.
+	sale := testBuyAccept(t)
+	sale.AcceptedMaxAmount = fn.Some[uint64](500_000)
+	err := store.StoreSalePolicy(ctx, sale)
+	require.NoError(t, err)
+
+	// Purchase policy with a fill cap.
+	purchase := testSellAccept(t)
+	purchase.AcceptedMaxAmount = fn.Some[uint64](250_000)
+	err = store.StorePurchasePolicy(ctx, purchase)
+	require.NoError(t, err)
+
+	// Peer-accepted buy quote with a fill cap.
+	peerBuy := testBuyAccept(t)
+	peerBuy.AcceptedMaxAmount = fn.Some[uint64](750_000)
+	err = store.StorePeerAcceptedBuyQuote(ctx, peerBuy)
+	require.NoError(t, err)
+
+	buys, sells, peerBuys, err := store.FetchAcceptedQuotes(ctx)
+	require.NoError(t, err)
+
+	require.Len(t, buys, 1)
+	require.Len(t, sells, 1)
+	require.Len(t, peerBuys, 1)
+
+	require.Equal(t, fn.Some[uint64](500_000),
+		buys[0].AcceptedMaxAmount)
+	require.Equal(t, fn.Some[uint64](250_000),
+		sells[0].AcceptedMaxAmount)
+	require.Equal(t, fn.Some[uint64](750_000),
+		peerBuys[0].AcceptedMaxAmount)
+}
+
+// TestAcceptedMaxAmountNilRoundTrip verifies that a policy stored
+// without AcceptedMaxAmount restores with None.
+func TestAcceptedMaxAmountNilRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := newPolicyStore(t)
+
+	sale := testBuyAccept(t)
+	err := store.StoreSalePolicy(ctx, sale)
+	require.NoError(t, err)
+
+	buys, _, _, err := store.FetchAcceptedQuotes(ctx)
+	require.NoError(t, err)
+	require.Len(t, buys, 1)
+	require.True(t, buys[0].AcceptedMaxAmount.IsNone())
+}
+
 // TestLookUpScidIgnoresSalePolicy verifies that a sale policy stored in the
 // database is not returned by LookUpScid, which is scoped to peer-accepted
 // buy quotes only.

--- a/tapdb/rfq_policies_test.go
+++ b/tapdb/rfq_policies_test.go
@@ -311,6 +311,64 @@ func TestAcceptedMaxAmountNilRoundTrip(t *testing.T) {
 	require.True(t, buys[0].AcceptedMaxAmount.IsNone())
 }
 
+// TestExecutionPolicyRoundTrip verifies that the ExecutionPolicy
+// field survives a store-then-fetch cycle for sale and purchase
+// policies.
+func TestExecutionPolicyRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := newPolicyStore(t)
+
+	// Sale policy with FOK execution policy.
+	sale := testBuyAccept(t)
+	sale.Request.ExecutionPolicy = fn.Some(
+		rfqmsg.ExecutionPolicyFOK,
+	)
+	err := store.StoreSalePolicy(ctx, sale)
+	require.NoError(t, err)
+
+	// Purchase policy with IOC execution policy.
+	purchase := testSellAccept(t)
+	purchase.Request.ExecutionPolicy = fn.Some(
+		rfqmsg.ExecutionPolicyIOC,
+	)
+	err = store.StorePurchasePolicy(ctx, purchase)
+	require.NoError(t, err)
+
+	// Sale policy without execution policy.
+	saleNone := testBuyAccept(t)
+	err = store.StoreSalePolicy(ctx, saleNone)
+	require.NoError(t, err)
+
+	buys, sells, _, err := store.FetchAcceptedQuotes(ctx)
+	require.NoError(t, err)
+	require.Len(t, buys, 2)
+	require.Len(t, sells, 1)
+
+	// Find the sale with FOK and verify.
+	for _, b := range buys {
+		if b.ID == sale.ID {
+			require.Equal(t,
+				fn.Some(rfqmsg.ExecutionPolicyFOK),
+				b.Request.ExecutionPolicy,
+			)
+		}
+		if b.ID == saleNone.ID {
+			require.True(
+				t,
+				b.Request.ExecutionPolicy.IsNone(),
+			)
+		}
+	}
+
+	// Verify purchase policy round-tripped IOC.
+	require.Equal(t,
+		fn.Some(rfqmsg.ExecutionPolicyIOC),
+		sells[0].Request.ExecutionPolicy,
+	)
+}
+
 // TestLookUpScidIgnoresSalePolicy verifies that a sale policy stored in the
 // database is not returned by LookUpScid, which is scoped to peer-accepted
 // buy quotes only.

--- a/tapdb/sqlc/migrations/000055_rfq_accepted_max.down.sql
+++ b/tapdb/sqlc/migrations/000055_rfq_accepted_max.down.sql
@@ -1,0 +1,97 @@
+-- Drop the accepted_max_amount column from rfq_policies.
+-- SQLite < 3.35 does not support DROP COLUMN, so we use the
+-- table-recreation pattern.  The forwards table has a FK to
+-- rfq_policies(rfq_id), so it must be handled as well.
+
+-- 1. Save forwards data and drop the table.
+CREATE TEMP TABLE IF NOT EXISTS forwards_backup
+    AS SELECT * FROM forwards;
+DROP TABLE IF EXISTS forwards;
+
+-- 2. Rename old rfq_policies and recreate without the column.
+ALTER TABLE rfq_policies RENAME TO rfq_policies_old;
+
+CREATE TABLE IF NOT EXISTS rfq_policies (
+    id INTEGER PRIMARY KEY,
+
+    policy_type TEXT NOT NULL CHECK (
+        policy_type IN (
+            'RFQ_POLICY_TYPE_SALE',
+            'RFQ_POLICY_TYPE_PURCHASE',
+            'RFQ_POLICY_TYPE_PEER_ACCEPTED_BUY'
+        )
+    ),
+
+    scid BIGINT NOT NULL,
+    rfq_id BLOB NOT NULL CHECK (length(rfq_id) = 32),
+    peer BLOB NOT NULL CHECK (length(peer) = 33),
+    asset_id BLOB CHECK (length(asset_id) = 32),
+    asset_group_key BLOB CHECK (length(asset_group_key) = 33),
+    rate_coefficient BLOB NOT NULL,
+    rate_scale INTEGER NOT NULL,
+    expiry BIGINT NOT NULL,
+    max_out_asset_amt BIGINT,
+    payment_max_msat BIGINT,
+    request_asset_max_amt BIGINT,
+    request_payment_max_msat BIGINT,
+    price_oracle_metadata TEXT,
+    request_version INTEGER,
+    agreed_at BIGINT NOT NULL
+);
+
+INSERT INTO rfq_policies (
+    id,
+    policy_type, scid, rfq_id, peer, asset_id, asset_group_key,
+    rate_coefficient, rate_scale, expiry, max_out_asset_amt,
+    payment_max_msat, request_asset_max_amt,
+    request_payment_max_msat, price_oracle_metadata,
+    request_version, agreed_at
+) SELECT
+    id,
+    policy_type, scid, rfq_id, peer, asset_id, asset_group_key,
+    rate_coefficient, rate_scale, expiry, max_out_asset_amt,
+    payment_max_msat, request_asset_max_amt,
+    request_payment_max_msat, price_oracle_metadata,
+    request_version, agreed_at
+FROM rfq_policies_old;
+DROP TABLE rfq_policies_old;
+
+CREATE UNIQUE INDEX IF NOT EXISTS rfq_policies_rfq_id_idx
+    ON rfq_policies (rfq_id);
+CREATE INDEX IF NOT EXISTS rfq_policies_scid_idx
+    ON rfq_policies (scid);
+
+-- 3. Recreate forwards table and restore data.
+CREATE TABLE IF NOT EXISTS forwards (
+    id INTEGER PRIMARY KEY,
+    opened_at TIMESTAMP NOT NULL,
+    settled_at TIMESTAMP,
+    failed_at TIMESTAMP,
+    rfq_id BLOB NOT NULL CHECK (length(rfq_id) = 32)
+        REFERENCES rfq_policies(rfq_id),
+    chan_id_in BIGINT NOT NULL,
+    chan_id_out BIGINT NOT NULL,
+    htlc_id BIGINT NOT NULL,
+    asset_amt BIGINT NOT NULL,
+    amt_in_msat BIGINT NOT NULL,
+    amt_out_msat BIGINT NOT NULL,
+    UNIQUE(chan_id_in, htlc_id)
+);
+
+INSERT INTO forwards (
+    id,
+    opened_at, settled_at, failed_at, rfq_id, chan_id_in,
+    chan_id_out, htlc_id, asset_amt, amt_in_msat, amt_out_msat
+) SELECT
+    id,
+    opened_at, settled_at, failed_at, rfq_id, chan_id_in,
+    chan_id_out, htlc_id, asset_amt, amt_in_msat, amt_out_msat
+FROM forwards_backup;
+DROP TABLE forwards_backup;
+
+CREATE INDEX IF NOT EXISTS forwards_opened_at_idx
+    ON forwards(opened_at);
+CREATE INDEX IF NOT EXISTS forwards_settled_at_idx
+    ON forwards(settled_at);
+CREATE INDEX IF NOT EXISTS forwards_rfq_id_idx
+    ON forwards(rfq_id);

--- a/tapdb/sqlc/migrations/000055_rfq_accepted_max.up.sql
+++ b/tapdb/sqlc/migrations/000055_rfq_accepted_max.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE rfq_policies
+    ADD COLUMN accepted_max_amount BIGINT;

--- a/tapdb/sqlc/migrations/000056_rfq_execution_policy.down.sql
+++ b/tapdb/sqlc/migrations/000056_rfq_execution_policy.down.sql
@@ -1,0 +1,98 @@
+-- Drop the execution_policy column from rfq_policies.
+-- SQLite < 3.35 does not support DROP COLUMN, so we use the
+-- table-recreation pattern.  The forwards table has a FK to
+-- rfq_policies(rfq_id), so it must be handled as well.
+
+-- 1. Save forwards data and drop the table.
+CREATE TEMP TABLE IF NOT EXISTS forwards_backup
+    AS SELECT * FROM forwards;
+DROP TABLE IF EXISTS forwards;
+
+-- 2. Rename old rfq_policies and recreate without the column.
+ALTER TABLE rfq_policies RENAME TO rfq_policies_old;
+
+CREATE TABLE IF NOT EXISTS rfq_policies (
+    id INTEGER PRIMARY KEY,
+
+    policy_type TEXT NOT NULL CHECK (
+        policy_type IN (
+            'RFQ_POLICY_TYPE_SALE',
+            'RFQ_POLICY_TYPE_PURCHASE',
+            'RFQ_POLICY_TYPE_PEER_ACCEPTED_BUY'
+        )
+    ),
+
+    scid BIGINT NOT NULL,
+    rfq_id BLOB NOT NULL CHECK (length(rfq_id) = 32),
+    peer BLOB NOT NULL CHECK (length(peer) = 33),
+    asset_id BLOB CHECK (length(asset_id) = 32),
+    asset_group_key BLOB CHECK (length(asset_group_key) = 33),
+    rate_coefficient BLOB NOT NULL,
+    rate_scale INTEGER NOT NULL,
+    expiry BIGINT NOT NULL,
+    max_out_asset_amt BIGINT,
+    payment_max_msat BIGINT,
+    request_asset_max_amt BIGINT,
+    request_payment_max_msat BIGINT,
+    price_oracle_metadata TEXT,
+    request_version INTEGER,
+    agreed_at BIGINT NOT NULL,
+    accepted_max_amount BIGINT
+);
+
+INSERT INTO rfq_policies (
+    id,
+    policy_type, scid, rfq_id, peer, asset_id, asset_group_key,
+    rate_coefficient, rate_scale, expiry, max_out_asset_amt,
+    payment_max_msat, request_asset_max_amt,
+    request_payment_max_msat, price_oracle_metadata,
+    request_version, agreed_at, accepted_max_amount
+) SELECT
+    id,
+    policy_type, scid, rfq_id, peer, asset_id, asset_group_key,
+    rate_coefficient, rate_scale, expiry, max_out_asset_amt,
+    payment_max_msat, request_asset_max_amt,
+    request_payment_max_msat, price_oracle_metadata,
+    request_version, agreed_at, accepted_max_amount
+FROM rfq_policies_old;
+DROP TABLE rfq_policies_old;
+
+CREATE UNIQUE INDEX IF NOT EXISTS rfq_policies_rfq_id_idx
+    ON rfq_policies (rfq_id);
+CREATE INDEX IF NOT EXISTS rfq_policies_scid_idx
+    ON rfq_policies (scid);
+
+-- 3. Recreate forwards table and restore data.
+CREATE TABLE IF NOT EXISTS forwards (
+    id INTEGER PRIMARY KEY,
+    opened_at TIMESTAMP NOT NULL,
+    settled_at TIMESTAMP,
+    failed_at TIMESTAMP,
+    rfq_id BLOB NOT NULL CHECK (length(rfq_id) = 32)
+        REFERENCES rfq_policies(rfq_id),
+    chan_id_in BIGINT NOT NULL,
+    chan_id_out BIGINT NOT NULL,
+    htlc_id BIGINT NOT NULL,
+    asset_amt BIGINT NOT NULL,
+    amt_in_msat BIGINT NOT NULL,
+    amt_out_msat BIGINT NOT NULL,
+    UNIQUE(chan_id_in, htlc_id)
+);
+
+INSERT INTO forwards (
+    id,
+    opened_at, settled_at, failed_at, rfq_id, chan_id_in,
+    chan_id_out, htlc_id, asset_amt, amt_in_msat, amt_out_msat
+) SELECT
+    id,
+    opened_at, settled_at, failed_at, rfq_id, chan_id_in,
+    chan_id_out, htlc_id, asset_amt, amt_in_msat, amt_out_msat
+FROM forwards_backup;
+DROP TABLE forwards_backup;
+
+CREATE INDEX IF NOT EXISTS forwards_opened_at_idx
+    ON forwards(opened_at);
+CREATE INDEX IF NOT EXISTS forwards_settled_at_idx
+    ON forwards(settled_at);
+CREATE INDEX IF NOT EXISTS forwards_rfq_id_idx
+    ON forwards(rfq_id);

--- a/tapdb/sqlc/migrations/000056_rfq_execution_policy.up.sql
+++ b/tapdb/sqlc/migrations/000056_rfq_execution_policy.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE rfq_policies
+    ADD COLUMN execution_policy INTEGER;

--- a/tapdb/sqlc/models.go
+++ b/tapdb/sqlc/models.go
@@ -398,6 +398,7 @@ type RfqPolicy struct {
 	PriceOracleMetadata   sql.NullString
 	RequestVersion        sql.NullInt32
 	AgreedAt              int64
+	AcceptedMaxAmount     sql.NullInt64
 }
 
 type ScriptKey struct {

--- a/tapdb/sqlc/models.go
+++ b/tapdb/sqlc/models.go
@@ -399,6 +399,7 @@ type RfqPolicy struct {
 	RequestVersion        sql.NullInt32
 	AgreedAt              int64
 	AcceptedMaxAmount     sql.NullInt64
+	ExecutionPolicy       sql.NullInt32
 }
 
 type ScriptKey struct {

--- a/tapdb/sqlc/queries/rfq.sql
+++ b/tapdb/sqlc/queries/rfq.sql
@@ -4,11 +4,12 @@ INSERT INTO rfq_policies (
     rate_coefficient, rate_scale, expiry, max_out_asset_amt,
     payment_max_msat, request_asset_max_amt,
     request_payment_max_msat, price_oracle_metadata,
-    request_version, agreed_at, accepted_max_amount
+    request_version, agreed_at, accepted_max_amount,
+    execution_policy
 )
 VALUES (
     $1, $2, $3, $4, $5, $6, $7, $8, $9,
-    $10, $11, $12, $13, $14, $15, $16, $17
+    $10, $11, $12, $13, $14, $15, $16, $17, $18
 )
 RETURNING id;
 
@@ -18,7 +19,8 @@ SELECT
     rate_coefficient, rate_scale, expiry, max_out_asset_amt,
     payment_max_msat, request_asset_max_amt,
     request_payment_max_msat, price_oracle_metadata,
-    request_version, agreed_at, accepted_max_amount
+    request_version, agreed_at, accepted_max_amount,
+    execution_policy
 FROM rfq_policies
 WHERE expiry >= sqlc.arg('min_expiry');
 

--- a/tapdb/sqlc/queries/rfq.sql
+++ b/tapdb/sqlc/queries/rfq.sql
@@ -1,22 +1,24 @@
 -- name: InsertRfqPolicy :one
 INSERT INTO rfq_policies (
     policy_type, scid, rfq_id, peer, asset_id, asset_group_key,
-    rate_coefficient, rate_scale, expiry, max_out_asset_amt, payment_max_msat,
-    request_asset_max_amt, request_payment_max_msat, price_oracle_metadata,
-    request_version, agreed_at
+    rate_coefficient, rate_scale, expiry, max_out_asset_amt,
+    payment_max_msat, request_asset_max_amt,
+    request_payment_max_msat, price_oracle_metadata,
+    request_version, agreed_at, accepted_max_amount
 )
 VALUES (
     $1, $2, $3, $4, $5, $6, $7, $8, $9,
-    $10, $11, $12, $13, $14, $15, $16
+    $10, $11, $12, $13, $14, $15, $16, $17
 )
 RETURNING id;
 
 -- name: FetchActiveRfqPolicies :many
 SELECT
     id, policy_type, scid, rfq_id, peer, asset_id, asset_group_key,
-    rate_coefficient, rate_scale, expiry, max_out_asset_amt, payment_max_msat,
-    request_asset_max_amt, request_payment_max_msat, price_oracle_metadata,
-    request_version, agreed_at
+    rate_coefficient, rate_scale, expiry, max_out_asset_amt,
+    payment_max_msat, request_asset_max_amt,
+    request_payment_max_msat, price_oracle_metadata,
+    request_version, agreed_at, accepted_max_amount
 FROM rfq_policies
 WHERE expiry >= sqlc.arg('min_expiry');
 

--- a/tapdb/sqlc/rfq.sql.go
+++ b/tapdb/sqlc/rfq.sql.go
@@ -50,7 +50,8 @@ SELECT
     rate_coefficient, rate_scale, expiry, max_out_asset_amt,
     payment_max_msat, request_asset_max_amt,
     request_payment_max_msat, price_oracle_metadata,
-    request_version, agreed_at, accepted_max_amount
+    request_version, agreed_at, accepted_max_amount,
+    execution_policy
 FROM rfq_policies
 WHERE expiry >= $1
 `
@@ -83,6 +84,7 @@ func (q *Queries) FetchActiveRfqPolicies(ctx context.Context, minExpiry int64) (
 			&i.RequestVersion,
 			&i.AgreedAt,
 			&i.AcceptedMaxAmount,
+			&i.ExecutionPolicy,
 		); err != nil {
 			return nil, err
 		}
@@ -117,11 +119,12 @@ INSERT INTO rfq_policies (
     rate_coefficient, rate_scale, expiry, max_out_asset_amt,
     payment_max_msat, request_asset_max_amt,
     request_payment_max_msat, price_oracle_metadata,
-    request_version, agreed_at, accepted_max_amount
+    request_version, agreed_at, accepted_max_amount,
+    execution_policy
 )
 VALUES (
     $1, $2, $3, $4, $5, $6, $7, $8, $9,
-    $10, $11, $12, $13, $14, $15, $16, $17
+    $10, $11, $12, $13, $14, $15, $16, $17, $18
 )
 RETURNING id
 `
@@ -144,6 +147,7 @@ type InsertRfqPolicyParams struct {
 	RequestVersion        sql.NullInt32
 	AgreedAt              int64
 	AcceptedMaxAmount     sql.NullInt64
+	ExecutionPolicy       sql.NullInt32
 }
 
 func (q *Queries) InsertRfqPolicy(ctx context.Context, arg InsertRfqPolicyParams) (int64, error) {
@@ -165,6 +169,7 @@ func (q *Queries) InsertRfqPolicy(ctx context.Context, arg InsertRfqPolicyParams
 		arg.RequestVersion,
 		arg.AgreedAt,
 		arg.AcceptedMaxAmount,
+		arg.ExecutionPolicy,
 	)
 	var id int64
 	err := row.Scan(&id)

--- a/tapdb/sqlc/rfq.sql.go
+++ b/tapdb/sqlc/rfq.sql.go
@@ -47,9 +47,10 @@ func (q *Queries) CountForwards(ctx context.Context, arg CountForwardsParams) (i
 const FetchActiveRfqPolicies = `-- name: FetchActiveRfqPolicies :many
 SELECT
     id, policy_type, scid, rfq_id, peer, asset_id, asset_group_key,
-    rate_coefficient, rate_scale, expiry, max_out_asset_amt, payment_max_msat,
-    request_asset_max_amt, request_payment_max_msat, price_oracle_metadata,
-    request_version, agreed_at
+    rate_coefficient, rate_scale, expiry, max_out_asset_amt,
+    payment_max_msat, request_asset_max_amt,
+    request_payment_max_msat, price_oracle_metadata,
+    request_version, agreed_at, accepted_max_amount
 FROM rfq_policies
 WHERE expiry >= $1
 `
@@ -81,6 +82,7 @@ func (q *Queries) FetchActiveRfqPolicies(ctx context.Context, minExpiry int64) (
 			&i.PriceOracleMetadata,
 			&i.RequestVersion,
 			&i.AgreedAt,
+			&i.AcceptedMaxAmount,
 		); err != nil {
 			return nil, err
 		}
@@ -112,13 +114,14 @@ func (q *Queries) FetchPeerAcceptedBuyPeerByScid(ctx context.Context, scid int64
 const InsertRfqPolicy = `-- name: InsertRfqPolicy :one
 INSERT INTO rfq_policies (
     policy_type, scid, rfq_id, peer, asset_id, asset_group_key,
-    rate_coefficient, rate_scale, expiry, max_out_asset_amt, payment_max_msat,
-    request_asset_max_amt, request_payment_max_msat, price_oracle_metadata,
-    request_version, agreed_at
+    rate_coefficient, rate_scale, expiry, max_out_asset_amt,
+    payment_max_msat, request_asset_max_amt,
+    request_payment_max_msat, price_oracle_metadata,
+    request_version, agreed_at, accepted_max_amount
 )
 VALUES (
     $1, $2, $3, $4, $5, $6, $7, $8, $9,
-    $10, $11, $12, $13, $14, $15, $16
+    $10, $11, $12, $13, $14, $15, $16, $17
 )
 RETURNING id
 `
@@ -140,6 +143,7 @@ type InsertRfqPolicyParams struct {
 	PriceOracleMetadata   sql.NullString
 	RequestVersion        sql.NullInt32
 	AgreedAt              int64
+	AcceptedMaxAmount     sql.NullInt64
 }
 
 func (q *Queries) InsertRfqPolicy(ctx context.Context, arg InsertRfqPolicyParams) (int64, error) {
@@ -160,6 +164,7 @@ func (q *Queries) InsertRfqPolicy(ctx context.Context, arg InsertRfqPolicyParams
 		arg.PriceOracleMetadata,
 		arg.RequestVersion,
 		arg.AgreedAt,
+		arg.AcceptedMaxAmount,
 	)
 	var id int64
 	err := row.Scan(&id)

--- a/tapdb/sqlc/schemas/generated_schema.sql
+++ b/tapdb/sqlc/schemas/generated_schema.sql
@@ -882,7 +882,7 @@ CREATE TABLE rfq_policies (
 
     -- agreed_at is the timestamp when the policy was agreed upon.
     agreed_at BIGINT NOT NULL
-);
+, accepted_max_amount BIGINT);
 
 CREATE UNIQUE INDEX rfq_policies_rfq_id_idx ON rfq_policies (rfq_id);
 

--- a/tapdb/sqlc/schemas/generated_schema.sql
+++ b/tapdb/sqlc/schemas/generated_schema.sql
@@ -882,7 +882,7 @@ CREATE TABLE rfq_policies (
 
     -- agreed_at is the timestamp when the policy was agreed upon.
     agreed_at BIGINT NOT NULL
-, accepted_max_amount BIGINT);
+, accepted_max_amount BIGINT, execution_policy INTEGER);
 
 CREATE UNIQUE INDEX rfq_policies_rfq_id_idx ON rfq_policies (rfq_id);
 

--- a/taprpc/portfoliopilotrpc/portfolio_pilot.pb.go
+++ b/taprpc/portfoliopilotrpc/portfolio_pilot.pb.go
@@ -248,6 +248,9 @@ const (
 	// REJECT_CODE_FOK_NOT_VIABLE indicates that the FOK execution
 	// policy could not be satisfied at the accepted rate.
 	RejectCode_REJECT_CODE_FOK_NOT_VIABLE RejectCode = 4
+	// REJECT_CODE_FILL_EXCEEDS_MAX indicates that the negotiated
+	// fill amount exceeds the requester's maximum.
+	RejectCode_REJECT_CODE_FILL_EXCEEDS_MAX RejectCode = 5
 )
 
 // Enum value maps for RejectCode.
@@ -258,6 +261,7 @@ var (
 		2: "REJECT_CODE_MIN_FILL_NOT_MET",
 		3: "REJECT_CODE_PRICE_BOUND_MISS",
 		4: "REJECT_CODE_FOK_NOT_VIABLE",
+		5: "REJECT_CODE_FILL_EXCEEDS_MAX",
 	}
 	RejectCode_value = map[string]int32{
 		"REJECT_CODE_UNSPECIFIED":              0,
@@ -265,6 +269,7 @@ var (
 		"REJECT_CODE_MIN_FILL_NOT_MET":         2,
 		"REJECT_CODE_PRICE_BOUND_MISS":         3,
 		"REJECT_CODE_FOK_NOT_VIABLE":           4,
+		"REJECT_CODE_FILL_EXCEEDS_MAX":         5,
 	}
 )
 
@@ -323,6 +328,9 @@ const (
 	// FOK_NOT_VIABLE indicates that the FOK execution policy could
 	// not be satisfied at the accepted rate.
 	QuoteRespStatus_FOK_NOT_VIABLE QuoteRespStatus = 7
+	// FILL_EXCEEDS_MAX indicates that the negotiated fill amount
+	// exceeds the requester's maximum.
+	QuoteRespStatus_FILL_EXCEEDS_MAX QuoteRespStatus = 8
 )
 
 // Enum value maps for QuoteRespStatus.
@@ -336,6 +344,7 @@ var (
 		5: "MIN_FILL_NOT_MET",
 		6: "RATE_BOUND_MISS",
 		7: "FOK_NOT_VIABLE",
+		8: "FILL_EXCEEDS_MAX",
 	}
 	QuoteRespStatus_value = map[string]int32{
 		"INVALID_ASSET_RATES":    0,
@@ -346,6 +355,7 @@ var (
 		"MIN_FILL_NOT_MET":       5,
 		"RATE_BOUND_MISS":        6,
 		"FOK_NOT_VIABLE":         7,
+		"FILL_EXCEEDS_MAX":       8,
 	}
 )
 
@@ -1003,9 +1013,15 @@ type ResolveRequestResponse struct {
 	//
 	//	*ResolveRequestResponse_Accept
 	//	*ResolveRequestResponse_Reject
-	Result        isResolveRequestResponse_Result `protobuf_oneof:"result"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	Result isResolveRequestResponse_Result `protobuf_oneof:"result"`
+	// accepted_max_amount is an optional fill quantity that caps the
+	// amount the responder is willing to accept. Only meaningful when
+	// accept is set; 0 means no fill cap (full request max). The unit
+	// depends on the request type: asset units for a buy request, msat
+	// for a sell request.
+	AcceptedMaxAmount uint64 `protobuf:"varint,3,opt,name=accepted_max_amount,json=acceptedMaxAmount,proto3" json:"accepted_max_amount,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
 }
 
 func (x *ResolveRequestResponse) Reset() {
@@ -1063,6 +1079,13 @@ func (x *ResolveRequestResponse) GetReject() *RejectErr {
 	return nil
 }
 
+func (x *ResolveRequestResponse) GetAcceptedMaxAmount() uint64 {
+	if x != nil {
+		return x.AcceptedMaxAmount
+	}
+	return 0
+}
+
 type isResolveRequestResponse_Result interface {
 	isResolveRequestResponse_Result()
 }
@@ -1092,9 +1115,14 @@ type AcceptedQuote struct {
 	//
 	//	*AcceptedQuote_BuyRequest
 	//	*AcceptedQuote_SellRequest
-	Request       isAcceptedQuote_Request `protobuf_oneof:"request"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	Request isAcceptedQuote_Request `protobuf_oneof:"request"`
+	// accepted_max_amount is the optional negotiated fill quantity.
+	// 0 means no fill cap (full request max). The unit depends on
+	// the request type: asset units for a buy request, msat for a
+	// sell request.
+	AcceptedMaxAmount uint64 `protobuf:"varint,5,opt,name=accepted_max_amount,json=acceptedMaxAmount,proto3" json:"accepted_max_amount,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
 }
 
 func (x *AcceptedQuote) Reset() {
@@ -1164,6 +1192,13 @@ func (x *AcceptedQuote) GetSellRequest() *SellRequest {
 		}
 	}
 	return nil
+}
+
+func (x *AcceptedQuote) GetAcceptedMaxAmount() uint64 {
+	if x != nil {
+		return x.AcceptedMaxAmount
+	}
+	return 0
 }
 
 type isAcceptedQuote_Request interface {
@@ -1488,17 +1523,19 @@ const file_portfoliopilotrpc_portfolio_pilot_proto_rawDesc = "" +
 	"\vbuy_request\x18\x01 \x01(\v2\x1d.portfoliopilotrpc.BuyRequestH\x00R\n" +
 	"buyRequest\x12C\n" +
 	"\fsell_request\x18\x02 \x01(\v2\x1e.portfoliopilotrpc.SellRequestH\x00R\vsellRequestB\t\n" +
-	"\arequest\"\x92\x01\n" +
+	"\arequest\"\xc2\x01\n" +
 	"\x16ResolveRequestResponse\x126\n" +
 	"\x06accept\x18\x01 \x01(\v2\x1c.portfoliopilotrpc.AssetRateH\x00R\x06accept\x126\n" +
-	"\x06reject\x18\x02 \x01(\v2\x1c.portfoliopilotrpc.RejectErrH\x00R\x06rejectB\b\n" +
-	"\x06result\"\xfd\x01\n" +
+	"\x06reject\x18\x02 \x01(\v2\x1c.portfoliopilotrpc.RejectErrH\x00R\x06reject\x12.\n" +
+	"\x13accepted_max_amount\x18\x03 \x01(\x04R\x11acceptedMaxAmountB\b\n" +
+	"\x06result\"\xad\x02\n" +
 	"\rAcceptedQuote\x12\x17\n" +
 	"\apeer_id\x18\x01 \x01(\fR\x06peerId\x12A\n" +
 	"\raccepted_rate\x18\x02 \x01(\v2\x1c.portfoliopilotrpc.AssetRateR\facceptedRate\x12@\n" +
 	"\vbuy_request\x18\x03 \x01(\v2\x1d.portfoliopilotrpc.BuyRequestH\x00R\n" +
 	"buyRequest\x12C\n" +
-	"\fsell_request\x18\x04 \x01(\v2\x1e.portfoliopilotrpc.SellRequestH\x00R\vsellRequestB\t\n" +
+	"\fsell_request\x18\x04 \x01(\v2\x1e.portfoliopilotrpc.SellRequestH\x00R\vsellRequest\x12.\n" +
+	"\x13accepted_max_amount\x18\x05 \x01(\x04R\x11acceptedMaxAmountB\t\n" +
 	"\arequest\"T\n" +
 	"\x18VerifyAcceptQuoteRequest\x128\n" +
 	"\x06accept\x18\x01 \x01(\v2 .portfoliopilotrpc.AcceptedQuoteR\x06accept\"W\n" +
@@ -1531,14 +1568,15 @@ const file_portfoliopilotrpc_portfolio_pilot_proto_rawDesc = "" +
 	"\x1bINTENT_RECV_PAYMENT_QUALIFY\x10\x06*E\n" +
 	"\x0fExecutionPolicy\x12\x18\n" +
 	"\x14EXECUTION_POLICY_IOC\x10\x00\x12\x18\n" +
-	"\x14EXECUTION_POLICY_FOK\x10\x01*\xb7\x01\n" +
+	"\x14EXECUTION_POLICY_FOK\x10\x01*\xd9\x01\n" +
 	"\n" +
 	"RejectCode\x12\x1b\n" +
 	"\x17REJECT_CODE_UNSPECIFIED\x10\x00\x12(\n" +
 	"$REJECT_CODE_PRICE_ORACLE_UNAVAILABLE\x10\x01\x12 \n" +
 	"\x1cREJECT_CODE_MIN_FILL_NOT_MET\x10\x02\x12 \n" +
 	"\x1cREJECT_CODE_PRICE_BOUND_MISS\x10\x03\x12\x1e\n" +
-	"\x1aREJECT_CODE_FOK_NOT_VIABLE\x10\x04*\xca\x01\n" +
+	"\x1aREJECT_CODE_FOK_NOT_VIABLE\x10\x04\x12 \n" +
+	"\x1cREJECT_CODE_FILL_EXCEEDS_MAX\x10\x05*\xe0\x01\n" +
 	"\x0fQuoteRespStatus\x12\x17\n" +
 	"\x13INVALID_ASSET_RATES\x10\x00\x12\x12\n" +
 	"\x0eINVALID_EXPIRY\x10\x01\x12\x1a\n" +
@@ -1547,7 +1585,8 @@ const file_portfoliopilotrpc_portfolio_pilot_proto_rawDesc = "" +
 	"\x12VALID_ACCEPT_QUOTE\x10\x04\x12\x14\n" +
 	"\x10MIN_FILL_NOT_MET\x10\x05\x12\x13\n" +
 	"\x0fRATE_BOUND_MISS\x10\x06\x12\x12\n" +
-	"\x0eFOK_NOT_VIABLE\x10\a2\xd1\x02\n" +
+	"\x0eFOK_NOT_VIABLE\x10\a\x12\x14\n" +
+	"\x10FILL_EXCEEDS_MAX\x10\b2\xd1\x02\n" +
 	"\x0ePortfolioPilot\x12e\n" +
 	"\x0eResolveRequest\x12(.portfoliopilotrpc.ResolveRequestRequest\x1a).portfoliopilotrpc.ResolveRequestResponse\x12n\n" +
 	"\x11VerifyAcceptQuote\x12+.portfoliopilotrpc.VerifyAcceptQuoteRequest\x1a,.portfoliopilotrpc.VerifyAcceptQuoteResponse\x12h\n" +

--- a/taprpc/portfoliopilotrpc/portfolio_pilot.proto
+++ b/taprpc/portfoliopilotrpc/portfolio_pilot.proto
@@ -130,6 +130,10 @@ enum RejectCode {
     // REJECT_CODE_FOK_NOT_VIABLE indicates that the FOK execution
     // policy could not be satisfied at the accepted rate.
     REJECT_CODE_FOK_NOT_VIABLE = 4;
+
+    // REJECT_CODE_FILL_EXCEEDS_MAX indicates that the negotiated
+    // fill amount exceeds the requester's maximum.
+    REJECT_CODE_FILL_EXCEEDS_MAX = 5;
 }
 
 // QuoteRespStatus is an enum that represents the status of a quote response.
@@ -165,6 +169,10 @@ enum QuoteRespStatus {
     // FOK_NOT_VIABLE indicates that the FOK execution policy could
     // not be satisfied at the accepted rate.
     FOK_NOT_VIABLE = 7;
+
+    // FILL_EXCEEDS_MAX indicates that the negotiated fill amount
+    // exceeds the requester's maximum.
+    FILL_EXCEEDS_MAX = 8;
 }
 
 // RejectErr captures a rejection reason for a quote request.
@@ -318,6 +326,13 @@ message ResolveRequestResponse {
         // reject is the rejection reason for the request.
         RejectErr reject = 2;
     }
+
+    // accepted_max_amount is an optional fill quantity that caps the
+    // amount the responder is willing to accept. Only meaningful when
+    // accept is set; 0 means no fill cap (full request max). The unit
+    // depends on the request type: asset units for a buy request, msat
+    // for a sell request.
+    uint64 accepted_max_amount = 3;
 }
 
 // AcceptedQuote bundles an accepted quote and its original request.
@@ -335,6 +350,12 @@ message AcceptedQuote {
         // sell_request is the original sell request.
         SellRequest sell_request = 4;
     }
+
+    // accepted_max_amount is the optional negotiated fill quantity.
+    // 0 means no fill cap (full request max). The unit depends on
+    // the request type: asset units for a buy request, msat for a
+    // sell request.
+    uint64 accepted_max_amount = 5;
 }
 
 // VerifyAcceptQuoteRequest specifies an accepted quote to verify.

--- a/taprpc/portfoliopilotrpc/portfolio_pilot.swagger.json
+++ b/taprpc/portfoliopilotrpc/portfolio_pilot.swagger.json
@@ -139,6 +139,11 @@
         "sell_request": {
           "$ref": "#/definitions/portfoliopilotrpcSellRequest",
           "description": "sell_request is the original sell request."
+        },
+        "accepted_max_amount": {
+          "type": "string",
+          "format": "uint64",
+          "description": "accepted_max_amount is the optional negotiated fill quantity.\n0 means no fill cap (full request max). The unit depends on\nthe request type: asset units for a buy request, msat for a\nsell request."
         }
       },
       "description": "AcceptedQuote bundles an accepted quote and its original request."
@@ -336,10 +341,11 @@
         "VALID_ACCEPT_QUOTE",
         "MIN_FILL_NOT_MET",
         "RATE_BOUND_MISS",
-        "FOK_NOT_VIABLE"
+        "FOK_NOT_VIABLE",
+        "FILL_EXCEEDS_MAX"
       ],
       "default": "INVALID_ASSET_RATES",
-      "description": "QuoteRespStatus is an enum that represents the status of a quote response.\n\n - INVALID_ASSET_RATES: INVALID_ASSET_RATES indicates that at least one asset rate in the\nquote response is invalid.\n - INVALID_EXPIRY: INVALID_EXPIRY indicates that the expiry in the quote response is\ninvalid.\n - PRICE_ORACLE_QUERY_ERR: PRICE_ORACLE_QUERY_ERR indicates that an error occurred when querying the\nprice oracle whilst evaluating the quote response.\n - PORTFOLIO_PILOT_ERR: PORTFOLIO_PILOT_ERR indicates that an unexpected error occurred in the\nportfolio pilot while evaluating the quote response.\n - VALID_ACCEPT_QUOTE: VALID_ACCEPT_QUOTE indicates that the accepted quote passed all\nvalidation checks successfully.\n - MIN_FILL_NOT_MET: MIN_FILL_NOT_MET indicates that the minimum fill constraint was\nnot satisfiable at the accepted rate.\n - RATE_BOUND_MISS: RATE_BOUND_MISS indicates that the accepted rate violated the\nrequester's rate limit constraint.\n - FOK_NOT_VIABLE: FOK_NOT_VIABLE indicates that the FOK execution policy could\nnot be satisfied at the accepted rate."
+      "description": "QuoteRespStatus is an enum that represents the status of a quote response.\n\n - INVALID_ASSET_RATES: INVALID_ASSET_RATES indicates that at least one asset rate in the\nquote response is invalid.\n - INVALID_EXPIRY: INVALID_EXPIRY indicates that the expiry in the quote response is\ninvalid.\n - PRICE_ORACLE_QUERY_ERR: PRICE_ORACLE_QUERY_ERR indicates that an error occurred when querying the\nprice oracle whilst evaluating the quote response.\n - PORTFOLIO_PILOT_ERR: PORTFOLIO_PILOT_ERR indicates that an unexpected error occurred in the\nportfolio pilot while evaluating the quote response.\n - VALID_ACCEPT_QUOTE: VALID_ACCEPT_QUOTE indicates that the accepted quote passed all\nvalidation checks successfully.\n - MIN_FILL_NOT_MET: MIN_FILL_NOT_MET indicates that the minimum fill constraint was\nnot satisfiable at the accepted rate.\n - RATE_BOUND_MISS: RATE_BOUND_MISS indicates that the accepted rate violated the\nrequester's rate limit constraint.\n - FOK_NOT_VIABLE: FOK_NOT_VIABLE indicates that the FOK execution policy could\nnot be satisfied at the accepted rate.\n - FILL_EXCEEDS_MAX: FILL_EXCEEDS_MAX indicates that the negotiated fill amount\nexceeds the requester's maximum."
     },
     "portfoliopilotrpcRejectCode": {
       "type": "string",
@@ -348,10 +354,11 @@
         "REJECT_CODE_PRICE_ORACLE_UNAVAILABLE",
         "REJECT_CODE_MIN_FILL_NOT_MET",
         "REJECT_CODE_PRICE_BOUND_MISS",
-        "REJECT_CODE_FOK_NOT_VIABLE"
+        "REJECT_CODE_FOK_NOT_VIABLE",
+        "REJECT_CODE_FILL_EXCEEDS_MAX"
       ],
       "default": "REJECT_CODE_UNSPECIFIED",
-      "description": "RejectCode represents the possible error codes that can be returned in a\nResolveRequestResponse reject result.\n\n - REJECT_CODE_UNSPECIFIED: REJECT_CODE_UNSPECIFIED indicates an unspecified error.\n - REJECT_CODE_PRICE_ORACLE_UNAVAILABLE: REJECT_CODE_PRICE_ORACLE_UNAVAILABLE indicates that pricing could not be\nprovided due to an unavailable oracle.\n - REJECT_CODE_MIN_FILL_NOT_MET: REJECT_CODE_MIN_FILL_NOT_MET indicates that the minimum fill\nconstraint was not satisfiable at the accepted rate.\n - REJECT_CODE_PRICE_BOUND_MISS: REJECT_CODE_PRICE_BOUND_MISS indicates that the accepted rate\nviolated the requester's rate limit constraint.\n - REJECT_CODE_FOK_NOT_VIABLE: REJECT_CODE_FOK_NOT_VIABLE indicates that the FOK execution\npolicy could not be satisfied at the accepted rate."
+      "description": "RejectCode represents the possible error codes that can be returned in a\nResolveRequestResponse reject result.\n\n - REJECT_CODE_UNSPECIFIED: REJECT_CODE_UNSPECIFIED indicates an unspecified error.\n - REJECT_CODE_PRICE_ORACLE_UNAVAILABLE: REJECT_CODE_PRICE_ORACLE_UNAVAILABLE indicates that pricing could not be\nprovided due to an unavailable oracle.\n - REJECT_CODE_MIN_FILL_NOT_MET: REJECT_CODE_MIN_FILL_NOT_MET indicates that the minimum fill\nconstraint was not satisfiable at the accepted rate.\n - REJECT_CODE_PRICE_BOUND_MISS: REJECT_CODE_PRICE_BOUND_MISS indicates that the accepted rate\nviolated the requester's rate limit constraint.\n - REJECT_CODE_FOK_NOT_VIABLE: REJECT_CODE_FOK_NOT_VIABLE indicates that the FOK execution\npolicy could not be satisfied at the accepted rate.\n - REJECT_CODE_FILL_EXCEEDS_MAX: REJECT_CODE_FILL_EXCEEDS_MAX indicates that the negotiated\nfill amount exceeds the requester's maximum."
     },
     "portfoliopilotrpcRejectErr": {
       "type": "object",
@@ -391,6 +398,11 @@
         "reject": {
           "$ref": "#/definitions/portfoliopilotrpcRejectErr",
           "description": "reject is the rejection reason for the request."
+        },
+        "accepted_max_amount": {
+          "type": "string",
+          "format": "uint64",
+          "description": "accepted_max_amount is an optional fill quantity that caps the\namount the responder is willing to accept. Only meaningful when\naccept is set; 0 means no fill cap (full request max). The unit\ndepends on the request type: asset units for a buy request, msat\nfor a sell request."
         }
       },
       "description": "ResolveRequestResponse is the response to a ResolveRequest call."

--- a/taprpc/rfqrpc/rfq.pb.go
+++ b/taprpc/rfqrpc/rfq.pb.go
@@ -1199,9 +1199,13 @@ type PeerAcceptedBuyQuote struct {
 	// more accurate (or discount) asset rate.
 	PriceOracleMetadata string `protobuf:"bytes,8,opt,name=price_oracle_metadata,json=priceOracleMetadata,proto3" json:"price_oracle_metadata,omitempty"`
 	// The subject asset specifier.
-	AssetSpec     *AssetSpec `protobuf:"bytes,9,opt,name=asset_spec,json=assetSpec,proto3" json:"asset_spec,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	AssetSpec *AssetSpec `protobuf:"bytes,9,opt,name=asset_spec,json=assetSpec,proto3" json:"asset_spec,omitempty"`
+	// accepted_max_amount is an optional negotiated fill quantity. When
+	// non-zero the responder accepted up to this many asset units instead
+	// of the full request max.
+	AcceptedMaxAmount uint64 `protobuf:"varint,10,opt,name=accepted_max_amount,json=acceptedMaxAmount,proto3" json:"accepted_max_amount,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
 }
 
 func (x *PeerAcceptedBuyQuote) Reset() {
@@ -1297,6 +1301,13 @@ func (x *PeerAcceptedBuyQuote) GetAssetSpec() *AssetSpec {
 	return nil
 }
 
+func (x *PeerAcceptedBuyQuote) GetAcceptedMaxAmount() uint64 {
+	if x != nil {
+		return x.AcceptedMaxAmount
+	}
+	return 0
+}
+
 type PeerAcceptedSellQuote struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Quote counterparty peer.
@@ -1326,9 +1337,13 @@ type PeerAcceptedSellQuote struct {
 	// more accurate (or discount) asset rate.
 	PriceOracleMetadata string `protobuf:"bytes,8,opt,name=price_oracle_metadata,json=priceOracleMetadata,proto3" json:"price_oracle_metadata,omitempty"`
 	// The subject asset specifier.
-	AssetSpec     *AssetSpec `protobuf:"bytes,9,opt,name=asset_spec,json=assetSpec,proto3" json:"asset_spec,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	AssetSpec *AssetSpec `protobuf:"bytes,9,opt,name=asset_spec,json=assetSpec,proto3" json:"asset_spec,omitempty"`
+	// accepted_max_amount is an optional negotiated fill quantity. When
+	// non-zero the responder accepted up to this many msat instead of the
+	// full request max.
+	AcceptedMaxAmount uint64 `protobuf:"varint,10,opt,name=accepted_max_amount,json=acceptedMaxAmount,proto3" json:"accepted_max_amount,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
 }
 
 func (x *PeerAcceptedSellQuote) Reset() {
@@ -1422,6 +1437,13 @@ func (x *PeerAcceptedSellQuote) GetAssetSpec() *AssetSpec {
 		return x.AssetSpec
 	}
 	return nil
+}
+
+func (x *PeerAcceptedSellQuote) GetAcceptedMaxAmount() uint64 {
+	if x != nil {
+		return x.AcceptedMaxAmount
+	}
+	return 0
 }
 
 // InvalidQuoteResponse is a message that is returned when a quote response is
@@ -2308,7 +2330,7 @@ const file_rfqrpc_rfq_proto_rawDesc = "" +
 	"\x1eQueryPeerAcceptedQuotesRequest\"?\n" +
 	"\tAssetSpec\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\fR\x02id\x12\"\n" +
-	"\rgroup_pub_key\x18\x02 \x01(\fR\vgroupPubKey\"\xe8\x02\n" +
+	"\rgroup_pub_key\x18\x02 \x01(\fR\vgroupPubKey\"\x98\x03\n" +
 	"\x14PeerAcceptedBuyQuote\x12\x12\n" +
 	"\x04peer\x18\x01 \x01(\tR\x04peer\x12\x0e\n" +
 	"\x02id\x18\x02 \x01(\fR\x02id\x12\x12\n" +
@@ -2319,7 +2341,9 @@ const file_rfqrpc_rfq_proto_rawDesc = "" +
 	"\x17min_transportable_units\x18\a \x01(\x04R\x15minTransportableUnits\x122\n" +
 	"\x15price_oracle_metadata\x18\b \x01(\tR\x13priceOracleMetadata\x120\n" +
 	"\n" +
-	"asset_spec\x18\t \x01(\v2\x11.rfqrpc.AssetSpecR\tassetSpec\"\xe0\x02\n" +
+	"asset_spec\x18\t \x01(\v2\x11.rfqrpc.AssetSpecR\tassetSpec\x12.\n" +
+	"\x13accepted_max_amount\x18\n" +
+	" \x01(\x04R\x11acceptedMaxAmount\"\x90\x03\n" +
 	"\x15PeerAcceptedSellQuote\x12\x12\n" +
 	"\x04peer\x18\x01 \x01(\tR\x04peer\x12\x0e\n" +
 	"\x02id\x18\x02 \x01(\fR\x02id\x12\x12\n" +
@@ -2330,7 +2354,9 @@ const file_rfqrpc_rfq_proto_rawDesc = "" +
 	"\x16min_transportable_msat\x18\a \x01(\x04R\x14minTransportableMsat\x122\n" +
 	"\x15price_oracle_metadata\x18\b \x01(\tR\x13priceOracleMetadata\x120\n" +
 	"\n" +
-	"asset_spec\x18\t \x01(\v2\x11.rfqrpc.AssetSpecR\tassetSpec\"k\n" +
+	"asset_spec\x18\t \x01(\v2\x11.rfqrpc.AssetSpecR\tassetSpec\x12.\n" +
+	"\x13accepted_max_amount\x18\n" +
+	" \x01(\x04R\x11acceptedMaxAmount\"k\n" +
 	"\x14InvalidQuoteResponse\x12/\n" +
 	"\x06status\x18\x01 \x01(\x0e2\x17.rfqrpc.QuoteRespStatusR\x06status\x12\x12\n" +
 	"\x04peer\x18\x02 \x01(\tR\x04peer\x12\x0e\n" +

--- a/taprpc/rfqrpc/rfq.proto
+++ b/taprpc/rfqrpc/rfq.proto
@@ -344,6 +344,11 @@ message PeerAcceptedBuyQuote {
 
     // The subject asset specifier.
     AssetSpec asset_spec = 9;
+
+    // accepted_max_amount is an optional negotiated fill quantity. When
+    // non-zero the responder accepted up to this many asset units instead
+    // of the full request max.
+    uint64 accepted_max_amount = 10;
 }
 
 message PeerAcceptedSellQuote {
@@ -383,6 +388,11 @@ message PeerAcceptedSellQuote {
 
     // The subject asset specifier.
     AssetSpec asset_spec = 9;
+
+    // accepted_max_amount is an optional negotiated fill quantity. When
+    // non-zero the responder accepted up to this many msat instead of the
+    // full request max.
+    uint64 accepted_max_amount = 10;
 }
 
 // QuoteRespStatus is an enum that represents the status of a quote response.

--- a/taprpc/rfqrpc/rfq.swagger.json
+++ b/taprpc/rfqrpc/rfq.swagger.json
@@ -975,6 +975,11 @@
         "asset_spec": {
           "$ref": "#/definitions/rfqrpcAssetSpec",
           "description": "The subject asset specifier."
+        },
+        "accepted_max_amount": {
+          "type": "string",
+          "format": "uint64",
+          "description": "accepted_max_amount is an optional negotiated fill quantity. When\nnon-zero the responder accepted up to this many asset units instead\nof the full request max."
         }
       }
     },
@@ -1035,6 +1040,11 @@
         "asset_spec": {
           "$ref": "#/definitions/rfqrpcAssetSpec",
           "description": "The subject asset specifier."
+        },
+        "accepted_max_amount": {
+          "type": "string",
+          "format": "uint64",
+          "description": "accepted_max_amount is an optional negotiated fill quantity. When\nnon-zero the responder accepted up to this many msat instead of the\nfull request max."
         }
       }
     },

--- a/taprpc/tapchannelrpc/tapchannel.swagger.json
+++ b/taprpc/tapchannelrpc/tapchannel.swagger.json
@@ -1319,6 +1319,11 @@
         "asset_spec": {
           "$ref": "#/definitions/rfqrpcAssetSpec",
           "description": "The subject asset specifier."
+        },
+        "accepted_max_amount": {
+          "type": "string",
+          "format": "uint64",
+          "description": "accepted_max_amount is an optional negotiated fill quantity. When\nnon-zero the responder accepted up to this many asset units instead\nof the full request max."
         }
       }
     },
@@ -1365,6 +1370,11 @@
         "asset_spec": {
           "$ref": "#/definitions/rfqrpcAssetSpec",
           "description": "The subject asset specifier."
+        },
+        "accepted_max_amount": {
+          "type": "string",
+          "format": "uint64",
+          "description": "accepted_max_amount is an optional negotiated fill quantity. When\nnon-zero the responder accepted up to this many msat instead of the\nfull request max."
         }
       }
     },


### PR DESCRIPTION
Depends on #2049. Partially resolves #2004 (remainder of workstream C, and essence of workstream D).

Adds fill quantity negotiation to the RFQ wire protocol, such that a responder can propose a fill amount smaller than a requester's maximum, with validation against other limit order constraints at the quote acceptance level (including FOK execution semantics, which was added, but not meaningfully enforced, in #2049). HTLC forwarding policies are capped at the (persisted) negotiated amount so that the channel enforces the agreed-upon limit as a max bound.

There's also some substantial refactoring done around the limit order constraint logic via the RequestConstraints interface.

Here's an illustrative use of the feature from an e2e regtest demo:

```
Frank requests up to 1,000 USDX, min 200. Alice's pilot caps the fill at
500 — above the minimum, so the partial fill is accepted under IOC
semantics.

Fill cap:    500 USDX (pilot constraint)
Requested:   min=200, max=1000 USDX
Market rate: $66,805.00/BTC
✓ Accepted
  RFQ ID: VmojZCspNmgW...
  SCID:   17831787277827515184
  Rate:   $66,805.00/BTC
  Amount: 1000 USDX
  Fill:   min=200, max=1000 USDX
  Cap:    500 USDX (pilot fillcap)

→ AddInvoice (rfq_id: VmojZCspNmgW...)
  500 USDX from Frank, reusing negotiated quote
  Quote confirmed: VmojZCspNmgW...
  Invoice: lnbcrt74844690p1p5ulzcqpp5qnsy5r868n9ql4...

→ Payment: Alice → Eve → Frank
  ✓ Payment succeeded
```