### PR TITLE
itest: deflake custom channel liquidity cleanup

### DIFF
--- a/itest/custom_channels/helpers.go
+++ b/itest/custom_channels/helpers.go
@@ -2748,6 +2748,18 @@ func assertNumHtlcs(t *testing.T, node *itest.IntegratedNode,
 	require.NoError(t, err)
 }
 
+// assertNumHtlcsAll asserts that each node has exactly the expected number of
+// pending HTLCs across all channels.
+func assertNumHtlcsAll(t *testing.T, expected int,
+	nodes ...*itest.IntegratedNode) {
+
+	t.Helper()
+
+	for _, node := range nodes {
+		assertNumHtlcs(t, node, expected)
+	}
+}
+
 // assertHTLCNotActive asserts the node doesn't have an active pending HTLC
 // with the given payment hash.
 func assertHTLCNotActive(t *testing.T, hn *itest.IntegratedNode,

--- a/itest/custom_channels/liquidity_test.go
+++ b/itest/custom_channels/liquidity_test.go
@@ -636,8 +636,10 @@ func testCustomChannelsLiquidityEdgeCasesCore(ctx context.Context,
 	)
 	require.NoError(t.t, err)
 
-	// Let's assert that Erin cancelled all his HTLCs.
-	assertNumHtlcs(t.t, erin, 0)
+	// Wait for the full route to quiesce before attempting the next
+	// payment. Erin can drain first while Charlie and Dave are still
+	// processing the cancellation backwards.
+	assertNumHtlcsAll(t.t, 0, charlie, dave, erin, fabia)
 
 	logBalance(t.t, nodes, assetID, "after hodl cancel & 0 present HTLCs")
 


### PR DESCRIPTION
## Description

The fix removes the flake by waiting for HTLC cancellation to fully propagate across the whole
`Charlie->Dave->Erin->Fabia `
route before starting the next payment, which prevents a race where upstream nodes still report temporarily reduced bandwidth.

We basically have to wait for all HTLCs to fail on all the channels involved in the prior payment.

~Closes~ **Seals** https://github.com/lightninglabs/taproot-assets/issues/1900