### PR TITLE
authmailbox: cap subscriber queues and evict slow readers

### DIFF
--- a/authmailbox/server.go
+++ b/authmailbox/server.go
@@ -740,13 +740,13 @@ func (s *Server) RegisterSubscriber(receiver *fn.EventReceiver[[]*Message],
 // capacity is evicted to prevent unbounded memory growth.
 func (s *Server) publishMessage(msg *Message) {
 	s.msgEventsSubsMtx.Lock()
-	defer s.msgEventsSubsMtx.Unlock()
 
 	var slowSubs []uint64
 	for id, sub := range s.msgEventsSubs {
 		select {
 		case sub.NewItemCreated.ChanIn() <- []*Message{msg}:
 		case <-s.Done():
+			s.msgEventsSubsMtx.Unlock()
 			log.Errorf("Unable publish status event, " +
 				"server shutting down")
 			return
@@ -769,6 +769,34 @@ func (s *Server) publishMessage(msg *Message) {
 
 		sub.Stop()
 		delete(s.msgEventsSubs, id)
+	}
+
+	s.msgEventsSubsMtx.Unlock()
+
+	// Abort the owning streams outside the subscriber lock
+	// so that the handleStream defer (which calls
+	// disconnectClient → RemoveSubscriber) can acquire
+	// msgEventsSubsMtx without deadlocking.
+	if len(slowSubs) > 0 {
+		s.abortSlowStreams(slowSubs)
+	}
+}
+
+// abortSlowStreams finds and disconnects any connected streams
+// whose subscriber ID matches one of the evicted IDs. This
+// closes quitConn, which unblocks the handleStream select and
+// tears down the gRPC stream and its read goroutine.
+func (s *Server) abortSlowStreams(subIDs []uint64) {
+	s.connectedStreamsMtx.Lock()
+	defer s.connectedStreamsMtx.Unlock()
+
+	idSet := fn.NewSet(subIDs...)
+
+	for streamID, stream := range s.connectedStreams {
+		if idSet.Contains(stream.msgReceiver.ID()) {
+			stream.abort()
+			delete(s.connectedStreams, streamID)
+		}
 	}
 }
 

--- a/authmailbox/server.go
+++ b/authmailbox/server.go
@@ -47,6 +47,14 @@ const (
 	// maxRemoveMessageIDs is the maximum number of message IDs that can
 	// be removed in a single RemoveMessage RPC call.
 	maxRemoveMessageIDs = 1000
+
+	// maxSubscriberOverflow is the maximum number of items
+	// allowed to accumulate in a subscriber's overflow queue
+	// before the subscriber is evicted. This is a memory-
+	// safety bound, not a delivery guarantee: messages are
+	// persisted in MsgStore before being published, so an
+	// evicted subscriber recovers via replay on reconnect.
+	maxSubscriberOverflow = 64
 )
 
 // ServerConfig is the configuration struct for the mailbox server. It contains
@@ -726,21 +734,41 @@ func (s *Server) RegisterSubscriber(receiver *fn.EventReceiver[[]*Message],
 	return nil
 }
 
-// publishMessage publishes an event to all status event subscribers (which in
-// this case are all subscribed clients).
+// publishMessage publishes an event to all status event
+// subscribers (which in this case are all subscribed clients).
+// After publishing, any subscriber whose overflow queue is at
+// capacity is evicted to prevent unbounded memory growth.
 func (s *Server) publishMessage(msg *Message) {
-	// Lock the subscriber mutex to ensure that we don't modify the
-	// subscriber map while we're iterating over it.
 	s.msgEventsSubsMtx.Lock()
 	defer s.msgEventsSubsMtx.Unlock()
 
-	for _, sub := range s.msgEventsSubs {
+	var slowSubs []uint64
+	for id, sub := range s.msgEventsSubs {
 		select {
 		case sub.NewItemCreated.ChanIn() <- []*Message{msg}:
 		case <-s.Done():
-			log.Errorf("Unable publish status event, server " +
-				"shutting down")
+			log.Errorf("Unable publish status event, " +
+				"server shutting down")
+			return
 		}
+
+		if sub.NewItemCreated.OverflowLen() >=
+			maxSubscriberOverflow {
+
+			log.Warnf("Evicting slow subscriber %d: "+
+				"overflow queue at capacity", id)
+			slowSubs = append(slowSubs, id)
+		}
+	}
+
+	for _, id := range slowSubs {
+		sub, ok := s.msgEventsSubs[id]
+		if !ok {
+			continue
+		}
+
+		sub.Stop()
+		delete(s.msgEventsSubs, id)
 	}
 }
 

--- a/authmailbox/server.go
+++ b/authmailbox/server.go
@@ -536,7 +536,8 @@ func (s *Server) disconnectClient(stream *mailboxStream) error {
 
 	_, ok := s.connectedStreams[stream.streamID]
 	if !ok {
-		return fmt.Errorf("stream %d not found", stream.streamID)
+		// Already removed (e.g. by slow-subscriber eviction).
+		return nil
 	}
 
 	delete(s.connectedStreams, stream.streamID)

--- a/authmailbox/server.go
+++ b/authmailbox/server.go
@@ -743,12 +743,13 @@ func (s *Server) publishMessage(msg *Message) {
 	s.msgEventsSubsMtx.Lock()
 
 	var slowSubs []uint64
+	msgSlice := []*Message{msg}
 	for id, sub := range s.msgEventsSubs {
 		select {
-		case sub.NewItemCreated.ChanIn() <- []*Message{msg}:
+		case sub.NewItemCreated.ChanIn() <- msgSlice:
 		case <-s.Done():
 			s.msgEventsSubsMtx.Unlock()
-			log.Errorf("Unable publish status event, " +
+			log.Errorf("Unable to publish status event, " +
 				"server shutting down")
 			return
 		}

--- a/authmailbox/server_test.go
+++ b/authmailbox/server_test.go
@@ -3,11 +3,13 @@ package authmailbox
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/taproot-assets/fn"
 	"github.com/lightninglabs/taproot-assets/internal/test"
 	"github.com/lightninglabs/taproot-assets/proof"
 	mboxrpc "github.com/lightninglabs/taproot-assets/taprpc/authmailboxrpc"
@@ -398,4 +400,146 @@ func TestRemoveMessageChallengeConsistency(t *testing.T) {
 	h6 := RemoveMessageChallenge(receiverID, nil)
 	require.NotEqual(t, h1, h6)
 	require.NotEqual(t, h6, [32]byte{})
+}
+
+// registerTestStream constructs a mailboxStream wired the same
+// way as the live ReceiveMessages path: registered both as a
+// connected stream and as a message subscriber, with the
+// maxSubscriberOverflow cap applied.
+func registerTestStream(t *testing.T, srv *Server,
+	streamID uint64) *mailboxStream {
+
+	t.Helper()
+
+	stream, err := newMailboxStream(streamID, srv.Done())
+	require.NoError(t, err)
+
+	srv.connectedStreamsMtx.Lock()
+	srv.connectedStreams[streamID] = stream
+	srv.connectedStreamsMtx.Unlock()
+
+	err = srv.RegisterSubscriber(
+		stream.msgReceiver, false, MessageFilter{},
+	)
+	require.NoError(t, err)
+
+	return stream
+}
+
+// TestSlowSubscriberEviction verifies that publishMessage does
+// not stall when one subscriber fails to drain its queue. After
+// enough publishes to fill the stalled subscriber's overflow
+// cap, it must be evicted, its owning stream torn down, and a
+// healthy subscriber must continue receiving every message.
+func TestSlowSubscriberEviction(t *testing.T) {
+	t.Parallel()
+
+	srv := &Server{
+		msgEventsSubs: make(
+			map[uint64]*fn.EventReceiver[[]*Message],
+		),
+		connectedStreams: make(map[uint64]*mailboxStream),
+		cfg: &ServerConfig{
+			MsgStore: NewMockStore(),
+		},
+		ContextGuard: lfn.NewContextGuard(),
+	}
+	t.Cleanup(func() { _ = srv.Stop() })
+
+	healthy := registerTestStream(t, srv, 1)
+	stalled := registerTestStream(t, srv, 2)
+
+	// Drain the healthy subscriber as fast as the queue
+	// produces.
+	var healthyReceived atomic.Int64
+	drainerStarted := make(chan struct{})
+	drainerDone := make(chan struct{})
+	go func() {
+		close(drainerStarted)
+		for {
+			select {
+			case msgs := <-healthy.msgReceiver.
+				NewItemCreated.ChanOut():
+
+				healthyReceived.Add(
+					int64(len(msgs)),
+				)
+
+			case <-drainerDone:
+				return
+			}
+		}
+	}()
+	t.Cleanup(func() { close(drainerDone) })
+	<-drainerStarted
+
+	// Publish enough messages to overflow the stalled
+	// subscriber: chanOut buffer + cap + slack so we
+	// comfortably trip the >= maxSubscriberOverflow
+	// threshold.
+	totalPublishes := fn.DefaultQueueSize +
+		maxSubscriberOverflow + 5
+	receiverKey := test.RandPubKey(t)
+
+	publishDone := make(chan struct{})
+	go func() {
+		defer close(publishDone)
+		for i := 0; i < totalPublishes; i++ {
+			srv.publishMessage(&Message{
+				ReceiverKey:      *receiverKey,
+				EncryptedPayload: []byte("payload"),
+				ArrivalTimestamp: time.Now(),
+			})
+		}
+	}()
+
+	// The publish loop must complete promptly. If a slow
+	// subscriber could stall publishMessage, this is where
+	// the test would hang.
+	select {
+	case <-publishDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("publishMessage stalled on slow subscriber")
+	}
+
+	// The stalled subscriber must be evicted from the
+	// subscriber map.
+	require.Eventually(t, func() bool {
+		srv.msgEventsSubsMtx.Lock()
+		_, present := srv.msgEventsSubs[stalled.
+			msgReceiver.ID()]
+		srv.msgEventsSubsMtx.Unlock()
+		return !present
+	}, 2*time.Second, 10*time.Millisecond,
+		"stalled subscriber was not evicted")
+
+	// abortSlowStreams must remove the stalled stream from
+	// connectedStreams and close its quitConn.
+	srv.connectedStreamsMtx.Lock()
+	_, stillConnected := srv.connectedStreams[stalled.streamID]
+	srv.connectedStreamsMtx.Unlock()
+	require.False(t, stillConnected,
+		"stalled stream still in connectedStreams")
+
+	select {
+	case <-stalled.quitConn:
+	default:
+		t.Fatal("stalled stream quitConn was not closed")
+	}
+
+	// The healthy subscriber must still be registered and
+	// must have received every published message.
+	srv.msgEventsSubsMtx.Lock()
+	_, healthyPresent := srv.msgEventsSubs[healthy.
+		msgReceiver.ID()]
+	srv.msgEventsSubsMtx.Unlock()
+	require.True(t, healthyPresent,
+		"healthy subscriber was incorrectly evicted")
+
+	require.Eventually(t, func() bool {
+		return healthyReceived.Load() ==
+			int64(totalPublishes)
+	}, 2*time.Second, 10*time.Millisecond,
+		"healthy subscriber received %d / %d messages",
+		healthyReceived.Load(), totalPublishes)
 }

--- a/authmailbox/stream.go
+++ b/authmailbox/stream.go
@@ -79,6 +79,7 @@ func newMailboxStream(id uint64,
 		authSuccessChan: make(chan struct{}, 1),
 		msgReceiver: fn.NewEventReceiver[[]*Message](
 			fn.DefaultQueueSize,
+			fn.WithMaxOverflow(maxSubscriberOverflow),
 		),
 		callerQuit: callerQuit,
 		quitConn:   make(chan struct{}),

--- a/fn/events.go
+++ b/fn/events.go
@@ -42,12 +42,14 @@ func (e *EventReceiver[T]) Stop() {
 	e.ItemRemoved.Stop()
 }
 
-// NewEventReceiver creates a new event receiver with concurrent queues of the
-// given size.
-func NewEventReceiver[T any](queueSize int) *EventReceiver[T] {
-	created := NewConcurrentQueue[T](queueSize)
+// NewEventReceiver creates a new event receiver with concurrent
+// queues of the given size.
+func NewEventReceiver[T any](queueSize int,
+	opts ...QueueOption) *EventReceiver[T] {
+
+	created := NewConcurrentQueue[T](queueSize, opts...)
 	created.Start()
-	removed := NewConcurrentQueue[T](queueSize)
+	removed := NewConcurrentQueue[T](queueSize, opts...)
 	removed.Start()
 
 	id := atomic.AddUint64(&nextID, 1)

--- a/fn/queue.go
+++ b/fn/queue.go
@@ -3,13 +3,36 @@ package fn
 import (
 	"container/list"
 	"sync"
+	"sync/atomic"
 )
 
-// ConcurrentQueue is a typed concurrent-safe FIFO queue with unbounded
-// capacity. Clients interact with the queue by pushing items into the in
-// channel and popping items from the out channel. There is a goroutine that
-// manages moving items from the in channel to the out channel in the correct
-// order that must be started by calling Start().
+// QueueOption is a functional option for ConcurrentQueue.
+type QueueOption func(*queueConfig)
+
+type queueConfig struct {
+	maxOverflow int
+}
+
+// WithMaxOverflow sets the maximum number of items that can
+// accumulate in the overflow list. When the limit is reached,
+// the oldest item is dropped. A value of 0 (the default) means
+// no limit.
+func WithMaxOverflow(n int) QueueOption {
+	return func(c *queueConfig) {
+		c.maxOverflow = n
+	}
+}
+
+// ConcurrentQueue is a typed concurrent-safe FIFO queue with
+// unbounded capacity. Clients interact with the queue by pushing
+// items into the in channel and popping items from the out
+// channel. There is a goroutine that manages moving items from
+// the in channel to the out channel in the correct order that
+// must be started by calling Start().
+//
+// An optional overflow cap may be set via WithMaxOverflow. When
+// set, the overflow list will drop the oldest item once the cap
+// is reached.
 type ConcurrentQueue[T any] struct {
 	started sync.Once
 	stopped sync.Once
@@ -18,21 +41,39 @@ type ConcurrentQueue[T any] struct {
 	chanOut  chan T
 	overflow *list.List
 
+	maxOverflow int
+	overflowLen atomic.Int64
+
 	wg   sync.WaitGroup
 	quit chan struct{}
 }
 
-// NewConcurrentQueue constructs a ConcurrentQueue. The bufferSize parameter is
-// the capacity of the output channel. When the size of the queue is below this
-// threshold, pushes do not incur the overhead of the less efficient overflow
+// NewConcurrentQueue constructs a ConcurrentQueue. The
+// bufferSize parameter is the capacity of the output channel.
+// When the size of the queue is below this threshold, pushes do
+// not incur the overhead of the less efficient overflow
 // structure.
-func NewConcurrentQueue[T any](bufferSize int) *ConcurrentQueue[T] {
-	return &ConcurrentQueue[T]{
-		chanIn:   make(chan T),
-		chanOut:  make(chan T, bufferSize),
-		overflow: list.New(),
-		quit:     make(chan struct{}),
+func NewConcurrentQueue[T any](bufferSize int,
+	opts ...QueueOption) *ConcurrentQueue[T] {
+
+	var cfg queueConfig
+	for _, o := range opts {
+		o(&cfg)
 	}
+
+	return &ConcurrentQueue[T]{
+		chanIn:      make(chan T),
+		chanOut:     make(chan T, bufferSize),
+		overflow:    list.New(),
+		maxOverflow: cfg.maxOverflow,
+		quit:        make(chan struct{}),
+	}
+}
+
+// OverflowLen returns the current number of items in the
+// overflow list.
+func (cq *ConcurrentQueue[T]) OverflowLen() int64 {
+	return cq.overflowLen.Load()
 }
 
 // ChanIn returns a channel that can be used to push new items into the queue.
@@ -62,10 +103,10 @@ func (cq *ConcurrentQueue[T]) start() {
 		for {
 			nextElement := cq.overflow.Front()
 			if nextElement == nil {
-				// Overflow queue is empty so incoming items can
-				// be pushed directly to the output channel. If
-				// output channel is full though, push to
-				// overflow.
+				// Overflow queue is empty so incoming
+				// items can be pushed directly to the
+				// output channel. If output channel is
+				// full though, push to overflow.
 				select {
 				case item, ok := <-cq.chanIn:
 					if !ok {
@@ -73,38 +114,43 @@ func (cq *ConcurrentQueue[T]) start() {
 					}
 					select {
 					case cq.chanOut <- item:
-						// Optimistically push directly
-						// to chanOut.
 					default:
 						cq.overflow.PushBack(item)
+						cq.overflowLen.Add(1)
+						cq.trimOverflow()
 					}
 				case <-cq.quit:
 					return
 				}
 			} else {
-				// Overflow queue is not empty, so any new items
-				// get pushed to the back to preserve order.
+				// Overflow queue is not empty, so any
+				// new items get pushed to the back to
+				// preserve order.
 				select {
 				case item, ok := <-cq.chanIn:
 					if !ok {
 						break readLoop
 					}
 					cq.overflow.PushBack(item)
+					cq.overflowLen.Add(1)
+					cq.trimOverflow()
 				case cq.chanOut <- nextElement.Value.(T):
 					cq.overflow.Remove(nextElement)
+					cq.overflowLen.Add(-1)
 				case <-cq.quit:
 					return
 				}
 			}
 		}
 
-		// Incoming channel has been closed. Empty overflow queue into
-		// the outgoing channel.
+		// Incoming channel has been closed. Empty overflow
+		// queue into the outgoing channel.
 		nextElement := cq.overflow.Front()
 		for nextElement != nil {
 			select {
 			case cq.chanOut <- nextElement.Value.(T):
 				cq.overflow.Remove(nextElement)
+				cq.overflowLen.Add(-1)
 			case <-cq.quit:
 				return
 			}
@@ -114,6 +160,17 @@ func (cq *ConcurrentQueue[T]) start() {
 		// Close outgoing channel.
 		close(cq.chanOut)
 	}()
+}
+
+// trimOverflow drops the oldest element from the overflow list
+// if maxOverflow is set and the list exceeds the cap.
+func (cq *ConcurrentQueue[T]) trimOverflow() {
+	if cq.maxOverflow > 0 &&
+		cq.overflow.Len() > cq.maxOverflow {
+
+		cq.overflow.Remove(cq.overflow.Front())
+		cq.overflowLen.Add(-1)
+	}
 }
 
 // Stop ends the goroutine that moves items from the in channel to the out

--- a/fn/queue_test.go
+++ b/fn/queue_test.go
@@ -1,0 +1,125 @@
+package fn
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"pgregory.net/rapid"
+)
+
+// TestConcurrentQueueUnbounded verifies basic FIFO ordering with
+// no overflow cap.
+func TestConcurrentQueueUnbounded(t *testing.T) {
+	t.Parallel()
+
+	const n = 100
+
+	q := NewConcurrentQueue[int](10)
+	q.Start()
+
+	go func() {
+		for i := 0; i < n; i++ {
+			q.ChanIn() <- i
+		}
+		close(q.chanIn)
+	}()
+
+	var got []int
+	for v := range q.ChanOut() {
+		got = append(got, v)
+	}
+
+	require.Len(t, got, n)
+	for i := 0; i < n; i++ {
+		require.Equal(t, i, got[i])
+	}
+}
+
+// TestConcurrentQueueMaxOverflow verifies that WithMaxOverflow
+// caps the overflow list, dropping the oldest items when the
+// reader is stalled.
+func TestConcurrentQueueMaxOverflow(t *testing.T) {
+	t.Parallel()
+
+	const (
+		bufSize     = 1
+		maxOverflow = 5
+		total       = 20
+	)
+
+	q := NewConcurrentQueue[int](
+		bufSize, WithMaxOverflow(maxOverflow),
+	)
+	q.Start()
+
+	// Push all items while nobody is reading. The output
+	// channel (capacity 1) holds the first item directly;
+	// the rest spill into the overflow list, which trims
+	// to maxOverflow.
+	for i := 0; i < total; i++ {
+		q.ChanIn() <- i
+	}
+
+	close(q.chanIn)
+
+	var got []int
+	for v := range q.ChanOut() {
+		got = append(got, v)
+	}
+
+	// We receive the item in chanOut (the very first push)
+	// plus the maxOverflow survivors.
+	require.Len(t, got, bufSize+maxOverflow)
+
+	// The first item bypassed overflow entirely.
+	require.Equal(t, 0, got[0])
+
+	// The remaining items are the tail of the input
+	// sequence, in FIFO order.
+	for i := 1; i < len(got); i++ {
+		expected := total - maxOverflow + (i - 1)
+		require.Equal(t, expected, got[i])
+	}
+
+	// After drain, the overflow counter should be zero.
+	require.Equal(t, int64(0), q.OverflowLen())
+}
+
+// TestConcurrentQueueOverflowLenProperty uses property-based
+// testing to verify that OverflowLen never exceeds maxOverflow
+// after the goroutine settles, regardless of push count or
+// queue parameters.
+func TestConcurrentQueueOverflowLenProperty(t *testing.T) {
+	t.Parallel()
+
+	rapid.Check(t, func(t *rapid.T) {
+		bufSize := rapid.IntRange(1, 10).Draw(
+			t, "bufSize",
+		)
+		maxOverflow := rapid.IntRange(1, 50).Draw(
+			t, "maxOverflow",
+		)
+		numPushes := rapid.IntRange(
+			1, bufSize+maxOverflow*3,
+		).Draw(t, "numPushes")
+
+		q := NewConcurrentQueue[int](
+			bufSize, WithMaxOverflow(maxOverflow),
+		)
+		q.Start()
+
+		for i := 0; i < numPushes; i++ {
+			q.ChanIn() <- i
+
+			// Let the goroutine settle, then check
+			// the invariant.
+			require.Eventually(t, func() bool {
+				return q.OverflowLen() <=
+					int64(maxOverflow)
+			}, time.Second, time.Millisecond)
+		}
+
+		q.Stop()
+	})
+}


### PR DESCRIPTION
Adds an optional overflow cap to ConcurrentQueue so that subscriber queues in the authmailbox can be bounded. When a subscriber's queue is full, the oldest item is evicted and the owning stream is aborted, preventing a slow or stalled reader from blocking message delivery to all other subscribers.
