### PR TITLE
multi: make AddFederationServer idempotent on duplicate

### DIFF
--- a/itest/utils.go
+++ b/itest/utils.go
@@ -908,23 +908,7 @@ func SyncUniverses(ctx context.Context, t *testing.T, clientTapd,
 			},
 		},
 	)
-	if err != nil {
-		// Only fail the test for other errors than duplicate universe
-		// errors, as we might have already added the server in a
-		// previous run.
-		require.ErrorContains(
-			t, err, universe.ErrDuplicateUniverse.Error(),
-		)
-
-		// If we've already added the server in a previous run, we'll
-		// just need to kick off a sync (as that would otherwise be done
-		// by adding the server request already).
-		_, err := clientTapd.SyncUniverse(ctxt, &universerpc.SyncRequest{
-			UniverseHost: universeHost,
-			SyncMode:     options.syncMode,
-		})
-		require.NoError(t, err)
-	}
+	require.NoError(t, err)
 
 	require.Eventually(t, func() bool {
 		return AssertUniverseStateEqual(t, universeTapd, clientTapd)

--- a/tapdb/sqlc/queries/universe.sql
+++ b/tapdb/sqlc/queries/universe.sql
@@ -110,7 +110,7 @@ INSERT INTO universe_servers(
     server_host, last_sync_time
 ) VALUES (
     @server_host, @last_sync_time
-);
+) ON CONFLICT (server_host) DO NOTHING;
 
 -- name: DeleteUniverseServer :exec
 DELETE FROM universe_servers

--- a/tapdb/sqlc/universe.sql.go
+++ b/tapdb/sqlc/universe.sql.go
@@ -361,7 +361,7 @@ INSERT INTO universe_servers(
     server_host, last_sync_time
 ) VALUES (
     $1, $2
-)
+) ON CONFLICT (server_host) DO NOTHING
 `
 
 type InsertUniverseServerParams struct {

--- a/tapdb/universe_federation.go
+++ b/tapdb/universe_federation.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"database/sql"
-	"errors"
 	"fmt"
 	"sort"
 	"sync/atomic"
@@ -245,26 +244,21 @@ func (u *UniverseFederationDB) AddServers(ctx context.Context,
 	addrs ...universe.ServerAddr) error {
 
 	var writeTx UniverseFederationOptions
-	err := u.db.ExecTx(ctx, &writeTx, func(db UniverseServerStore) error {
-		return fn.ForEachErr(addrs, func(a universe.ServerAddr) error {
-			addr := NewUniverseServer{
-				ServerHost:   a.HostStr(),
-				LastSyncTime: time.Now(),
-			}
-			return db.InsertUniverseServer(ctx, addr)
-		})
-	})
-	if err != nil {
-		// Add context to unique constraint errors.
-		var uniqueConstraintErr *ErrSqlUniqueConstraintViolation
-		if errors.As(err, &uniqueConstraintErr) {
-			return universe.ErrDuplicateUniverse
-		}
-
-		return err
-	}
-
-	return nil
+	return u.db.ExecTx(
+		ctx, &writeTx, func(db UniverseServerStore) error {
+			return fn.ForEachErr(
+				addrs, func(a universe.ServerAddr) error {
+					addr := NewUniverseServer{
+						ServerHost:   a.HostStr(),
+						LastSyncTime: time.Now(),
+					}
+					return db.InsertUniverseServer(
+						ctx, addr,
+					)
+				},
+			)
+		},
+	)
 }
 
 // RemoveServers removes a set of servers from the federation.

--- a/tapdb/universe_federation_test.go
+++ b/tapdb/universe_federation_test.go
@@ -50,10 +50,10 @@ func TestUniverseFederationCRUD(t *testing.T) {
 	// Next, we'll try to add a new series of servers to the DB.
 	addrs := db.AddRandomServerAddrs(t, 10)
 
-	// If we try to insert them all again, then we should get an error as
-	// we ensure the host names are unique.
+	// Re-inserting the same servers should be idempotent (the
+	// underlying INSERT uses ON CONFLICT DO NOTHING).
 	err = fedDB.AddServers(ctx, addrs...)
-	require.ErrorIs(t, err, universe.ErrDuplicateUniverse)
+	require.NoError(t, err)
 
 	// Next, we should be able to fetch all the active hosts.
 	dbAddrs, err := fedDB.UniverseServers(ctx)

--- a/universe/federation.go
+++ b/universe/federation.go
@@ -2,7 +2,6 @@ package universe
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -159,11 +158,9 @@ func (f *FederationEnvoy) Start() error {
 		})
 
 		err := f.AddServer(serverAddrs...)
-		// On restart, we'll get an error for universe servers already
-		// inserted in our DB, since we can't store duplicates.
-		// We can safely ignore that error.
-		if err != nil && !errors.Is(err, ErrDuplicateUniverse) {
-			log.Warnf("Unable to add universe servers: %v", err)
+		if err != nil {
+			log.Warnf("Unable to add universe "+
+				"servers: %v", err)
 		}
 
 		f.Wg.Add(1)

--- a/universe/interface.go
+++ b/universe/interface.go
@@ -29,10 +29,6 @@ var (
 	// found in the DB.
 	ErrNoUniverseServers = fmt.Errorf("no active federation servers")
 
-	// ErrDuplicateUniverse is returned when the Universe server being added
-	// to the DB already exists.
-	ErrDuplicateUniverse = fmt.Errorf("universe server already added")
-
 	// ErrNoUniverseProofFound is returned when a user attempts to look up
 	// a key in the universe that actually points to the empty leaf.
 	ErrNoUniverseProofFound = fmt.Errorf("no universe proof found")


### PR DESCRIPTION
Resolves #2078. Opus's summary:

> Use ON CONFLICT (server_host) DO NOTHING in the InsertUniverseServer SQL query so that duplicate peers are silently skipped within the same atomic transaction. This preserves batch atomicity while making the RPC idempotent for already-registered peers.
> 
> Remove the now-dead ErrDuplicateUniverse sentinel and simplify the Start() loop to a single batch AddServer call.