### PR TITLE
itest: wait for HTLC settlement in oracle_pricing test

### DIFF
--- a/itest/custom_channels/oracle_pricing_test.go
+++ b/itest/custom_channels/oracle_pricing_test.go
@@ -201,6 +201,14 @@ func testCustomChannelsOraclePricing(_ context.Context,
 	numUnits, rate := payInvoiceWithAssets(
 		t.t, charlie, dave, invoiceResp.PaymentRequest, assetID,
 	)
+
+	// Wait for the HTLC to fully settle on both asset channels
+	// in the multi-hop path before asserting balances. Without
+	// this, the commitment round-trip may not have completed on
+	// all nodes yet.
+	waitForAssetChannelHtlcSettlement(t.t, charlie, chanPointCD)
+	waitForAssetChannelHtlcSettlement(t.t, fabia, chanPointEF)
+
 	logBalance(t.t, nodes, assetID, "after invoice")
 
 	// The calculated amount Charlie has to pay should come out as


### PR DESCRIPTION
Resolves #2101.

This employs the same fix as was used in #2071 (self_payment): wait for the commitment round-trip to complete on the receiver before asserting channel balances. Fixes a flake where Fabia's localSat reads as 0 instead of the expected assetHtlcCarryAmount (354) because the HTLC hasn't settled on her end yet.