### PR TITLE
authmailbox: cap concurrent ReceiveMessages streams per peer

### DIFF
--- a/authmailbox/mock.go
+++ b/authmailbox/mock.go
@@ -244,11 +244,12 @@ func NewMockServerWithSigner(t *testing.T,
 	listenAddr := fmt.Sprintf(test.ListenAddrTemplate, nextPort)
 
 	serverCfg := &ServerConfig{
-		AuthTimeout:    testTimeout,
-		Signer:         signer,
-		HeaderVerifier: proof.MockHeaderVerifier,
-		MerkleVerifier: proof.DefaultMerkleVerifier,
-		MsgStore:       inMemMsgStore,
+		AuthTimeout:       testTimeout,
+		Signer:            signer,
+		HeaderVerifier:    proof.MockHeaderVerifier,
+		MerkleVerifier:    proof.DefaultMerkleVerifier,
+		MsgStore:          inMemMsgStore,
+		MaxStreamsPerPeer: 10,
 	}
 	h := &MockServer{
 		ListenAddr: listenAddr,

--- a/authmailbox/server.go
+++ b/authmailbox/server.go
@@ -7,6 +7,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
+	"net/netip"
 	"slices"
 	"sync"
 	"sync/atomic"
@@ -25,6 +27,7 @@ import (
 	lfn "github.com/lightningnetwork/lnd/fn/v2"
 	"golang.org/x/exp/maps"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/peer"
 )
 
 const (
@@ -91,6 +94,11 @@ type ServerConfig struct {
 	// CleanupCheckTimeout is the per-outpoint timeout when checking if
 	// an outpoint has been spent. Defaults to 30s if zero.
 	CleanupCheckTimeout time.Duration
+
+	// MaxStreamsPerPeer is the maximum number of concurrent
+	// ReceiveMessages streams from a single peer (by IP). A
+	// zero value means no limit.
+	MaxStreamsPerPeer uint
 }
 
 // Server is the mailbox server that handles incoming messages from clients and
@@ -119,6 +127,13 @@ type Server struct {
 	// msgEventsSubsMtx guards the general message events subscribers map.
 	msgEventsSubsMtx sync.Mutex
 
+	// peerStreamCount tracks the number of active streams per
+	// peer IP address.
+	peerStreamCount map[netip.Addr]uint
+
+	// peerStreamCountMtx guards peerStreamCount.
+	peerStreamCountMtx sync.Mutex
+
 	*lfn.ContextGuard
 }
 
@@ -129,6 +144,7 @@ func NewServer() *Server {
 			map[uint64]*fn.EventReceiver[[]*Message],
 		),
 		connectedStreams: make(map[uint64]*mailboxStream),
+		peerStreamCount:  make(map[netip.Addr]uint),
 		ContextGuard:     lfn.NewContextGuard(),
 	}
 }
@@ -338,6 +354,45 @@ func (s *Server) SendMessage(ctx context.Context,
 	}, nil
 }
 
+// peerAddr extracts the IP address (without port) from a gRPC
+// stream context. IPv4-mapped IPv6 addresses are collapsed via
+// Unmap so dual-stack clients share a single bucket. IPv6
+// addresses are truncated to a /64 prefix, since the lower 64
+// bits are host-controlled and trivially rotated. Returns the
+// zero Addr if the peer address is unavailable or not TCP.
+func peerAddr(ctx context.Context) netip.Addr {
+	p, ok := peer.FromContext(ctx)
+	if !ok || p.Addr == nil {
+		return netip.Addr{}
+	}
+
+	tcpAddr, ok := p.Addr.(*net.TCPAddr)
+	if !ok {
+		return netip.Addr{}
+	}
+
+	a, ok := netip.AddrFromSlice(tcpAddr.IP)
+	if !ok {
+		return netip.Addr{}
+	}
+
+	// Collapse IPv4-mapped IPv6 (::ffff:1.2.3.4 -> 1.2.3.4)
+	// so a dual-stack client doesn't get two budgets.
+	a = a.Unmap()
+
+	// The lower 64 bits of an IPv6 address are
+	// host-controlled and trivially rotated by an attacker
+	// with a routed /64. Bucket per /64.
+	if a.Is6() {
+		pfx, err := a.Prefix(64)
+		if err == nil {
+			return pfx.Addr()
+		}
+	}
+
+	return a
+}
+
 // ReceiveMessages initiates a bidirectional stream to receive messages for a
 // specific receiver. This stream implements the challenge-response handshake
 // required for receiver authentication before messages are delivered.
@@ -351,13 +406,40 @@ func (s *Server) SendMessage(ctx context.Context,
 //  5. Server -> Client: ReceiveMessagesResponse(eos = EndOfStream{}) or
 //     ReceiveMessagesResponse(error = ReceiveError{...})
 func (s *Server) ReceiveMessages(grpcStream serverStream) error {
+	ctx := grpcStream.Context()
+	peerIP := peerAddr(ctx)
+
+	if !peerIP.IsValid() {
+		log.DebugS(ctx, "Could not extract peer IP, "+
+			"skipping per-peer stream limit")
+	}
+
+	// Enforce per-peer stream limit.
+	if peerIP.IsValid() && s.cfg.MaxStreamsPerPeer > 0 {
+		s.peerStreamCountMtx.Lock()
+		if s.peerStreamCount[peerIP] >= s.cfg.MaxStreamsPerPeer {
+			s.peerStreamCountMtx.Unlock()
+
+			log.WarnS(ctx, "Max streams reached "+
+				"for peer", nil, "peer", peerIP)
+
+			return fmt.Errorf("max streams for peer %s "+
+				"reached", peerIP)
+		}
+		s.peerStreamCount[peerIP]++
+		s.peerStreamCountMtx.Unlock()
+
+		defer s.decrementPeerCount(peerIP)
+	}
+
 	id := s.nextStreamID.Add(1) - 1
 
-	ctxl := btclog.WithCtx(grpcStream.Context(), "sid", id, "server", true)
+	ctxl := btclog.WithCtx(ctx, "sid", id, "server", true)
 
 	stream, err := newMailboxStream(id, s.Done())
 	if err != nil {
-		return fmt.Errorf("error creating mailbox stream: %w", err)
+		return fmt.Errorf("error creating mailbox stream: %w",
+			err)
 	}
 
 	s.connectedStreamsMtx.Lock()
@@ -367,6 +449,23 @@ func (s *Server) ReceiveMessages(grpcStream serverStream) error {
 	log.DebugS(ctxl, "New ReceiveMessages stream created")
 
 	return s.handleStream(ctxl, grpcStream, stream)
+}
+
+// decrementPeerCount decreases the stream count for the given
+// peer IP. If the count reaches zero, the entry is removed.
+func (s *Server) decrementPeerCount(peerIP netip.Addr) {
+	if !peerIP.IsValid() {
+		return
+	}
+
+	s.peerStreamCountMtx.Lock()
+	defer s.peerStreamCountMtx.Unlock()
+
+	if s.peerStreamCount[peerIP] <= 1 {
+		delete(s.peerStreamCount, peerIP)
+	} else {
+		s.peerStreamCount[peerIP]--
+	}
 }
 
 // MailboxInfo returns basic server information.

--- a/authmailbox/server.go
+++ b/authmailbox/server.go
@@ -351,8 +351,7 @@ func (s *Server) SendMessage(ctx context.Context,
 //  5. Server -> Client: ReceiveMessagesResponse(eos = EndOfStream{}) or
 //     ReceiveMessagesResponse(error = ReceiveError{...})
 func (s *Server) ReceiveMessages(grpcStream serverStream) error {
-	id := s.nextStreamID.Load()
-	_ = s.nextStreamID.Add(1)
+	id := s.nextStreamID.Add(1) - 1
 
 	ctxl := btclog.WithCtx(grpcStream.Context(), "sid", id, "server", true)
 

--- a/authmailbox/server_test.go
+++ b/authmailbox/server_test.go
@@ -2,6 +2,9 @@ package authmailbox
 
 import (
 	"context"
+	"fmt"
+	"net"
+	"net/netip"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -14,7 +17,11 @@ import (
 	"github.com/lightninglabs/taproot-assets/proof"
 	mboxrpc "github.com/lightninglabs/taproot-assets/taprpc/authmailboxrpc"
 	lfn "github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/lightningnetwork/lnd/lntest/port"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/peer"
 )
 
 // TestCleanupSpentOutpoints verifies that cleanupSpentOutpoints deletes
@@ -542,4 +549,177 @@ func TestSlowSubscriberEviction(t *testing.T) {
 	}, 2*time.Second, 10*time.Millisecond,
 		"healthy subscriber received %d / %d messages",
 		healthyReceived.Load(), totalPublishes)
+}
+
+// TestPeerAddr verifies that peerAddr correctly extracts and
+// normalises IP addresses from gRPC peer context.
+func TestPeerAddr(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		addr net.Addr
+		want netip.Addr
+	}{
+		{
+			name: "IPv4 TCP",
+			addr: &net.TCPAddr{
+				IP:   net.ParseIP("192.168.1.1"),
+				Port: 1234,
+			},
+			want: netip.MustParseAddr("192.168.1.1"),
+		},
+		{
+			name: "IPv4-mapped IPv6 collapsed",
+			addr: &net.TCPAddr{
+				IP:   net.ParseIP("::ffff:10.0.0.1"),
+				Port: 1234,
+			},
+			want: netip.MustParseAddr("10.0.0.1"),
+		},
+		{
+			name: "IPv6 truncated to /64",
+			addr: &net.TCPAddr{
+				IP: net.ParseIP(
+					"2001:db8:abcd:0012:1:2:3:4",
+				),
+				Port: 1234,
+			},
+			want: netip.MustParseAddr("2001:db8:abcd:12::"),
+		},
+		{
+			name: "two IPv6 in same /64 share bucket",
+			addr: &net.TCPAddr{
+				IP: net.ParseIP(
+					"2001:db8:abcd:0012:ffff::1",
+				),
+				Port: 5678,
+			},
+			want: netip.MustParseAddr("2001:db8:abcd:12::"),
+		},
+		{
+			name: "nil addr returns zero",
+			addr: nil,
+			want: netip.Addr{},
+		},
+		{
+			name: "non-TCP addr returns zero",
+			addr: &net.UnixAddr{
+				Name: "/tmp/test.sock",
+				Net:  "unix",
+			},
+			want: netip.Addr{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+			if tc.addr != nil {
+				ctx = peer.NewContext(ctx, &peer.Peer{
+					Addr: tc.addr,
+				})
+			}
+
+			got := peerAddr(ctx)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// rawMboxClient creates a raw gRPC ReceiveMessages bidi stream
+// to the given server address. The caller controls what (if
+// anything) is sent on the stream.
+func rawMboxClient(t *testing.T,
+	addr string) mboxrpc.Mailbox_ReceiveMessagesClient {
+
+	t.Helper()
+
+	conn, err := grpc.NewClient(
+		addr,
+		grpc.WithTransportCredentials(
+			insecure.NewCredentials(),
+		),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { conn.Close() })
+
+	client := mboxrpc.NewMailboxClient(conn)
+	stream, err := client.ReceiveMessages(
+		context.Background(),
+	)
+	require.NoError(t, err)
+
+	return stream
+}
+
+// newTestServer spins up a gRPC server with the given per-peer
+// stream cap. Returns the listen address and a cleanup function.
+func newTestServer(t *testing.T,
+	maxPerPeer uint) string {
+
+	t.Helper()
+
+	signer := test.NewMockSigner()
+	signer.Signature = test.RandBytes(64)
+	store := NewMockStore()
+
+	serverCfg := &ServerConfig{
+		AuthTimeout:       testTimeout,
+		Signer:            signer,
+		HeaderVerifier:    proof.MockHeaderVerifier,
+		MerkleVerifier:    proof.DefaultMerkleVerifier,
+		MsgStore:          store,
+		MaxStreamsPerPeer: maxPerPeer,
+	}
+
+	listenAddr := fmt.Sprintf(
+		test.ListenAddrTemplate,
+		port.NextAvailablePort(),
+	)
+
+	grpcServer := grpc.NewServer(
+		grpc.Creds(insecure.NewCredentials()),
+	)
+	srv := NewServer()
+	require.NoError(t, srv.Start(serverCfg))
+	mboxrpc.RegisterMailboxServer(grpcServer, srv)
+
+	cleanup, err := test.StartMockGRPCServerWithAddr(
+		t, grpcServer, false, listenAddr,
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, srv.Stop())
+		grpcServer.GracefulStop()
+		cleanup()
+	})
+
+	return listenAddr
+}
+
+// TestPerPeerStreamCapReject verifies that a peer at the cap is
+// rejected on the next stream attempt.
+func TestPerPeerStreamCapReject(t *testing.T) {
+	t.Parallel()
+
+	const cap = 2
+
+	addr := newTestServer(t, cap)
+
+	// Open 'cap' streams — all should succeed.
+	streams := make(
+		[]mboxrpc.Mailbox_ReceiveMessagesClient, cap,
+	)
+	for i := range streams {
+		streams[i] = rawMboxClient(t, addr)
+	}
+
+	// The next stream should be rejected.
+	rejected := rawMboxClient(t, addr)
+	_, err := rejected.Recv()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "max streams")
 }

--- a/docs/release-notes/release-notes-0.8.0.md
+++ b/docs/release-notes/release-notes-0.8.0.md
@@ -389,6 +389,10 @@
   `universe.mbox-cleanup-check-timeout` to configure periodic cleanup of
   auth mailbox messages whose claimed outpoints have been spent on chain.
 
+- [PR#2096](https://github.com/lightninglabs/taproot-assets/pull/2096)
+  Add `universe.mbox-max-streams-per-peer` to cap concurrent auth
+  mailbox `ReceiveMessages` streams per peer IP.
+
 ## Breaking Changes
 
 - [PR#1935](https://github.com/lightninglabs/taproot-assets/pull/1935)

--- a/sample-tapd.conf
+++ b/sample-tapd.conf
@@ -388,6 +388,9 @@
 ; Valid time units are {s, m, h}.
 ; universe.mbox-cleanup-check-timeout=0s
 
+; Maximum concurrent mailbox streams from a single peer IP. 0 means unlimited.
+; universe.mbox-max-streams-per-peer=10
+
 ; The maximum number of entries in the supply ignore checker's negative lookup
 ; LRU cache.
 ; universe.supply-ignore-cache-size=10000

--- a/tapcfg/config.go
+++ b/tapcfg/config.go
@@ -151,6 +151,10 @@ const (
 	// messages.
 	defaultMboxCleanupInterval = 24 * time.Hour
 
+	// defaultMaxMboxStreamsPerPeer is the default maximum number
+	// of concurrent ReceiveMessages streams from a single peer.
+	defaultMaxMboxStreamsPerPeer = 10
+
 	// DefaultPsbtMaxFeeRatio is the default maximum for fees to total
 	// output amount ratio to use when funding PSBTs.
 	DefaultPsbtMaxFeeRatio = lndservices.DefaultPsbtMaxFeeRatio
@@ -359,6 +363,8 @@ type UniverseConfig struct {
 
 	MboxCleanupCheckTimeout time.Duration `long:"mbox-cleanup-check-timeout" description:"Per-outpoint timeout when checking if an outpoint has been spent on chain. Valid time units are {s, m, h}."`
 
+	MboxMaxStreamsPerPeer uint `long:"mbox-max-streams-per-peer" description:"Maximum concurrent mailbox streams from a single peer IP. 0 means unlimited."`
+
 	MultiverseCaches *tapdb.MultiverseCacheConfig `group:"multiverse-caches" namespace:"multiverse-caches"`
 
 	SupplyIgnoreCacheSize uint64 `long:"supply-ignore-cache-size" description:"The maximum number of entries in the supply ignore checker's negative lookup LRU cache."`
@@ -539,6 +545,7 @@ func DefaultConfig() Config {
 			),
 			MboxAuthTimeout:                 defaultMailboxAuthTimeout,
 			MboxCleanupInterval:             defaultMboxCleanupInterval,
+			MboxMaxStreamsPerPeer:           defaultMaxMboxStreamsPerPeer,
 			SupplyIgnoreCacheSize:           tapdb.DefaultNegativeLookupCacheSize,
 			DisableSupplyVerifierChainWatch: false,
 		},

--- a/tapcfg/server.go
+++ b/tapcfg/server.go
@@ -951,11 +951,12 @@ func mboxServerConfig(cfg *Config, lndServices *lndclient.LndServices,
 	store authmailbox.MsgStore) authmailbox.ServerConfig {
 
 	mboxCfg := authmailbox.ServerConfig{
-		AuthTimeout:    cfg.Universe.MboxAuthTimeout,
-		Signer:         lndServices.Signer,
-		HeaderVerifier: headerVerifier,
-		MerkleVerifier: proof.DefaultMerkleVerifier,
-		MsgStore:       store,
+		AuthTimeout:       cfg.Universe.MboxAuthTimeout,
+		Signer:            lndServices.Signer,
+		HeaderVerifier:    headerVerifier,
+		MerkleVerifier:    proof.DefaultMerkleVerifier,
+		MsgStore:          store,
+		MaxStreamsPerPeer: cfg.Universe.MboxMaxStreamsPerPeer,
 	}
 
 	// Only enable periodic cleanup if the interval is not explicitly set


### PR DESCRIPTION
Caps the number of concurrent ReceiveMessages streams a single peer can hold open. Streams are tracked per-IP and new connections beyond the limit are rejected immediately.

Configurable via `--universe.mbox-max-streams` and `--universe.mbox-max-streams-per-peer`.