### PR TITLE
server: fix corner case shutdown hang

### DIFF
--- a/server.go
+++ b/server.go
@@ -247,6 +247,10 @@ func (s *Server) initialize(interceptorChain *rpcperms.InterceptorChain) error {
 	if err := s.cfg.AuxInvoiceManager.Start(); err != nil {
 		return fmt.Errorf("unable to start aux invoice mgr: %w", err)
 	}
+	if err := s.cfg.AuxChanCloser.Start(); err != nil {
+		return fmt.Errorf("unable to start aux chan closer: %w",
+			err)
+	}
 	if err := s.cfg.AuxSweeper.Start(); err != nil {
 		return fmt.Errorf("unable to start aux sweeper mgr: %w", err)
 	}
@@ -862,6 +866,10 @@ func (s *Server) Stop() error {
 			err)
 	}
 
+	if err := s.cfg.AuxChanCloser.Stop(); err != nil {
+		return fmt.Errorf("unable to stop aux chan closer: %w",
+			err)
+	}
 	if err := s.cfg.AuxLeafSigner.Stop(); err != nil {
 		return err
 	}

--- a/tapchannel/aux_closer.go
+++ b/tapchannel/aux_closer.go
@@ -110,11 +110,18 @@ type assetCloseInfo struct {
 
 // AuxChanCloser is used to implement asset-aware co-op close for channels.
 type AuxChanCloser struct {
+	startOnce sync.Once
+	stopOnce  sync.Once
+
 	cfg AuxChanCloserCfg
 
 	sync.RWMutex
 
 	closeInfo map[wire.OutPoint]*assetCloseInfo
+
+	// ContextGuard provides a wait group and main quit channel that can
+	// be used to create guarded contexts.
+	*fn.ContextGuard
 }
 
 // NewAuxChanCloser creates a new instance of the auxiliary channel closer.
@@ -122,6 +129,10 @@ func NewAuxChanCloser(cfg AuxChanCloserCfg) *AuxChanCloser {
 	return &AuxChanCloser{
 		cfg:       cfg,
 		closeInfo: make(map[wire.OutPoint]*assetCloseInfo),
+		ContextGuard: &fn.ContextGuard{
+			DefaultTimeout: DefaultTimeout,
+			Quit:           make(chan struct{}),
+		},
 	}
 }
 
@@ -130,6 +141,28 @@ func NewAuxChanCloser(cfg AuxChanCloserCfg) *AuxChanCloser {
 // LND-side AuxChanCloser interface doesn't pass a context through.
 func auxOpCtx() (context.Context, context.CancelFunc) {
 	return context.WithTimeout(context.Background(), DefaultTimeout)
+}
+
+// Start attempts to start the auxiliary channel closer.
+func (a *AuxChanCloser) Start() error {
+	var startErr error
+	a.startOnce.Do(func() {
+		log.Info("Starting aux chan closer")
+	})
+	return startErr
+}
+
+// Stop signals for the auxiliary channel closer to gracefully exit.
+func (a *AuxChanCloser) Stop() error {
+	var stopErr error
+	a.stopOnce.Do(func() {
+		log.Info("Stopping aux chan closer")
+
+		close(a.Quit)
+		a.Wg.Wait()
+	})
+
+	return stopErr
 }
 
 // createCloseAlloc is a helper function that creates an allocation for an asset
@@ -859,8 +892,14 @@ func (a *AuxChanCloser) FinalizeClose(desc types.AuxCloseDesc,
 			ChainLookupGen: a.cfg.ChainBridge,
 			IgnoreChecker:  a.cfg.IgnoreChecker,
 		}
+		ctx, cancel := a.WithCtxQuitNoTimeout()
+		defer cancel()
+
+		a.Wg.Add(1)
+		defer a.Wg.Done()
+
 		err = importOutputProofs(
-			desc.ShortChanID, fundingInputProofs,
+			ctx, desc.ShortChanID, fundingInputProofs,
 			a.cfg.DefaultCourierAddr, a.cfg.ProofFetcher,
 			a.cfg.ChainBridge, vCtx, a.cfg.ProofArchive,
 		)

--- a/tapchannel/aux_sweeper.go
+++ b/tapchannel/aux_sweeper.go
@@ -1400,7 +1400,7 @@ func (a *AuxSweeper) importOutputScriptKeys(desc tapscriptSweepDescs) error {
 
 // importOutputProofs imports the output proofs into the pending asset funding
 // into our local database. This preps us to be able to detect force closes.
-func importOutputProofs(scid lnwire.ShortChannelID,
+func importOutputProofs(ctx context.Context, scid lnwire.ShortChannelID,
 	outputProofs []*proof.Proof, courierAddr *url.URL,
 	proofDispatch proof.CourierDispatch, chainBridge tapgarden.ChainBridge,
 	vCtx proof.VerifierCtx, proofArchive proof.Archiver) error {
@@ -1415,7 +1415,6 @@ func importOutputProofs(scid lnwire.ShortChannelID,
 	// the funding outputs we need.
 	//
 	// TODO(roasbeef): assume single asset for now, also additional inputs
-	ctxb := context.Background()
 	for _, proofToImport := range outputProofs {
 		// Check if the proof is already imported to avoid redundant
 		// work.
@@ -1424,7 +1423,7 @@ func importOutputProofs(scid lnwire.ShortChannelID,
 			ScriptKey: *proofToImport.Asset.ScriptKey.PubKey,
 			OutPoint:  fn.Ptr(proofToImport.OutPoint()),
 		}
-		proofExists, err := proofArchive.HasProof(ctxb, fundingLocator)
+		proofExists, err := proofArchive.HasProof(ctx, fundingLocator)
 		if err != nil {
 			return fmt.Errorf("unable to check if proof "+
 				"exists: %w", err)
@@ -1463,7 +1462,7 @@ func importOutputProofs(scid lnwire.ShortChannelID,
 		// First, we'll make a courier to use in fetching the proofs we
 		// need.
 		proofFetcher, err := proofDispatch.NewCourier(
-			ctxb, courierAddr, true,
+			ctx, courierAddr, true,
 		)
 		if err != nil {
 			return fmt.Errorf("unable to create proof courier: %w",
@@ -1476,7 +1475,7 @@ func importOutputProofs(scid lnwire.ShortChannelID,
 			Amount:    proofToImport.Asset.Amount,
 		}
 		prefixProof, err := proofFetcher.ReceiveProof(
-			ctxb, recipient, inputProofLocator,
+			ctx, recipient, inputProofLocator,
 		)
 
 		// Always attempt to close the courier, even if we encounter an
@@ -1496,7 +1495,7 @@ func importOutputProofs(scid lnwire.ShortChannelID,
 		// the transition proof to include the proper block+merkle proof
 		// information.
 		err = updateProofsFromShortChanID(
-			ctxb, chainBridge, scid, []*proof.Proof{proofToImport},
+			ctx, chainBridge, scid, []*proof.Proof{proofToImport},
 		)
 		if err != nil {
 			return fmt.Errorf("error updating transition "+
@@ -1524,7 +1523,7 @@ func importOutputProofs(scid lnwire.ShortChannelID,
 		}
 
 		err = proofArchive.ImportProofs(
-			ctxb, vCtx, false, &proof.AnnotatedProof{
+			ctx, vCtx, false, &proof.AnnotatedProof{
 				Locator: fundingLocator,
 				Blob:    finalProofBuf.Bytes(),
 			},
@@ -1597,7 +1596,7 @@ func (a *AuxSweeper) importCommitTx(req lnwallet.ResolutionReq,
 		IgnoreChecker:  a.cfg.IgnoreChecker,
 	}
 	err = importOutputProofs(
-		req.ShortChanID, maps.Values(fundingInputProofs),
+		ctxb, req.ShortChanID, maps.Values(fundingInputProofs),
 		a.cfg.DefaultCourierAddr, a.cfg.ProofFetcher,
 		a.cfg.ChainBridge, vCtx, a.cfg.ProofArchive,
 	)


### PR DESCRIPTION
Resolves #2109. This is a borderline-overfitting issue identified by Opus while diagnosing #2108, but the fix is simple, and does marginally improve the daemon's stability, so IMO it's worth making.

Previously an unresponsive proof courier could cause importOutputProofs to block indefinitely while a co-op close was in flight, preventing tapd from shutting down cleanly. The fix simply wires up AuxChanCloser with a ContextGuard lifecycle in the same manner as other Aux components (AuxFundingController, AuxSweeper, etc.), also threading a cancellable context through importOutputProofs.

(Shutting down the daemon in this situation is safe in terms of ultimately handling the coop close; the retry logic is handled by lnd.)