### PR TITLE
taprpc: clarify proto docs for OutPoint, ReceiveEvent, ScriptKey

### DIFF
--- a/taprpc/assetwalletrpc/assetwallet.swagger.json
+++ b/taprpc/assetwalletrpc/assetwallet.swagger.json
@@ -1172,7 +1172,7 @@
         "txid": {
           "type": "string",
           "format": "byte",
-          "description": "Raw bytes representing the transaction id."
+          "description": "Raw bytes representing the transaction id. Must be in\ninternal byte order (little-endian), i.e. reversed\ncompared to the human-readable (RPC/block explorer)\nhex encoding."
         },
         "output_index": {
           "type": "integer",
@@ -1207,7 +1207,7 @@
         "pub_key": {
           "type": "string",
           "format": "byte",
-          "description": "The full Taproot output key the asset is locked to. This is either a BIP-86\nkey if the tap_tweak below is empty, or a key with the tap tweak applied to\nit."
+          "description": "The full Taproot output key the asset is locked to, as a\n32-byte x-only (Schnorr) public key. This is either a\nBIP-86 key if the tap_tweak below is empty, or a key with\nthe tap tweak applied to it."
         },
         "key_desc": {
           "$ref": "#/definitions/taprpcKeyDescriptor",

--- a/taprpc/authmailboxrpc/mailbox.swagger.json
+++ b/taprpc/authmailboxrpc/mailbox.swagger.json
@@ -452,7 +452,7 @@
         "txid": {
           "type": "string",
           "format": "byte",
-          "description": "Raw bytes representing the transaction id."
+          "description": "Raw bytes representing the transaction id. Must be in\ninternal byte order (little-endian), i.e. reversed\ncompared to the human-readable (RPC/block explorer)\nhex encoding."
         },
         "output_index": {
           "type": "integer",

--- a/taprpc/mintrpc/mint.swagger.json
+++ b/taprpc/mintrpc/mint.swagger.json
@@ -889,7 +889,7 @@
         "pub_key": {
           "type": "string",
           "format": "byte",
-          "description": "The full Taproot output key the asset is locked to. This is either a BIP-86\nkey if the tap_tweak below is empty, or a key with the tap tweak applied to\nit."
+          "description": "The full Taproot output key the asset is locked to, as a\n32-byte x-only (Schnorr) public key. This is either a\nBIP-86 key if the tap_tweak below is empty, or a key with\nthe tap tweak applied to it."
         },
         "key_desc": {
           "$ref": "#/definitions/taprpcKeyDescriptor",

--- a/taprpc/tapcommon.pb.go
+++ b/taprpc/tapcommon.pb.go
@@ -72,7 +72,10 @@ func (SortDirection) EnumDescriptor() ([]byte, []int) {
 // Represents a Bitcoin transaction outpoint.
 type OutPoint struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// Raw bytes representing the transaction id.
+	// Raw bytes representing the transaction id. Must be in
+	// internal byte order (little-endian), i.e. reversed
+	// compared to the human-readable (RPC/block explorer)
+	// hex encoding.
 	Txid []byte `protobuf:"bytes,1,opt,name=txid,proto3" json:"txid,omitempty"`
 	// The index of the output on the transaction.
 	OutputIndex   uint32 `protobuf:"varint,2,opt,name=output_index,json=outputIndex,proto3" json:"output_index,omitempty"`

--- a/taprpc/tapcommon.proto
+++ b/taprpc/tapcommon.proto
@@ -7,7 +7,10 @@ option go_package = "github.com/lightninglabs/taproot-assets/taprpc";
 // Represents a Bitcoin transaction outpoint.
 message OutPoint {
     /*
-    Raw bytes representing the transaction id.
+    Raw bytes representing the transaction id. Must be in
+    internal byte order (little-endian), i.e. reversed
+    compared to the human-readable (RPC/block explorer)
+    hex encoding.
     */
     bytes txid = 1;
 

--- a/taprpc/taprootassets.pb.go
+++ b/taprpc/taprootassets.pb.go
@@ -4457,9 +4457,10 @@ func (*ScriptKeyTypeQuery_AllTypes) isScriptKeyTypeQuery_Type() {}
 
 type ScriptKey struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// The full Taproot output key the asset is locked to. This is either a BIP-86
-	// key if the tap_tweak below is empty, or a key with the tap tweak applied to
-	// it.
+	// The full Taproot output key the asset is locked to, as a
+	// 32-byte x-only (Schnorr) public key. This is either a
+	// BIP-86 key if the tap_tweak below is empty, or a key with
+	// the tap tweak applied to it.
 	PubKey []byte `protobuf:"bytes,1,opt,name=pub_key,json=pubKey,proto3" json:"pub_key,omitempty"`
 	// The key descriptor describing the internal key of the above Taproot key.
 	KeyDesc *KeyDescriptor `protobuf:"bytes,2,opt,name=key_desc,json=keyDesc,proto3" json:"key_desc,omitempty"`
@@ -6765,7 +6766,10 @@ type ReceiveEvent struct {
 	Timestamp int64 `protobuf:"varint,1,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
 	// The address that received the asset.
 	Address *Addr `protobuf:"bytes,2,opt,name=address,proto3" json:"address,omitempty"`
-	// The outpoint of the transaction that was used to receive the asset.
+	// The outpoint of the transaction that was used to receive
+	// the asset. To resolve the received amount, use
+	// ListAssets with the anchor_outpoint filter set to this
+	// outpoint.
 	Outpoint string `protobuf:"bytes,3,opt,name=outpoint,proto3" json:"outpoint,omitempty"`
 	// The status of the event. If error below is set, then the status is the
 	// state that lead to the error during its execution.

--- a/taprpc/taprootassets.proto
+++ b/taprpc/taprootassets.proto
@@ -1345,9 +1345,10 @@ message ScriptKeyTypeQuery {
 
 message ScriptKey {
     /*
-    The full Taproot output key the asset is locked to. This is either a BIP-86
-    key if the tap_tweak below is empty, or a key with the tap tweak applied to
-    it.
+    The full Taproot output key the asset is locked to, as a
+    32-byte x-only (Schnorr) public key. This is either a
+    BIP-86 key if the tap_tweak below is empty, or a key with
+    the tap tweak applied to it.
     */
     bytes pub_key = 1;
 
@@ -1882,7 +1883,10 @@ message ReceiveEvent {
     // The address that received the asset.
     taprpc.Addr address = 2;
 
-    // The outpoint of the transaction that was used to receive the asset.
+    // The outpoint of the transaction that was used to receive
+    // the asset. To resolve the received amount, use
+    // ListAssets with the anchor_outpoint filter set to this
+    // outpoint.
     string outpoint = 3;
 
     // The status of the event. If error below is set, then the status is the

--- a/taprpc/taprootassets.swagger.json
+++ b/taprpc/taprootassets.swagger.json
@@ -243,7 +243,7 @@
           },
           {
             "name": "script_key.pub_key",
-            "description": "The full Taproot output key the asset is locked to. This is either a BIP-86\nkey if the tap_tweak below is empty, or a key with the tap tweak applied to\nit.",
+            "description": "The full Taproot output key the asset is locked to, as a\n32-byte x-only (Schnorr) public key. This is either a\nBIP-86 key if the tap_tweak below is empty, or a key with\nthe tap tweak applied to it.",
             "in": "query",
             "required": false,
             "type": "string",
@@ -300,7 +300,7 @@
           },
           {
             "name": "anchor_outpoint.txid",
-            "description": "Raw bytes representing the transaction id.",
+            "description": "Raw bytes representing the transaction id. Must be in\ninternal byte order (little-endian), i.e. reversed\ncompared to the human-readable (RPC/block explorer)\nhex encoding.",
             "in": "query",
             "required": false,
             "type": "string",
@@ -2735,7 +2735,7 @@
         "txid": {
           "type": "string",
           "format": "byte",
-          "description": "Raw bytes representing the transaction id."
+          "description": "Raw bytes representing the transaction id. Must be in\ninternal byte order (little-endian), i.e. reversed\ncompared to the human-readable (RPC/block explorer)\nhex encoding."
         },
         "output_index": {
           "type": "integer",
@@ -2861,7 +2861,7 @@
         },
         "outpoint": {
           "type": "string",
-          "description": "The outpoint of the transaction that was used to receive the asset."
+          "description": "The outpoint of the transaction that was used to receive\nthe asset. To resolve the received amount, use\nListAssets with the anchor_outpoint filter set to this\noutpoint."
         },
         "status": {
           "$ref": "#/definitions/taprpcAddrEventStatus",
@@ -2917,7 +2917,7 @@
         "pub_key": {
           "type": "string",
           "format": "byte",
-          "description": "The full Taproot output key the asset is locked to. This is either a BIP-86\nkey if the tap_tweak below is empty, or a key with the tap tweak applied to\nit."
+          "description": "The full Taproot output key the asset is locked to, as a\n32-byte x-only (Schnorr) public key. This is either a\nBIP-86 key if the tap_tweak below is empty, or a key with\nthe tap tweak applied to it."
         },
         "key_desc": {
           "$ref": "#/definitions/taprpcKeyDescriptor",

--- a/taprpc/universerpc/universe.swagger.json
+++ b/taprpc/universerpc/universe.swagger.json
@@ -1643,7 +1643,7 @@
           },
           {
             "name": "commit_outpoint.txid",
-            "description": "Raw bytes representing the transaction id.",
+            "description": "Raw bytes representing the transaction id. Must be in\ninternal byte order (little-endian), i.e. reversed\ncompared to the human-readable (RPC/block explorer)\nhex encoding.",
             "in": "query",
             "required": false,
             "type": "string",
@@ -1659,7 +1659,7 @@
           },
           {
             "name": "spent_commit_outpoint.txid",
-            "description": "Raw bytes representing the transaction id.",
+            "description": "Raw bytes representing the transaction id. Must be in\ninternal byte order (little-endian), i.e. reversed\ncompared to the human-readable (RPC/block explorer)\nhex encoding.",
             "in": "query",
             "required": false,
             "type": "string",
@@ -2310,7 +2310,7 @@
         "txid": {
           "type": "string",
           "format": "byte",
-          "description": "Raw bytes representing the transaction id."
+          "description": "Raw bytes representing the transaction id. Must be in\ninternal byte order (little-endian), i.e. reversed\ncompared to the human-readable (RPC/block explorer)\nhex encoding."
         },
         "output_index": {
           "type": "integer",


### PR DESCRIPTION
Adds some basic ListAssets-related information to the proto docs, per [this discussion](https://github.com/lightninglabs/taproot-assets/discussions/2083). Just clarifies the OutPoint.txid & ScriptKey.pub_key formats and points to the anchor_outpoint filter.