### PR TITLE
tapgarden: persist frozen state to db on startup batch resume

### DIFF
--- a/tapgarden/planter.go
+++ b/tapgarden/planter.go
@@ -610,6 +610,18 @@ func (c *ChainPlanter) Start() error {
 				// can now be set as frozen. We are already not
 				// able to add new seedlings to the batch.
 				batch.UpdateState(BatchStateFrozen)
+
+				err := c.cfg.Log.UpdateBatchState(
+					ctx, batch.BatchKey.PubKey,
+					BatchStateFrozen,
+				)
+				if err != nil {
+					log.Warnf("Failed to update batch "+
+						"state to frozen (%x): %s",
+						batchKey, err.Error())
+					cancelBatch()
+					continue
+				}
 			}
 
 			log.Infof("Launching ChainCaretaker(%x)", batchKey)


### PR DESCRIPTION
Resolves #2018.

When resuming a pending batch on restart, the in-memory state was updated to BatchStateFrozen but never persisted to the DB. This created a race where the batch remained BatchStatePending in the DB until the caretaker goroutine eventually advanced it, causing flaky test failures in fund_seal_on_restart.

The fix is to persist the frozen state to the DB before launching the caretaker, matching the error-handling pattern used by cancelBatch().