### PR TITLE
proof: add caching header verifier w/parallel prefetch

### DIFF
--- a/docs/release-notes/release-notes-0.8.0.md
+++ b/docs/release-notes/release-notes-0.8.0.md
@@ -369,6 +369,13 @@
 
 ## Performance Improvements
 
+* [PR#2104](https://github.com/lightninglabs/taproot-assets/pull/2104)
+  Dramatically improves block header verification performance during
+  proof receipt. Header verification RPCs are now deduplicated
+  and executed in parallel, replacing the previous sequential per-proof
+  approach. Benchmarks show a ~7x speedup for files with many unique
+  headers.
+
 ## Deprecations
 
 # Technical and Architectural Updates

--- a/proof/header_cache_test.go
+++ b/proof/header_cache_test.go
@@ -1,0 +1,373 @@
+package proof
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/wire"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+)
+
+// TestCachingHeaderVerifier tests deduplication and error non-caching
+// of the cachingHeaderVerifier.
+func TestCachingHeaderVerifier(t *testing.T) {
+	t.Parallel()
+
+	t.Run("dedup", func(t *testing.T) {
+		t.Parallel()
+
+		var calls atomic.Int64
+		inner := func(_ wire.BlockHeader,
+			_ uint32) error {
+
+			calls.Add(1)
+			return nil
+		}
+
+		cv := newCachingHeaderVerifier(inner)
+		header := wire.BlockHeader{Nonce: 42}
+
+		// Call three times with the same header+height.
+		for i := 0; i < 3; i++ {
+			err := cv.verify(header, 100)
+			require.NoError(t, err)
+		}
+
+		require.Equal(t, int64(1), calls.Load())
+	})
+
+	t.Run("distinct_keys", func(t *testing.T) {
+		t.Parallel()
+
+		var calls atomic.Int64
+		inner := func(_ wire.BlockHeader,
+			_ uint32) error {
+
+			calls.Add(1)
+			return nil
+		}
+
+		cv := newCachingHeaderVerifier(inner)
+
+		// Different heights should each trigger a call.
+		for i := uint32(0); i < 5; i++ {
+			h := wire.BlockHeader{Nonce: i}
+			err := cv.verify(h, i)
+			require.NoError(t, err)
+		}
+
+		require.Equal(t, int64(5), calls.Load())
+	})
+
+	t.Run("error_not_cached", func(t *testing.T) {
+		t.Parallel()
+
+		var calls atomic.Int64
+		errBad := fmt.Errorf("bad block")
+		inner := func(_ wire.BlockHeader,
+			_ uint32) error {
+
+			calls.Add(1)
+			return errBad
+		}
+
+		cv := newCachingHeaderVerifier(inner)
+		header := wire.BlockHeader{Nonce: 1}
+
+		err := cv.verify(header, 200)
+		require.ErrorIs(t, err, errBad)
+
+		// Errors are not cached — each call retries
+		// the inner verifier.
+		err = cv.verify(header, 200)
+		require.ErrorIs(t, err, errBad)
+
+		require.Equal(t, int64(2), calls.Load())
+	})
+}
+
+// TestPrefetchHeaders verifies that prefetchHeaders deduplicates
+// headers and populates the cache.
+func TestPrefetchHeaders(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int64
+	inner := func(_ wire.BlockHeader, _ uint32) error {
+		calls.Add(1)
+		return nil
+	}
+
+	cv := newCachingHeaderVerifier(inner)
+
+	// Create proofs with some duplicate block heights/hashes.
+	proofs := make([]*Proof, 10)
+	for i := range proofs {
+		// Heights 0-4 repeated twice.
+		proofs[i] = &Proof{
+			BlockHeight: uint32(i % 5),
+			BlockHeader: wire.BlockHeader{
+				Nonce: uint32(i % 5),
+			},
+		}
+	}
+
+	err := prefetchHeaders(
+		context.Background(), proofs, cv,
+	)
+	require.NoError(t, err)
+
+	// Only 5 unique headers, so only 5 calls.
+	require.Equal(t, int64(5), calls.Load())
+
+	// Subsequent verify calls should hit the cache.
+	for _, p := range proofs {
+		err := cv.verify(p.BlockHeader, p.BlockHeight)
+		require.NoError(t, err)
+	}
+
+	// No additional calls.
+	require.Equal(t, int64(5), calls.Load())
+}
+
+// BenchmarkHeaderPrefetch compares sequential header verification
+// against the cached parallel prefetch approach with simulated RPC
+// latency.
+func BenchmarkHeaderPrefetch(b *testing.B) {
+	const (
+		numHeaders = 200
+		rpcLatency = 5 * time.Millisecond
+	)
+
+	slowVerifier := func(_ wire.BlockHeader,
+		_ uint32) error {
+
+		time.Sleep(rpcLatency)
+		return nil
+	}
+
+	// Build N unique (header, height) pairs.
+	proofs := make([]*Proof, numHeaders)
+	for i := range proofs {
+		proofs[i] = &Proof{
+			BlockHeight: uint32(i + 1),
+			BlockHeader: wire.BlockHeader{
+				Nonce: uint32(i),
+			},
+		}
+	}
+
+	b.Run("sequential", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			for _, p := range proofs {
+				_ = slowVerifier(
+					p.BlockHeader, p.BlockHeight,
+				)
+			}
+		}
+	})
+
+	b.Run("cached_parallel", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			cv := newCachingHeaderVerifier(slowVerifier)
+			err := prefetchHeaders(
+				context.Background(), proofs, cv,
+			)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	// Sub-benchmark with duplicate headers to show dedup
+	// benefit.
+	dupeProofs := make([]*Proof, numHeaders)
+	for i := range dupeProofs {
+		// Only 20 unique blocks, rest are duplicates.
+		idx := i % 20
+		dupeProofs[i] = &Proof{
+			BlockHeight: uint32(idx + 1),
+			BlockHeader: wire.BlockHeader{
+				Nonce: uint32(idx),
+			},
+		}
+	}
+
+	b.Run("cached_parallel_dedup", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			cv := newCachingHeaderVerifier(slowVerifier)
+			err := prefetchHeaders(
+				context.Background(), dupeProofs, cv,
+			)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
+// BenchmarkPrefetchWorkerCount compares prefetch throughput at
+// different worker pool sizes to inform the headerPrefetchWorkers
+// default.
+func BenchmarkPrefetchWorkerCount(b *testing.B) {
+	const (
+		numHeaders = 200
+		rpcLatency = 5 * time.Millisecond
+	)
+
+	slowVerifier := func(_ wire.BlockHeader,
+		_ uint32) error {
+
+		time.Sleep(rpcLatency)
+		return nil
+	}
+
+	proofs := make([]*Proof, numHeaders)
+	for i := range proofs {
+		proofs[i] = &Proof{
+			BlockHeight: uint32(i + 1),
+			BlockHeader: wire.BlockHeader{
+				Nonce: uint32(i),
+			},
+		}
+	}
+
+	for _, workers := range []int{4, 8, 16} {
+		b.Run(fmt.Sprintf("workers_%d", workers), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				cv := newCachingHeaderVerifier(slowVerifier)
+				err := prefetchWithLimit(
+					context.Background(), proofs,
+					cv, workers,
+				)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// prefetchWithLimit is a test helper that mirrors prefetchHeaders
+// but accepts a configurable worker limit.
+func prefetchWithLimit(ctx context.Context, proofs []*Proof,
+	hv *cachingHeaderVerifier, workers int) error {
+
+	type headerInfo struct {
+		header wire.BlockHeader
+		height uint32
+	}
+
+	seen := make(map[headerCacheKey]struct{})
+	var unique []headerInfo
+
+	for _, p := range proofs {
+		key := headerCacheKey{
+			height: p.BlockHeight,
+			hash:   p.BlockHeader.BlockHash(),
+		}
+		if _, ok := seen[key]; !ok {
+			seen[key] = struct{}{}
+			unique = append(unique, headerInfo{
+				header: p.BlockHeader,
+				height: p.BlockHeight,
+			})
+		}
+	}
+
+	g, gCtx := errgroup.WithContext(ctx)
+	g.SetLimit(workers)
+
+	for _, h := range unique {
+		if err := gCtx.Err(); err != nil {
+			break
+		}
+
+		g.Go(func() error {
+			select {
+			case <-gCtx.Done():
+				return gCtx.Err()
+			default:
+			}
+
+			return hv.verify(h.header, h.height)
+		})
+	}
+
+	return g.Wait()
+}
+
+// TestPrefetchHeadersError verifies that a header verification
+// failure during prefetch propagates correctly.
+func TestPrefetchHeadersError(t *testing.T) {
+	t.Parallel()
+
+	errBad := fmt.Errorf("block not found")
+
+	var calls atomic.Int64
+	inner := func(_ wire.BlockHeader, h uint32) error {
+		calls.Add(1)
+		if h == 3 {
+			return errBad
+		}
+		return nil
+	}
+
+	cv := newCachingHeaderVerifier(inner)
+	proofs := make([]*Proof, 5)
+	for i := range proofs {
+		proofs[i] = &Proof{
+			BlockHeight: uint32(i + 1),
+			BlockHeader: wire.BlockHeader{Nonce: uint32(i)},
+		}
+	}
+
+	err := prefetchHeaders(
+		context.Background(), proofs, cv,
+	)
+	require.Error(t, err)
+	require.ErrorIs(t, err, errBad)
+}
+
+// TestPrefetchSkipsLastProof verifies that the prefetch set
+// excludes the last proof when skipChainForFinalProof is set,
+// matching the File.Verify behavior for pre-broadcast
+// verification.
+func TestPrefetchSkipsLastProof(t *testing.T) {
+	t.Parallel()
+
+	verified := make(map[uint32]bool)
+	var mu sync.Mutex
+	inner := func(_ wire.BlockHeader, h uint32) error {
+		mu.Lock()
+		verified[h] = true
+		mu.Unlock()
+		return nil
+	}
+
+	proofs := make([]*Proof, 5)
+	for i := range proofs {
+		proofs[i] = &Proof{
+			BlockHeight: uint32(i + 1),
+			BlockHeader: wire.BlockHeader{Nonce: uint32(i)},
+		}
+	}
+
+	// Prefetch only the first 4 (simulating
+	// skipChainForFinalProof exclusion).
+	cv := newCachingHeaderVerifier(inner)
+	err := prefetchHeaders(
+		context.Background(), proofs[:4], cv,
+	)
+	require.NoError(t, err)
+
+	// Heights 1-4 should be verified, 5 should not.
+	for h := uint32(1); h <= 4; h++ {
+		require.True(t, verified[h])
+	}
+	require.False(t, verified[5])
+}

--- a/proof/verifier.go
+++ b/proof/verifier.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/taproot-assets/asset"
@@ -827,6 +828,69 @@ func (p *Proof) verifyGroupKeyReveal() error {
 // block header is invalid (usually: not present on chain).
 type HeaderVerifier func(blockHeader wire.BlockHeader, blockHeight uint32) error
 
+// headerPrefetchWorkers is the maximum number of concurrent goroutines
+// used to pre-fetch block headers during proof file verification. This
+// is a backend-capacity knob (RPC concurrency), not a CPU knob.
+const headerPrefetchWorkers = 8
+
+// headerCacheKey uniquely identifies a block for header verification
+// caching purposes.
+type headerCacheKey struct {
+	height uint32
+	hash   chainhash.Hash
+}
+
+// cachingHeaderVerifier wraps a HeaderVerifier with a concurrency-safe
+// cache keyed on (height, blockHash). The first call for each unique
+// key delegates to the inner verifier; subsequent calls return the
+// cached result. This deduplicates RPC calls when multiple proofs
+// reference the same block.
+type cachingHeaderVerifier struct {
+	inner HeaderVerifier
+	mu    sync.Mutex
+	cache map[headerCacheKey]error
+}
+
+// newCachingHeaderVerifier returns a cachingHeaderVerifier that wraps
+// the given HeaderVerifier.
+func newCachingHeaderVerifier(
+	inner HeaderVerifier) *cachingHeaderVerifier {
+
+	return &cachingHeaderVerifier{
+		inner: inner,
+		cache: make(map[headerCacheKey]error),
+	}
+}
+
+// verify checks the cache for a previous result and, on miss,
+// delegates to the inner verifier and caches the outcome.
+func (c *cachingHeaderVerifier) verify(header wire.BlockHeader,
+	height uint32) error {
+
+	key := headerCacheKey{
+		height: height,
+		hash:   header.BlockHash(),
+	}
+
+	c.mu.Lock()
+	if err, ok := c.cache[key]; ok {
+		c.mu.Unlock()
+		return err
+	}
+	c.mu.Unlock()
+
+	err := c.inner(header, height)
+	if err != nil {
+		return err
+	}
+
+	c.mu.Lock()
+	c.cache[key] = nil
+	c.mu.Unlock()
+
+	return nil
+}
+
 // MerkleVerifier is a callback function which returns an error if the given
 // merkle proof is invalid.
 type MerkleVerifier func(tx *wire.MsgTx, proof *TxMerkleProof,
@@ -1007,9 +1071,11 @@ func (p *Proof) VerifyProofIntegrity(ctx context.Context, vCtx VerifierCtx,
 		ScriptKey: asset.ToSerialized(p.Asset.ScriptKey.PubKey),
 	}
 
-	// Before we do any other validation, we'll check to see if we can halt
-	// validation here, as the proof is already known to be invalid. This
-	// can be used as a rejection caching mechanism.
+	// Before we do any other per-proof validation, check if this
+	// proof is already known to be invalid. This is a rejection
+	// caching mechanism. Note: when called from File.Verify, block
+	// headers may have already been prefetched in parallel before
+	// this point.
 	fail, err := lfn.MapOptionZ(
 		vCtx.IgnoreChecker, func(c IgnoreChecker) lfn.Result[bool] {
 			return c.IsIgnored(ctx, assetPoint)
@@ -1171,6 +1237,97 @@ func (p *Proof) VerifyProofs() (*commitment.TapCommitment, error) {
 	return tapCommitment, nil
 }
 
+// filterIgnored removes proofs that the IgnoreChecker identifies as
+// already known-invalid, so they don't incur unnecessary header RPCs
+// during prefetch.
+func filterIgnored(ctx context.Context,
+	checker lfn.Option[IgnoreChecker],
+	proofs []*Proof) ([]*Proof, error) {
+
+	if checker.IsNone() {
+		return proofs, nil
+	}
+
+	result := make([]*Proof, 0, len(proofs))
+	for _, p := range proofs {
+		assetPoint := AssetPoint{
+			OutPoint: p.OutPoint(),
+			ID:       p.Asset.ID(),
+			ScriptKey: asset.ToSerialized(
+				p.Asset.ScriptKey.PubKey,
+			),
+		}
+
+		ignored, err := lfn.MapOptionZ(
+			checker,
+			func(c IgnoreChecker) lfn.Result[bool] {
+				return c.IsIgnored(ctx, assetPoint)
+			},
+		).Unpack()
+		if err != nil {
+			return nil, fmt.Errorf("failed to check "+
+				"if proof is ignored: %w", err)
+		}
+
+		if !ignored {
+			result = append(result, p)
+		}
+	}
+
+	return result, nil
+}
+
+// prefetchHeaders deduplicates block headers from the given proofs
+// and verifies each unique header in parallel using the given caching
+// verifier. This turns O(n) sequential RPC round-trips into bounded
+// parallel batches.
+func prefetchHeaders(ctx context.Context,
+	proofs []*Proof, hv *cachingHeaderVerifier) error {
+
+	type headerInfo struct {
+		header wire.BlockHeader
+		height uint32
+	}
+
+	seen := make(map[headerCacheKey]struct{})
+	var unique []headerInfo
+
+	for _, p := range proofs {
+		key := headerCacheKey{
+			height: p.BlockHeight,
+			hash:   p.BlockHeader.BlockHash(),
+		}
+		if _, ok := seen[key]; !ok {
+			seen[key] = struct{}{}
+			unique = append(unique, headerInfo{
+				header: p.BlockHeader,
+				height: p.BlockHeight,
+			})
+		}
+	}
+
+	g, gCtx := errgroup.WithContext(ctx)
+	g.SetLimit(headerPrefetchWorkers)
+
+	for _, h := range unique {
+		if err := gCtx.Err(); err != nil {
+			break
+		}
+
+		g.Go(func() error {
+			select {
+			case <-gCtx.Done():
+				return gCtx.Err()
+			default:
+			}
+
+			return hv.verify(h.header, h.height)
+		})
+	}
+
+	return g.Wait()
+}
+
 // Verify attempts to verify a full proof file starting from the asset's
 // genesis.
 //
@@ -1200,17 +1357,55 @@ func (f *File) Verify(ctx context.Context,
 
 	chainLookup := vCtx.ChainLookupGen.GenFileChainLookup(f)
 
-	var prev *AssetSnapshot
+	// Decode all proofs upfront so we can batch-verify block
+	// headers in parallel before the sequential verification
+	// pass.
+	decoded := make([]*Proof, len(f.proofs))
 	for idx := range f.proofs {
+		p, err := f.ProofAt(uint32(idx))
+		if err != nil {
+			return nil, err
+		}
+		decoded[idx] = p
+	}
+
+	// Wrap the header verifier with a cache and pre-fetch all
+	// unique block headers in parallel. Nested File.Verify calls
+	// (AdditionalInputs) inherit the cached verify function via
+	// vCtx, so cross-file cache hits occur transitively.
+	//
+	// When skipChainForFinalProof is set, exclude the last proof
+	// from the prefetch — its block may not yet be on chain.
+	//
+	// Filter out proofs that are already known to be invalid via
+	// the IgnoreChecker rejection cache, so that ignored proofs
+	// don't incur unnecessary header RPCs.
+	prefetchSet := decoded
+	if verifyOpts.skipChainForFinalProof && len(decoded) > 0 {
+		prefetchSet = prefetchSet[:len(prefetchSet)-1]
+	}
+
+	prefetchSet, err := filterIgnored(
+		ctx, vCtx.IgnoreChecker, prefetchSet,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	cached := newCachingHeaderVerifier(vCtx.HeaderVerifier)
+	if err := prefetchHeaders(
+		ctx, prefetchSet, cached,
+	); err != nil {
+		return nil, err
+	}
+	vCtx.HeaderVerifier = cached.verify
+
+	var prev *AssetSnapshot
+	for idx, decodedProof := range decoded {
 		select {
 		case <-ctx.Done():
 			return nil, ctx.Err()
 		default:
-		}
-
-		decodedProof, err := f.ProofAt(uint32(idx))
-		if err != nil {
-			return nil, err
 		}
 
 		var proofOpts []ProofVerificationOption
@@ -1237,9 +1432,10 @@ func (f *File) Verify(ctx context.Context,
 			return nil, err
 		}
 
-		// At this point, we'll check to see if we can halt validation
-		// here, as the proof is already known to be invalid. This can
-		// be used as a rejection caching mechanism.
+		// At this point, we'll check to see if we can halt
+		// validation here, as the proof is already known to be
+		// invalid. This can be used as a rejection caching
+		// mechanism.
 		fail, err := lfn.MapOptionZ(
 			vCtx.IgnoreChecker,
 			func(checker IgnoreChecker) lfn.Result[bool] {


### PR DESCRIPTION
Resolves #2103.

Previously, proof files with many transitions could time out during receipt. Each proof's block header was verified sequentially via two chain RPCs, GetBlockHash and GetBlockHeader, so e.g. 183 proofs resulted in 366 serial round-trips, which was enough to exceed the 30s context deadline, causing the problem in the linked issue.

The fix is to introduce 1) a caching header verifier, and 2) a header prefetcher that fires all unique verifications in parallel. The former is useful when multiple proofs in a file land in the same block (since we avoid multiple, redundant GetBlockHash/GetBlockHeader calls for that block), and the latter is useful when there are many blocks.

I benchmarked this with simulated RPC latency and it appears to be roughly 10-100x faster than the old version, depending on the proof file structure (with the much faster measurements naturally occurring when we hit the cache).