### PR TITLE
itest: wait for policy propagation

### DIFF
--- a/itest/custom_channels/helpers.go
+++ b/itest/custom_channels/helpers.go
@@ -2775,6 +2775,57 @@ func assertNumHtlcsAll(t *testing.T, expected int,
 	}
 }
 
+// assertChannelPolicyUpdate polls GetChanInfo on the given node until
+// the specified peer's policy reflects the expected base fee. This is
+// needed because UpdateChannelPolicy returns before the gossip message
+// has propagated to peers.
+func assertChannelPolicyUpdate(t *testing.T, node *itest.IntegratedNode,
+	chanID uint64, peerPubKey string, expectedBaseFeeMsat int64) {
+
+	t.Helper()
+
+	ctxb := context.Background()
+
+	err := wait.NoError(func() error {
+		ctxt, cancel := context.WithTimeout(ctxb, 5*time.Second)
+		defer cancel()
+
+		edge, err := node.LightningClient.GetChanInfo(
+			ctxt, &lnrpc.ChanInfoRequest{
+				ChanId: chanID,
+			},
+		)
+		if err != nil {
+			return err
+		}
+
+		// Find the policy set by the peer.
+		var policy *lnrpc.RoutingPolicy
+		switch {
+		case edge.Node1Pub == peerPubKey:
+			policy = edge.Node1Policy
+		case edge.Node2Pub == peerPubKey:
+			policy = edge.Node2Policy
+		default:
+			return fmt.Errorf("peer %s not found in "+
+				"channel edge", peerPubKey)
+		}
+
+		if policy == nil {
+			return fmt.Errorf("policy not yet available")
+		}
+
+		if policy.FeeBaseMsat != expectedBaseFeeMsat {
+			return fmt.Errorf("expected base fee %d, "+
+				"got %d", expectedBaseFeeMsat,
+				policy.FeeBaseMsat)
+		}
+
+		return nil
+	}, wait.DefaultTimeout)
+	require.NoError(t, err)
+}
+
 // waitForAssetChannelHtlcSettlement polls until IncomingHtlcBalance
 // and OutgoingHtlcBalance are both zero on the given channel,
 // meaning all HTLCs have been fully committed.

--- a/itest/custom_channels/liquidity_test.go
+++ b/itest/custom_channels/liquidity_test.go
@@ -686,6 +686,14 @@ func testCustomChannelsLiquidityEdgeCasesCore(ctx context.Context,
 	require.NoError(t.t, err)
 	require.Empty(t.t, resp.FailedUpdates)
 
+	// Wait for Erin's policy update to propagate to Fabia's graph
+	// before creating the invoice. Without this, Fabia may still see
+	// the old default policy (BaseFeeMsat=1000).
+	erinFabiaChanID := fetchChannel(t.t, fabia, chanPointEF).ChanId
+	assertChannelPolicyUpdate(
+		t.t, fabia, erinFabiaChanID, erin.PubKeyStr, 31337,
+	)
+
 	// We now create an invoice on Fabia and expect Erin's policy to be used
 	// in the invoice.
 	invoiceResp = createAssetInvoice(t.t, erin, fabia, 1_000, assetID)


### PR DESCRIPTION
This should resolve a nagging liquidity edge cases.. uh, edge case, as observed in [this job](https://github.com/lightninglabs/taproot-assets/actions/runs/24673242375/job/72150481956).

Opus's summary:

> The test updates Erin's channel policy, then immediately creates an invoice on Fabia, expecting the route hint to reflect the new policy. But UpdateChannelPolicy returns before the gossip ChannelUpdate has propagated to Fabia's graph, so Fabia may still see the default BaseFeeMsat=1000 instead of 31337.
> 
> Adds assertChannelPolicyUpdate, which polls GetChanInfo on the target node until the peer's policy reflects the expected base fee, and call it before creating the invoice.