### PR TITLE
itest: add graph sync assertions to limit_constraints test

### DIFF
--- a/itest/custom_channels/limit_constraints_test.go
+++ b/itest/custom_channels/limit_constraints_test.go
@@ -184,6 +184,15 @@ func testCustomChannelsLimitConstraints(_ context.Context,
 		},
 	}
 
+	// Wait for all nodes to see each other in the graph,
+	// ensuring the full route Charlie→Dave→Erin is available
+	// before we attempt any payments.
+	require.NoError(t.t, net.AssertNodeKnown(charlie, dave))
+	require.NoError(t.t, net.AssertNodeKnown(dave, charlie))
+	require.NoError(t.t, net.AssertNodeKnown(charlie, erin))
+	require.NoError(t.t, net.AssertNodeKnown(dave, erin))
+	require.NoError(t.t, net.AssertNodeKnown(erin, dave))
+
 	logBalance(t.t, nodes, assetID, "after channel open")
 
 	// -----------------------------------------------------------------


### PR DESCRIPTION
This should fix a flake in the limit-constraints custom channels itest that @darioAnongba flagged out of band, visible in [this CI job](https://github.com/lightninglabs/taproot-assets/actions/runs/24341975290/job/71073751155).

Adds AssertNodeKnown calls for all nodes along the payment path (Charlie→Dave→Erin) before attempting payments. Without these, Charlie's pathfinder may not yet know about Erin, causing intermittent routing failures.

This matches the pattern used by all other 3+ node custom channel tests (e.g. core_test, oracle_pricing_test).