### PR TITLE
docs: expand example portfolio pilot

### DIFF
--- a/docs/examples/basic-portfolio-pilot/Dockerfile
+++ b/docs/examples/basic-portfolio-pilot/Dockerfile
@@ -1,0 +1,17 @@
+FROM golang:1.25.5-alpine AS builder
+
+RUN apk add --no-cache alpine-sdk make
+
+COPY . /build/taproot-assets
+WORKDIR /build/taproot-assets
+
+RUN go build -o /go/bin/portfolio-pilot \
+    ./docs/examples/basic-portfolio-pilot
+
+FROM alpine:3.22
+
+RUN apk add --no-cache ca-certificates
+
+COPY --from=builder /go/bin/portfolio-pilot /bin/
+
+ENTRYPOINT ["portfolio-pilot"]

--- a/docs/examples/basic-portfolio-pilot/main.go
+++ b/docs/examples/basic-portfolio-pilot/main.go
@@ -1,6 +1,27 @@
-// This example demonstrates a basic RPC portfolio pilot server that implements
-// ResolveRequest, VerifyAcceptQuote, and QueryAssetRates. The server listens on
-// localhost:8096 and returns fixed asset rates for demonstration purposes.
+// WARNING: This is a demonstration example only and is NOT
+// suitable for production use. Using this code in production
+// will almost certainly result in loss of funds. It is
+// intended solely to illustrate the PortfolioPilot RPC
+// interface.
+//
+// This example demonstrates a basic RPC portfolio pilot server
+// that implements ResolveRequest, VerifyAcceptQuote, and
+// QueryAssetRates. The server returns asset rates fetched
+// live from CoinGecko (or a static rate if configured),
+// supports configurable fill caps, and enforces rate bound,
+// min fill, and fill constraint checks on accepted quotes.
+//
+// Flags:
+//
+//	-listen             Listen address (default
+//	                    "localhost:8096").
+//	-rate               Rate coefficient in units/BTC.
+//	                    0 (default) fetches live from
+//	                    CoinGecko.
+//	-fillcap-asset-units  Fill cap for buy orders (asset
+//	                    units). 0 = no cap.
+//	-fillcap-msat       Fill cap for sell orders (msat).
+//	                    0 = no cap.
 package main
 
 import (
@@ -11,15 +32,19 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/json"
 	"encoding/pem"
 	"errors"
+	"flag"
 	"fmt"
 	"io"
 	"log"
 	"math/big"
 	"net"
+	"net/http"
 	"os"
 	"os/signal"
+	"sync"
 	"syscall"
 	"time"
 
@@ -27,19 +52,160 @@ import (
 	"github.com/lightninglabs/taproot-assets/rfqmsg"
 	"github.com/lightninglabs/taproot-assets/rpcutils"
 	"github.com/lightninglabs/taproot-assets/taprpc/portfoliopilotrpc"
+	"github.com/lightningnetwork/lnd/lnwire"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/keepalive"
 )
 
 const (
-	// serviceListenAddress is the listening address of the service.
-	serviceListenAddress = "localhost:8096"
+	// defaultListenAddress is the default listening address.
+	defaultListenAddress = "localhost:8096"
 
-	// defaultRateCoefficient is the default rate coefficient used for the
-	// fixed asset rate. This is an arbitrary demo value, not a live price.
+	// defaultRateCoefficient is the default rate coefficient
+	// in units per BTC. This is an arbitrary demo value.
 	defaultRateCoefficient = 42_000_160_000
 )
+
+// pilotConfig holds the runtime configuration parsed from flags.
+type pilotConfig struct {
+	listenAddr      string
+	rateCoefficient uint64
+	fillCapAsset    uint64
+	fillCapMsat     uint64
+}
+
+// parseFlags parses command-line flags into a pilotConfig.
+func parseFlags() pilotConfig {
+	cfg := pilotConfig{}
+
+	flag.StringVar(
+		&cfg.listenAddr, "listen",
+		defaultListenAddress, "listen address (host:port)",
+	)
+	flag.Uint64Var(
+		&cfg.rateCoefficient, "rate", 0,
+		"rate coefficient in asset units per BTC "+
+			"(0 = fetch live from CoinGecko)",
+	)
+	flag.Uint64Var(
+		&cfg.fillCapAsset, "fillcap-asset-units", 0,
+		"fill cap for buy orders (asset units); "+
+			"0 = no cap",
+	)
+	flag.Uint64Var(
+		&cfg.fillCapMsat, "fillcap-msat", 0,
+		"fill cap for sell orders (msat); 0 = no cap",
+	)
+
+	flag.Parse()
+
+	return cfg
+}
+
+// coingeckoURL is the CoinGecko simple-price endpoint.
+const coingeckoURL = "https://api.coingecko.com/api/v3" +
+	"/simple/price?ids=bitcoin&vs_currencies=usd"
+
+// fetchBTCPrice fetches the current BTC/USD price from
+// CoinGecko and returns the rate coefficient (price * 100,
+// since 1 USDX = 1 cent).
+func fetchBTCPrice() (uint64, error) {
+	client := &http.Client{Timeout: 10 * time.Second}
+
+	resp, err := client.Get(coingeckoURL)
+	if err != nil {
+		return 0, fmt.Errorf("coingecko request: %w",
+			err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return 0, fmt.Errorf(
+			"coingecko status: %d", resp.StatusCode,
+		)
+	}
+
+	var result struct {
+		Bitcoin struct {
+			USD float64 `json:"usd"`
+		} `json:"bitcoin"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(
+		&result,
+	); err != nil {
+		return 0, fmt.Errorf("decode response: %w", err)
+	}
+
+	if result.Bitcoin.USD <= 0 {
+		return 0, fmt.Errorf("invalid price: %f",
+			result.Bitcoin.USD)
+	}
+
+	// Price in dollars → coefficient in cents.
+	coefficient := uint64(result.Bitcoin.USD * 100)
+
+	return coefficient, nil
+}
+
+// rateCache caches the live BTC/USD rate coefficient,
+// refreshing from CoinGecko when the TTL expires.
+type rateCache struct {
+	mu        sync.Mutex
+	rate      uint64
+	fetchedAt time.Time
+	ttl       time.Duration
+	fallback  uint64
+}
+
+// newRateCache creates a rate cache. If fallback is 0 the
+// default demo coefficient is used.
+func newRateCache(
+	ttl time.Duration, fallback uint64) *rateCache {
+
+	if fallback == 0 {
+		fallback = defaultRateCoefficient
+	}
+
+	return &rateCache{
+		ttl:      ttl,
+		fallback: fallback,
+	}
+}
+
+// getRate returns a fresh rate coefficient (cents/BTC).
+func (c *rateCache) getRate() uint64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if !c.fetchedAt.IsZero() &&
+		time.Since(c.fetchedAt) < c.ttl {
+
+		return c.rate
+	}
+
+	price, err := fetchBTCPrice()
+	if err != nil {
+		log.Printf("CoinGecko fetch error: %v", err)
+
+		if c.rate != 0 {
+			log.Printf("Using stale rate: %d",
+				c.rate)
+			return c.rate
+		}
+
+		log.Printf("Using fallback rate: %d",
+			c.fallback)
+		return c.fallback
+	}
+
+	c.rate = price
+	c.fetchedAt = time.Now()
+	log.Printf("Fetched live rate: %d (≈$%d/BTC)",
+		price, price/100)
+
+	return c.rate
+}
 
 // setupLogger sets up the logger to write logs to both stdout and a file.
 func setupLogger() {
@@ -60,38 +226,45 @@ func setupLogger() {
 	log.SetFlags(log.LstdFlags)
 }
 
-// defaultAssetRate returns a fixed asset rate with a short expiry window.
-func defaultAssetRate() (rfqmsg.AssetRate, error) {
-	rate := rfqmath.NewBigIntFixedPoint(defaultRateCoefficient, 0)
+// makeAssetRate builds an asset rate from the given coefficient.
+func makeAssetRate(
+	coefficient uint64) (rfqmsg.AssetRate, error) {
+
+	rate := rfqmath.NewBigIntFixedPoint(coefficient, 0)
 	expiry := time.Now().Add(5 * time.Minute).UTC()
 
 	return rfqmsg.NewAssetRate(rate, expiry), nil
 }
 
-// defaultRpcAssetRate returns the fixed asset rate in RPC form.
-func defaultRpcAssetRate() (*portfoliopilotrpc.AssetRate, error) {
-	assetRate, err := defaultAssetRate()
+// makeRpcAssetRate returns the asset rate in RPC form.
+func makeRpcAssetRate(
+	coefficient uint64) (*portfoliopilotrpc.AssetRate, error) {
+
+	assetRate, err := makeAssetRate(coefficient)
 	if err != nil {
-		return nil, fmt.Errorf("create default asset rate: %w", err)
+		return nil, fmt.Errorf("create asset rate: %w", err)
 	}
 
 	rpcRate, err := rpcutils.MarshalPortfolioAssetRate(assetRate)
 	if err != nil {
-		return nil, fmt.Errorf("marshal default asset rate: %w", err)
+		return nil, fmt.Errorf("marshal asset rate: %w", err)
 	}
 
 	return rpcRate, nil
 }
 
-// RpcPortfolioPilotServer is a basic example RPC portfolio pilot server.
+// RpcPortfolioPilotServer is a basic example RPC portfolio pilot
+// server.
 type RpcPortfolioPilotServer struct {
-	// UnimplementedPortfolioPilotServer enables forward compatibility.
 	portfoliopilotrpc.UnimplementedPortfolioPilotServer
+
+	cfg   pilotConfig
+	cache *rateCache
 }
 
-// ResolveRequest resolves an incoming quote request by returning either a
-// provided rate hint or a fixed default rate. This example always accepts
-// requests; real implementations should apply business-specific rules.
+// ResolveRequest resolves an incoming quote request by returning
+// either a provided rate hint or the configured rate. When a
+// fill cap is configured it is returned as AcceptedMaxAmount.
 func (p *RpcPortfolioPilotServer) ResolveRequest(_ context.Context,
 	req *portfoliopilotrpc.ResolveRequestRequest) (
 	*portfoliopilotrpc.ResolveRequestResponse, error) {
@@ -100,12 +273,15 @@ func (p *RpcPortfolioPilotServer) ResolveRequest(_ context.Context,
 		return nil, fmt.Errorf("resolve request is nil")
 	}
 
-	// If a rate hint was provided, accept it as-is.
-	var hint *portfoliopilotrpc.AssetRate
+	var (
+		hint    *portfoliopilotrpc.AssetRate
+		fillCap uint64
+	)
 	switch r := req.GetRequest().(type) {
 	case *portfoliopilotrpc.ResolveRequestRequest_BuyRequest:
 		br := r.BuyRequest
 		hint = br.GetAssetRateHint()
+		fillCap = p.cfg.fillCapAsset
 		log.Printf("ResolveRequest buy: max=%d min=%d "+
 			"rate_limit=%v", br.GetAssetMaxAmount(),
 			br.GetAssetMinAmount(),
@@ -113,6 +289,7 @@ func (p *RpcPortfolioPilotServer) ResolveRequest(_ context.Context,
 	case *portfoliopilotrpc.ResolveRequestRequest_SellRequest:
 		sr := r.SellRequest
 		hint = sr.GetAssetRateHint()
+		fillCap = p.cfg.fillCapMsat
 		log.Printf("ResolveRequest sell: max=%d min=%d "+
 			"rate_limit=%v", sr.GetPaymentMaxAmount(),
 			sr.GetPaymentMinAmount(),
@@ -121,35 +298,65 @@ func (p *RpcPortfolioPilotServer) ResolveRequest(_ context.Context,
 		return nil, fmt.Errorf("unknown request type: %T", r)
 	}
 
-	if hint != nil {
-		log.Print("ResolveRequest using provided rate hint")
-		acceptResult :=
-			&portfoliopilotrpc.ResolveRequestResponse_Accept{
-				Accept: hint,
-			}
-		return &portfoliopilotrpc.ResolveRequestResponse{
-			Result: acceptResult,
-		}, nil
+	if hint == nil {
+		coeff := p.cfg.rateCoefficient
+		if p.cache != nil {
+			coeff = p.cache.getRate()
+		}
+
+		var err error
+		hint, err = makeRpcAssetRate(coeff)
+		if err != nil {
+			return nil, fmt.Errorf("make asset rate: %w",
+				err)
+		}
 	}
 
-	rpcRate, err := defaultRpcAssetRate()
-	if err != nil {
-		return nil, fmt.Errorf("default rpc asset rate: %w", err)
-	}
+	log.Printf("ResolveRequest accepting (fillcap=%d)",
+		fillCap)
 
-	log.Print("ResolveRequest returning default rate")
-	acceptResult := &portfoliopilotrpc.ResolveRequestResponse_Accept{
-		Accept: rpcRate,
-	}
 	return &portfoliopilotrpc.ResolveRequestResponse{
-		Result: acceptResult,
+		Result: &portfoliopilotrpc.
+			ResolveRequestResponse_Accept{
+			Accept: hint,
+		},
+		AcceptedMaxAmount: fillCap,
 	}, nil
 }
 
-// VerifyAcceptQuote verifies an accepted quote from a peer and returns the
-// validation status. This example logs the peer ID and always returns
-// VALID_ACCEPT_QUOTE.
-func (p *RpcPortfolioPilotServer) VerifyAcceptQuote(_ context.Context,
+// amountIsTransportable returns true when amt converts to a
+// non-zero result at the given rate. For buy (rateBoundCmp < 0)
+// the amount is asset units converting to msat; for sell
+// (rateBoundCmp > 0) the amount is msat converting to asset
+// units.
+func amountIsTransportable(amt uint64,
+	rate rfqmath.BigIntFixedPoint, rateBoundCmp int) bool {
+
+	if rateBoundCmp < 0 {
+		// Buy: asset units → msat.
+		units := rfqmath.FixedPoint[rfqmath.BigInt]{
+			Coefficient: rfqmath.NewBigIntFromUint64(
+				amt,
+			),
+			Scale: 0,
+		}
+		return rfqmath.UnitsToMilliSatoshi(units, rate) != 0
+	}
+
+	// Sell: msat → asset units.
+	units := rfqmath.MilliSatoshiToUnits(
+		lnwire.MilliSatoshi(amt), rate,
+	)
+	zero := rfqmath.NewBigIntFromUint64(0)
+
+	return !units.Coefficient.Equals(zero)
+}
+
+// VerifyAcceptQuote verifies an accepted quote from a peer by
+// checking rate bound, min fill, and fill constraints. Returns
+// the appropriate QuoteRespStatus.
+func (p *RpcPortfolioPilotServer) VerifyAcceptQuote(
+	_ context.Context,
 	req *portfoliopilotrpc.VerifyAcceptQuoteRequest) (
 	*portfoliopilotrpc.VerifyAcceptQuoteResponse, error) {
 
@@ -157,16 +364,169 @@ func (p *RpcPortfolioPilotServer) VerifyAcceptQuote(_ context.Context,
 		return nil, fmt.Errorf("accept quote is nil")
 	}
 
-	log.Printf("VerifyAcceptQuote peer=%x", req.Accept.PeerId)
+	accept := req.Accept
+	log.Printf("VerifyAcceptQuote peer=%x", accept.PeerId)
 
+	// Parse accepted rate.
+	rpcRate := accept.GetAcceptedRate()
+	if rpcRate == nil || rpcRate.GetRate() == nil {
+		log.Printf("VerifyAcceptQuote: invalid rate")
+		return &portfoliopilotrpc.VerifyAcceptQuoteResponse{
+			Status: portfoliopilotrpc.
+				QuoteRespStatus_INVALID_ASSET_RATES,
+		}, nil
+	}
+	acceptedRate, err := rpcutils.UnmarshalPortfolioFixedPoint(
+		rpcRate.GetRate(),
+	)
+	if err != nil {
+		log.Printf("VerifyAcceptQuote: unmarshal rate: %v",
+			err)
+		return &portfoliopilotrpc.VerifyAcceptQuoteResponse{
+			Status: portfoliopilotrpc.
+				QuoteRespStatus_INVALID_ASSET_RATES,
+		}, nil
+	}
+
+	// Extract constraints based on request type.
+	var (
+		minAmount    uint64
+		maxAmount    uint64
+		rateLimit    *portfoliopilotrpc.FixedPoint
+		rateBoundCmp int
+		isFOK        bool
+	)
+	switch r := accept.GetRequest().(type) {
+	case *portfoliopilotrpc.AcceptedQuote_BuyRequest:
+		br := r.BuyRequest
+		minAmount = br.GetAssetMinAmount()
+		maxAmount = br.GetAssetMaxAmount()
+		rateLimit = br.GetAssetRateLimit()
+		rateBoundCmp = -1 // floor
+		isFOK = br.GetExecutionPolicy() ==
+			portfoliopilotrpc.ExecutionPolicy_EXECUTION_POLICY_FOK
+	case *portfoliopilotrpc.AcceptedQuote_SellRequest:
+		sr := r.SellRequest
+		minAmount = sr.GetPaymentMinAmount()
+		maxAmount = sr.GetPaymentMaxAmount()
+		rateLimit = sr.GetAssetRateLimit()
+		rateBoundCmp = 1 // ceiling
+		isFOK = sr.GetExecutionPolicy() ==
+			portfoliopilotrpc.ExecutionPolicy_EXECUTION_POLICY_FOK
+	default:
+		return nil, fmt.Errorf(
+			"unknown request type: %T", r,
+		)
+	}
+
+	// Check expiry.
+	if rpcRate.GetExpiryTimestamp() > 0 {
+		expiry := time.Unix(
+			int64(rpcRate.GetExpiryTimestamp()), 0,
+		)
+		if time.Now().After(expiry) {
+			log.Printf("VerifyAcceptQuote: expired "+
+				"at %v", expiry)
+			return &portfoliopilotrpc.
+				VerifyAcceptQuoteResponse{
+				Status: portfoliopilotrpc.
+					QuoteRespStatus_INVALID_EXPIRY,
+			}, nil
+		}
+	}
+
+	// Check rate bound: buy requires accepted >= limit,
+	// sell requires accepted <= limit.
+	if rateLimit != nil {
+		limit, err := rpcutils.UnmarshalPortfolioFixedPoint(
+			rateLimit,
+		)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"unmarshal rate limit: %w", err,
+			)
+		}
+		if acceptedRate.Cmp(*limit) == rateBoundCmp {
+			log.Printf("VerifyAcceptQuote: rate bound "+
+				"miss (accepted=%v limit=%v cmp=%d)",
+				acceptedRate, *limit, rateBoundCmp)
+			return &portfoliopilotrpc.
+				VerifyAcceptQuoteResponse{
+				Status: portfoliopilotrpc.
+					QuoteRespStatus_RATE_BOUND_MISS,
+			}, nil
+		}
+	}
+
+	// FOK: full max amount must be transportable.
+	if isFOK && !amountIsTransportable(
+		maxAmount, *acceptedRate, rateBoundCmp,
+	) {
+
+		log.Printf("VerifyAcceptQuote: FOK not viable "+
+			"(max=%d)", maxAmount)
+		return &portfoliopilotrpc.VerifyAcceptQuoteResponse{
+			Status: portfoliopilotrpc.
+				QuoteRespStatus_FOK_NOT_VIABLE,
+		}, nil
+	}
+
+	// Fill must not exceed the request max.
+	fillAmt := accept.GetAcceptedMaxAmount()
+	if fillAmt > 0 && fillAmt > maxAmount {
+		log.Printf("VerifyAcceptQuote: fill %d > max %d",
+			fillAmt, maxAmount)
+		return &portfoliopilotrpc.VerifyAcceptQuoteResponse{
+			Status: portfoliopilotrpc.
+				QuoteRespStatus_FILL_EXCEEDS_MAX,
+		}, nil
+	}
+
+	// FOK + fill cap: if cap < max, reject.
+	if isFOK && fillAmt > 0 && fillAmt < maxAmount {
+		log.Printf("VerifyAcceptQuote: FOK fill cap "+
+			"%d < max %d", fillAmt, maxAmount)
+		return &portfoliopilotrpc.VerifyAcceptQuoteResponse{
+			Status: portfoliopilotrpc.
+				QuoteRespStatus_FOK_NOT_VIABLE,
+		}, nil
+	}
+
+	// Check min fill is transportable at the accepted rate.
+	if minAmount > 0 && !amountIsTransportable(
+		minAmount, *acceptedRate, rateBoundCmp,
+	) {
+
+		log.Printf("VerifyAcceptQuote: min fill not met "+
+			"(min=%d)", minAmount)
+		return &portfoliopilotrpc.VerifyAcceptQuoteResponse{
+			Status: portfoliopilotrpc.
+				QuoteRespStatus_MIN_FILL_NOT_MET,
+		}, nil
+	}
+
+	// Check fill constraints: if a fill cap was negotiated,
+	// it must satisfy the minimum.
+	if fillAmt > 0 && minAmount > 0 && fillAmt < minAmount {
+		log.Printf("VerifyAcceptQuote: fill %d < min %d",
+			fillAmt, minAmount)
+		return &portfoliopilotrpc.VerifyAcceptQuoteResponse{
+			Status: portfoliopilotrpc.
+				QuoteRespStatus_MIN_FILL_NOT_MET,
+		}, nil
+	}
+
+	log.Printf("VerifyAcceptQuote: valid")
 	return &portfoliopilotrpc.VerifyAcceptQuoteResponse{
-		Status: portfoliopilotrpc.QuoteRespStatus_VALID_ACCEPT_QUOTE,
+		Status: portfoliopilotrpc.
+			QuoteRespStatus_VALID_ACCEPT_QUOTE,
 	}, nil
 }
 
-// QueryAssetRates returns an asset rate for the given query. It prefers a rate
-// hint if provided, otherwise it returns the fixed default rate.
-func (p *RpcPortfolioPilotServer) QueryAssetRates(_ context.Context,
+// QueryAssetRates returns the configured asset rate, or the
+// provided hint if one is given.
+func (p *RpcPortfolioPilotServer) QueryAssetRates(
+	_ context.Context,
 	req *portfoliopilotrpc.QueryAssetRatesRequest) (
 	*portfoliopilotrpc.QueryAssetRatesResponse, error) {
 
@@ -175,37 +535,67 @@ func (p *RpcPortfolioPilotServer) QueryAssetRates(_ context.Context,
 	}
 
 	if req.AssetRateHint != nil {
-		log.Print("QueryAssetRates using provided rate hint")
+		log.Print("QueryAssetRates using provided hint")
 		return &portfoliopilotrpc.QueryAssetRatesResponse{
 			AssetRate: req.AssetRateHint,
 		}, nil
 	}
 
-	rpcRate, err := defaultRpcAssetRate()
-	if err != nil {
-		return nil, fmt.Errorf("default rpc asset rate: %w", err)
+	coeff := p.cfg.rateCoefficient
+	if p.cache != nil {
+		coeff = p.cache.getRate()
 	}
 
-	log.Print("QueryAssetRates returning default rate")
+	rpcRate, err := makeRpcAssetRate(coeff)
+	if err != nil {
+		return nil, fmt.Errorf("make asset rate: %w", err)
+	}
+
+	log.Print("QueryAssetRates returning configured rate")
 	return &portfoliopilotrpc.QueryAssetRatesResponse{
 		AssetRate: rpcRate,
 	}, nil
 }
 
-// startService starts the given RPC server and blocks until the server is
-// shut down.
-func startService(grpcServer *grpc.Server) error {
-	serviceAddr := fmt.Sprintf("portfoliopilotrpc://%s",
-		serviceListenAddress)
-	log.Printf("Starting RPC portfolio pilot service at address: %s",
-		serviceAddr)
+// startService starts the given RPC server and blocks until the
+// server is shut down.
+func startService(grpcServer *grpc.Server, cfg pilotConfig) error {
+	serviceAddr := fmt.Sprintf(
+		"portfoliopilotrpc://%s", cfg.listenAddr,
+	)
 
-	server := RpcPortfolioPilotServer{}
-	portfoliopilotrpc.RegisterPortfolioPilotServer(grpcServer, &server)
-	grpcListener, err := net.Listen("tcp", serviceListenAddress)
+	var cache *rateCache
+	if cfg.rateCoefficient == 0 {
+		cache = newRateCache(
+			30*time.Second, 0,
+		)
+		log.Printf("Starting portfolio pilot at "+
+			"%s (rate=live, fillcap_asset=%d, "+
+			"fillcap_msat=%d)",
+			serviceAddr, cfg.fillCapAsset,
+			cfg.fillCapMsat)
+	} else {
+		log.Printf("Starting portfolio pilot at "+
+			"%s (rate=%d, fillcap_asset=%d, "+
+			"fillcap_msat=%d)",
+			serviceAddr, cfg.rateCoefficient,
+			cfg.fillCapAsset, cfg.fillCapMsat)
+	}
+
+	server := &RpcPortfolioPilotServer{
+		cfg:   cfg,
+		cache: cache,
+	}
+	portfoliopilotrpc.RegisterPortfolioPilotServer(
+		grpcServer, server,
+	)
+
+	grpcListener, err := net.Listen("tcp", cfg.listenAddr)
 	if err != nil {
-		return fmt.Errorf("RPC server unable to listen on %s: %w",
-			serviceListenAddress, err)
+		return fmt.Errorf(
+			"RPC server unable to listen on %s: %w",
+			cfg.listenAddr, err,
+		)
 	}
 	if err := grpcServer.Serve(grpcListener); err != nil {
 		if errors.Is(err, grpc.ErrServerStopped) {
@@ -273,57 +663,36 @@ func generateSelfSignedCert() (tls.Certificate, error) {
 
 // main runs the example RPC portfolio pilot server.
 func main() {
+	cfg := parseFlags()
 	setupLogger()
 
-	// Generate a self-signed certificate. This allows us to use TLS for the
-	// gRPC server.
 	tlsCert, err := generateSelfSignedCert()
 	if err != nil {
-		log.Fatalf("Failed to generate TLS certificate: %v", err)
+		log.Fatalf("Failed to generate TLS cert: %v", err)
 	}
 
-	// Configure server-side keepalive parameters. These settings ensure the
-	// server actively probes client connection health and allows long-lived
-	// idle connections.
 	serverKeepalive := keepalive.ServerParameters{
-		// Ping clients after 1 minute of inactivity.
-		Time: time.Minute,
-
-		// Wait 20 seconds for ping response.
-		Timeout: 20 * time.Second,
-
-		// Allow connections to stay idle for 24 hours. The active
-		// pinging mechanism (via Time parameter) handles health
-		// checking, so we don't need aggressive idle timeouts.
-		MaxConnectionIdle: time.Hour * 24,
+		Time:              time.Minute,
+		Timeout:           20 * time.Second,
+		MaxConnectionIdle: 24 * time.Hour,
 	}
-
-	// Configure client keepalive enforcement policy. This tells the server
-	// how to handle client keepalive pings.
 	clientKeepalive := keepalive.EnforcementPolicy{
-		// Allow client to ping even when there are no active RPCs.
-		// This is critical for long-lived connections with infrequent
-		// requests.
 		PermitWithoutStream: true,
-
-		// Prevent abusive clients from pinging too frequently (DoS
-		// protection).
-		MinTime: 5 * time.Second,
+		MinTime:             5 * time.Second,
 	}
 
-	// Create the gRPC server with TLS and keepalive configuration.
-	transportCredentials := credentials.NewTLS(&tls.Config{
+	creds := credentials.NewTLS(&tls.Config{
 		Certificates: []tls.Certificate{tlsCert},
 	})
 	backendService := grpc.NewServer(
-		grpc.Creds(transportCredentials),
+		grpc.Creds(creds),
 		grpc.KeepaliveParams(serverKeepalive),
 		grpc.KeepaliveEnforcementPolicy(clientKeepalive),
 	)
 
 	errChan := make(chan error, 1)
 	go func() {
-		errChan <- startService(backendService)
+		errChan <- startService(backendService, cfg)
 	}()
 
 	signalChan := make(chan os.Signal, 1)
@@ -337,10 +706,10 @@ func main() {
 		}
 
 	case sig := <-signalChan:
-		log.Printf("Shutting down service on signal: %v", sig)
+		log.Printf("Shutting down on signal: %v", sig)
 		backendService.GracefulStop()
 		if err = <-errChan; err != nil {
-			log.Printf("Service shutdown error: %v", err)
+			log.Printf("Shutdown error: %v", err)
 		}
 	}
 }

--- a/docs/release-notes/release-notes-0.8.0.md
+++ b/docs/release-notes/release-notes-0.8.0.md
@@ -427,4 +427,7 @@
 - [PR#1962](https://github.com/lightninglabs/taproot-assets/pull/1962)
   Add a basic PortfolioPilot RPC example under `docs/examples`.
 
-# Contributors (Alphabetical Order)
+- [PR#2056](https://github.com/lightninglabs/taproot-assets/pull/2056)
+  expands the example portfolio pilot with constraint enforcement,
+  configurable fill caps, and live CoinGecko pricing.
+


### PR DESCRIPTION
Partially resolves #2004.

Expands the example portfolio pilot with limit order constraints (rate limits, min fill, execution policy), configurable fill caps, and access to a BTC/USD rate via CoinGecko's API for basic illustrative usage.
