### PR TITLE
tapdb: surface underlying tx retry errors and fix per-attempt rollback scope

### DIFF
--- a/tapdb/interfaces.go
+++ b/tapdb/interfaces.go
@@ -3,6 +3,7 @@ package tapdb
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"math"
 	prand "math/rand"
 	"time"
@@ -232,12 +233,13 @@ func NewTransactionExecutor[Querier any](db BatchedQuerier,
 func (t *TransactionExecutor[Q]) ExecTx(ctx context.Context,
 	txOptions TxOptions, txBody func(Q) error) error {
 
-	waitBeforeRetry := func(attemptNumber int) {
+	var lastErr error
+	waitBeforeRetry := func(attemptNumber int, retryErr error) {
 		retryDelay := t.opts.randRetryDelay(attemptNumber)
 
-		log.Tracef("Retrying transaction due to tx serialization or "+
-			"deadlock error, attempt_number=%v, delay=%v",
-			attemptNumber, retryDelay)
+		log.Warnf("Retrying transaction due to tx serialization or "+
+			"deadlock error, attempt_number=%v, delay=%v, "+
+			"err=%v", attemptNumber, retryDelay, retryErr)
 
 		// Before we try again, we'll wait with a random backoff based
 		// on the retry delay.
@@ -252,7 +254,8 @@ func (t *TransactionExecutor[Q]) ExecTx(ctx context.Context,
 			if IsSerializationOrDeadlockError(dbErr) {
 				// Nothing to roll back here, since we didn't
 				// even get a transaction yet.
-				waitBeforeRetry(i)
+				lastErr = dbErr
+				waitBeforeRetry(i, dbErr)
 				continue
 			}
 
@@ -272,7 +275,8 @@ func (t *TransactionExecutor[Q]) ExecTx(ctx context.Context,
 				// to try once again.
 				_ = tx.Rollback()
 
-				waitBeforeRetry(i)
+				lastErr = dbErr
+				waitBeforeRetry(i, dbErr)
 				continue
 			}
 
@@ -287,7 +291,8 @@ func (t *TransactionExecutor[Q]) ExecTx(ctx context.Context,
 				// to try once again.
 				_ = tx.Rollback()
 
-				waitBeforeRetry(i)
+				lastErr = dbErr
+				waitBeforeRetry(i, dbErr)
 				continue
 			}
 
@@ -299,7 +304,14 @@ func (t *TransactionExecutor[Q]) ExecTx(ctx context.Context,
 
 	// If we get to this point, then we weren't able to successfully commit
 	// a tx given the max number of retries.
-	return ErrRetriesExceeded
+	log.Errorf("Transaction retries exceeded (num_retries=%v), last "+
+		"error: %v", t.opts.numRetries, lastErr)
+
+	if lastErr == nil {
+		return ErrRetriesExceeded
+	}
+
+	return fmt.Errorf("%w: %w", ErrRetriesExceeded, lastErr)
 }
 
 // Backend returns the type of the database backend used.

--- a/tapdb/interfaces.go
+++ b/tapdb/interfaces.go
@@ -246,20 +246,17 @@ func (t *TransactionExecutor[Q]) ExecTx(ctx context.Context,
 		time.Sleep(retryDelay)
 	}
 
-	for i := 0; i < t.opts.numRetries; i++ {
-		// Create the db transaction.
-		tx, err := t.BatchedQuerier.BeginTx(ctx, txOptions)
-		if err != nil {
-			dbErr := MapSQLError(err)
+	attempt := func() (done bool, err error) {
+		tx, beginErr := t.BatchedQuerier.BeginTx(ctx, txOptions)
+		if beginErr != nil {
+			dbErr := MapSQLError(beginErr)
 			if IsSerializationOrDeadlockError(dbErr) {
 				// Nothing to roll back here, since we didn't
 				// even get a transaction yet.
-				lastErr = dbErr
-				waitBeforeRetry(i, dbErr)
-				continue
+				return false, dbErr
 			}
 
-			return dbErr
+			return true, dbErr
 		}
 
 		// Rollback is safe to call even if the tx is already closed,
@@ -268,38 +265,36 @@ func (t *TransactionExecutor[Q]) ExecTx(ctx context.Context,
 			_ = tx.Rollback()
 		}()
 
-		if err := txBody(t.createQuery(tx)); err != nil {
-			dbErr := MapSQLError(err)
+		if bodyErr := txBody(t.createQuery(tx)); bodyErr != nil {
+			dbErr := MapSQLError(bodyErr)
 			if IsSerializationOrDeadlockError(dbErr) {
-				// Roll back the transaction, then pop back up
-				// to try once again.
-				_ = tx.Rollback()
-
-				lastErr = dbErr
-				waitBeforeRetry(i, dbErr)
-				continue
+				return false, dbErr
 			}
 
-			return dbErr
+			return true, dbErr
 		}
 
 		// Commit transaction.
-		if err = tx.Commit(); err != nil {
-			dbErr := MapSQLError(err)
+		if commitErr := tx.Commit(); commitErr != nil {
+			dbErr := MapSQLError(commitErr)
 			if IsSerializationOrDeadlockError(dbErr) {
-				// Roll back the transaction, then pop back up
-				// to try once again.
-				_ = tx.Rollback()
-
-				lastErr = dbErr
-				waitBeforeRetry(i, dbErr)
-				continue
+				return false, dbErr
 			}
 
-			return dbErr
+			return true, dbErr
 		}
 
-		return nil
+		return true, nil
+	}
+
+	for i := 0; i < t.opts.numRetries; i++ {
+		done, err := attempt()
+		if done {
+			return err
+		}
+
+		lastErr = err
+		waitBeforeRetry(i, err)
 	}
 
 	// If we get to this point, then we weren't able to successfully commit


### PR DESCRIPTION
- **Stop swallowing the underlying cause on tx retry exhaustion.** `ExecTx` previously returned only the opaque `ErrRetriesExceeded` sentinel and logged the underlying serialization/deadlock error at `Trace`, so operators running at default log level had no way to see the real cause. Per-retry logging is now at `Warn` (with the mapped SQL error), and on final exhaustion we `Errorf` and wrap the last underlying error into the returned error via multi-`%w`, so existing `errors.Is(err, ErrRetriesExceeded)` checks keep working while callers also see the root cause.

  This was surfaced by a user hitting `error funding channel: unable to fund vPacket: unable to derive script key: unable to insert script key: db tx retries exceeded` — with nothing actionable in the logs.

- **Scope the tx rollback `defer` per attempt, not per function.** The `defer tx.Rollback()` lived inside the for-loop body, so each retry pushed a new rollback onto `ExecTx`'s defer stack. With the default 10 retries that meant up to 10 stacked `Rollback` calls at function exit, all but one running against an already-closed tx (returning `sql.ErrTxDone`, silently ignored). Harmless today, but wasteful and a latent footgun. Each attempt is now an inner closure so the defer is scoped correctly and runs exactly once per attempt.