### PR TITLE
itest: wait for HTLC settlement before checking balances

### DIFF
--- a/itest/custom_channels/helpers.go
+++ b/itest/custom_channels/helpers.go
@@ -2775,6 +2775,40 @@ func assertNumHtlcsAll(t *testing.T, expected int,
 	}
 }
 
+// waitForAssetChannelHtlcSettlement polls until IncomingHtlcBalance
+// and OutgoingHtlcBalance are both zero on the given channel,
+// meaning all HTLCs have been fully committed.
+func waitForAssetChannelHtlcSettlement(t *testing.T,
+	node *itest.IntegratedNode,
+	chanPoint *lnrpc.ChannelPoint) {
+
+	t.Helper()
+
+	err := wait.NoError(func() error {
+		ch := fetchChannel(t, node, chanPoint)
+		assetBalance, err := parseChannelData(
+			ch.CustomChannelData,
+		)
+		if err != nil {
+			return err
+		}
+
+		if assetBalance.IncomingHtlcBalance > 0 {
+			return fmt.Errorf("incoming HTLC balance "+
+				"not yet settled: %d",
+				assetBalance.IncomingHtlcBalance)
+		}
+		if assetBalance.OutgoingHtlcBalance > 0 {
+			return fmt.Errorf("outgoing HTLC balance "+
+				"not yet settled: %d",
+				assetBalance.OutgoingHtlcBalance)
+		}
+
+		return nil
+	}, wait.DefaultTimeout)
+	require.NoError(t, err)
+}
+
 // assertHTLCNotActive asserts the node doesn't have an active pending HTLC
 // with the given payment hash.
 func assertHTLCNotActive(t *testing.T, hn *itest.IntegratedNode,

--- a/itest/custom_channels/self_payment_test.go
+++ b/itest/custom_channels/self_payment_test.go
@@ -170,6 +170,12 @@ func testCustomChannelsSelfPayment(_ context.Context,
 			"after paying invoice "+strconv.Itoa(i),
 		)
 
+		// Wait for the asset channel commitment to settle
+		// all HTLCs before checking balances.
+		waitForAssetChannelHtlcSettlement(
+			t.t, alice, assetChanPoint,
+		)
+
 		// The accumulated delta from the rounding of multiple sends.
 		// We basically allow the balance to be off by one unit for
 		// each payment.
@@ -239,6 +245,12 @@ func testCustomChannelsSelfPayment(_ context.Context,
 		logBalance(
 			t.t, nodes, assetID,
 			"after paying sat invoice "+strconv.Itoa(i),
+		)
+
+		// Wait for the asset channel commitment to settle
+		// all HTLCs before checking balances.
+		waitForAssetChannelHtlcSettlement(
+			t.t, alice, assetChanPoint,
 		)
 
 		// The accumulated delta from the rounding of multiple sends.


### PR DESCRIPTION
Resolves #2052.

The `self_payment` test flakes because assertChannelAssetBalanceWithDelta queries Alice's asset channel state immediately after payInvoiceWithSatoshi returns. The payment is marked SUCCEEDED when the sender sees the preimage on the BTC channel, but the asset channel's commitment round may not have completed yet, leaving units in IncomingHtlcBalance instead of LocalBalance. (NB, the exact amount missing from LocalBalance can be verified as remaining in IncomingHtlcBalance on failing itest cases.)

The fix adds a waitForAssetChannelHtlcSettlement helper that polls until both IncomingHtlcBalance and OutgoingHtlcBalance are zero, and calls it before each balance assertion in testCustomChannelsSelfPayment.