### PR TITLE
rpcserver: add per-client universe rate limiting

### DIFF
--- a/docs/release-notes/release-notes-0.8.0.md
+++ b/docs/release-notes/release-notes-0.8.0.md
@@ -288,6 +288,10 @@
   publish `AssetReceiveErrorEvent` notifications, allowing clients to monitor
   and react to failures without requiring log parsing.
 
+- [PR#2099](https://github.com/lightninglabs/taproot-assets/pull/2099)
+  Universe RPC rate limiting is now applied per client IP instead
+  of globally, preventing a single client from starving others.
+
 - [PR#1775](https://github.com/lightninglabs/taproot-assets/pull/1775):
   Price oracle connections now verify TLS certificates by
   default, using the OS root CA list. New config options under

--- a/rpcserver/peerrlimiter.go
+++ b/rpcserver/peerrlimiter.go
@@ -1,0 +1,262 @@
+package rpcserver
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"sync"
+	"time"
+
+	"golang.org/x/time/rate"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/peer"
+)
+
+const (
+	// ClientIPMetadataKey is the gRPC metadata key used to
+	// propagate the original client IP from the REST gateway
+	// to the gRPC server. Exported so server.go can set it
+	// via grpc-gateway's WithMetadata option.
+	ClientIPMetadataKey = "x-real-ip"
+
+	// peerLimiterCleanupInterval is how often we scan for and
+	// remove stale per-peer rate limiter entries.
+	peerLimiterCleanupInterval = 5 * time.Minute
+
+	// peerLimiterStaleThreshold is how long a peer entry must
+	// be idle before it is eligible for removal.
+	peerLimiterStaleThreshold = 10 * time.Minute
+
+	// maxPeerLimiterEntries is the maximum number of per-IP
+	// entries. When the map is at capacity, the
+	// least-recently-seen entry is evicted to make room.
+	maxPeerLimiterEntries = 10_000
+
+	// globalLimiterMultiplier scales the per-IP rate to
+	// produce the global aggregate rate cap. High enough
+	// that normal multi-client traffic never hits it, low
+	// enough to bound pathological aggregate load.
+	globalLimiterMultiplier = 100
+)
+
+// peerLimiterEntry holds a rate limiter and the last time it was
+// accessed.
+type peerLimiterEntry struct {
+	limiter  *rate.Limiter
+	lastSeen time.Time
+}
+
+// PeerRateLimiter maintains a separate rate.Limiter per client IP
+// so that one client cannot starve others. A high-rate global
+// limiter caps pathological aggregate load.
+type PeerRateLimiter struct {
+	mu      sync.Mutex
+	entries map[string]*peerLimiterEntry
+
+	// global caps aggregate query rate across all clients.
+	// Set to globalLimiterMultiplier * per-IP rate so normal
+	// multi-client traffic is unaffected.
+	global *rate.Limiter
+
+	rateLimit rate.Limit
+	burst     int
+
+	quit chan struct{}
+	wg   sync.WaitGroup
+}
+
+// NewPeerRateLimiter creates a new per-peer rate limiter. Each
+// peer gets its own token bucket with the given rate and burst.
+// A global limiter at globalLimiterMultiplier * r caps aggregate
+// load as a circuit breaker.
+func NewPeerRateLimiter(r rate.Limit,
+	burst int) *PeerRateLimiter {
+
+	globalRate := rate.Limit(
+		float64(r) * globalLimiterMultiplier,
+	)
+	globalBurst := burst * globalLimiterMultiplier
+
+	prl := &PeerRateLimiter{
+		entries:   make(map[string]*peerLimiterEntry),
+		global:    rate.NewLimiter(globalRate, globalBurst),
+		rateLimit: r,
+		burst:     burst,
+		quit:      make(chan struct{}),
+	}
+
+	prl.wg.Add(1)
+	go prl.cleanupLoop()
+
+	return prl
+}
+
+// Wait blocks until the per-peer rate limiter for the caller
+// (identified by IP from gRPC peer context) allows the event,
+// then checks the global aggregate limiter. If the context has
+// no peer info, a shared "unknown" bucket is used.
+func (p *PeerRateLimiter) Wait(ctx context.Context) error {
+	ip := peerIP(ctx)
+	limiter := p.getLimiter(ip)
+
+	// Per-IP limit (fairness / isolation).
+	if err := limiter.Wait(ctx); err != nil {
+		return err
+	}
+
+	// Global limit (aggregate circuit breaker).
+	return p.global.Wait(ctx)
+}
+
+// Stop shuts down the background cleanup goroutine.
+func (p *PeerRateLimiter) Stop() {
+	close(p.quit)
+	p.wg.Wait()
+}
+
+// getLimiter returns the rate limiter for the given IP, creating
+// one if it doesn't exist yet. If the map is at capacity, the
+// least-recently-seen entry is evicted to make room.
+func (p *PeerRateLimiter) getLimiter(ip string) *rate.Limiter {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	entry, ok := p.entries[ip]
+	if ok {
+		entry.lastSeen = time.Now()
+		return entry.limiter
+	}
+
+	// Map at capacity — evict the least-recently-seen entry.
+	if len(p.entries) >= maxPeerLimiterEntries {
+		p.evictOldest()
+	}
+
+	entry = &peerLimiterEntry{
+		limiter:  rate.NewLimiter(p.rateLimit, p.burst),
+		lastSeen: time.Now(),
+	}
+	p.entries[ip] = entry
+
+	return entry.limiter
+}
+
+// evictOldest removes the entry with the oldest lastSeen time.
+// Must be called with p.mu held.
+func (p *PeerRateLimiter) evictOldest() {
+	var oldestIP string
+	var oldestTime time.Time
+
+	for ip, entry := range p.entries {
+		if oldestIP == "" ||
+			entry.lastSeen.Before(oldestTime) {
+
+			oldestIP = ip
+			oldestTime = entry.lastSeen
+		}
+	}
+
+	if oldestIP != "" {
+		delete(p.entries, oldestIP)
+	}
+}
+
+// cleanupLoop periodically removes stale entries from the map.
+func (p *PeerRateLimiter) cleanupLoop() {
+	defer p.wg.Done()
+
+	ticker := time.NewTicker(peerLimiterCleanupInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			p.cleanup()
+
+		case <-p.quit:
+			return
+		}
+	}
+}
+
+// cleanup removes entries that have not been seen recently.
+func (p *PeerRateLimiter) cleanup() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	threshold := time.Now().Add(-peerLimiterStaleThreshold)
+	for ip, entry := range p.entries {
+		if entry.lastSeen.Before(threshold) {
+			delete(p.entries, ip)
+		}
+	}
+}
+
+// peerIP extracts the client IP from the gRPC context. For
+// requests arriving via the REST gateway (loopback transport
+// peer), it uses the ClientIPMetadataKey set by the gateway.
+// For direct gRPC clients, it uses the transport peer and
+// ignores any metadata to prevent spoofing.
+func peerIP(ctx context.Context) string {
+	// Extract the transport peer first — we need it both
+	// as the primary key for direct clients and to decide
+	// whether to trust metadata.
+	var transportIP string
+	if p, ok := peer.FromContext(ctx); ok && p.Addr != nil {
+		transportIP = p.Addr.String()
+		if host, _, err := net.SplitHostPort(
+			transportIP,
+		); err == nil {
+			transportIP = host
+		}
+	}
+
+	// Only trust metadata when the transport peer is
+	// loopback, i.e. the request came through the local
+	// grpc-gateway. Direct gRPC clients could set this
+	// header to arbitrary values to rotate buckets.
+	if isLoopback(transportIP) {
+		if md, ok := metadata.FromIncomingContext(ctx); ok {
+			vals := md.Get(ClientIPMetadataKey)
+			if len(vals) > 0 {
+				ip := vals[0]
+				if host, _, err := net.SplitHostPort(
+					ip,
+				); err == nil {
+					ip = host
+				}
+				if ip != "" {
+					return ip
+				}
+			}
+		}
+	}
+
+	if transportIP != "" {
+		return transportIP
+	}
+
+	return "unknown"
+}
+
+// isLoopback reports whether ip is a loopback address.
+func isLoopback(ip string) bool {
+	parsed := net.ParseIP(ip)
+	return parsed != nil && parsed.IsLoopback()
+}
+
+// AnnotateClientIP is a grpc-gateway metadata annotator that
+// extracts the client IP from the HTTP request and attaches it
+// as gRPC metadata. This allows the per-IP rate limiter to
+// distinguish REST clients that would otherwise all appear as
+// localhost.
+func AnnotateClientIP(_ context.Context,
+	req *http.Request) metadata.MD {
+
+	ip := req.RemoteAddr
+	if host, _, err := net.SplitHostPort(ip); err == nil {
+		ip = host
+	}
+
+	return metadata.Pairs(ClientIPMetadataKey, ip)
+}

--- a/rpcserver/peerrlimiter_test.go
+++ b/rpcserver/peerrlimiter_test.go
@@ -1,0 +1,230 @@
+package rpcserver
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/time/rate"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/peer"
+)
+
+// mockAddr implements net.Addr for testing.
+type mockAddr struct {
+	addr string
+}
+
+func (m mockAddr) Network() string { return "tcp" }
+func (m mockAddr) String() string  { return m.addr }
+
+// peerCtx returns a context with gRPC peer info for the given
+// IP address.
+func peerCtx(ip string) context.Context {
+	return peer.NewContext(context.Background(), &peer.Peer{
+		Addr: mockAddr{addr: net.JoinHostPort(ip, "12345")},
+	})
+}
+
+// TestPeerRateLimiterIsolation verifies that different IPs get
+// independent buckets and that exhausting one does not affect
+// another.
+func TestPeerRateLimiterIsolation(t *testing.T) {
+	prl := NewPeerRateLimiter(rate.Limit(100), 10)
+	defer prl.Stop()
+
+	// Different IPs get different limiters.
+	lA := prl.getLimiter("10.0.0.1")
+	lB := prl.getLimiter("10.0.0.2")
+	require.True(t, lA != lB,
+		"different IPs should get different limiters")
+
+	// Same IP reuses the same limiter.
+	lA2 := prl.getLimiter("10.0.0.1")
+	require.True(t, lA == lA2,
+		"same IP should reuse its limiter")
+
+	// Exhaust A's burst budget.
+	for i := 0; i < 10; i++ {
+		require.True(t, lA.Allow())
+	}
+	require.False(t, lA.Allow(), "A should be exhausted")
+
+	// B is unaffected.
+	require.True(t, lB.Allow(), "B should be unaffected")
+}
+
+// TestPeerRateLimiterWaitIsolation verifies the end-to-end Wait
+// flow: peer A exhausting its budget does not block peer B.
+func TestPeerRateLimiterWaitIsolation(t *testing.T) {
+	// 1 QPS, burst 1 — very tight so we can observe blocking.
+	prl := NewPeerRateLimiter(rate.Limit(1), 1)
+	defer prl.Stop()
+
+	ctxA := peerCtx("10.0.0.1")
+	ctxB := peerCtx("10.0.0.2")
+
+	// Peer A consumes its burst token.
+	require.NoError(t, prl.Wait(ctxA))
+
+	// Peer B succeeds immediately — tight deadline proves it
+	// doesn't wait for A's token to replenish.
+	ctxBTight, cancelB := context.WithTimeout(
+		ctxB, 10*time.Millisecond,
+	)
+	defer cancelB()
+	require.NoError(t, prl.Wait(ctxBTight),
+		"peer B should not be blocked by peer A")
+
+	// Peer A is rate limited — its own burst is exhausted.
+	shortA, cancelA := context.WithTimeout(
+		ctxA, 5*time.Millisecond,
+	)
+	defer cancelA()
+	require.Error(t, prl.Wait(shortA),
+		"peer A should be rate limited")
+}
+
+// TestPeerRateLimiterMetadataLoopback verifies that the client
+// IP is extracted from gRPC metadata when the transport peer is
+// loopback (i.e. the request came through the REST gateway).
+func TestPeerRateLimiterMetadataLoopback(t *testing.T) {
+	prl := NewPeerRateLimiter(rate.Limit(100), 10)
+	defer prl.Stop()
+
+	// Simulate a REST request: transport peer is localhost,
+	// but metadata carries the real client IP.
+	ctx := peer.NewContext(context.Background(), &peer.Peer{
+		Addr: mockAddr{
+			addr: net.JoinHostPort("127.0.0.1", "9999"),
+		},
+	})
+	md := metadata.Pairs(ClientIPMetadataKey, "203.0.113.5")
+	ctx = metadata.NewIncomingContext(ctx, md)
+
+	require.NoError(t, prl.Wait(ctx))
+
+	// The limiter should be keyed on the metadata IP, not
+	// localhost.
+	prl.mu.Lock()
+	_, hasReal := prl.entries["203.0.113.5"]
+	_, hasLocal := prl.entries["127.0.0.1"]
+	prl.mu.Unlock()
+
+	require.True(t, hasReal,
+		"should be keyed on metadata IP")
+	require.False(t, hasLocal,
+		"should not be keyed on transport peer")
+}
+
+// TestPeerRateLimiterMetadataSpoofing verifies that a direct
+// gRPC client (non-loopback peer) cannot spoof the client IP
+// via metadata to rotate rate limit buckets.
+func TestPeerRateLimiterMetadataSpoofing(t *testing.T) {
+	prl := NewPeerRateLimiter(rate.Limit(100), 10)
+	defer prl.Stop()
+
+	// Direct gRPC client with a non-loopback peer sets
+	// metadata trying to spoof a different IP.
+	ctx := peer.NewContext(context.Background(), &peer.Peer{
+		Addr: mockAddr{
+			addr: net.JoinHostPort("198.51.100.7", "5555"),
+		},
+	})
+	md := metadata.Pairs(ClientIPMetadataKey, "10.0.0.99")
+	ctx = metadata.NewIncomingContext(ctx, md)
+
+	require.NoError(t, prl.Wait(ctx))
+
+	// Should be keyed on the real transport peer, not the
+	// spoofed metadata value.
+	prl.mu.Lock()
+	_, hasReal := prl.entries["198.51.100.7"]
+	_, hasSpoofed := prl.entries["10.0.0.99"]
+	prl.mu.Unlock()
+
+	require.True(t, hasReal,
+		"should be keyed on transport peer")
+	require.False(t, hasSpoofed,
+		"spoofed metadata should be ignored")
+}
+
+// TestPeerRateLimiterNoPeer verifies that requests with no
+// peer info fall back to a shared "unknown" bucket.
+func TestPeerRateLimiterNoPeer(t *testing.T) {
+	prl := NewPeerRateLimiter(rate.Limit(1), 1)
+	defer prl.Stop()
+
+	// No peer context — should use "unknown" key.
+	require.NoError(t, prl.Wait(context.Background()))
+}
+
+// TestPeerRateLimiterCleanup verifies that stale entries are
+// removed.
+func TestPeerRateLimiterCleanup(t *testing.T) {
+	prl := NewPeerRateLimiter(rate.Limit(100), 10)
+	defer prl.Stop()
+
+	ctx := peerCtx("10.0.0.99")
+	require.NoError(t, prl.Wait(ctx))
+
+	// Manually backdate the entry so it appears stale.
+	prl.mu.Lock()
+	entry := prl.entries["10.0.0.99"]
+	entry.lastSeen = time.Now().Add(
+		-peerLimiterStaleThreshold - time.Second,
+	)
+	prl.mu.Unlock()
+
+	prl.cleanup()
+
+	prl.mu.Lock()
+	_, exists := prl.entries["10.0.0.99"]
+	prl.mu.Unlock()
+
+	require.False(t, exists, "stale entry should be removed")
+}
+
+// TestPeerRateLimiterEviction verifies that when the per-IP map
+// is at capacity, the least-recently-seen entry is evicted to
+// make room for the new IP.
+func TestPeerRateLimiterEviction(t *testing.T) {
+	prl := NewPeerRateLimiter(rate.Limit(100), 10)
+	defer prl.Stop()
+
+	// Fill the map to capacity. The first IP inserted will
+	// have the oldest lastSeen.
+	for i := 0; i < maxPeerLimiterEntries; i++ {
+		ip := fmt.Sprintf("10.%d.%d.%d",
+			(i>>16)&0xff, (i>>8)&0xff, i&0xff)
+		prl.getLimiter(ip)
+	}
+
+	prl.mu.Lock()
+	require.Equal(t, maxPeerLimiterEntries, len(prl.entries))
+
+	// The first IP (oldest) should still be present.
+	_, hasOldest := prl.entries["10.0.0.0"]
+	require.True(t, hasOldest)
+	prl.mu.Unlock()
+
+	// Insert a new IP — should evict the oldest and keep
+	// the map at capacity.
+	l := prl.getLimiter("192.168.0.1")
+	require.NotNil(t, l)
+
+	prl.mu.Lock()
+	require.Equal(t, maxPeerLimiterEntries, len(prl.entries),
+		"map should not have grown")
+
+	_, hasNew := prl.entries["192.168.0.1"]
+	require.True(t, hasNew, "new IP should be present")
+
+	_, hasOldest = prl.entries["10.0.0.0"]
+	require.False(t, hasOldest,
+		"oldest entry should have been evicted")
+	prl.mu.Unlock()
+}

--- a/rpcserver/rpcserver.go
+++ b/rpcserver/rpcserver.go
@@ -78,7 +78,6 @@ import (
 	"github.com/lightningnetwork/lnd/tlv"
 	"github.com/lightningnetwork/lnd/zpay32"
 	"golang.org/x/exp/maps"
-	"golang.org/x/time/rate"
 	"google.golang.org/grpc"
 )
 
@@ -205,7 +204,7 @@ type RPCServer struct {
 
 	cfg *tapconfig.Config
 
-	proofQueryRateLimiter *rate.Limiter
+	proofQueryRateLimiter *PeerRateLimiter
 
 	quit chan struct{}
 	wg   sync.WaitGroup
@@ -232,8 +231,9 @@ func (r *RPCServer) Start(cfg *tapconfig.Config) error {
 
 	r.interceptor = cfg.SignalInterceptor
 	r.cfg = cfg
-	r.proofQueryRateLimiter = rate.NewLimiter(
-		r.cfg.UniverseQueriesPerSecond, r.cfg.UniverseQueriesBurst,
+	r.proofQueryRateLimiter = NewPeerRateLimiter(
+		r.cfg.UniverseQueriesPerSecond,
+		r.cfg.UniverseQueriesBurst,
 	)
 
 	rpcsLog.Infof("Starting Taproot Assets RPC Server")
@@ -249,6 +249,10 @@ func (r *RPCServer) Stop() error {
 	}
 
 	rpcsLog.Infof("Stopping Taproot Assets RPC Server")
+
+	if r.proofQueryRateLimiter != nil {
+		r.proofQueryRateLimiter.Stop()
+	}
 
 	close(r.quit)
 

--- a/server.go
+++ b/server.go
@@ -705,6 +705,11 @@ func startRestProxy(cfg *tapconfig.Config, rpcServer *rpcserver.RPCServer,
 		// reason for not specifying the correct method in the first
 		// place.
 		proxy.WithDisablePathLengthFallback(),
+
+		// Propagate the original client IP to gRPC metadata
+		// so the per-IP rate limiter can distinguish REST
+		// clients (which otherwise all appear as localhost).
+		proxy.WithMetadata(rpcserver.AnnotateClientIP),
 	)
 
 	// Register our services with the REST proxy.

--- a/tapcfg/config.go
+++ b/tapcfg/config.go
@@ -349,9 +349,9 @@ type UniverseConfig struct {
 
 	StatsCacheDuration time.Duration `long:"stats-cache-duration" description:"The amount of time to cache stats for before refreshing them. Valid time units are {s, m, h}."`
 
-	UniverseQueriesPerSecond rate.Limit `long:"max-qps" description:"The maximum number of queries per second across the set of active universe queries that is permitted. Anything above this starts to get rate limited."`
+	UniverseQueriesPerSecond rate.Limit `long:"max-qps" description:"The maximum number of universe queries per second permitted per client IP. Anything above this starts to get rate limited."`
 
-	UniverseQueriesBurst int `long:"req-burst-budget" description:"The burst budget for the universe query rate limiting."`
+	UniverseQueriesBurst int `long:"req-burst-budget" description:"The per-client burst budget for universe query rate limiting."`
 
 	MboxAuthTimeout time.Duration `long:"mbox-auth-timeout" description:"The timeout for mailbox message retrieval client authentication. Valid time units are {s, m, h}."`
 

--- a/tapconfig/config.go
+++ b/tapconfig/config.go
@@ -263,13 +263,13 @@ type Config struct {
 	// behaviour.
 	UniversePublicAccess UniversePublicAccessStatus
 
-	// UniverseQueriesPerSecond is the maximum number of queries per
-	// second across the set of active universe queries that is permitted.
-	// Anything above this starts to get rate limited.
+	// UniverseQueriesPerSecond is the maximum number of universe
+	// queries per second permitted per client IP. Anything above
+	// this starts to get rate limited.
 	UniverseQueriesPerSecond rate.Limit
 
-	// UniverseQueriesBurst is the burst budget for the universe query rate
-	// limiting.
+	// UniverseQueriesBurst is the per-client burst budget for
+	// universe query rate limiting.
 	UniverseQueriesBurst int
 
 	Prometheus monitoring.PrometheusConfig


### PR DESCRIPTION
Replace the single global rate.Limiter for universe RPCs with a per-client rate limiter keyed by IP address. Each client IP gets its own token bucket with the configured rate and burst. When the per-IP map reaches its 10k entry cap, the least-recently-seen entry is evicted (LRU) so that active legitimate clients always get their own bucket. A background goroutine also evicts idle entries every 5 minutes.

A high-rate global limiter (100x per-IP rate) acts as a circuit breaker against pathological aggregate load without interfering with normal multi-client traffic.