### PR TITLE
rfq+tapdb: persist peer-accepted sell quotes

### DIFF
--- a/docs/release-notes/release-notes-0.8.0.md
+++ b/docs/release-notes/release-notes-0.8.0.md
@@ -77,6 +77,11 @@
   quotes are restored into the active map so payment flows survive
   restarts.
 
+* [PR#2051](https://github.com/lightninglabs/taproot-assets/pull/2051)
+  persists peer-accepted sell quotes to the database on acceptance and
+  restores them into the active cache on startup, ensuring sell-side
+  payment flows survive restarts.
+
 * [PR#2010](https://github.com/lightninglabs/taproot-assets/pull/2010)
   fixes an issue that prevented asset roots from being deleted on
   universes with existing federation sync log entries.

--- a/rfq/interface.go
+++ b/rfq/interface.go
@@ -25,6 +25,11 @@ const (
 	// quote that was persisted for historical SCID lookup.
 	//nolint:lll
 	RfqPolicyTypeAssetPeerAcceptedBuy RfqPolicyType = "RFQ_POLICY_TYPE_PEER_ACCEPTED_BUY"
+
+	// RfqPolicyTypeAssetPeerAcceptedSell identifies a peer-accepted
+	// sell quote that was persisted for restart continuity.
+	//nolint:lll
+	RfqPolicyTypeAssetPeerAcceptedSell RfqPolicyType = "RFQ_POLICY_TYPE_PEER_ACCEPTED_SELL"
 )
 
 // String converts the policy type to its string representation.
@@ -41,15 +46,22 @@ type PolicyStore interface {
 	StorePurchasePolicy(ctx context.Context, accept rfqmsg.SellAccept) error
 
 	// FetchAcceptedQuotes fetches all non-expired accepted quotes.
-	// Returns sale policies as buy accepts, purchase policies as sell
-	// accepts, and peer-accepted buy quotes separately.
+	// Returns sale policies as buy accepts, purchase policies as
+	// sell accepts, peer-accepted buy quotes, and peer-accepted
+	// sell quotes separately.
 	FetchAcceptedQuotes(ctx context.Context) ([]rfqmsg.BuyAccept,
-		[]rfqmsg.SellAccept, []rfqmsg.BuyAccept, error)
+		[]rfqmsg.SellAccept, []rfqmsg.BuyAccept,
+		[]rfqmsg.SellAccept, error)
 
-	// StorePeerAcceptedBuyQuote persists a peer-accepted buy quote for
-	// historical SCID-to-peer lookup.
+	// StorePeerAcceptedBuyQuote persists a peer-accepted buy quote
+	// for historical SCID-to-peer lookup.
 	StorePeerAcceptedBuyQuote(ctx context.Context,
 		accept rfqmsg.BuyAccept) error
+
+	// StorePeerAcceptedSellQuote persists a peer-accepted sell
+	// quote for restart continuity.
+	StorePeerAcceptedSellQuote(ctx context.Context,
+		accept rfqmsg.SellAccept) error
 
 	// LookUpScid looks up the peer associated with the given SCID from
 	// persisted peer-accepted buy quote policies.

--- a/rfq/manager.go
+++ b/rfq/manager.go
@@ -529,6 +529,18 @@ func (m *Manager) handleIncomingMessage(ctx context.Context,
 			scid := msg.ShortChannelId()
 			m.orderHandler.peerSellQuotes.Store(scid, msg)
 
+			// Persist the peer sell quote to DB so that
+			// the peerSellQuotes cache survives restarts.
+			pStore := m.cfg.PolicyStore
+			storeErr := pStore.StorePeerAcceptedSellQuote(
+				ctx, msg,
+			)
+			if storeErr != nil {
+				log.Errorf("Failed to persist peer sell "+
+					"quote for SCID %d: %v", scid,
+					storeErr)
+			}
+
 			// Notify subscribers of the incoming peer accepted
 			// asset sell quote.
 			event := NewPeerAcceptedSellQuoteEvent(&msg)

--- a/rfq/manager.go
+++ b/rfq/manager.go
@@ -456,23 +456,25 @@ func (m *Manager) handleIncomingMessage(ctx context.Context,
 				return
 			}
 
-			// The quote request has been accepted. Store accepted
-			// quote so that it can be used to send a payment by our
-			// lightning node.
+			// The quote request has been accepted. Persist to
+			// DB first so that on restart the quote is not
+			// silently lost.
 			scid := msg.ShortChannelId()
-			m.orderHandler.peerBuyQuotes.Store(scid, msg)
-
-			// Persist the peer buy quote to DB so that
-			// historical SCID lookups survive quote expiry
-			// and restarts.
-			storeErr := m.cfg.PolicyStore.StorePeerAcceptedBuyQuote(
+			pStore := m.cfg.PolicyStore
+			storeErr := pStore.StorePeerAcceptedBuyQuote(
 				ctx, msg,
 			)
 			if storeErr != nil {
-				log.Errorf("Failed to persist peer buy "+
-					"quote for SCID %d: %v", scid,
-					storeErr)
+				m.handleError(fmt.Errorf("failed to "+
+					"persist peer buy quote for "+
+					"SCID %d: %w", scid, storeErr))
+
+				return
 			}
+
+			// DB write succeeded; populate the in-memory
+			// cache.
+			m.orderHandler.peerBuyQuotes.Store(scid, msg)
 
 			// Since we're going to buy assets from our peer, we
 			// need to make sure we can identify the incoming asset
@@ -523,23 +525,26 @@ func (m *Manager) handleIncomingMessage(ctx context.Context,
 				return
 			}
 
-			// The quote request has been accepted. Store accepted
-			// quote so that it can be used to send a payment by our
-			// lightning node.
+			// The quote request has been accepted. Persist to
+			// DB first so that on restart the quote is not
+			// silently lost.
 			scid := msg.ShortChannelId()
-			m.orderHandler.peerSellQuotes.Store(scid, msg)
-
-			// Persist the peer sell quote to DB so that
-			// the peerSellQuotes cache survives restarts.
 			pStore := m.cfg.PolicyStore
 			storeErr := pStore.StorePeerAcceptedSellQuote(
 				ctx, msg,
 			)
 			if storeErr != nil {
-				log.Errorf("Failed to persist peer sell "+
-					"quote for SCID %d: %v", scid,
-					storeErr)
+				m.handleError(fmt.Errorf("failed to "+
+					"persist peer sell quote "+
+					"for SCID %d: %w", scid,
+					storeErr))
+
+				return
 			}
+
+			// DB write succeeded; populate the in-memory
+			// cache.
+			m.orderHandler.peerSellQuotes.Store(scid, msg)
 
 			// Notify subscribers of the incoming peer accepted
 			// asset sell quote.

--- a/rfq/manager_test.go
+++ b/rfq/manager_test.go
@@ -391,8 +391,8 @@ func TestLookUpScidPersistenceFailure(t *testing.T) {
 
 	manager.orderHandler = &OrderHandler{}
 
-	// Simulate the active map having been populated (which happens
-	// regardless of DB write success in the real code path).
+	// Directly populate the active map to verify that LookUpScid
+	// resolves entries from the in-memory tier independently.
 	scid := rfqmsg.SerialisedScid(42)
 	manager.orderHandler.peerBuyQuotes.Store(scid, rfqmsg.BuyAccept{
 		Peer: peer1,

--- a/rfq/manager_test.go
+++ b/rfq/manager_test.go
@@ -78,13 +78,20 @@ func (mockPolicyStore) StorePurchasePolicy(context.Context,
 }
 
 func (mockPolicyStore) FetchAcceptedQuotes(context.Context) (
-	[]rfqmsg.BuyAccept, []rfqmsg.SellAccept, []rfqmsg.BuyAccept, error) {
+	[]rfqmsg.BuyAccept, []rfqmsg.SellAccept, []rfqmsg.BuyAccept,
+	[]rfqmsg.SellAccept, error) {
 
-	return nil, nil, nil, nil
+	return nil, nil, nil, nil, nil
 }
 
 func (mockPolicyStore) StorePeerAcceptedBuyQuote(context.Context,
 	rfqmsg.BuyAccept) error {
+
+	return nil
+}
+
+func (mockPolicyStore) StorePeerAcceptedSellQuote(context.Context,
+	rfqmsg.SellAccept) error {
 
 	return nil
 }
@@ -345,6 +352,12 @@ type failingPolicyStore struct {
 
 func (f *failingPolicyStore) StorePeerAcceptedBuyQuote(context.Context,
 	rfqmsg.BuyAccept) error {
+
+	return fmt.Errorf("simulated DB write failure")
+}
+
+func (f *failingPolicyStore) StorePeerAcceptedSellQuote(context.Context,
+	rfqmsg.SellAccept) error {
 
 	return fmt.Errorf("simulated DB write failure")
 }

--- a/rfq/order.go
+++ b/rfq/order.go
@@ -1473,7 +1473,7 @@ func (h *OrderHandler) RegisterAssetPurchasePolicy(ctx context.Context,
 
 // restorePersistedPolicies restores persisted policies from the policy store.
 func (h *OrderHandler) restorePersistedPolicies(ctx context.Context) error {
-	buyAccepts, sellAccepts, peerBuyAccepts,
+	buyAccepts, sellAccepts, peerBuyAccepts, peerSellAccepts,
 		err := h.cfg.PolicyStore.FetchAcceptedQuotes(ctx)
 	if err != nil {
 		return fmt.Errorf("error fetching persisted policies: %w", err)
@@ -1501,6 +1501,10 @@ func (h *OrderHandler) restorePersistedPolicies(ctx context.Context) error {
 
 	for _, accept := range peerBuyAccepts {
 		h.peerBuyQuotes.Store(accept.ShortChannelId(), accept)
+	}
+
+	for _, accept := range peerSellAccepts {
+		h.peerSellQuotes.Store(accept.ShortChannelId(), accept)
 	}
 
 	return nil

--- a/tapdb/forwards_test.go
+++ b/tapdb/forwards_test.go
@@ -72,7 +72,7 @@ func insertTestPolicy(t *testing.T, ctx context.Context, db sqlc.Querier,
 	// Create a simple rate coefficient (just bytes for testing).
 	rateCoeffBytes := []byte{0x01, 0x23, 0x45}
 
-	_, err := db.InsertRfqPolicy(ctx, sqlc.InsertRfqPolicyParams{
+	err := db.UpsertRfqPolicy(ctx, sqlc.UpsertRfqPolicyParams{
 		PolicyType:      string(policyType),
 		Scid:            12345,
 		RfqID:           rfqID[:],

--- a/tapdb/migrations.go
+++ b/tapdb/migrations.go
@@ -24,7 +24,7 @@ const (
 	// daemon.
 	//
 	// NOTE: This MUST be updated when a new migration is added.
-	LatestMigrationVersion = 56
+	LatestMigrationVersion = 57
 )
 
 // DatabaseBackend is an interface that contains all methods our different

--- a/tapdb/rfq_policies.go
+++ b/tapdb/rfq_policies.go
@@ -79,9 +79,11 @@ type rfqPolicy struct {
 
 // RfqPolicyStore is the database interface for RFQ policies.
 type RfqPolicyStore interface {
-	// InsertRfqPolicy inserts a new RFQ policy into the database.
-	InsertRfqPolicy(context.Context,
-		sqlc.InsertRfqPolicyParams) (int64, error)
+	// UpsertRfqPolicy inserts a new RFQ policy into the database,
+	// or does nothing if a policy with the same rfq_id already
+	// exists.
+	UpsertRfqPolicy(context.Context,
+		sqlc.UpsertRfqPolicyParams) error
 
 	// FetchActiveRfqPolicies retrieves all active RFQ policies from the
 	// database.
@@ -202,9 +204,10 @@ func (s *PersistedPolicyStore) storePolicy(ctx context.Context,
 
 	writeOpts := WriteTxOption()
 	return s.db.ExecTx(ctx, writeOpts, func(q RfqPolicyStore) error {
-		_, err := q.InsertRfqPolicy(ctx, newInsertParams(policy))
+		err := q.UpsertRfqPolicy(ctx, newUpsertParams(policy))
 		if err != nil {
-			return fmt.Errorf("error inserting RFQ policy: %w", err)
+			return fmt.Errorf("error upserting RFQ "+
+				"policy: %w", err)
 		}
 
 		return nil
@@ -402,10 +405,10 @@ func (s *PersistedPolicyStore) LookUpScid(ctx context.Context,
 	return peer, nil
 }
 
-// newInsertParams creates the parameters for inserting an RFQ policy into the
-// database.
-func newInsertParams(policy rfqPolicy) sqlc.InsertRfqPolicyParams {
-	params := sqlc.InsertRfqPolicyParams{
+// newUpsertParams creates the parameters for upserting an RFQ policy
+// into the database.
+func newUpsertParams(policy rfqPolicy) sqlc.UpsertRfqPolicyParams {
+	params := sqlc.UpsertRfqPolicyParams{
 		PolicyType:      policy.PolicyType.String(),
 		Scid:            int64(policy.Scid),
 		RfqID:           policy.RfqID[:],

--- a/tapdb/rfq_policies.go
+++ b/tapdb/rfq_policies.go
@@ -211,17 +211,20 @@ func (s *PersistedPolicyStore) storePolicy(ctx context.Context,
 	})
 }
 
-// FetchAcceptedQuotes retrieves all non-expired policies from the database.
-// Sale policies are returned as buy accepts, purchase policies as sell accepts,
-// and peer-accepted buy quotes are returned separately.
+// FetchAcceptedQuotes retrieves all non-expired policies from the
+// database. Sale policies are returned as buy accepts, purchase
+// policies as sell accepts, and peer-accepted buy/sell quotes are
+// returned separately.
 func (s *PersistedPolicyStore) FetchAcceptedQuotes(ctx context.Context) (
-	[]rfqmsg.BuyAccept, []rfqmsg.SellAccept, []rfqmsg.BuyAccept, error) {
+	[]rfqmsg.BuyAccept, []rfqmsg.SellAccept, []rfqmsg.BuyAccept,
+	[]rfqmsg.SellAccept, error) {
 
 	readOpts := ReadTxOption()
 	var (
-		buyAccepts     []rfqmsg.BuyAccept
-		sellAccepts    []rfqmsg.SellAccept
-		peerBuyAccepts []rfqmsg.BuyAccept
+		buyAccepts      []rfqmsg.BuyAccept
+		sellAccepts     []rfqmsg.SellAccept
+		peerBuyAccepts  []rfqmsg.BuyAccept
+		peerSellAccepts []rfqmsg.SellAccept
 	)
 	now := time.Now().UTC()
 
@@ -261,6 +264,17 @@ func (s *PersistedPolicyStore) FetchAcceptedQuotes(ctx context.Context) (
 					peerBuyAccepts, accept,
 				)
 
+			case rfq.RfqPolicyTypeAssetPeerAcceptedSell:
+				accept, err := sellAcceptFromStored(policy)
+				if err != nil {
+					return fmt.Errorf("error restoring "+
+						"peer sell quote: %w",
+						err)
+				}
+				peerSellAccepts = append(
+					peerSellAccepts, accept,
+				)
+
 			default:
 				// This should never happen by assertion.
 				return fmt.Errorf("unknown policy type: %s",
@@ -271,10 +285,11 @@ func (s *PersistedPolicyStore) FetchAcceptedQuotes(ctx context.Context) (
 		return nil
 	})
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
 
-	return buyAccepts, sellAccepts, peerBuyAccepts, nil
+	return buyAccepts, sellAccepts, peerBuyAccepts,
+		peerSellAccepts, nil
 }
 
 // StorePeerAcceptedBuyQuote persists a peer-accepted buy quote for historical
@@ -316,6 +331,40 @@ func (s *PersistedPolicyStore) StorePeerAcceptedBuyQuote(ctx context.Context,
 		PriceOracleMetadata: acpt.Request.PriceOracleMetadata,
 		RequestVersion:      fn.Ptr(uint32(acpt.Request.Version)),
 		AgreedAt:            acpt.AgreedAt.UTC(),
+	}
+
+	return s.storePolicy(ctx, record)
+}
+
+// StorePeerAcceptedSellQuote persists a peer-accepted sell quote for
+// restart continuity.
+func (s *PersistedPolicyStore) StorePeerAcceptedSellQuote(
+	ctx context.Context, acpt rfqmsg.SellAccept) error {
+
+	assetID, groupKey := specifierPointers(
+		acpt.Request.AssetSpecifier,
+	)
+	rateBytes := coefficientBytes(acpt.AssetRate.Rate)
+	expiry := acpt.AssetRate.Expiry.UTC()
+	paymentMax := int64(acpt.Request.PaymentMaxAmt)
+
+	record := rfqPolicy{
+		PolicyType:            rfq.RfqPolicyTypeAssetPeerAcceptedSell,
+		Scid:                  uint64(acpt.ShortChannelId()),
+		RfqID:                 rfqIDArray(acpt.ID),
+		Peer:                  serializePeer(acpt.Peer),
+		AssetID:               assetID,
+		AssetGroupKey:         groupKey,
+		RateCoefficient:       rateBytes,
+		RateScale:             acpt.AssetRate.Rate.Scale,
+		ExpiryUnix:            uint64(expiry.Unix()),
+		PaymentMaxMsat:        fn.Ptr(paymentMax),
+		RequestPaymentMaxMsat: fn.Ptr(paymentMax),
+		PriceOracleMetadata:   acpt.Request.PriceOracleMetadata,
+		RequestVersion: fn.Ptr(
+			uint32(acpt.Request.Version),
+		),
+		AgreedAt: acpt.AgreedAt.UTC(),
 	}
 
 	return s.storePolicy(ctx, record)

--- a/tapdb/rfq_policies_test.go
+++ b/tapdb/rfq_policies_test.go
@@ -278,7 +278,7 @@ func TestAcceptedMaxAmountRoundTrip(t *testing.T) {
 	err = store.StorePeerAcceptedBuyQuote(ctx, peerBuy)
 	require.NoError(t, err)
 
-	buys, sells, peerBuys, err := store.FetchAcceptedQuotes(ctx)
+	buys, sells, peerBuys, _, err := store.FetchAcceptedQuotes(ctx)
 	require.NoError(t, err)
 
 	require.Len(t, buys, 1)
@@ -305,7 +305,7 @@ func TestAcceptedMaxAmountNilRoundTrip(t *testing.T) {
 	err := store.StoreSalePolicy(ctx, sale)
 	require.NoError(t, err)
 
-	buys, _, _, err := store.FetchAcceptedQuotes(ctx)
+	buys, _, _, _, err := store.FetchAcceptedQuotes(ctx)
 	require.NoError(t, err)
 	require.Len(t, buys, 1)
 	require.True(t, buys[0].AcceptedMaxAmount.IsNone())
@@ -341,7 +341,7 @@ func TestExecutionPolicyRoundTrip(t *testing.T) {
 	err = store.StoreSalePolicy(ctx, saleNone)
 	require.NoError(t, err)
 
-	buys, sells, _, err := store.FetchAcceptedQuotes(ctx)
+	buys, sells, _, _, err := store.FetchAcceptedQuotes(ctx)
 	require.NoError(t, err)
 	require.Len(t, buys, 2)
 	require.Len(t, sells, 1)

--- a/tapdb/rfq_policies_test.go
+++ b/tapdb/rfq_policies_test.go
@@ -450,3 +450,27 @@ func TestFetchAcceptedQuotesSeparatesPeerAcceptedSell(t *testing.T) {
 	require.Equal(t, purchase.ID, sellAccepts[0].ID)
 	require.Equal(t, peerSell.ID, peerSells[0].ID)
 }
+
+// TestUpsertPolicyIdempotent verifies that storing the same quote
+// twice (identical rfq_id) does not error and does not create a
+// duplicate row.
+func TestUpsertPolicyIdempotent(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := newPolicyStore(t)
+
+	accept := testBuyAccept(t)
+
+	err := store.StorePeerAcceptedBuyQuote(ctx, accept)
+	require.NoError(t, err)
+
+	// Second store with the same rfq_id must not error.
+	err = store.StorePeerAcceptedBuyQuote(ctx, accept)
+	require.NoError(t, err)
+
+	// Only one row should exist.
+	_, _, peerBuys, _, err := store.FetchAcceptedQuotes(ctx)
+	require.NoError(t, err)
+	require.Len(t, peerBuys, 1)
+}

--- a/tapdb/rfq_policies_test.go
+++ b/tapdb/rfq_policies_test.go
@@ -142,7 +142,7 @@ func TestFetchAcceptedQuotesSeparatesPeerAcceptedBuy(t *testing.T) {
 	err = store.StoreSalePolicy(ctx, saleAccept)
 	require.NoError(t, err)
 
-	buyAccepts, sellAccepts, peerBuys, err :=
+	buyAccepts, sellAccepts, peerBuys, peerSells, err :=
 		store.FetchAcceptedQuotes(ctx)
 	require.NoError(t, err)
 
@@ -151,6 +151,7 @@ func TestFetchAcceptedQuotesSeparatesPeerAcceptedBuy(t *testing.T) {
 	require.Len(t, buyAccepts, 1)
 	require.Len(t, sellAccepts, 0)
 	require.Len(t, peerBuys, 1)
+	require.Len(t, peerSells, 0)
 	require.Equal(t, saleAccept.ID, buyAccepts[0].ID)
 	require.Equal(t, accept.ID, peerBuys[0].ID)
 }
@@ -216,11 +217,11 @@ func testSellAccept(t *testing.T) rfqmsg.SellAccept {
 	}
 }
 
-// TestFetchAcceptedQuotesAllThreeTypes verifies that FetchAcceptedQuotes
-// correctly categorises all three policy types: sale policies appear as buy
-// accepts, purchase policies appear as sell accepts, and peer-accepted buy
-// quotes are returned separately.
-func TestFetchAcceptedQuotesAllThreeTypes(t *testing.T) {
+// TestFetchAcceptedQuotesAllFourTypes verifies that FetchAcceptedQuotes
+// correctly categorises all four policy types: sale policies appear as
+// buy accepts, purchase policies appear as sell accepts, and
+// peer-accepted buy/sell quotes are returned separately.
+func TestFetchAcceptedQuotesAllFourTypes(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
@@ -239,17 +240,22 @@ func TestFetchAcceptedQuotesAllThreeTypes(t *testing.T) {
 	err = store.StorePeerAcceptedBuyQuote(ctx, peerBuy)
 	require.NoError(t, err)
 
-	buyAccepts, sellAccepts, peerBuys, err :=
+	peerSell := testSellAccept(t)
+	err = store.StorePeerAcceptedSellQuote(ctx, peerSell)
+	require.NoError(t, err)
+
+	buyAccepts, sellAccepts, peerBuys, peerSells, err :=
 		store.FetchAcceptedQuotes(ctx)
 	require.NoError(t, err)
 
-	// Sale → buyAccepts, Purchase → sellAccepts, PeerBuy → peerBuys.
 	require.Len(t, buyAccepts, 1)
 	require.Len(t, sellAccepts, 1)
 	require.Len(t, peerBuys, 1)
+	require.Len(t, peerSells, 1)
 	require.Equal(t, sale.ID, buyAccepts[0].ID)
 	require.Equal(t, purchase.ID, sellAccepts[0].ID)
 	require.Equal(t, peerBuy.ID, peerBuys[0].ID)
+	require.Equal(t, peerSell.ID, peerSells[0].ID)
 }
 
 // TestAcceptedMaxAmountRoundTrip verifies that the AcceptedMaxAmount
@@ -385,4 +391,62 @@ func TestLookUpScidIgnoresSalePolicy(t *testing.T) {
 	_, err = store.LookUpScid(ctx, uint64(accept.ShortChannelId()))
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "error fetching policy by SCID")
+}
+
+// TestStorePeerAcceptedSellQuote tests that a peer-accepted sell quote
+// can be persisted and round-tripped through FetchAcceptedQuotes.
+func TestStorePeerAcceptedSellQuote(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := newPolicyStore(t)
+
+	accept := testSellAccept(t)
+
+	err := store.StorePeerAcceptedSellQuote(ctx, accept)
+	require.NoError(t, err)
+
+	_, _, _, peerSells, err := store.FetchAcceptedQuotes(ctx)
+	require.NoError(t, err)
+
+	require.Len(t, peerSells, 1)
+	require.Equal(t, accept.ID, peerSells[0].ID)
+	require.Equal(t, accept.Peer, peerSells[0].Peer)
+	require.Equal(
+		t, accept.Request.PaymentMaxAmt,
+		peerSells[0].Request.PaymentMaxAmt,
+	)
+}
+
+// TestFetchAcceptedQuotesSeparatesPeerAcceptedSell verifies that
+// FetchAcceptedQuotes returns peer-accepted sell quotes in the fourth
+// return value, separate from purchase policies.
+func TestFetchAcceptedQuotesSeparatesPeerAcceptedSell(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := newPolicyStore(t)
+
+	// Store a peer-accepted sell quote.
+	peerSell := testSellAccept(t)
+	err := store.StorePeerAcceptedSellQuote(ctx, peerSell)
+	require.NoError(t, err)
+
+	// Also store a regular purchase policy.
+	purchase := testSellAccept(t)
+	err = store.StorePurchasePolicy(ctx, purchase)
+	require.NoError(t, err)
+
+	buyAccepts, sellAccepts, peerBuys, peerSells, err :=
+		store.FetchAcceptedQuotes(ctx)
+	require.NoError(t, err)
+
+	// Purchase policy appears in sellAccepts, peer sell quote
+	// appears separately in peerSells.
+	require.Len(t, buyAccepts, 0)
+	require.Len(t, sellAccepts, 1)
+	require.Len(t, peerBuys, 0)
+	require.Len(t, peerSells, 1)
+	require.Equal(t, purchase.ID, sellAccepts[0].ID)
+	require.Equal(t, peerSell.ID, peerSells[0].ID)
 }

--- a/tapdb/sqlc/migrations/000057_rfq_peer_accepted_sell.down.sql
+++ b/tapdb/sqlc/migrations/000057_rfq_peer_accepted_sell.down.sql
@@ -1,0 +1,162 @@
+-- Revert rfq_policies CHECK constraint to 3 types (remove
+-- peer-accepted sell). Must also handle the forwards table FK
+-- reference.
+
+DELETE FROM rfq_policies
+    WHERE policy_type = 'RFQ_POLICY_TYPE_PEER_ACCEPTED_SELL';
+
+-- 1. Save existing forwards data and drop the table.
+CREATE TEMP TABLE IF NOT EXISTS forwards_backup
+    AS SELECT * FROM forwards;
+DROP TABLE IF EXISTS forwards;
+
+DROP INDEX IF EXISTS rfq_policies_scid_idx;
+
+-- 2. Rename and recreate rfq_policies with 3-type CHECK constraint.
+ALTER TABLE rfq_policies RENAME TO rfq_policies_old;
+
+CREATE TABLE IF NOT EXISTS rfq_policies (
+    id INTEGER PRIMARY KEY,
+
+    -- policy_type denotes the type of the policy.
+    policy_type TEXT NOT NULL CHECK (
+        policy_type IN (
+            'RFQ_POLICY_TYPE_SALE',
+            'RFQ_POLICY_TYPE_PURCHASE',
+            'RFQ_POLICY_TYPE_PEER_ACCEPTED_BUY'
+        )
+    ),
+
+    -- scid is the short channel ID associated with the policy.
+    scid BIGINT NOT NULL,
+
+    -- rfq_id is the unique identifier for the RFQ session.
+    rfq_id BLOB NOT NULL CHECK (length(rfq_id) = 32),
+
+    -- peer is the public key of the peer node.
+    peer BLOB NOT NULL CHECK (length(peer) = 33),
+
+    -- asset_id is the optional asset ID.
+    asset_id BLOB CHECK (length(asset_id) = 32),
+
+    -- asset_group_key is the optional asset group key.
+    asset_group_key BLOB CHECK (length(asset_group_key) = 33),
+
+    -- rate_coefficient is the coefficient of the exchange rate.
+    rate_coefficient BLOB NOT NULL,
+
+    -- rate_scale is the scale of the exchange rate.
+    rate_scale INTEGER NOT NULL,
+
+    -- expiry is the expiration timestamp of the policy.
+    expiry BIGINT NOT NULL,
+
+    -- max_out_asset_amt is the maximum asset amount for sale
+    -- policies.
+    max_out_asset_amt BIGINT,
+
+    -- payment_max_msat is the maximum payment amount for purchase
+    -- policies.
+    payment_max_msat BIGINT,
+
+    -- request_asset_max_amt is the requested maximum asset amount.
+    request_asset_max_amt BIGINT,
+
+    -- request_payment_max_msat is the requested maximum payment
+    -- amount.
+    request_payment_max_msat BIGINT,
+
+    -- price_oracle_metadata contains metadata about the price
+    -- oracle.
+    price_oracle_metadata TEXT,
+
+    -- request_version is the version of the RFQ request.
+    request_version INTEGER,
+
+    -- agreed_at is the timestamp when the policy was agreed upon.
+    agreed_at BIGINT NOT NULL,
+
+    -- accepted_max_amount is the maximum amount accepted.
+    accepted_max_amount BIGINT,
+
+    -- execution_policy is the execution policy type.
+    execution_policy INTEGER
+);
+
+INSERT INTO rfq_policies (
+    policy_type, scid, rfq_id, peer, asset_id, asset_group_key,
+    rate_coefficient, rate_scale, expiry, max_out_asset_amt,
+    payment_max_msat, request_asset_max_amt,
+    request_payment_max_msat, price_oracle_metadata,
+    request_version, agreed_at, accepted_max_amount,
+    execution_policy
+) SELECT
+    policy_type, scid, rfq_id, peer, asset_id, asset_group_key,
+    rate_coefficient, rate_scale, expiry, max_out_asset_amt,
+    payment_max_msat, request_asset_max_amt,
+    request_payment_max_msat, price_oracle_metadata,
+    request_version, agreed_at, accepted_max_amount,
+    execution_policy
+FROM rfq_policies_old;
+DROP TABLE rfq_policies_old;
+
+CREATE UNIQUE INDEX IF NOT EXISTS rfq_policies_rfq_id_idx
+    ON rfq_policies (rfq_id);
+CREATE INDEX IF NOT EXISTS rfq_policies_scid_idx
+    ON rfq_policies (scid);
+
+-- 3. Recreate forwards table and restore data.
+CREATE TABLE IF NOT EXISTS forwards (
+    id INTEGER PRIMARY KEY,
+
+    -- opened_at is the timestamp when the forward was initiated.
+    opened_at TIMESTAMP NOT NULL,
+
+    -- settled_at is the timestamp when the forward settled.
+    settled_at TIMESTAMP,
+
+    -- failed_at is the timestamp when the forward failed.
+    failed_at TIMESTAMP,
+
+    -- rfq_id is the foreign key to the RFQ policy.
+    rfq_id BLOB NOT NULL CHECK (length(rfq_id) = 32)
+        REFERENCES rfq_policies(rfq_id),
+
+    -- chan_id_in is the short channel ID of the incoming channel.
+    chan_id_in BIGINT NOT NULL,
+
+    -- chan_id_out is the short channel ID of the outgoing channel.
+    chan_id_out BIGINT NOT NULL,
+
+    -- htlc_id is the HTLC ID on the incoming channel.
+    htlc_id BIGINT NOT NULL,
+
+    -- asset_amt is the asset amount involved in this swap.
+    asset_amt BIGINT NOT NULL,
+
+    -- amt_in_msat is the actual amount received on the incoming
+    -- channel in millisatoshis.
+    amt_in_msat BIGINT NOT NULL,
+
+    -- amt_out_msat is the actual amount sent on the outgoing
+    -- channel in millisatoshis.
+    amt_out_msat BIGINT NOT NULL,
+
+    UNIQUE(chan_id_in, htlc_id)
+);
+
+INSERT INTO forwards (
+    opened_at, settled_at, failed_at, rfq_id, chan_id_in,
+    chan_id_out, htlc_id, asset_amt, amt_in_msat, amt_out_msat
+) SELECT
+    opened_at, settled_at, failed_at, rfq_id, chan_id_in,
+    chan_id_out, htlc_id, asset_amt, amt_in_msat, amt_out_msat
+FROM forwards_backup;
+DROP TABLE forwards_backup;
+
+CREATE INDEX IF NOT EXISTS forwards_opened_at_idx
+    ON forwards(opened_at);
+CREATE INDEX IF NOT EXISTS forwards_settled_at_idx
+    ON forwards(settled_at);
+CREATE INDEX IF NOT EXISTS forwards_rfq_id_idx
+    ON forwards(rfq_id);

--- a/tapdb/sqlc/migrations/000057_rfq_peer_accepted_sell.up.sql
+++ b/tapdb/sqlc/migrations/000057_rfq_peer_accepted_sell.up.sql
@@ -1,0 +1,166 @@
+-- Recreate rfq_policies with an expanded CHECK constraint that also
+-- allows peer-accepted sell quotes
+-- ('RFQ_POLICY_TYPE_PEER_ACCEPTED_SELL').
+-- SQLite does not support ALTER CONSTRAINT, so we recreate the table.
+--
+-- Because the forwards table has a foreign key reference to
+-- rfq_policies(rfq_id), and SQLite rewrites FK references on table
+-- rename, we must also drop and recreate the forwards table to avoid
+-- a dangling FK.
+
+-- 1. Save existing forwards data and drop the table.
+CREATE TEMP TABLE IF NOT EXISTS forwards_backup
+    AS SELECT * FROM forwards;
+DROP TABLE IF EXISTS forwards;
+
+-- 2. Rename the old rfq_policies table and create the new one with
+--    the expanded CHECK constraint.
+ALTER TABLE rfq_policies RENAME TO rfq_policies_old;
+
+CREATE TABLE IF NOT EXISTS rfq_policies (
+    id INTEGER PRIMARY KEY,
+
+    -- policy_type denotes the type of the policy.
+    policy_type TEXT NOT NULL CHECK (
+        policy_type IN (
+            'RFQ_POLICY_TYPE_SALE',
+            'RFQ_POLICY_TYPE_PURCHASE',
+            'RFQ_POLICY_TYPE_PEER_ACCEPTED_BUY',
+            'RFQ_POLICY_TYPE_PEER_ACCEPTED_SELL'
+        )
+    ),
+
+    -- scid is the short channel ID associated with the policy.
+    scid BIGINT NOT NULL,
+
+    -- rfq_id is the unique identifier for the RFQ session.
+    rfq_id BLOB NOT NULL CHECK (length(rfq_id) = 32),
+
+    -- peer is the public key of the peer node.
+    peer BLOB NOT NULL CHECK (length(peer) = 33),
+
+    -- asset_id is the optional asset ID.
+    asset_id BLOB CHECK (length(asset_id) = 32),
+
+    -- asset_group_key is the optional asset group key.
+    asset_group_key BLOB CHECK (length(asset_group_key) = 33),
+
+    -- rate_coefficient is the coefficient of the exchange rate.
+    rate_coefficient BLOB NOT NULL,
+
+    -- rate_scale is the scale of the exchange rate.
+    rate_scale INTEGER NOT NULL,
+
+    -- expiry is the expiration timestamp of the policy.
+    expiry BIGINT NOT NULL,
+
+    -- max_out_asset_amt is the maximum asset amount for sale
+    -- policies.
+    max_out_asset_amt BIGINT,
+
+    -- payment_max_msat is the maximum payment amount for purchase
+    -- policies.
+    payment_max_msat BIGINT,
+
+    -- request_asset_max_amt is the requested maximum asset amount.
+    request_asset_max_amt BIGINT,
+
+    -- request_payment_max_msat is the requested maximum payment
+    -- amount.
+    request_payment_max_msat BIGINT,
+
+    -- price_oracle_metadata contains metadata about the price
+    -- oracle.
+    price_oracle_metadata TEXT,
+
+    -- request_version is the version of the RFQ request.
+    request_version INTEGER,
+
+    -- agreed_at is the timestamp when the policy was agreed upon.
+    agreed_at BIGINT NOT NULL,
+
+    -- accepted_max_amount is the maximum amount accepted.
+    accepted_max_amount BIGINT,
+
+    -- execution_policy is the execution policy type.
+    execution_policy INTEGER
+);
+
+INSERT INTO rfq_policies (
+    policy_type, scid, rfq_id, peer, asset_id, asset_group_key,
+    rate_coefficient, rate_scale, expiry, max_out_asset_amt,
+    payment_max_msat, request_asset_max_amt,
+    request_payment_max_msat, price_oracle_metadata,
+    request_version, agreed_at, accepted_max_amount,
+    execution_policy
+) SELECT
+    policy_type, scid, rfq_id, peer, asset_id, asset_group_key,
+    rate_coefficient, rate_scale, expiry, max_out_asset_amt,
+    payment_max_msat, request_asset_max_amt,
+    request_payment_max_msat, price_oracle_metadata,
+    request_version, agreed_at, accepted_max_amount,
+    execution_policy
+FROM rfq_policies_old;
+DROP TABLE rfq_policies_old;
+
+CREATE UNIQUE INDEX IF NOT EXISTS rfq_policies_rfq_id_idx
+    ON rfq_policies (rfq_id);
+CREATE INDEX IF NOT EXISTS rfq_policies_scid_idx
+    ON rfq_policies (scid);
+
+-- 3. Recreate the forwards table with the FK pointing to the new
+--    rfq_policies table, restore data and indexes.
+CREATE TABLE IF NOT EXISTS forwards (
+    id INTEGER PRIMARY KEY,
+
+    -- opened_at is the timestamp when the forward was initiated.
+    opened_at TIMESTAMP NOT NULL,
+
+    -- settled_at is the timestamp when the forward settled.
+    settled_at TIMESTAMP,
+
+    -- failed_at is the timestamp when the forward failed.
+    failed_at TIMESTAMP,
+
+    -- rfq_id is the foreign key to the RFQ policy.
+    rfq_id BLOB NOT NULL CHECK (length(rfq_id) = 32)
+        REFERENCES rfq_policies(rfq_id),
+
+    -- chan_id_in is the short channel ID of the incoming channel.
+    chan_id_in BIGINT NOT NULL,
+
+    -- chan_id_out is the short channel ID of the outgoing channel.
+    chan_id_out BIGINT NOT NULL,
+
+    -- htlc_id is the HTLC ID on the incoming channel.
+    htlc_id BIGINT NOT NULL,
+
+    -- asset_amt is the asset amount involved in this swap.
+    asset_amt BIGINT NOT NULL,
+
+    -- amt_in_msat is the actual amount received on the incoming
+    -- channel in millisatoshis.
+    amt_in_msat BIGINT NOT NULL,
+
+    -- amt_out_msat is the actual amount sent on the outgoing
+    -- channel in millisatoshis.
+    amt_out_msat BIGINT NOT NULL,
+
+    UNIQUE(chan_id_in, htlc_id)
+);
+
+INSERT INTO forwards (
+    opened_at, settled_at, failed_at, rfq_id, chan_id_in,
+    chan_id_out, htlc_id, asset_amt, amt_in_msat, amt_out_msat
+) SELECT
+    opened_at, settled_at, failed_at, rfq_id, chan_id_in,
+    chan_id_out, htlc_id, asset_amt, amt_in_msat, amt_out_msat
+FROM forwards_backup;
+DROP TABLE forwards_backup;
+
+CREATE INDEX IF NOT EXISTS forwards_opened_at_idx
+    ON forwards(opened_at);
+CREATE INDEX IF NOT EXISTS forwards_settled_at_idx
+    ON forwards(settled_at);
+CREATE INDEX IF NOT EXISTS forwards_rfq_id_idx
+    ON forwards(rfq_id);

--- a/tapdb/sqlc/querier.go
+++ b/tapdb/sqlc/querier.go
@@ -150,7 +150,6 @@ type Querier interface {
 	InsertNewProofEvent(ctx context.Context, arg InsertNewProofEventParams) error
 	InsertNewSyncEvent(ctx context.Context, arg InsertNewSyncEventParams) error
 	InsertPassiveAsset(ctx context.Context, arg InsertPassiveAssetParams) error
-	InsertRfqPolicy(ctx context.Context, arg InsertRfqPolicyParams) (int64, error)
 	InsertRootKey(ctx context.Context, arg InsertRootKeyParams) error
 	InsertSupplyCommitTransition(ctx context.Context, arg InsertSupplyCommitTransitionParams) (int64, error)
 	InsertSupplyCommitment(ctx context.Context, arg InsertSupplyCommitmentParams) (int64, error)
@@ -270,6 +269,7 @@ type Querier interface {
 	UpsertMintSupplyPreCommit(ctx context.Context, arg UpsertMintSupplyPreCommitParams) (int64, error)
 	UpsertMultiverseLeaf(ctx context.Context, arg UpsertMultiverseLeafParams) (int64, error)
 	UpsertMultiverseRoot(ctx context.Context, arg UpsertMultiverseRootParams) (int64, error)
+	UpsertRfqPolicy(ctx context.Context, arg UpsertRfqPolicyParams) error
 	UpsertRootNode(ctx context.Context, arg UpsertRootNodeParams) error
 	UpsertScriptKey(ctx context.Context, arg UpsertScriptKeyParams) (int64, error)
 	// Return the ID of the state that was actually set (either inserted or updated),

--- a/tapdb/sqlc/queries/rfq.sql
+++ b/tapdb/sqlc/queries/rfq.sql
@@ -1,4 +1,4 @@
--- name: InsertRfqPolicy :one
+-- name: UpsertRfqPolicy :exec
 INSERT INTO rfq_policies (
     policy_type, scid, rfq_id, peer, asset_id, asset_group_key,
     rate_coefficient, rate_scale, expiry, max_out_asset_amt,
@@ -11,7 +11,7 @@ VALUES (
     $1, $2, $3, $4, $5, $6, $7, $8, $9,
     $10, $11, $12, $13, $14, $15, $16, $17, $18
 )
-RETURNING id;
+ON CONFLICT(rfq_id) DO NOTHING;
 
 -- name: FetchActiveRfqPolicies :many
 SELECT

--- a/tapdb/sqlc/rfq.sql.go
+++ b/tapdb/sqlc/rfq.sql.go
@@ -113,69 +113,6 @@ func (q *Queries) FetchPeerAcceptedBuyPeerByScid(ctx context.Context, scid int64
 	return peer, err
 }
 
-const InsertRfqPolicy = `-- name: InsertRfqPolicy :one
-INSERT INTO rfq_policies (
-    policy_type, scid, rfq_id, peer, asset_id, asset_group_key,
-    rate_coefficient, rate_scale, expiry, max_out_asset_amt,
-    payment_max_msat, request_asset_max_amt,
-    request_payment_max_msat, price_oracle_metadata,
-    request_version, agreed_at, accepted_max_amount,
-    execution_policy
-)
-VALUES (
-    $1, $2, $3, $4, $5, $6, $7, $8, $9,
-    $10, $11, $12, $13, $14, $15, $16, $17, $18
-)
-RETURNING id
-`
-
-type InsertRfqPolicyParams struct {
-	PolicyType            string
-	Scid                  int64
-	RfqID                 []byte
-	Peer                  []byte
-	AssetID               []byte
-	AssetGroupKey         []byte
-	RateCoefficient       []byte
-	RateScale             int32
-	Expiry                int64
-	MaxOutAssetAmt        sql.NullInt64
-	PaymentMaxMsat        sql.NullInt64
-	RequestAssetMaxAmt    sql.NullInt64
-	RequestPaymentMaxMsat sql.NullInt64
-	PriceOracleMetadata   sql.NullString
-	RequestVersion        sql.NullInt32
-	AgreedAt              int64
-	AcceptedMaxAmount     sql.NullInt64
-	ExecutionPolicy       sql.NullInt32
-}
-
-func (q *Queries) InsertRfqPolicy(ctx context.Context, arg InsertRfqPolicyParams) (int64, error) {
-	row := q.db.QueryRowContext(ctx, InsertRfqPolicy,
-		arg.PolicyType,
-		arg.Scid,
-		arg.RfqID,
-		arg.Peer,
-		arg.AssetID,
-		arg.AssetGroupKey,
-		arg.RateCoefficient,
-		arg.RateScale,
-		arg.Expiry,
-		arg.MaxOutAssetAmt,
-		arg.PaymentMaxMsat,
-		arg.RequestAssetMaxAmt,
-		arg.RequestPaymentMaxMsat,
-		arg.PriceOracleMetadata,
-		arg.RequestVersion,
-		arg.AgreedAt,
-		arg.AcceptedMaxAmount,
-		arg.ExecutionPolicy,
-	)
-	var id int64
-	err := row.Scan(&id)
-	return id, err
-}
-
 const QueryForwards = `-- name: QueryForwards :many
 SELECT
     f.id, f.opened_at, f.settled_at, f.failed_at, f.rfq_id,
@@ -372,4 +309,65 @@ func (q *Queries) UpsertForward(ctx context.Context, arg UpsertForwardParams) (i
 	var id int64
 	err := row.Scan(&id)
 	return id, err
+}
+
+const UpsertRfqPolicy = `-- name: UpsertRfqPolicy :exec
+INSERT INTO rfq_policies (
+    policy_type, scid, rfq_id, peer, asset_id, asset_group_key,
+    rate_coefficient, rate_scale, expiry, max_out_asset_amt,
+    payment_max_msat, request_asset_max_amt,
+    request_payment_max_msat, price_oracle_metadata,
+    request_version, agreed_at, accepted_max_amount,
+    execution_policy
+)
+VALUES (
+    $1, $2, $3, $4, $5, $6, $7, $8, $9,
+    $10, $11, $12, $13, $14, $15, $16, $17, $18
+)
+ON CONFLICT(rfq_id) DO NOTHING
+`
+
+type UpsertRfqPolicyParams struct {
+	PolicyType            string
+	Scid                  int64
+	RfqID                 []byte
+	Peer                  []byte
+	AssetID               []byte
+	AssetGroupKey         []byte
+	RateCoefficient       []byte
+	RateScale             int32
+	Expiry                int64
+	MaxOutAssetAmt        sql.NullInt64
+	PaymentMaxMsat        sql.NullInt64
+	RequestAssetMaxAmt    sql.NullInt64
+	RequestPaymentMaxMsat sql.NullInt64
+	PriceOracleMetadata   sql.NullString
+	RequestVersion        sql.NullInt32
+	AgreedAt              int64
+	AcceptedMaxAmount     sql.NullInt64
+	ExecutionPolicy       sql.NullInt32
+}
+
+func (q *Queries) UpsertRfqPolicy(ctx context.Context, arg UpsertRfqPolicyParams) error {
+	_, err := q.db.ExecContext(ctx, UpsertRfqPolicy,
+		arg.PolicyType,
+		arg.Scid,
+		arg.RfqID,
+		arg.Peer,
+		arg.AssetID,
+		arg.AssetGroupKey,
+		arg.RateCoefficient,
+		arg.RateScale,
+		arg.Expiry,
+		arg.MaxOutAssetAmt,
+		arg.PaymentMaxMsat,
+		arg.RequestAssetMaxAmt,
+		arg.RequestPaymentMaxMsat,
+		arg.PriceOracleMetadata,
+		arg.RequestVersion,
+		arg.AgreedAt,
+		arg.AcceptedMaxAmount,
+		arg.ExecutionPolicy,
+	)
+	return err
 }

--- a/tapdb/sqlc/schemas/generated_schema.sql
+++ b/tapdb/sqlc/schemas/generated_schema.sql
@@ -889,8 +889,14 @@ CREATE TABLE rfq_policies (
     request_version INTEGER,
 
     -- agreed_at is the timestamp when the policy was agreed upon.
-    agreed_at BIGINT NOT NULL
-, accepted_max_amount BIGINT, execution_policy INTEGER);
+    agreed_at BIGINT NOT NULL,
+
+    -- accepted_max_amount is the maximum amount accepted.
+    accepted_max_amount BIGINT,
+
+    -- execution_policy is the execution policy type.
+    execution_policy INTEGER
+);
 
 CREATE UNIQUE INDEX rfq_policies_rfq_id_idx
     ON rfq_policies (rfq_id);

--- a/tapdb/sqlc/schemas/generated_schema.sql
+++ b/tapdb/sqlc/schemas/generated_schema.sql
@@ -529,22 +529,25 @@ CREATE TABLE forwards (
     -- asset_amt is the asset amount involved in this swap.
     asset_amt BIGINT NOT NULL,
 
-    -- amt_in_msat is the actual amount received on the incoming channel in
-    -- millisatoshis.
+    -- amt_in_msat is the actual amount received on the incoming
+    -- channel in millisatoshis.
     amt_in_msat BIGINT NOT NULL,
 
-    -- amt_out_msat is the actual amount sent on the outgoing channel in
-    -- millisatoshis.
+    -- amt_out_msat is the actual amount sent on the outgoing
+    -- channel in millisatoshis.
     amt_out_msat BIGINT NOT NULL,
 
     UNIQUE(chan_id_in, htlc_id)
 );
 
-CREATE INDEX forwards_opened_at_idx ON forwards(opened_at);
+CREATE INDEX forwards_opened_at_idx
+    ON forwards(opened_at);
 
-CREATE INDEX forwards_rfq_id_idx ON forwards(rfq_id);
+CREATE INDEX forwards_rfq_id_idx
+    ON forwards(rfq_id);
 
-CREATE INDEX forwards_settled_at_idx ON forwards(settled_at);
+CREATE INDEX forwards_settled_at_idx
+    ON forwards(settled_at);
 
 CREATE TABLE genesis_assets (
     gen_asset_id INTEGER PRIMARY KEY,
@@ -834,7 +837,8 @@ CREATE TABLE rfq_policies (
         policy_type IN (
             'RFQ_POLICY_TYPE_SALE',
             'RFQ_POLICY_TYPE_PURCHASE',
-            'RFQ_POLICY_TYPE_PEER_ACCEPTED_BUY'
+            'RFQ_POLICY_TYPE_PEER_ACCEPTED_BUY',
+            'RFQ_POLICY_TYPE_PEER_ACCEPTED_SELL'
         )
     ),
 
@@ -862,19 +866,23 @@ CREATE TABLE rfq_policies (
     -- expiry is the expiration timestamp of the policy.
     expiry BIGINT NOT NULL,
 
-    -- max_out_asset_amt is the maximum asset amount for sale policies.
+    -- max_out_asset_amt is the maximum asset amount for sale
+    -- policies.
     max_out_asset_amt BIGINT,
 
-    -- payment_max_msat is the maximum payment amount for purchase policies.
+    -- payment_max_msat is the maximum payment amount for purchase
+    -- policies.
     payment_max_msat BIGINT,
 
     -- request_asset_max_amt is the requested maximum asset amount.
     request_asset_max_amt BIGINT,
 
-    -- request_payment_max_msat is the requested maximum payment amount.
+    -- request_payment_max_msat is the requested maximum payment
+    -- amount.
     request_payment_max_msat BIGINT,
 
-    -- price_oracle_metadata contains metadata about the price oracle.
+    -- price_oracle_metadata contains metadata about the price
+    -- oracle.
     price_oracle_metadata TEXT,
 
     -- request_version is the version of the RFQ request.
@@ -884,9 +892,11 @@ CREATE TABLE rfq_policies (
     agreed_at BIGINT NOT NULL
 , accepted_max_amount BIGINT, execution_policy INTEGER);
 
-CREATE UNIQUE INDEX rfq_policies_rfq_id_idx ON rfq_policies (rfq_id);
+CREATE UNIQUE INDEX rfq_policies_rfq_id_idx
+    ON rfq_policies (rfq_id);
 
-CREATE INDEX rfq_policies_scid_idx ON rfq_policies (scid);
+CREATE INDEX rfq_policies_scid_idx
+    ON rfq_policies (scid);
 
 CREATE TABLE script_keys (
     script_key_id INTEGER PRIMARY KEY,


### PR DESCRIPTION
Partially addresses #2003 (together with the peer-accepted buy quote persistence that was added in #2009, this fully resolves "gap 3").

Persists peer-accepted sell quotes to the database. Quotes are now written to the `rfq_policies` table on acceptance and restored into the in-memory cache on restart, mirroring our existing practice for buy-side persistence.
