### PR TITLE
authmailbox: fix race between auth handshake and message delivery

### DIFF
--- a/authmailbox/receive_subscription.go
+++ b/authmailbox/receive_subscription.go
@@ -58,9 +58,10 @@ type receiveSubscription struct {
 
 	client mboxrpc.MailboxClient
 
-	serverStream clientStream
-	streamMutex  sync.RWMutex
-	streamCancel func()
+	serverStream  clientStream
+	streamMutex   sync.RWMutex
+	streamCancel  func()
+	authenticated bool
 
 	authOkChan chan struct{}
 	msgChan    chan<- *ReceivedMessages
@@ -154,6 +155,10 @@ func (s *receiveSubscription) connectAndAuthenticate(ctx context.Context,
 	case <-s.authOkChan:
 		log.DebugS(ctx, "Received auth success, subscription is active")
 
+		s.streamMutex.Lock()
+		s.authenticated = true
+		s.streamMutex.Unlock()
+
 	case err := <-s.errChan:
 		return fmt.Errorf("error during authentication, before "+
 			"sending subscribe: %v", err)
@@ -195,13 +200,13 @@ func (s *receiveSubscription) wait(backoff time.Duration) error {
 	}
 }
 
-// IsSubscribed returns true if at least one account is in an active state and
-// the subscription stream to the server was established successfully.
+// IsSubscribed returns true if the stream to the server is open and the
+// 3-way authentication handshake has completed successfully.
 func (s *receiveSubscription) IsSubscribed() bool {
 	s.streamMutex.RLock()
 	defer s.streamMutex.RUnlock()
 
-	return s.serverStream != nil
+	return s.serverStream != nil && s.authenticated
 }
 
 // connectServerStream opens the initial connection to the server for the stream
@@ -489,6 +494,7 @@ func (s *receiveSubscription) closeStream(ctx context.Context) error {
 	log.DebugS(ctx, "Closing server stream")
 	err := s.serverStream.CloseSend()
 	s.serverStream = nil
+	s.authenticated = false
 
 	return err
 }

--- a/authmailbox/server.go
+++ b/authmailbox/server.go
@@ -430,7 +430,8 @@ func (s *Server) handleStream(ctx context.Context,
 			stream.RLock()
 			err := s.RegisterSubscriber(
 				stream.msgReceiver,
-				stream.filter.DeliverExisting(), stream.filter,
+				stream.filter.DeliverExisting(),
+				stream.filter,
 			)
 			stream.RUnlock()
 			if err != nil {
@@ -439,6 +440,20 @@ func (s *Server) handleStream(ctx context.Context,
 			}
 
 			log.TraceS(ctx, "Client registered as subscriber")
+
+			// Inform the client that auth is complete.
+			// This is sent after RegisterSubscriber so
+			// that the subscriber is in the map before
+			// the client can observe IsSubscribed()=true.
+			err = grpcStream.Send(&toClientMsg{
+				ResponseType: &respTypeAuthSuccess{
+					AuthSuccess: true,
+				},
+			})
+			if err != nil {
+				return fmt.Errorf("unable to send "+
+					"auth success: %w", err)
+			}
 
 		// A new message was received by the server that needs to be
 		// forwarded to the client.
@@ -665,18 +680,8 @@ func handleAuthMessage(ctx context.Context, signer lndclient.SignerClient,
 				"key %x", pubKey[:])
 		}
 
-		// We inform the client that we received their signature and
-		// that we are now authenticated.
-		err = grpcStream.Send(&toClientMsg{
-			ResponseType: &respTypeAuthSuccess{
-				AuthSuccess: true,
-			},
-		})
-		if err != nil {
-			return fmt.Errorf("unable to send success: %w", err)
-		}
-
-		// The client is now successfully authenticated.
+		// Signal handleStream to complete registration
+		// and send AuthSuccess to the client.
 		stream.authSuccessChan <- struct{}{}
 
 	default:

--- a/authmailbox/stream.go
+++ b/authmailbox/stream.go
@@ -35,9 +35,9 @@ type mailboxStream struct {
 	// authNonce is a nonce used during the authentication process.
 	authNonce [32]byte
 
-	// authSuccessChan is a channel that is closed when the client has
-	// successfully authenticated. This is used to signal to the caller
-	// that they can start sending messages to the client.
+	// authSuccessChan is signaled (once) when the client has
+	// successfully authenticated. Buffered (size 1) so the
+	// send does not block if handleStream has already exited.
 	authSuccessChan chan struct{}
 
 	// msgReceiver is the channel through which messages are sent to the
@@ -76,7 +76,7 @@ func newMailboxStream(id uint64,
 
 	stream := &mailboxStream{
 		streamID:        id,
-		authSuccessChan: make(chan struct{}),
+		authSuccessChan: make(chan struct{}, 1),
 		msgReceiver: fn.NewEventReceiver[[]*Message](
 			fn.DefaultQueueSize,
 		),


### PR DESCRIPTION
This is expected to address a TestServerClientAuthAndRestart flake that has been popping up relentlessly in the merge queue since #2067 was merged (see #2069, in particular).

(N.b., I'm confident that the fix is morally and technically correct, but I'm not 100% sure on how the error condition relates to the observed flake incidence. The strange thing to me is that the flake has only seemed to pop up in the merge queue, in particular. I can't duplicate it locally, and I don't think I've seen it triggered in pull request CI jobs. AFAICT, GitHub's merge queue runners don't differ from other runners, so we _shouldn't_ expect to see any differential between them. But regardless, the race definitely exists, and the fix should, from first principles, eliminate the flake. It's possible we've just gotten [particularly unlucky](https://en.wikipedia.org/wiki/Poisson_clumping) on that merge queue run, as there have indeed been some runs there in which the flake [hasn't triggered](https://github.com/lightninglabs/taproot-assets/actions/runs/24453228871).)

The crux is that there was a race condition in which an authmailbox subscription check could return too early, before an actual auth handshake had completed. This has been latent since the code was written, and it's _hypothesised_ that the recent grpc version bump exacerbated the race for some reason (which, again, has been observed particularly in the merge queue jobs). If the subscription check returned 'true' too early, then, TLDR, messages sent too early could be silently dropped.

The fix is basically to require that 1) the server registers the subscriber _before_ notifying the client of auth success, and 2) the client confirms that the auth handshake has completed successfully before confirming subscription. Previously the order of both of these things was inverted.

UPDATE: this same fix should also resolve the TestReconnectAfterStreamError flake seen in [this job](https://github.com/lightninglabs/taproot-assets/actions/runs/24550554213/job/71775253521).