### PR TITLE
tapgarden: surface non-critical custodian errors to subscribers

### DIFF
--- a/docs/release-notes/release-notes-0.8.0.md
+++ b/docs/release-notes/release-notes-0.8.0.md
@@ -263,6 +263,13 @@
   - Added a limit (`MaxOrphanUTXOs = 20`) to prevent transactions from becoming
     too large when sweeping many orphan UTXOs at once.
 
+- [PR#2070](https://github.com/lightninglabs/taproot-assets/pull/2070)
+  Non-critical custodian errors are now surfaced to RPC clients subscribed via
+  `SubscribeReceiveEvents`. Errors during proof availability checks, proof
+  retrieval, wallet transaction inspection, and mailbox message handling now
+  publish `AssetReceiveErrorEvent` notifications, allowing clients to monitor
+  and react to failures without requiring log parsing.
+
 - [PR#1775](https://github.com/lightninglabs/taproot-assets/pull/1775):
   Price oracle connections now verify TLS certificates by
   default, using the OS root CA list. New config options under

--- a/tapgarden/custodian.go
+++ b/tapgarden/custodian.go
@@ -741,11 +741,22 @@ func (c *Custodian) inspectWalletTx(walletTx *lndclient.Transaction) error {
 			if event.ConfirmationHeight == 0 &&
 				walletTx.Confirmations > 0 {
 
+				// Save these before GetOrCreateEvent, which may
+				// return nil on error.
+				tapAddr := event.Addr.Tap
+				prevStatus := event.Status
+
 				xfer, err := address.NewTransferFromWalletTx(
 					event.Addr, walletTx, uint32(idx),
 					sendOutputs,
 				)
 				if err != nil {
+					errEvent := NewAssetReceiveErrorEvent(
+						err, *tapAddr, op,
+						0, prevStatus,
+					)
+					c.publishSubscriberStatusEvent(errEvent)
+
 					return fmt.Errorf("error creating "+
 						"event source: %w", err)
 				}
@@ -758,6 +769,12 @@ func (c *Custodian) inspectWalletTx(walletTx *lndclient.Transaction) error {
 				)
 				cancel()
 				if err != nil {
+					errEvent := NewAssetReceiveErrorEvent(
+						err, *tapAddr, op,
+						0, prevStatus,
+					)
+					c.publishSubscriberStatusEvent(errEvent)
+
 					return fmt.Errorf("error updating "+
 						"event: %w", err)
 				}
@@ -778,7 +795,7 @@ func (c *Custodian) inspectWalletTx(walletTx *lndclient.Transaction) error {
 				)
 				c.Goroutine(func() error {
 					return c.receiveProofs(
-						event.Addr.Tap, op,
+						tapAddr, op,
 						event.Outputs,
 						event.ConfirmationHeight,
 					)
@@ -787,8 +804,8 @@ func (c *Custodian) inspectWalletTx(walletTx *lndclient.Transaction) error {
 						//nolint:lll
 						NewAssetReceiveErrorEvent(
 							err,
-							*event.Addr.Tap,
-							event.Outpoint,
+							*tapAddr,
+							op,
 							event.ConfirmationHeight,
 							event.Status,
 						),
@@ -1184,6 +1201,12 @@ func (c *Custodian) handleMailboxMessages(msgs *mbox.ReceivedMessages) error {
 				output.DerivationMethod,
 			)
 			if err != nil {
+				errEvent := NewAssetReceiveErrorEvent(
+					err, *tapAddr.Tap, op, 0,
+					address.StatusTransactionDetected,
+				)
+				c.publishSubscriberStatusEvent(errEvent)
+
 				return fmt.Errorf("unable to derive script "+
 					"key for asset: %w", err)
 			}
@@ -1192,6 +1215,12 @@ func (c *Custodian) handleMailboxMessages(msgs *mbox.ReceivedMessages) error {
 				ctx, scriptKey, scriptKey.Type,
 			)
 			if err != nil {
+				errEvent := NewAssetReceiveErrorEvent(
+					err, *tapAddr.Tap, op, 0,
+					address.StatusTransactionDetected,
+				)
+				c.publishSubscriberStatusEvent(errEvent)
+
 				return fmt.Errorf("unable to insert script "+
 					"key into address book: %w", err)
 			}
@@ -1226,6 +1255,13 @@ func (c *Custodian) handleMailboxMessages(msgs *mbox.ReceivedMessages) error {
 			ctx, fragment.BlockHeader.BlockHash(),
 		)
 		if err != nil {
+			c.publishSubscriberStatusEvent(
+				NewAssetReceiveErrorEvent(
+					err, *tapAddr.Tap, op,
+					0, address.StatusTransactionDetected,
+				),
+			)
+
 			return fmt.Errorf("unable to fetch block %s: %w",
 				fragment.BlockHeader.BlockHash(), err)
 		}
@@ -1234,6 +1270,13 @@ func (c *Custodian) handleMailboxMessages(msgs *mbox.ReceivedMessages) error {
 			tapAddr, block, fragment, outputs,
 		)
 		if err != nil {
+			c.publishSubscriberStatusEvent(
+				NewAssetReceiveErrorEvent(
+					err, *tapAddr.Tap, op,
+					0, address.StatusTransactionDetected,
+				),
+			)
+
 			return fmt.Errorf("error creating event source from "+
 				"fragment: %w", err)
 		}
@@ -1247,6 +1290,13 @@ func (c *Custodian) handleMailboxMessages(msgs *mbox.ReceivedMessages) error {
 		)
 		cancel()
 		if err != nil {
+			c.publishSubscriberStatusEvent(
+				NewAssetReceiveErrorEvent(
+					err, *tapAddr.Tap, op,
+					0, address.StatusTransactionDetected,
+				),
+			)
+
 			return fmt.Errorf("error creating event: %w", err)
 		}
 
@@ -1485,6 +1535,8 @@ func (c *Custodian) mapProofToEvent(p proof.Blob) error {
 		log.Debugf("Received single proof, inspecting if matches event")
 		lastProof, err = p.AsSingleProof()
 		if err != nil {
+			// No error event published here since we haven't
+			// matched this proof to any address event yet.
 			return fmt.Errorf("error decoding proof: %w", err)
 		}
 
@@ -1493,12 +1545,14 @@ func (c *Custodian) mapProofToEvent(p proof.Blob) error {
 		// because we receive all transfer proofs inserted into the
 		// local universe here. So they could just be from a proof sync
 		// run and not actually be for an address we are interested in.
-		haveMatchingEvents := fn.AnyMapItem(
-			c.events, func(e *address.Event) bool {
-				return EventMatchesProof(e, lastProof)
-			},
+		// We capture the matching event so we can use it in error
+		// paths to publish error events to subscribers.
+		matchingEvent, ok := c.events[lastProof.OutPoint()]
+		addrMatches := ok && AddrMatchesAsset(
+			matchingEvent.Addr,
+			&lastProof.Asset,
 		)
-		if !haveMatchingEvents {
+		if !addrMatches {
 			log.Debugf("Proof doesn't match any events, skipping.")
 			return nil
 		}
@@ -1518,6 +1572,15 @@ func (c *Custodian) mapProofToEvent(p proof.Blob) error {
 		log.Debugf("Received single proof, fetching full file")
 		proofBlob, err = c.cfg.ProofNotifier.FetchProof(ctxt, loc)
 		if err != nil {
+			c.publishSubscriberStatusEvent(
+				NewAssetReceiveErrorEvent(
+					err, *matchingEvent.Addr.Tap,
+					matchingEvent.Outpoint,
+					matchingEvent.ConfirmationHeight,
+					matchingEvent.Status,
+				),
+			)
+
 			return fmt.Errorf("error fetching full proof file for "+
 				"event: %w", err)
 		}
@@ -1532,6 +1595,15 @@ func (c *Custodian) mapProofToEvent(p proof.Blob) error {
 			Blob:    proofBlob,
 		})
 		if err != nil {
+			c.publishSubscriberStatusEvent(
+				NewAssetReceiveErrorEvent(
+					err, *matchingEvent.Addr.Tap,
+					matchingEvent.Outpoint,
+					matchingEvent.ConfirmationHeight,
+					matchingEvent.Status,
+				),
+			)
+
 			return fmt.Errorf("error asserting proof in local "+
 				"archive: %w", err)
 		}

--- a/tapgarden/custodian_test.go
+++ b/tapgarden/custodian_test.go
@@ -1216,3 +1216,149 @@ func TestAddrMatchesAsset(t *testing.T) {
 		})
 	}
 }
+
+// TestCustodianEventSubscriber tests that subscribers receive events when
+// assets are received. This validates the publishSubscriberStatusEvent
+// mechanism used by both success and error events.
+func TestCustodianEventSubscriber(t *testing.T) {
+	t.Parallel()
+
+	h := newHarness(t, nil)
+
+	// Create an address and insert it.
+	ctx := context.Background()
+	addr, genesis := randAddrV1(h)
+	err := h.tapdbBook.InsertAddrs(ctx, *addr)
+	require.NoError(t, err)
+
+	require.NoError(t, h.c.Start())
+	t.Cleanup(func() {
+		require.NoError(t, h.c.Stop())
+	})
+	h.assertStartup()
+
+	// Register a subscriber to receive events.
+	subscriber := fn.NewEventReceiver[fn.Event](fn.DefaultQueueSize)
+	err = h.c.RegisterSubscriber(subscriber, false, time.Time{})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		err := h.c.RemoveSubscriber(subscriber)
+		require.NoError(t, err)
+	})
+
+	// Wait for the address to be registered.
+	h.assertAddrsRegistered(addr)
+
+	// Create a wallet transaction for the address.
+	outputIdx, tx := randWalletTx(addr)
+	tx.Confirmations = 1
+
+	// Prepare a proof for the courier to deliver.
+	mockProof := randProof(t, outputIdx, tx.Tx, genesis, addr)
+	recipient := proof.Recipient{}
+	err = h.courier.DeliverProof(
+		context.Background(), recipient, mockProof, nil,
+	)
+	require.NoError(t, err)
+
+	// Send the transaction through the wallet anchor to trigger processing.
+	h.walletAnchor.SubscribeTx <- *tx
+
+	// We should receive events on the subscriber channel. The flow is:
+	// StatusTransactionConfirmed -> StatusProofReceived -> StatusCompleted.
+	// We verify we receive at least one AssetReceiveEvent.
+	var receivedEvents []*tapgarden.AssetReceiveEvent
+	require.Eventually(t, func() bool {
+		select {
+		case event := <-subscriber.NewItemCreated.ChanOut():
+			receiveEvent, ok :=
+				event.(*tapgarden.AssetReceiveEvent)
+			if ok {
+				receivedEvents = append(
+					receivedEvents, receiveEvent,
+				)
+				// Keep collecting until we get
+				// StatusCompleted.
+				completed := address.StatusCompleted
+				if receiveEvent.Status == completed {
+					return true
+				}
+			}
+		default:
+		}
+		return false
+	}, testTimeout, testPollInterval)
+
+	// Verify we received events and the final one has the correct address.
+	require.NotEmpty(t, receivedEvents)
+	lastEvent := receivedEvents[len(receivedEvents)-1]
+	require.Equal(t, addr.AssetID, lastEvent.Address.AssetID)
+	require.Equal(t, address.StatusCompleted, lastEvent.Status)
+	require.Nil(t, lastEvent.Error)
+}
+
+// TestAssetReceiveErrorEvent tests that AssetReceiveErrorEvent correctly
+// captures error information and can be distinguished from success events.
+// This validates the error event structure used by error paths in
+// inspectWalletTx, mapProofToEvent, and handleMailboxMessages.
+func TestAssetReceiveErrorEvent(t *testing.T) {
+	t.Parallel()
+
+	// Create a random address for the event.
+	proofCourierAddr := address.RandProofCourierAddrForVersion(
+		t, address.V1,
+	)
+	addr, _, _ := address.RandAddrWithVersion(
+		t, chainParams, proofCourierAddr, address.V1,
+	)
+
+	outpoint := wire.OutPoint{
+		Hash:  test.RandHash(),
+		Index: 0,
+	}
+	confHeight := uint32(100)
+	status := address.StatusTransactionConfirmed
+	testErr := fmt.Errorf("test error: proof fetch failed")
+
+	// Create a success event.
+	successEvent := tapgarden.NewAssetReceiveEvent(
+		*addr.Tap, outpoint, confHeight, status,
+	)
+
+	// Create an error event with the same parameters plus an error.
+	errorEvent := tapgarden.NewAssetReceiveErrorEvent(
+		testErr, *addr.Tap, outpoint, confHeight, status,
+	)
+
+	// Verify success event has no error.
+	require.Nil(t, successEvent.Error)
+	require.Equal(t, addr.Tap.AssetID, successEvent.Address.AssetID)
+	require.Equal(t, outpoint, successEvent.OutPoint)
+	require.Equal(t, confHeight, successEvent.ConfirmationHeight)
+	require.Equal(t, status, successEvent.Status)
+
+	// Verify error event captures the error and all other fields.
+	require.NotNil(t, errorEvent.Error)
+	require.Equal(t, testErr, errorEvent.Error)
+	require.Equal(t, addr.Tap.AssetID, errorEvent.Address.AssetID)
+	require.Equal(t, outpoint, errorEvent.OutPoint)
+	require.Equal(t, confHeight, errorEvent.ConfirmationHeight)
+	require.Equal(t, status, errorEvent.Status)
+
+	// Verify both events have valid timestamps.
+	require.False(t, successEvent.Timestamp().IsZero())
+	require.False(t, errorEvent.Timestamp().IsZero())
+
+	// Test error event with zero/default values (as used in early error
+	// paths where full context isn't available).
+	earlyErrorEvent := tapgarden.NewAssetReceiveErrorEvent(
+		testErr, *addr.Tap, wire.OutPoint{},
+		0, address.StatusTransactionDetected,
+	)
+	require.NotNil(t, earlyErrorEvent.Error)
+	require.Equal(t, wire.OutPoint{}, earlyErrorEvent.OutPoint)
+	require.Equal(t, uint32(0), earlyErrorEvent.ConfirmationHeight)
+	require.Equal(
+		t, address.StatusTransactionDetected, earlyErrorEvent.Status,
+	)
+}


### PR DESCRIPTION
Fixes #1942.

Adds `NewAssetReceiveErrorEvent` to publish error events through the existing subscriber mechanism. Error paths in `inspectWalletTx`, `handleMailboxMessages`, and `mapProofToEvent` now notify subscribers before returning/continuing on errors.

This enables subscribers (e.g., RPC clients watching for receives) to be notified about errors during asset receive processing, rather than only learning about successful completions or silent failures logged to the daemon.

Unit tests added for both the subscriber event flow and error event structure.