### PR TITLE
universe: replace backend map with LRU cache

### DIFF
--- a/universe/archive.go
+++ b/universe/archive.go
@@ -5,11 +5,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sync"
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/davecgh/go-spew/spew"
+	"github.com/lightninglabs/neutrino/cache/lru"
 	"github.com/lightninglabs/taproot-assets/asset"
 	"github.com/lightninglabs/taproot-assets/fn"
 	"github.com/lightninglabs/taproot-assets/mssmt"
@@ -58,6 +58,24 @@ type ArchiveConfig struct {
 	// TODO(roasbeef): load all at once, or lazy load dynamic?
 }
 
+const (
+	// defaultMaxCachedUniverses is the maximum number of base
+	// universe backends cached simultaneously. This bounds memory
+	// usage against requests for arbitrary asset IDs.
+	defaultMaxCachedUniverses = 10_000
+)
+
+// cachedUniBackend wraps a StorageBackend so it can be stored in an
+// LRU cache that requires the cache.Value interface.
+type cachedUniBackend struct {
+	StorageBackend
+}
+
+// Size returns 1 so the LRU cache counts entries rather than bytes.
+func (c *cachedUniBackend) Size() (uint64, error) {
+	return 1, nil
+}
+
 // Archive is a persistence implementation of the universe interface. This is
 // used by minting sub-systems to upsert new universe issuance proofs each time
 // an asset is created. It can also be used to synchronize state amongst
@@ -68,21 +86,19 @@ type ArchiveConfig struct {
 type Archive struct {
 	cfg ArchiveConfig
 
-	// baseUniverses is a map of all the current known base universe
-	// instances for the archive.
-	baseUniverses map[Identifier]StorageBackend
-
-	sync.RWMutex
+	// baseUniverses is a bounded LRU cache of base universe
+	// backend instances, keyed by identifier.
+	baseUniverses *lru.Cache[IdentifierKey, *cachedUniBackend]
 }
 
 // NewArchive creates a new universe archive based on the passed config.
 func NewArchive(cfg ArchiveConfig) *Archive {
-	a := &Archive{
-		cfg:           cfg,
-		baseUniverses: make(map[Identifier]StorageBackend),
+	return &Archive{
+		cfg: cfg,
+		baseUniverses: lru.NewCache[
+			IdentifierKey, *cachedUniBackend,
+		](defaultMaxCachedUniverses),
 	}
-
-	return a
 }
 
 // Close closes the archive, stopping all goroutines and freeing all resources.
@@ -90,17 +106,21 @@ func (a *Archive) Close() error {
 	return nil
 }
 
-// fetchUniverse returns the base universe instance for the passed identifier.
-// The universe will be loaded in on demand if it has not been seen before.
+// fetchUniverse returns the base universe instance for the passed
+// identifier. The universe will be loaded on demand if it has not
+// been seen before. The LRU cache bounds the number of cached
+// backends.
 func (a *Archive) fetchUniverse(id Identifier) StorageBackend {
-	a.Lock()
-	defer a.Unlock()
+	idKey := id.Key()
 
-	baseUni, ok := a.baseUniverses[id]
-	if !ok {
-		baseUni = a.cfg.NewBaseTree(id)
-		a.baseUniverses[id] = baseUni
+	cached, err := a.baseUniverses.Get(idKey)
+	if err == nil {
+		return cached.StorageBackend
 	}
+
+	baseUni := a.cfg.NewBaseTree(id)
+	wrapped := &cachedUniBackend{StorageBackend: baseUni}
+	_, _ = a.baseUniverses.Put(idKey, wrapped)
 
 	return baseUni
 }
@@ -725,6 +745,17 @@ func (a *Archive) FetchLeaves(ctx context.Context,
 
 	log.Debugf("Retrieving all leaves for universe (id=%v)",
 		id.StringForLog())
+
+	// Verify the universe exists before allocating a cached
+	// backend for it. This prevents unbounded cache growth from
+	// requests with random asset IDs.
+	_, err := a.cfg.Multiverse.UniverseRootNode(ctx, id)
+	if errors.Is(err, ErrNoUniverseRoot) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
 
 	return withUni(
 		a, id, func(uni StorageBackend) ([]Leaf, error) {

--- a/universe/archive_test.go
+++ b/universe/archive_test.go
@@ -1,0 +1,208 @@
+package universe
+
+import (
+	"context"
+	"math/rand"
+	"testing"
+
+	"github.com/lightninglabs/taproot-assets/asset"
+	"github.com/lightninglabs/taproot-assets/fn"
+	"github.com/lightninglabs/taproot-assets/mssmt"
+	"github.com/lightninglabs/taproot-assets/proof"
+	"github.com/stretchr/testify/require"
+)
+
+// mockMultiverse implements MultiverseArchive, returning
+// ErrNoUniverseRoot for any unknown universe.
+type mockMultiverse struct {
+	knownRoots map[IdentifierKey]Root
+}
+
+func (m *mockMultiverse) UniverseRootNode(_ context.Context,
+	id Identifier) (Root, error) {
+
+	root, ok := m.knownRoots[id.Key()]
+	if !ok {
+		return Root{}, ErrNoUniverseRoot
+	}
+
+	return root, nil
+}
+
+func (m *mockMultiverse) RootNodes(context.Context,
+	RootNodesQuery) ([]Root, error) {
+
+	return nil, nil
+}
+
+func (m *mockMultiverse) UpsertProofLeaf(context.Context,
+	Identifier, LeafKey, *Leaf,
+	*proof.MetaReveal) (*Proof, error) {
+
+	return nil, nil
+}
+
+func (m *mockMultiverse) UpsertProofLeafBatch(context.Context,
+	[]*Item) error {
+
+	return nil
+}
+
+func (m *mockMultiverse) FetchProofLeaf(context.Context,
+	Identifier, LeafKey) ([]*Proof, error) {
+
+	return nil, nil
+}
+
+func (m *mockMultiverse) DeleteUniverse(context.Context,
+	Identifier) (string, error) {
+
+	return "", nil
+}
+
+func (m *mockMultiverse) DeleteProofLeaf(context.Context,
+	Identifier, LeafKey) (string, error) {
+
+	return "", nil
+}
+
+func (m *mockMultiverse) UniverseLeafKeys(context.Context,
+	UniverseLeafKeysQuery) ([]LeafKey, error) {
+
+	return nil, nil
+}
+
+func (m *mockMultiverse) FetchLeaves(context.Context,
+	[]MultiverseLeafDesc, ProofType) ([]MultiverseLeaf, error) {
+
+	return nil, nil
+}
+
+func (m *mockMultiverse) MultiverseRootNode(context.Context,
+	ProofType) (fn.Option[MultiverseRoot], error) {
+
+	return fn.None[MultiverseRoot](), nil
+}
+
+// mockStorageBackend implements StorageBackend as a no-op.
+type mockStorageBackend struct{}
+
+func (m *mockStorageBackend) RootNode(
+	context.Context) (mssmt.Node, string, error) {
+
+	return nil, "", nil
+}
+
+func (m *mockStorageBackend) UpsertProofLeaf(context.Context,
+	LeafKey, *Leaf, *proof.MetaReveal) (*Proof, error) {
+
+	return nil, nil
+}
+
+func (m *mockStorageBackend) FetchProof(context.Context,
+	LeafKey) ([]*Proof, error) {
+
+	return nil, nil
+}
+
+func (m *mockStorageBackend) FetchKeys(context.Context,
+	UniverseLeafKeysQuery) ([]LeafKey, error) {
+
+	return nil, nil
+}
+
+func (m *mockStorageBackend) FetchLeaves(
+	context.Context) ([]Leaf, error) {
+
+	return nil, nil
+}
+
+func (m *mockStorageBackend) DeleteUniverse(
+	context.Context) (string, error) {
+
+	return "", nil
+}
+
+func (m *mockStorageBackend) DeleteProofLeaf(context.Context,
+	LeafKey) (string, error) {
+
+	return "", nil
+}
+
+// newTestArchive creates an Archive with a mock multiverse and a
+// NewBaseTree that tracks how many times it's been called.
+func newTestArchive(
+	mv *mockMultiverse) (*Archive, *int) {
+
+	var newTreeCalls int
+	a := NewArchive(ArchiveConfig{
+		NewBaseTree: func(id Identifier) StorageBackend {
+			newTreeCalls++
+			return &mockStorageBackend{}
+		},
+		Multiverse: mv,
+	})
+
+	return a, &newTreeCalls
+}
+
+func randIdentifier() Identifier {
+	var id asset.ID
+	//nolint:gosec
+	_, _ = rand.Read(id[:])
+	return Identifier{
+		AssetID:   id,
+		ProofType: ProofTypeIssuance,
+	}
+}
+
+// TestFetchLeavesNonExistentUniverse verifies that FetchLeaves for
+// a nonexistent universe returns empty results and does not allocate
+// a cached backend.
+func TestFetchLeavesNonExistentUniverse(t *testing.T) {
+	t.Parallel()
+
+	mv := &mockMultiverse{
+		knownRoots: make(map[IdentifierKey]Root),
+	}
+	archive, newTreeCalls := newTestArchive(mv)
+
+	ctx := context.Background()
+
+	// Request leaves for many random (nonexistent) universes.
+	for i := 0; i < 100; i++ {
+		leaves, err := archive.FetchLeaves(ctx, randIdentifier())
+		require.NoError(t, err)
+		require.Nil(t, leaves)
+	}
+
+	// NewBaseTree should never have been called.
+	require.Equal(t, 0, *newTreeCalls)
+}
+
+// TestFetchLeavesExistingUniverse verifies that FetchLeaves for a
+// known universe does allocate a cached backend.
+func TestFetchLeavesExistingUniverse(t *testing.T) {
+	t.Parallel()
+
+	id := randIdentifier()
+	mv := &mockMultiverse{
+		knownRoots: map[IdentifierKey]Root{
+			id.Key(): {ID: id},
+		},
+	}
+	archive, newTreeCalls := newTestArchive(mv)
+
+	ctx := context.Background()
+
+	leaves, err := archive.FetchLeaves(ctx, id)
+	require.NoError(t, err)
+	require.Nil(t, leaves) // mock returns nil
+
+	require.Equal(t, 1, *newTreeCalls)
+
+	// Second call should hit the cache, not allocate again.
+	_, err = archive.FetchLeaves(ctx, id)
+	require.NoError(t, err)
+	require.Equal(t, 1, *newTreeCalls)
+}


### PR DESCRIPTION
Replaces the unbounded baseUniverses map with an LRU cache capped at 10,000 entries, and add a universe existence check in FetchLeaves before allocating a cached backend.
