### PR TITLE
rpcserver: add optional constraint fields to AddInvoice

### DIFF
--- a/docs/release-notes/release-notes-0.8.0.md
+++ b/docs/release-notes/release-notes-0.8.0.md
@@ -194,13 +194,6 @@
   requests, and to `PortfolioPilot.ResolveRequest` for constraint
   forwarding. Add `FOK_NOT_VIABLE` to `QuoteRespStatus`.
 
-- [PR#2050](https://github.com/lightninglabs/taproot-assets/pull/2050):
-  Add `max_in_asset` to `PeerAcceptedBuyQuote` and
-  `PeerAcceptedSellQuote` in both the RFQ and PortfolioPilot
-  services, exposing the negotiated fill quantity to RPC clients.
-  Add `fill_amount` to `PortfolioPilot.ResolveResponse` for
-  responder-side fill signalling.
-
 ## tapcli Additions
 
 - [Wallet Backup CLI](https://github.com/lightninglabs/taproot-assets/pull/1980):
@@ -402,6 +395,19 @@
 
 - [PR#2049](https://github.com/lightninglabs/taproot-assets/pull/2049):
   Add unit, property-based, and integration tests for execution policy.
+
+- [PR#2050](https://github.com/lightninglabs/taproot-assets/pull/2050):
+  Add unit and integration tests for fill quantity negotiation,
+  including wire roundtrip, zero-normalisation, fill-vs-constraint
+  validation, sell-side FOK/IOC with fill caps, and responder
+  constraint rejection.
+
+- [PR#2053](https://github.com/lightninglabs/taproot-assets/pull/2053):
+  Add integration test for inline AddInvoice constraint fields
+  and for responder-side constraint validation (rate bound,
+  min fill, FOK/IOC acceptance and rejection across sub-tests).
+  Add sell-side constraint rejection unit tests for
+  TestResolveRequest.
 
 ## Database
 

--- a/itest/custom_channels/limit_constraints_test.go
+++ b/itest/custom_channels/limit_constraints_test.go
@@ -365,6 +365,92 @@ func testCustomChannelsLimitConstraints(_ context.Context,
 	logBalance(t.t, nodes, assetID, "after explicit IOC payment")
 	t.Logf("IOC payment completed: %d units sent", numUnitsIOC)
 
+	// -----------------------------------------------------------------
+	// AddInvoice with inline constraints.
+	//
+	// Dave calls AddInvoice with asset_rate_limit and
+	// asset_min_amt. The internal buy order is sent to Charlie,
+	// who needs a sell offer to accept it.
+	// -----------------------------------------------------------------
+	t.Logf("Registering sell offer on Charlie...")
+	_, err = asTapd(charlie).RfqClient.AddAssetSellOffer(
+		ctxb, &rfqrpc.AddAssetSellOfferRequest{
+			AssetSpecifier: &rfqrpc.AssetSpecifier{
+				Id: &rfqrpc.AssetSpecifier_AssetId{
+					AssetId: assetID,
+				},
+			},
+			MaxUnits: 1_000_000_000,
+		},
+	)
+	require.NoError(t.t, err)
+
+	// Positive: satisfied constraints. Use an amount above
+	// the minimum transportable threshold (~230k units at
+	// the test's exchange rate).
+	t.Logf("AddInvoice with satisfied constraints...")
+	invoiceConstraints, err := asTapd(dave).
+		TaprootAssetChannelsClient.AddInvoice(
+			ctxb, &tchrpc.AddInvoiceRequest{
+				AssetId:     assetID,
+				AssetAmount: 1_000_000,
+				PeerPubkey:  charlie.PubKey[:],
+				InvoiceRequest: &lnrpc.Invoice{
+					Expiry: 60,
+				},
+				AssetMinAmt: 1,
+				AssetRateLimit: &rfqrpc.FixedPoint{
+					// Floor well below oracle
+					// rate — constraint satisfied.
+					Coefficient: "1000000",
+					Scale:       2,
+				},
+			},
+		)
+	require.NoError(t.t, err)
+	require.NotNil(t.t, invoiceConstraints.AcceptedBuyQuote)
+	require.NotEmpty(
+		t.t,
+		invoiceConstraints.InvoiceResult.PaymentRequest,
+	)
+	t.Logf("AddInvoice with constraints succeeded")
+
+	// Negative: rate limit above oracle rate.
+	t.Logf("AddInvoice with violated rate limit...")
+	_, err = asTapd(dave).
+		TaprootAssetChannelsClient.AddInvoice(
+			ctxb, &tchrpc.AddInvoiceRequest{
+				AssetId:     assetID,
+				AssetAmount: 1_000_000,
+				PeerPubkey:  charlie.PubKey[:],
+				InvoiceRequest: &lnrpc.Invoice{
+					Expiry: 60,
+				},
+				AssetRateLimit: &rfqrpc.FixedPoint{
+					// Floor above oracle rate.
+					Coefficient: "9999999999999999",
+					Scale:       2,
+				},
+			},
+		)
+	require.ErrorContains(t.t, err, "rejected quote")
+
+	// Negative: min_amt exceeds max_amt.
+	t.Logf("AddInvoice with min > max...")
+	_, err = asTapd(dave).
+		TaprootAssetChannelsClient.AddInvoice(
+			ctxb, &tchrpc.AddInvoiceRequest{
+				AssetId:     assetID,
+				AssetAmount: 1_000_000,
+				PeerPubkey:  charlie.PubKey[:],
+				InvoiceRequest: &lnrpc.Invoice{
+					Expiry: 60,
+				},
+				AssetMinAmt: 2_000_000,
+			},
+		)
+	require.ErrorContains(t.t, err, "exceeds max amount")
+
 	// Close channels.
 	closeAssetChannelAndAssert(
 		t, net, charlie, dave, chanPointCD,

--- a/itest/custom_channels/limit_constraints_test.go
+++ b/itest/custom_channels/limit_constraints_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/lightninglabs/taproot-assets/asset"
+	"github.com/lightninglabs/taproot-assets/fn"
 	"github.com/lightninglabs/taproot-assets/itest"
 	"github.com/lightninglabs/taproot-assets/proof"
 	"github.com/lightninglabs/taproot-assets/rfqmath"
@@ -325,7 +326,7 @@ func testCustomChannelsLimitConstraints(_ context.Context,
 				},
 			},
 			PaymentMaxAmt: 180_000_000,
-			PaymentMinAmt: 1000,
+			PaymentMinAmt: fn.Ptr[uint64](1000),
 			AssetRateLimit: &rfqrpc.FixedPoint{
 				Coefficient: "100000000000000",
 				Scale:       2,
@@ -398,7 +399,7 @@ func testCustomChannelsLimitConstraints(_ context.Context,
 				InvoiceRequest: &lnrpc.Invoice{
 					Expiry: 60,
 				},
-				AssetMinAmt: 1,
+				AssetMinAmt: fn.Ptr[uint64](1),
 				AssetRateLimit: &rfqrpc.FixedPoint{
 					// Floor well below oracle
 					// rate — constraint satisfied.
@@ -446,7 +447,7 @@ func testCustomChannelsLimitConstraints(_ context.Context,
 				InvoiceRequest: &lnrpc.Invoice{
 					Expiry: 60,
 				},
-				AssetMinAmt: 2_000_000,
+				AssetMinAmt: fn.Ptr[uint64](2_000_000),
 			},
 		)
 	require.ErrorContains(t.t, err, "exceeds max amount")

--- a/itest/custom_channels/liquidity_test.go
+++ b/itest/custom_channels/liquidity_test.go
@@ -340,7 +340,7 @@ func testCustomChannelsLiquidityEdgeCasesCore(ctx context.Context,
 	// amount of 354 sats.
 	createAssetInvoice(
 		t.t, dave, charlie, 1, assetID, withInvoiceErrSubStr(
-			"no quotes with sufficient expiry",
+			"minimal transportable amount",
 		),
 		withInvGroupKey(groupID),
 	)

--- a/itest/rfq_test.go
+++ b/itest/rfq_test.go
@@ -400,6 +400,7 @@ func testRfqAssetSellHtlcIntercept(t *harnessTest) {
 			},
 		},
 		PaymentMaxAmt: askAmt,
+		PaymentMinAmt: fn.Ptr[uint64](0),
 		Expiry:        sellOrderExpiry,
 
 		// Here we explicitly specify Bob as the destination
@@ -676,6 +677,7 @@ func testRfqNegotiationGroupKey(t *harnessTest) {
 			},
 		},
 		PaymentMaxAmt: askAmt,
+		PaymentMinAmt: fn.Ptr[uint64](0),
 		Expiry:        sellOrderExpiry,
 
 		// Here we explicitly specify Bob as the destination
@@ -1015,6 +1017,7 @@ func testRfqPortfolioPilotRpc(t *harnessTest) {
 			},
 		},
 		PaymentMaxAmt: 42000,
+		PaymentMinAmt: fn.Ptr[uint64](0),
 		Expiry:        sellOrderExpiry,
 		PeerPubKey:    ts.BobLnd.PubKey[:],
 		TimeoutSeconds: uint32(
@@ -1141,7 +1144,7 @@ func testRfqLimitConstraints(t *harnessTest) {
 			},
 		},
 		AssetMaxAmt: 6,
-		AssetMinAmt: 1,
+		AssetMinAmt: fn.Ptr[uint64](1),
 		AssetRateLimit: &rfqrpc.FixedPoint{
 			Coefficient: "500000",
 			Scale:       3,
@@ -1218,7 +1221,7 @@ func testRfqLimitConstraints(t *harnessTest) {
 			},
 		},
 		PaymentMaxAmt: 200_000_000,
-		PaymentMinAmt: 100_000_000,
+		PaymentMinAmt: fn.Ptr[uint64](100_000_000),
 		AssetRateLimit: &rfqrpc.FixedPoint{
 			Coefficient: "2000000",
 			Scale:       3,
@@ -1289,7 +1292,7 @@ func testRfqLimitConstraints(t *harnessTest) {
 			},
 		},
 		AssetMaxAmt:           5,
-		AssetMinAmt:           10,
+		AssetMinAmt:           fn.Ptr[uint64](10),
 		Expiry:                expiry,
 		PeerPubKey:            ts.BobLnd.PubKey[:],
 		TimeoutSeconds:        uint32(rfqTimeout.Seconds()),
@@ -1438,6 +1441,7 @@ func testRfqLimitConstraints(t *harnessTest) {
 			},
 		},
 		AssetMaxAmt:           1,
+		AssetMinAmt:           fn.Ptr[uint64](0),
 		Expiry:                expiry,
 		PeerPubKey:            ts.BobLnd.PubKey[:],
 		TimeoutSeconds:        uint32(rfqTimeout.Seconds()),
@@ -1515,6 +1519,7 @@ func testRfqLimitConstraints(t *harnessTest) {
 			},
 		},
 		PaymentMaxAmt: 1,
+		PaymentMinAmt: fn.Ptr[uint64](0),
 		Expiry:        expiry,
 		PeerPubKey:    ts.BobLnd.PubKey[:],
 		TimeoutSeconds: uint32(

--- a/rfq/manager.go
+++ b/rfq/manager.go
@@ -1362,6 +1362,14 @@ func EstimateAssetUnits(ctx context.Context, oracle PriceOracle,
 			oracleRes.Err.Error())
 	}
 
+	// Ensure the oracle returned a usable rate. A zero-valued
+	// BigIntFixedPoint has a nil coefficient, which would panic
+	// in downstream arithmetic.
+	rate := oracleRes.AssetRate.Rate
+	if rate.Coefficient == (rfqmath.BigInt{}) {
+		return 0, fmt.Errorf("oracle returned empty asset rate")
+	}
+
 	assetUnits := rfqmath.MilliSatoshiToUnits(
 		amtMsat, oracleRes.AssetRate.Rate,
 	)

--- a/rpcserver/invoiceamount_test.go
+++ b/rpcserver/invoiceamount_test.go
@@ -1,0 +1,72 @@
+package rpcserver
+
+import (
+	"testing"
+
+	"github.com/lightninglabs/taproot-assets/taprpc/rfqrpc"
+	"github.com/lightningnetwork/lnd/lnrpc"
+	"github.com/stretchr/testify/require"
+)
+
+// TestValidateInvoiceAmountPartialFill checks that passing a
+// capped asset amount to validateInvoiceAmount produces a
+// proportionally smaller msat value than the full amount.
+func TestValidateInvoiceAmountPartialFill(t *testing.T) {
+	t.Parallel()
+
+	// Rate: 10,000,000 cents/BTC ($100k).
+	quote := &rfqrpc.PeerAcceptedBuyQuote{
+		AskAssetRate: &rfqrpc.FixedPoint{
+			Coefficient: "10000000",
+			Scale:       0,
+		},
+		AssetMaxAmount:    1000,
+		AcceptedMaxAmount: 500,
+	}
+
+	emptyInv := &lnrpc.Invoice{}
+
+	fullMsat, err := validateInvoiceAmount(
+		quote, 1000, emptyInv,
+	)
+	require.NoError(t, err)
+
+	cappedMsat, err := validateInvoiceAmount(
+		quote, 500, emptyInv,
+	)
+	require.NoError(t, err)
+
+	require.Greater(t, fullMsat, cappedMsat)
+
+	// The capped amount should be exactly half the full
+	// amount, since 500 is half of 1000.
+	require.Equal(t, fullMsat/2, cappedMsat)
+}
+
+// TestValidateInvoiceAmountSatPartialFill checks that a
+// sat-denominated invoice is rejected when the negotiated fill
+// quantity (AcceptedMaxAmount) cannot carry the requested msat.
+func TestValidateInvoiceAmountSatPartialFill(t *testing.T) {
+	t.Parallel()
+
+	// Rate: 10,000,000 units/BTC.
+	quote := &rfqrpc.PeerAcceptedBuyQuote{
+		AskAssetRate: &rfqrpc.FixedPoint{
+			Coefficient: "10000000",
+			Scale:       0,
+		},
+		AssetMaxAmount:    1000,
+		AcceptedMaxAmount: 500,
+	}
+
+	// At this rate, 1000 units ≈ 10,000,000 msat and 500 units
+	// ≈ 5,000,000 msat. Request an amount between the two so it
+	// passes with AssetMaxAmount but fails with the negotiated
+	// AcceptedMaxAmount.
+	inv := &lnrpc.Invoice{
+		ValueMsat: 7_000_000,
+	}
+
+	_, err := validateInvoiceAmount(quote, 0, inv)
+	require.ErrorContains(t, err, "max routable amount")
+}

--- a/rpcserver/rpcserver.go
+++ b/rpcserver/rpcserver.go
@@ -8490,10 +8490,18 @@ func unmarshalAssetBuyOrder(
 			len(req.PriceOracleMetadata))
 	}
 
-	// Unmarshal optional min amount.
+	// Unmarshal optional min amount. When the caller omits the
+	// field we default to the full max amount so that a naive
+	// request gets full-fill semantics. An explicit zero means
+	// "accept any partial fill".
 	var assetMinAmt fn.Option[uint64]
-	if req.AssetMinAmt > 0 {
-		assetMinAmt = fn.Some(req.AssetMinAmt)
+	switch {
+	case req.AssetMinAmt == nil:
+		assetMinAmt = fn.Some(req.AssetMaxAmt)
+	case *req.AssetMinAmt == 0:
+		// Explicit zero means "accept any partial fill".
+	default:
+		assetMinAmt = fn.Some(*req.AssetMinAmt)
 	}
 
 	// Unmarshal optional rate limit.
@@ -8743,11 +8751,21 @@ func unmarshalAssetSellOrder(
 			len(req.PriceOracleMetadata))
 	}
 
-	// Unmarshal optional min payment amount.
+	// Unmarshal optional min payment amount. When the caller
+	// omits the field we default to the full max amount so that
+	// a naive request gets full-fill semantics. An explicit zero
+	// means "accept any partial fill".
 	var paymentMinAmt fn.Option[lnwire.MilliSatoshi]
-	if req.PaymentMinAmt > 0 {
+	switch {
+	case req.PaymentMinAmt == nil:
 		paymentMinAmt = fn.Some(
-			lnwire.MilliSatoshi(req.PaymentMinAmt),
+			lnwire.MilliSatoshi(req.PaymentMaxAmt),
+		)
+	case *req.PaymentMinAmt == 0:
+		// Explicit zero means "accept any partial fill".
+	default:
+		paymentMinAmt = fn.Some(
+			lnwire.MilliSatoshi(*req.PaymentMinAmt),
 		)
 	}
 
@@ -9842,7 +9860,7 @@ func (r *RPCServer) AddInvoice(ctx context.Context,
 	// would be silently ignored.
 	nonDefaultPolicy := req.ExecutionPolicy !=
 		rfqrpc.ExecutionPolicy_EXECUTION_POLICY_IOC
-	hasConstraints := req.AssetMinAmt > 0 ||
+	hasConstraints := req.AssetMinAmt != nil ||
 		req.AssetRateLimit != nil || nonDefaultPolicy
 	if existingQuotes && hasConstraints {
 		return nil, fmt.Errorf("constraint fields " +
@@ -10436,7 +10454,7 @@ func validateInvoiceAmount(acceptedQuote *rfqrpc.PeerAcceptedBuyQuote,
 func (r *RPCServer) acquireBuyOrder(ctx context.Context,
 	rpcSpecifier *rfqrpc.AssetSpecifier, assetMaxAmt uint64,
 	expiryTimestamp time.Time, peerPubKey *route.Vertex,
-	metadata string, assetMinAmt uint64,
+	metadata string, assetMinAmt *uint64,
 	assetRateLimit *rfqrpc.FixedPoint,
 	executionPolicy rfqrpc.ExecutionPolicy,
 ) (*rfqrpc.PeerAcceptedBuyQuote, error) {

--- a/rpcserver/rpcserver.go
+++ b/rpcserver/rpcserver.go
@@ -9825,6 +9825,7 @@ func (r *RPCServer) AddInvoice(ctx context.Context,
 		return nil, fmt.Errorf("invoice request must be specified")
 	}
 	iReq := req.InvoiceRequest
+
 	existingQuotes := iReq.RouteHints != nil
 
 	if existingQuotes && !tapchannel.IsAssetInvoice(
@@ -9833,6 +9834,21 @@ func (r *RPCServer) AddInvoice(ctx context.Context,
 
 		return nil, fmt.Errorf("existing route hints should only " +
 			"contain valid accepted quotes")
+	}
+
+	// Constraint fields only apply during buy-order negotiation.
+	// Reject the request if the caller provides both pre-existing
+	// route hints and constraint fields, since the constraints
+	// would be silently ignored.
+	nonDefaultPolicy := req.ExecutionPolicy !=
+		rfqrpc.ExecutionPolicy_EXECUTION_POLICY_IOC
+	hasConstraints := req.AssetMinAmt > 0 ||
+		req.AssetRateLimit != nil || nonDefaultPolicy
+	if existingQuotes && hasConstraints {
+		return nil, fmt.Errorf("constraint fields " +
+			"(asset_min_amt, asset_rate_limit, " +
+			"execution_policy) cannot be used with " +
+			"pre-existing route hints")
 	}
 
 	assetID, groupKey, err := parseAssetSpecifier(
@@ -9860,13 +9876,16 @@ func (r *RPCServer) AddInvoice(ctx context.Context,
 		peerPubKey = &parsedKey
 	}
 
-	// We can now query the asset channels we have.
-	chanMap, err := r.cfg.RfqManager.FetchChannel(
-		ctx, specifier, peerPubKey, rfq.ReceiveIntention,
-	)
-	if err != nil {
-		return nil, fmt.Errorf("error finding asset channel to use: %w",
-			err)
+	var chanMap rfq.PeerChanMap
+	if !existingQuotes {
+		chanMap, err = r.cfg.RfqManager.FetchChannel(
+			ctx, specifier, peerPubKey,
+			rfq.ReceiveIntention,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("error finding asset "+
+				"channel to use: %w", err)
+		}
 	}
 
 	expirySeconds := iReq.Expiry
@@ -9909,6 +9928,7 @@ func (r *RPCServer) AddInvoice(ctx context.Context,
 	}
 
 	var acquiredQuotes []quoteWithInfo
+	var lastBuyOrderErr error
 
 	for peer, channels := range chanMap {
 		if existingQuotes {
@@ -9918,10 +9938,13 @@ func (r *RPCServer) AddInvoice(ctx context.Context,
 		quote, err := r.acquireBuyOrder(
 			ctx, &rpcSpecifier, maxUnits, expiryTimestamp,
 			&peer, req.PriceOracleMetadata,
+			req.AssetMinAmt, req.AssetRateLimit,
+			req.ExecutionPolicy,
 		)
 		if err != nil {
 			rpcsLog.Errorf("error while trying to acquire a buy "+
 				"order for invoice: %v", err)
+			lastBuyOrderErr = err
 			continue
 		}
 
@@ -9954,6 +9977,8 @@ func (r *RPCServer) AddInvoice(ctx context.Context,
 	// Filter quotes to only those that expire after the requested invoice
 	// expiry. This ensures the invoice cannot outlive its backing quotes,
 	// which would cause payments to settle in BTC instead of assets.
+	preFilterCount := len(acquiredQuotes)
+
 	var validQuotes []quoteWithInfo
 	for _, q := range acquiredQuotes {
 		quoteExpiry := time.Unix(int64(q.quote.Expiry), 0)
@@ -9967,8 +9992,24 @@ func (r *RPCServer) AddInvoice(ctx context.Context,
 	// user has already defined quotes in the request we don't return an
 	// error.
 	if len(acquiredQuotes) == 0 && !existingQuotes {
-		return nil, fmt.Errorf("no quotes with sufficient expiry for "+
-			"the requested invoice expiry of %v", expiryTimestamp)
+		// If quotes were acquired but all removed by the
+		// expiry filter, report the expiry mismatch.
+		if preFilterCount > 0 {
+			return nil, fmt.Errorf("no quotes with "+
+				"sufficient expiry for the requested "+
+				"invoice expiry of %v",
+				expiryTimestamp)
+		}
+
+		// No quotes acquired at all — surface the reason.
+		if lastBuyOrderErr != nil {
+			return nil, fmt.Errorf("error acquiring buy "+
+				"order for invoice: %w",
+				lastBuyOrderErr)
+		}
+
+		return nil, fmt.Errorf("no asset channels " +
+			"available for quote negotiation")
 	}
 
 	// We need to trim any extra quotes that cannot make it into the bolt11
@@ -10058,8 +10099,18 @@ func (r *RPCServer) AddInvoice(ctx context.Context,
 	// Now that we have the accepted quote, we know the amount in (milli)
 	// Satoshi that we need to pay. We can now update the invoice with this
 	// amount.
+	//
+	// Cap asset amount to negotiated fill quantity so partial fills don't
+	// produce an invoice that exceeds the policy cap.
+	effectiveAssetAmt := req.AssetAmount
+	if expensiveQuote.AcceptedMaxAmount > 0 &&
+		expensiveQuote.AcceptedMaxAmount < effectiveAssetAmt {
+
+		effectiveAssetAmt = expensiveQuote.AcceptedMaxAmount
+	}
+
 	invoiceAmtMsat, err := validateInvoiceAmount(
-		expensiveQuote, req.AssetAmount, iReq,
+		expensiveQuote, effectiveAssetAmt, iReq,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("error validating invoice amount: %w",
@@ -10333,10 +10384,18 @@ func validateInvoiceAmount(acceptedQuote *rfqrpc.PeerAcceptedBuyQuote,
 			invoiceAmtMsat, *askAssetRate,
 		).ScaleTo(0).ToUint64()
 
-		// Now let's see if the negotiated quote can actually route the
-		// amount we need in msat.
+		// Now let's see if the negotiated quote can actually
+		// route the amount we need in msat. Use the
+		// negotiated fill quantity when available so that
+		// partial fills are correctly bounded.
+		maxAmt := acceptedQuote.AssetMaxAmount
+		if acceptedQuote.AcceptedMaxAmount > 0 &&
+			acceptedQuote.AcceptedMaxAmount < maxAmt {
+
+			maxAmt = acceptedQuote.AcceptedMaxAmount
+		}
 		maxFixedUnits := rfqmath.NewBigIntFixedPoint(
-			acceptedQuote.AssetMaxAmount, 0,
+			maxAmt, 0,
 		)
 		maxRoutableMsat := rfqmath.UnitsToMilliSatoshi(
 			maxFixedUnits, *askAssetRate,
@@ -10377,7 +10436,10 @@ func validateInvoiceAmount(acceptedQuote *rfqrpc.PeerAcceptedBuyQuote,
 func (r *RPCServer) acquireBuyOrder(ctx context.Context,
 	rpcSpecifier *rfqrpc.AssetSpecifier, assetMaxAmt uint64,
 	expiryTimestamp time.Time, peerPubKey *route.Vertex,
-	metadata string) (*rfqrpc.PeerAcceptedBuyQuote, error) {
+	metadata string, assetMinAmt uint64,
+	assetRateLimit *rfqrpc.FixedPoint,
+	executionPolicy rfqrpc.ExecutionPolicy,
+) (*rfqrpc.PeerAcceptedBuyQuote, error) {
 
 	var quote *rfqrpc.PeerAcceptedBuyQuote
 
@@ -10390,6 +10452,9 @@ func (r *RPCServer) acquireBuyOrder(ctx context.Context,
 			rfq.DefaultTimeout.Seconds(),
 		),
 		PriceOracleMetadata: metadata,
+		AssetMinAmt:         assetMinAmt,
+		AssetRateLimit:      assetRateLimit,
+		ExecutionPolicy:     executionPolicy,
 	})
 	if err != nil {
 		return quote, fmt.Errorf("error adding buy order: %w", err)

--- a/taprpc/rfqrpc/rfq.pb.go
+++ b/taprpc/rfqrpc/rfq.pb.go
@@ -428,10 +428,12 @@ type AddAssetBuyOrderRequest struct {
 	// This field is optional and can be left empty if no metadata is available.
 	// The maximum length of this field is 32'768 bytes.
 	PriceOracleMetadata string `protobuf:"bytes,7,opt,name=price_oracle_metadata,json=priceOracleMetadata,proto3" json:"price_oracle_metadata,omitempty"`
-	// The optional minimum amount of the asset that the provider must be
-	// willing to offer. If set, must be less than or equal to asset_max_amt.
-	// A value of 0 means unset.
-	AssetMinAmt uint64 `protobuf:"varint,8,opt,name=asset_min_amt,json=assetMinAmt,proto3" json:"asset_min_amt,omitempty"`
+	// The optional minimum amount of the asset that the provider
+	// must be willing to offer. If set, must be less than or equal
+	// to asset_max_amt. When omitted, defaults to asset_max_amt
+	// (full-fill expected). Set explicitly to 0 to accept any
+	// partial fill.
+	AssetMinAmt *uint64 `protobuf:"varint,8,opt,name=asset_min_amt,json=assetMinAmt,proto3,oneof" json:"asset_min_amt,omitempty"`
 	// An optional rate limit constraint expressed as a fixed-point number.
 	// For buy orders this is the minimum acceptable rate (asset units per
 	// BTC). If unset, no rate floor is enforced.
@@ -524,8 +526,8 @@ func (x *AddAssetBuyOrderRequest) GetPriceOracleMetadata() string {
 }
 
 func (x *AddAssetBuyOrderRequest) GetAssetMinAmt() uint64 {
-	if x != nil {
-		return x.AssetMinAmt
+	if x != nil && x.AssetMinAmt != nil {
+		return *x.AssetMinAmt
 	}
 	return 0
 }
@@ -676,10 +678,12 @@ type AddAssetSellOrderRequest struct {
 	// This field is optional and can be left empty if no metadata is available.
 	// The maximum length of this field is 32'768 bytes.
 	PriceOracleMetadata string `protobuf:"bytes,7,opt,name=price_oracle_metadata,json=priceOracleMetadata,proto3" json:"price_oracle_metadata,omitempty"`
-	// The optional minimum msat amount that the responding peer must agree
-	// to pay. If set, must be less than or equal to payment_max_amt.
-	// A value of 0 means unset (units: millisats).
-	PaymentMinAmt uint64 `protobuf:"varint,8,opt,name=payment_min_amt,json=paymentMinAmt,proto3" json:"payment_min_amt,omitempty"`
+	// The optional minimum msat amount that the responding peer
+	// must agree to pay. If set, must be less than or equal to
+	// payment_max_amt. When omitted, defaults to payment_max_amt
+	// (full-fill expected). Set explicitly to 0 to accept any
+	// partial fill (units: millisats).
+	PaymentMinAmt *uint64 `protobuf:"varint,8,opt,name=payment_min_amt,json=paymentMinAmt,proto3,oneof" json:"payment_min_amt,omitempty"`
 	// An optional rate limit constraint expressed as a fixed-point number.
 	// For sell orders this is the maximum acceptable rate (asset units per
 	// BTC). If unset, no rate ceiling is enforced.
@@ -772,8 +776,8 @@ func (x *AddAssetSellOrderRequest) GetPriceOracleMetadata() string {
 }
 
 func (x *AddAssetSellOrderRequest) GetPaymentMinAmt() uint64 {
-	if x != nil {
-		return x.PaymentMinAmt
+	if x != nil && x.PaymentMinAmt != nil {
+		return *x.PaymentMinAmt
 	}
 	return 0
 }
@@ -2280,7 +2284,7 @@ const file_rfqrpc_rfq_proto_rawDesc = "" +
 	"\n" +
 	"FixedPoint\x12 \n" +
 	"\vcoefficient\x18\x01 \x01(\tR\vcoefficient\x12\x14\n" +
-	"\x05scale\x18\x02 \x01(\rR\x05scale\"\xf4\x03\n" +
+	"\x05scale\x18\x02 \x01(\rR\x05scale\"\x8b\x04\n" +
 	"\x17AddAssetBuyOrderRequest\x12?\n" +
 	"\x0fasset_specifier\x18\x01 \x01(\v2\x16.rfqrpc.AssetSpecifierR\x0eassetSpecifier\x12\"\n" +
 	"\rasset_max_amt\x18\x02 \x01(\x04R\vassetMaxAmt\x12\x16\n" +
@@ -2289,17 +2293,18 @@ const file_rfqrpc_rfq_proto_rawDesc = "" +
 	"peerPubKey\x12'\n" +
 	"\x0ftimeout_seconds\x18\x05 \x01(\rR\x0etimeoutSeconds\x127\n" +
 	"\x18skip_asset_channel_check\x18\x06 \x01(\bR\x15skipAssetChannelCheck\x122\n" +
-	"\x15price_oracle_metadata\x18\a \x01(\tR\x13priceOracleMetadata\x12\"\n" +
-	"\rasset_min_amt\x18\b \x01(\x04R\vassetMinAmt\x12<\n" +
+	"\x15price_oracle_metadata\x18\a \x01(\tR\x13priceOracleMetadata\x12'\n" +
+	"\rasset_min_amt\x18\b \x01(\x04H\x00R\vassetMinAmt\x88\x01\x01\x12<\n" +
 	"\x10asset_rate_limit\x18\t \x01(\v2\x12.rfqrpc.FixedPointR\x0eassetRateLimit\x12B\n" +
 	"\x10execution_policy\x18\n" +
-	" \x01(\x0e2\x17.rfqrpc.ExecutionPolicyR\x0fexecutionPolicy\"\xfa\x01\n" +
+	" \x01(\x0e2\x17.rfqrpc.ExecutionPolicyR\x0fexecutionPolicyB\x10\n" +
+	"\x0e_asset_min_amt\"\xfa\x01\n" +
 	"\x18AddAssetBuyOrderResponse\x12E\n" +
 	"\x0eaccepted_quote\x18\x01 \x01(\v2\x1c.rfqrpc.PeerAcceptedBuyQuoteH\x00R\racceptedQuote\x12C\n" +
 	"\rinvalid_quote\x18\x02 \x01(\v2\x1c.rfqrpc.InvalidQuoteResponseH\x00R\finvalidQuote\x12F\n" +
 	"\x0erejected_quote\x18\x03 \x01(\v2\x1d.rfqrpc.RejectedQuoteResponseH\x00R\rrejectedQuoteB\n" +
 	"\n" +
-	"\bresponse\"\xfd\x03\n" +
+	"\bresponse\"\x96\x04\n" +
 	"\x18AddAssetSellOrderRequest\x12?\n" +
 	"\x0fasset_specifier\x18\x01 \x01(\v2\x16.rfqrpc.AssetSpecifierR\x0eassetSpecifier\x12&\n" +
 	"\x0fpayment_max_amt\x18\x02 \x01(\x04R\rpaymentMaxAmt\x12\x16\n" +
@@ -2308,11 +2313,12 @@ const file_rfqrpc_rfq_proto_rawDesc = "" +
 	"peerPubKey\x12'\n" +
 	"\x0ftimeout_seconds\x18\x05 \x01(\rR\x0etimeoutSeconds\x127\n" +
 	"\x18skip_asset_channel_check\x18\x06 \x01(\bR\x15skipAssetChannelCheck\x122\n" +
-	"\x15price_oracle_metadata\x18\a \x01(\tR\x13priceOracleMetadata\x12&\n" +
-	"\x0fpayment_min_amt\x18\b \x01(\x04R\rpaymentMinAmt\x12<\n" +
+	"\x15price_oracle_metadata\x18\a \x01(\tR\x13priceOracleMetadata\x12+\n" +
+	"\x0fpayment_min_amt\x18\b \x01(\x04H\x00R\rpaymentMinAmt\x88\x01\x01\x12<\n" +
 	"\x10asset_rate_limit\x18\t \x01(\v2\x12.rfqrpc.FixedPointR\x0eassetRateLimit\x12B\n" +
 	"\x10execution_policy\x18\n" +
-	" \x01(\x0e2\x17.rfqrpc.ExecutionPolicyR\x0fexecutionPolicy\"\xfc\x01\n" +
+	" \x01(\x0e2\x17.rfqrpc.ExecutionPolicyR\x0fexecutionPolicyB\x12\n" +
+	"\x10_payment_min_amt\"\xfc\x01\n" +
 	"\x19AddAssetSellOrderResponse\x12F\n" +
 	"\x0eaccepted_quote\x18\x01 \x01(\v2\x1d.rfqrpc.PeerAcceptedSellQuoteH\x00R\racceptedQuote\x12C\n" +
 	"\rinvalid_quote\x18\x02 \x01(\v2\x1c.rfqrpc.InvalidQuoteResponseH\x00R\finvalidQuote\x12F\n" +
@@ -2552,11 +2558,13 @@ func file_rfqrpc_rfq_proto_init() {
 		(*AssetSpecifier_GroupKey)(nil),
 		(*AssetSpecifier_GroupKeyStr)(nil),
 	}
+	file_rfqrpc_rfq_proto_msgTypes[2].OneofWrappers = []any{}
 	file_rfqrpc_rfq_proto_msgTypes[3].OneofWrappers = []any{
 		(*AddAssetBuyOrderResponse_AcceptedQuote)(nil),
 		(*AddAssetBuyOrderResponse_InvalidQuote)(nil),
 		(*AddAssetBuyOrderResponse_RejectedQuote)(nil),
 	}
+	file_rfqrpc_rfq_proto_msgTypes[4].OneofWrappers = []any{}
 	file_rfqrpc_rfq_proto_msgTypes[5].OneofWrappers = []any{
 		(*AddAssetSellOrderResponse_AcceptedQuote)(nil),
 		(*AddAssetSellOrderResponse_InvalidQuote)(nil),

--- a/taprpc/rfqrpc/rfq.proto
+++ b/taprpc/rfqrpc/rfq.proto
@@ -172,10 +172,12 @@ message AddAssetBuyOrderRequest {
     // The maximum length of this field is 32'768 bytes.
     string price_oracle_metadata = 7;
 
-    // The optional minimum amount of the asset that the provider must be
-    // willing to offer. If set, must be less than or equal to asset_max_amt.
-    // A value of 0 means unset.
-    uint64 asset_min_amt = 8;
+    // The optional minimum amount of the asset that the provider
+    // must be willing to offer. If set, must be less than or equal
+    // to asset_max_amt. When omitted, defaults to asset_max_amt
+    // (full-fill expected). Set explicitly to 0 to accept any
+    // partial fill.
+    optional uint64 asset_min_amt = 8;
 
     // An optional rate limit constraint expressed as a fixed-point number.
     // For buy orders this is the minimum acceptable rate (asset units per
@@ -238,10 +240,12 @@ message AddAssetSellOrderRequest {
     // The maximum length of this field is 32'768 bytes.
     string price_oracle_metadata = 7;
 
-    // The optional minimum msat amount that the responding peer must agree
-    // to pay. If set, must be less than or equal to payment_max_amt.
-    // A value of 0 means unset (units: millisats).
-    uint64 payment_min_amt = 8;
+    // The optional minimum msat amount that the responding peer
+    // must agree to pay. If set, must be less than or equal to
+    // payment_max_amt. When omitted, defaults to payment_max_amt
+    // (full-fill expected). Set explicitly to 0 to accept any
+    // partial fill (units: millisats).
+    optional uint64 payment_min_amt = 8;
 
     // An optional rate limit constraint expressed as a fixed-point number.
     // For sell orders this is the maximum acceptable rate (asset units per

--- a/taprpc/rfqrpc/rfq.swagger.json
+++ b/taprpc/rfqrpc/rfq.swagger.json
@@ -588,7 +588,7 @@
         "asset_min_amt": {
           "type": "string",
           "format": "uint64",
-          "description": "The optional minimum amount of the asset that the provider must be\nwilling to offer. If set, must be less than or equal to asset_max_amt.\nA value of 0 means unset."
+          "description": "The optional minimum amount of the asset that the provider\nmust be willing to offer. If set, must be less than or equal\nto asset_max_amt. When omitted, defaults to asset_max_amt\n(full-fill expected). Set explicitly to 0 to accept any\npartial fill."
         },
         "asset_rate_limit": {
           "$ref": "#/definitions/rfqrpcFixedPoint",
@@ -686,7 +686,7 @@
         "payment_min_amt": {
           "type": "string",
           "format": "uint64",
-          "description": "The optional minimum msat amount that the responding peer must agree\nto pay. If set, must be less than or equal to payment_max_amt.\nA value of 0 means unset (units: millisats)."
+          "description": "The optional minimum msat amount that the responding peer\nmust agree to pay. If set, must be less than or equal to\npayment_max_amt. When omitted, defaults to payment_max_amt\n(full-fill expected). Set explicitly to 0 to accept any\npartial fill (units: millisats)."
         },
         "asset_rate_limit": {
           "$ref": "#/definitions/rfqrpcFixedPoint",

--- a/taprpc/tapchannelrpc/tapchannel.pb.go
+++ b/taprpc/tapchannelrpc/tapchannel.pb.go
@@ -729,8 +729,17 @@ type AddInvoiceRequest struct {
 	// This field is optional and can be left empty if no metadata is available.
 	// The maximum length of this field is 32'768 bytes.
 	PriceOracleMetadata string `protobuf:"bytes,7,opt,name=price_oracle_metadata,json=priceOracleMetadata,proto3" json:"price_oracle_metadata,omitempty"`
-	unknownFields       protoimpl.UnknownFields
-	sizeCache           protoimpl.SizeCache
+	// Optional minimum asset amount the peer must accept.
+	// Forwarded to AddAssetBuyOrder. 0 means unset.
+	AssetMinAmt uint64 `protobuf:"varint,9,opt,name=asset_min_amt,json=assetMinAmt,proto3" json:"asset_min_amt,omitempty"`
+	// Optional rate floor (asset units per BTC) as a
+	// fixed-point number. Forwarded to AddAssetBuyOrder.
+	AssetRateLimit *rfqrpc.FixedPoint `protobuf:"bytes,10,opt,name=asset_rate_limit,json=assetRateLimit,proto3" json:"asset_rate_limit,omitempty"`
+	// Execution policy (IOC default, FOK). Forwarded to
+	// AddAssetBuyOrder.
+	ExecutionPolicy rfqrpc.ExecutionPolicy `protobuf:"varint,11,opt,name=execution_policy,json=executionPolicy,proto3,enum=rfqrpc.ExecutionPolicy" json:"execution_policy,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
 }
 
 func (x *AddInvoiceRequest) Reset() {
@@ -810,6 +819,27 @@ func (x *AddInvoiceRequest) GetPriceOracleMetadata() string {
 		return x.PriceOracleMetadata
 	}
 	return ""
+}
+
+func (x *AddInvoiceRequest) GetAssetMinAmt() uint64 {
+	if x != nil {
+		return x.AssetMinAmt
+	}
+	return 0
+}
+
+func (x *AddInvoiceRequest) GetAssetRateLimit() *rfqrpc.FixedPoint {
+	if x != nil {
+		return x.AssetRateLimit
+	}
+	return nil
+}
+
+func (x *AddInvoiceRequest) GetExecutionPolicy() rfqrpc.ExecutionPolicy {
+	if x != nil {
+		return x.ExecutionPolicy
+	}
+	return rfqrpc.ExecutionPolicy(0)
 }
 
 type AddInvoiceResponse struct {
@@ -1078,7 +1108,7 @@ const file_tapchannelrpc_tapchannel_proto_rawDesc = "" +
 	"\x0epayment_result\x18\x02 \x01(\v2\x0e.lnrpc.PaymentH\x00R\rpaymentResultB\b\n" +
 	"\x06result\"0\n" +
 	"\vHodlInvoice\x12!\n" +
-	"\fpayment_hash\x18\x01 \x01(\fR\vpaymentHash\"\xbb\x02\n" +
+	"\fpayment_hash\x18\x01 \x01(\fR\vpaymentHash\"\xe7\x03\n" +
 	"\x11AddInvoiceRequest\x12\x19\n" +
 	"\basset_id\x18\x01 \x01(\fR\aassetId\x12!\n" +
 	"\fasset_amount\x18\x02 \x01(\x04R\vassetAmount\x12\x1f\n" +
@@ -1087,7 +1117,11 @@ const file_tapchannelrpc_tapchannel_proto_rawDesc = "" +
 	"\x0finvoice_request\x18\x04 \x01(\v2\x0e.lnrpc.InvoiceR\x0einvoiceRequest\x12=\n" +
 	"\fhodl_invoice\x18\x05 \x01(\v2\x1a.tapchannelrpc.HodlInvoiceR\vhodlInvoice\x12\x1b\n" +
 	"\tgroup_key\x18\x06 \x01(\fR\bgroupKey\x122\n" +
-	"\x15price_oracle_metadata\x18\a \x01(\tR\x13priceOracleMetadata\"\xa2\x01\n" +
+	"\x15price_oracle_metadata\x18\a \x01(\tR\x13priceOracleMetadata\x12\"\n" +
+	"\rasset_min_amt\x18\t \x01(\x04R\vassetMinAmt\x12<\n" +
+	"\x10asset_rate_limit\x18\n" +
+	" \x01(\v2\x12.rfqrpc.FixedPointR\x0eassetRateLimit\x12B\n" +
+	"\x10execution_policy\x18\v \x01(\x0e2\x17.rfqrpc.ExecutionPolicyR\x0fexecutionPolicyJ\x04\b\b\x10\t\"\xa2\x01\n" +
 	"\x12AddInvoiceResponse\x12J\n" +
 	"\x12accepted_buy_quote\x18\x01 \x01(\v2\x1c.rfqrpc.PeerAcceptedBuyQuoteR\x10acceptedBuyQuote\x12@\n" +
 	"\x0einvoice_result\x18\x02 \x01(\v2\x19.lnrpc.AddInvoiceResponseR\rinvoiceResult\"\x9f\x01\n" +
@@ -1144,12 +1178,14 @@ var file_tapchannelrpc_tapchannel_proto_goTypes = []any{
 	(*rfqrpc.PeerAcceptedSellQuote)(nil), // 16: rfqrpc.PeerAcceptedSellQuote
 	(*lnrpc.Payment)(nil),                // 17: lnrpc.Payment
 	(*lnrpc.Invoice)(nil),                // 18: lnrpc.Invoice
-	(*rfqrpc.PeerAcceptedBuyQuote)(nil),  // 19: rfqrpc.PeerAcceptedBuyQuote
-	(*lnrpc.AddInvoiceResponse)(nil),     // 20: lnrpc.AddInvoiceResponse
-	(*taprpc.DecimalDisplay)(nil),        // 21: taprpc.DecimalDisplay
-	(*taprpc.AssetGroup)(nil),            // 22: taprpc.AssetGroup
-	(*taprpc.GenesisInfo)(nil),           // 23: taprpc.GenesisInfo
-	(*lnrpc.PayReq)(nil),                 // 24: lnrpc.PayReq
+	(*rfqrpc.FixedPoint)(nil),            // 19: rfqrpc.FixedPoint
+	(rfqrpc.ExecutionPolicy)(0),          // 20: rfqrpc.ExecutionPolicy
+	(*rfqrpc.PeerAcceptedBuyQuote)(nil),  // 21: rfqrpc.PeerAcceptedBuyQuote
+	(*lnrpc.AddInvoiceResponse)(nil),     // 22: lnrpc.AddInvoiceResponse
+	(*taprpc.DecimalDisplay)(nil),        // 23: taprpc.DecimalDisplay
+	(*taprpc.AssetGroup)(nil),            // 24: taprpc.AssetGroup
+	(*taprpc.GenesisInfo)(nil),           // 25: taprpc.GenesisInfo
+	(*lnrpc.PayReq)(nil),                 // 26: lnrpc.PayReq
 }
 var file_tapchannelrpc_tapchannel_proto_depIdxs = []int32{
 	13, // 0: tapchannelrpc.RouterSendPaymentData.asset_amounts:type_name -> tapchannelrpc.RouterSendPaymentData.AssetAmountsEntry
@@ -1162,27 +1198,29 @@ var file_tapchannelrpc_tapchannel_proto_depIdxs = []int32{
 	17, // 7: tapchannelrpc.SendPaymentResponse.payment_result:type_name -> lnrpc.Payment
 	18, // 8: tapchannelrpc.AddInvoiceRequest.invoice_request:type_name -> lnrpc.Invoice
 	8,  // 9: tapchannelrpc.AddInvoiceRequest.hodl_invoice:type_name -> tapchannelrpc.HodlInvoice
-	19, // 10: tapchannelrpc.AddInvoiceResponse.accepted_buy_quote:type_name -> rfqrpc.PeerAcceptedBuyQuote
-	20, // 11: tapchannelrpc.AddInvoiceResponse.invoice_result:type_name -> lnrpc.AddInvoiceResponse
-	21, // 12: tapchannelrpc.AssetPayReqResponse.decimal_display:type_name -> taprpc.DecimalDisplay
-	22, // 13: tapchannelrpc.AssetPayReqResponse.asset_group:type_name -> taprpc.AssetGroup
-	23, // 14: tapchannelrpc.AssetPayReqResponse.genesis_info:type_name -> taprpc.GenesisInfo
-	24, // 15: tapchannelrpc.AssetPayReqResponse.pay_req:type_name -> lnrpc.PayReq
-	0,  // 16: tapchannelrpc.TaprootAssetChannels.FundChannel:input_type -> tapchannelrpc.FundChannelRequest
-	3,  // 17: tapchannelrpc.TaprootAssetChannels.EncodeCustomRecords:input_type -> tapchannelrpc.EncodeCustomRecordsRequest
-	5,  // 18: tapchannelrpc.TaprootAssetChannels.SendPayment:input_type -> tapchannelrpc.SendPaymentRequest
-	9,  // 19: tapchannelrpc.TaprootAssetChannels.AddInvoice:input_type -> tapchannelrpc.AddInvoiceRequest
-	11, // 20: tapchannelrpc.TaprootAssetChannels.DecodeAssetPayReq:input_type -> tapchannelrpc.AssetPayReq
-	1,  // 21: tapchannelrpc.TaprootAssetChannels.FundChannel:output_type -> tapchannelrpc.FundChannelResponse
-	4,  // 22: tapchannelrpc.TaprootAssetChannels.EncodeCustomRecords:output_type -> tapchannelrpc.EncodeCustomRecordsResponse
-	7,  // 23: tapchannelrpc.TaprootAssetChannels.SendPayment:output_type -> tapchannelrpc.SendPaymentResponse
-	10, // 24: tapchannelrpc.TaprootAssetChannels.AddInvoice:output_type -> tapchannelrpc.AddInvoiceResponse
-	12, // 25: tapchannelrpc.TaprootAssetChannels.DecodeAssetPayReq:output_type -> tapchannelrpc.AssetPayReqResponse
-	21, // [21:26] is the sub-list for method output_type
-	16, // [16:21] is the sub-list for method input_type
-	16, // [16:16] is the sub-list for extension type_name
-	16, // [16:16] is the sub-list for extension extendee
-	0,  // [0:16] is the sub-list for field type_name
+	19, // 10: tapchannelrpc.AddInvoiceRequest.asset_rate_limit:type_name -> rfqrpc.FixedPoint
+	20, // 11: tapchannelrpc.AddInvoiceRequest.execution_policy:type_name -> rfqrpc.ExecutionPolicy
+	21, // 12: tapchannelrpc.AddInvoiceResponse.accepted_buy_quote:type_name -> rfqrpc.PeerAcceptedBuyQuote
+	22, // 13: tapchannelrpc.AddInvoiceResponse.invoice_result:type_name -> lnrpc.AddInvoiceResponse
+	23, // 14: tapchannelrpc.AssetPayReqResponse.decimal_display:type_name -> taprpc.DecimalDisplay
+	24, // 15: tapchannelrpc.AssetPayReqResponse.asset_group:type_name -> taprpc.AssetGroup
+	25, // 16: tapchannelrpc.AssetPayReqResponse.genesis_info:type_name -> taprpc.GenesisInfo
+	26, // 17: tapchannelrpc.AssetPayReqResponse.pay_req:type_name -> lnrpc.PayReq
+	0,  // 18: tapchannelrpc.TaprootAssetChannels.FundChannel:input_type -> tapchannelrpc.FundChannelRequest
+	3,  // 19: tapchannelrpc.TaprootAssetChannels.EncodeCustomRecords:input_type -> tapchannelrpc.EncodeCustomRecordsRequest
+	5,  // 20: tapchannelrpc.TaprootAssetChannels.SendPayment:input_type -> tapchannelrpc.SendPaymentRequest
+	9,  // 21: tapchannelrpc.TaprootAssetChannels.AddInvoice:input_type -> tapchannelrpc.AddInvoiceRequest
+	11, // 22: tapchannelrpc.TaprootAssetChannels.DecodeAssetPayReq:input_type -> tapchannelrpc.AssetPayReq
+	1,  // 23: tapchannelrpc.TaprootAssetChannels.FundChannel:output_type -> tapchannelrpc.FundChannelResponse
+	4,  // 24: tapchannelrpc.TaprootAssetChannels.EncodeCustomRecords:output_type -> tapchannelrpc.EncodeCustomRecordsResponse
+	7,  // 25: tapchannelrpc.TaprootAssetChannels.SendPayment:output_type -> tapchannelrpc.SendPaymentResponse
+	10, // 26: tapchannelrpc.TaprootAssetChannels.AddInvoice:output_type -> tapchannelrpc.AddInvoiceResponse
+	12, // 27: tapchannelrpc.TaprootAssetChannels.DecodeAssetPayReq:output_type -> tapchannelrpc.AssetPayReqResponse
+	23, // [23:28] is the sub-list for method output_type
+	18, // [18:23] is the sub-list for method input_type
+	18, // [18:18] is the sub-list for extension type_name
+	18, // [18:18] is the sub-list for extension extendee
+	0,  // [0:18] is the sub-list for field type_name
 }
 
 func init() { file_tapchannelrpc_tapchannel_proto_init() }

--- a/taprpc/tapchannelrpc/tapchannel.pb.go
+++ b/taprpc/tapchannelrpc/tapchannel.pb.go
@@ -730,8 +730,10 @@ type AddInvoiceRequest struct {
 	// The maximum length of this field is 32'768 bytes.
 	PriceOracleMetadata string `protobuf:"bytes,7,opt,name=price_oracle_metadata,json=priceOracleMetadata,proto3" json:"price_oracle_metadata,omitempty"`
 	// Optional minimum asset amount the peer must accept.
-	// Forwarded to AddAssetBuyOrder. 0 means unset.
-	AssetMinAmt uint64 `protobuf:"varint,9,opt,name=asset_min_amt,json=assetMinAmt,proto3" json:"asset_min_amt,omitempty"`
+	// Forwarded to AddAssetBuyOrder. When omitted, defaults
+	// to the full asset amount (full-fill expected). Set
+	// explicitly to 0 to accept any partial fill.
+	AssetMinAmt *uint64 `protobuf:"varint,9,opt,name=asset_min_amt,json=assetMinAmt,proto3,oneof" json:"asset_min_amt,omitempty"`
 	// Optional rate floor (asset units per BTC) as a
 	// fixed-point number. Forwarded to AddAssetBuyOrder.
 	AssetRateLimit *rfqrpc.FixedPoint `protobuf:"bytes,10,opt,name=asset_rate_limit,json=assetRateLimit,proto3" json:"asset_rate_limit,omitempty"`
@@ -822,8 +824,8 @@ func (x *AddInvoiceRequest) GetPriceOracleMetadata() string {
 }
 
 func (x *AddInvoiceRequest) GetAssetMinAmt() uint64 {
-	if x != nil {
-		return x.AssetMinAmt
+	if x != nil && x.AssetMinAmt != nil {
+		return *x.AssetMinAmt
 	}
 	return 0
 }
@@ -1108,7 +1110,7 @@ const file_tapchannelrpc_tapchannel_proto_rawDesc = "" +
 	"\x0epayment_result\x18\x02 \x01(\v2\x0e.lnrpc.PaymentH\x00R\rpaymentResultB\b\n" +
 	"\x06result\"0\n" +
 	"\vHodlInvoice\x12!\n" +
-	"\fpayment_hash\x18\x01 \x01(\fR\vpaymentHash\"\xe7\x03\n" +
+	"\fpayment_hash\x18\x01 \x01(\fR\vpaymentHash\"\xfe\x03\n" +
 	"\x11AddInvoiceRequest\x12\x19\n" +
 	"\basset_id\x18\x01 \x01(\fR\aassetId\x12!\n" +
 	"\fasset_amount\x18\x02 \x01(\x04R\vassetAmount\x12\x1f\n" +
@@ -1117,11 +1119,12 @@ const file_tapchannelrpc_tapchannel_proto_rawDesc = "" +
 	"\x0finvoice_request\x18\x04 \x01(\v2\x0e.lnrpc.InvoiceR\x0einvoiceRequest\x12=\n" +
 	"\fhodl_invoice\x18\x05 \x01(\v2\x1a.tapchannelrpc.HodlInvoiceR\vhodlInvoice\x12\x1b\n" +
 	"\tgroup_key\x18\x06 \x01(\fR\bgroupKey\x122\n" +
-	"\x15price_oracle_metadata\x18\a \x01(\tR\x13priceOracleMetadata\x12\"\n" +
-	"\rasset_min_amt\x18\t \x01(\x04R\vassetMinAmt\x12<\n" +
+	"\x15price_oracle_metadata\x18\a \x01(\tR\x13priceOracleMetadata\x12'\n" +
+	"\rasset_min_amt\x18\t \x01(\x04H\x00R\vassetMinAmt\x88\x01\x01\x12<\n" +
 	"\x10asset_rate_limit\x18\n" +
 	" \x01(\v2\x12.rfqrpc.FixedPointR\x0eassetRateLimit\x12B\n" +
-	"\x10execution_policy\x18\v \x01(\x0e2\x17.rfqrpc.ExecutionPolicyR\x0fexecutionPolicyJ\x04\b\b\x10\t\"\xa2\x01\n" +
+	"\x10execution_policy\x18\v \x01(\x0e2\x17.rfqrpc.ExecutionPolicyR\x0fexecutionPolicyB\x10\n" +
+	"\x0e_asset_min_amtJ\x04\b\b\x10\t\"\xa2\x01\n" +
 	"\x12AddInvoiceResponse\x12J\n" +
 	"\x12accepted_buy_quote\x18\x01 \x01(\v2\x1c.rfqrpc.PeerAcceptedBuyQuoteR\x10acceptedBuyQuote\x12@\n" +
 	"\x0einvoice_result\x18\x02 \x01(\v2\x19.lnrpc.AddInvoiceResponseR\rinvoiceResult\"\x9f\x01\n" +
@@ -1236,6 +1239,7 @@ func file_tapchannelrpc_tapchannel_proto_init() {
 		(*SendPaymentResponse_AcceptedSellOrders)(nil),
 		(*SendPaymentResponse_PaymentResult)(nil),
 	}
+	file_tapchannelrpc_tapchannel_proto_msgTypes[9].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{

--- a/taprpc/tapchannelrpc/tapchannel.proto
+++ b/taprpc/tapchannelrpc/tapchannel.proto
@@ -256,8 +256,10 @@ message AddInvoiceRequest {
     reserved 8;
 
     // Optional minimum asset amount the peer must accept.
-    // Forwarded to AddAssetBuyOrder. 0 means unset.
-    uint64 asset_min_amt = 9;
+    // Forwarded to AddAssetBuyOrder. When omitted, defaults
+    // to the full asset amount (full-fill expected). Set
+    // explicitly to 0 to accept any partial fill.
+    optional uint64 asset_min_amt = 9;
 
     // Optional rate floor (asset units per BTC) as a
     // fixed-point number. Forwarded to AddAssetBuyOrder.

--- a/taprpc/tapchannelrpc/tapchannel.proto
+++ b/taprpc/tapchannelrpc/tapchannel.proto
@@ -251,6 +251,21 @@ message AddInvoiceRequest {
     // This field is optional and can be left empty if no metadata is available.
     // The maximum length of this field is 32'768 bytes.
     string price_oracle_metadata = 7;
+
+    // Reserved: was rfq_id.
+    reserved 8;
+
+    // Optional minimum asset amount the peer must accept.
+    // Forwarded to AddAssetBuyOrder. 0 means unset.
+    uint64 asset_min_amt = 9;
+
+    // Optional rate floor (asset units per BTC) as a
+    // fixed-point number. Forwarded to AddAssetBuyOrder.
+    rfqrpc.FixedPoint asset_rate_limit = 10;
+
+    // Execution policy (IOC default, FOK). Forwarded to
+    // AddAssetBuyOrder.
+    rfqrpc.ExecutionPolicy execution_policy = 11;
 }
 
 message AddInvoiceResponse {

--- a/taprpc/tapchannelrpc/tapchannel.swagger.json
+++ b/taprpc/tapchannelrpc/tapchannel.swagger.json
@@ -1261,6 +1261,15 @@
         }
       }
     },
+    "rfqrpcExecutionPolicy": {
+      "type": "string",
+      "enum": [
+        "EXECUTION_POLICY_IOC",
+        "EXECUTION_POLICY_FOK"
+      ],
+      "default": "EXECUTION_POLICY_IOC",
+      "description": "ExecutionPolicy specifies how a quote request should be filled.\n\n - EXECUTION_POLICY_IOC: EXECUTION_POLICY_IOC is Immediate-Or-Cancel: accept any partial\nfill at or above the minimum threshold. This is the default.\n - EXECUTION_POLICY_FOK: EXECUTION_POLICY_FOK is Fill-Or-Kill: the accepted rate must\nsupport the full maximum amount or the quote is rejected."
+    },
     "rfqrpcFixedPoint": {
       "type": "object",
       "properties": {
@@ -1583,6 +1592,19 @@
         "price_oracle_metadata": {
           "type": "string",
           "description": "An optional text field that can be used to provide additional metadata\nabout the invoice to the price oracle. This can include information\nabout the wallet end user that initiated the transaction, or any\nauthentication information that the price oracle can use to give out a\nmore accurate (or discount) asset rate. Though not verified or enforced\nby tapd, the suggested format for this field is a JSON string.\nThis field is optional and can be left empty if no metadata is available.\nThe maximum length of this field is 32'768 bytes."
+        },
+        "asset_min_amt": {
+          "type": "string",
+          "format": "uint64",
+          "description": "Optional minimum asset amount the peer must accept.\nForwarded to AddAssetBuyOrder. 0 means unset."
+        },
+        "asset_rate_limit": {
+          "$ref": "#/definitions/rfqrpcFixedPoint",
+          "description": "Optional rate floor (asset units per BTC) as a\nfixed-point number. Forwarded to AddAssetBuyOrder."
+        },
+        "execution_policy": {
+          "$ref": "#/definitions/rfqrpcExecutionPolicy",
+          "description": "Execution policy (IOC default, FOK). Forwarded to\nAddAssetBuyOrder."
         }
       }
     },

--- a/taprpc/tapchannelrpc/tapchannel.swagger.json
+++ b/taprpc/tapchannelrpc/tapchannel.swagger.json
@@ -1596,7 +1596,7 @@
         "asset_min_amt": {
           "type": "string",
           "format": "uint64",
-          "description": "Optional minimum asset amount the peer must accept.\nForwarded to AddAssetBuyOrder. 0 means unset."
+          "description": "Optional minimum asset amount the peer must accept.\nForwarded to AddAssetBuyOrder. When omitted, defaults\nto the full asset amount (full-fill expected). Set\nexplicitly to 0 to accept any partial fill."
         },
         "asset_rate_limit": {
           "$ref": "#/definitions/rfqrpcFixedPoint",


### PR DESCRIPTION
Depends on #2050.

Adds the limit order constraint fields (`asset_min_amt`, `asset_rate_limit`, and `execution_policy`) to the AddInvoice RPC, such that invoice quotes can be negotiated using limit order semantics. The fields are all optional; without them we just proceed with "vanilla" RFQ negotiation.