### PR TITLE
backup: fix group key verification and add skip-on-error

### DIFF
--- a/backup/import.go
+++ b/backup/import.go
@@ -7,11 +7,13 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/lndclient"
 	"github.com/lightninglabs/taproot-assets/asset"
 	"github.com/lightninglabs/taproot-assets/proof"
 	"github.com/lightningnetwork/lnd/chainntnfs"
+	lfn "github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/lightningnetwork/lnd/keychain"
 )
 
@@ -70,17 +72,90 @@ type ImportConfig struct {
 	// keys so the wallet can sign for imported assets.
 	KeyRegistrar KeyRegistrar
 
-	// ProofVerifier provides the verification context for imported proofs.
+	// ProofVerifier provides the verification context for imported
+	// proofs.
 	ProofVerifier proof.VerifierCtx
 }
 
-// ImportBackup decodes and imports assets from a backup blob. Returns the
-// number of newly imported assets.
+// extractGroupKeys extracts group public keys from genesis proofs
+// that contain a GroupKeyReveal. The keys are added to the provided
+// map. Errors are non-fatal; this is a best-effort extraction used
+// to pre-populate the augmented GroupVerifier.
+func extractGroupKeys(proofBlob []byte,
+	keys map[asset.SerializedKey]bool) {
+
+	file, err := proof.DecodeFile(proofBlob)
+	if err != nil {
+		log.Debugf("extractGroupKeys: decode file: %v", err)
+		return
+	}
+
+	if file.NumProofs() == 0 {
+		return
+	}
+
+	rawGenesis, err := file.RawProofAt(0)
+	if err != nil {
+		log.Debugf("extractGroupKeys: raw proof: %v", err)
+		return
+	}
+
+	// Use SparseDecode to extract only the fields we need.
+	// This works on both full and stripped proof bytes.
+	var p proof.Proof
+	err = proof.SparseDecode(
+		bytes.NewReader(rawGenesis),
+		proof.AssetLeafRecord(&p.Asset),
+		proof.GroupKeyRevealRecord(&p.GroupKeyReveal),
+	)
+	if err != nil {
+		log.Debugf("extractGroupKeys: sparse decode: %v", err)
+		return
+	}
+
+	if p.GroupKeyReveal == nil || p.Asset.GroupKey == nil {
+		return
+	}
+
+	// Verify the reveal actually derives the claimed group key.
+	// Without this check, a tampered backup could whitelist an
+	// arbitrary group key. This mirrors verifyGroupKeyReveal()
+	// in proof/verifier.go.
+	derivedKey, err := p.GroupKeyReveal.GroupPubKey(
+		p.Asset.ID(),
+	)
+	if err != nil {
+		log.Debugf("extractGroupKeys: derive key: %v", err)
+		return
+	}
+	if !derivedKey.IsEqual(&p.Asset.GroupKey.GroupPubKey) {
+		assetID := p.Asset.ID()
+		log.Warnf("extractGroupKeys: asset %x — derived "+
+			"key %x does not match claimed group "+
+			"key %x; backup may be tampered",
+			assetID[:],
+			asset.ToSerialized(derivedKey),
+			asset.ToSerialized(
+				&p.Asset.GroupKey.GroupPubKey,
+			))
+		return
+	}
+
+	gk := asset.ToSerialized(&p.Asset.GroupKey.GroupPubKey)
+	keys[gk] = true
+
+	log.Debugf("Pre-extracted group key %x from proof chain",
+		gk[:])
+}
+
+// ImportBackup decodes and imports assets from a backup blob.
+// Returns the number of newly imported assets and the number
+// skipped due to per-asset errors.
 func ImportBackup(ctx context.Context, backupBlob []byte,
-	cfg *ImportConfig) (uint32, error) {
+	cfg *ImportConfig) (uint32, uint32, error) {
 
 	if len(backupBlob) == 0 {
-		return 0, fmt.Errorf("backup data is empty")
+		return 0, 0, fmt.Errorf("backup data is empty")
 	}
 
 	log.Infof("Importing assets from backup (%d bytes)",
@@ -89,7 +164,8 @@ func ImportBackup(ctx context.Context, backupBlob []byte,
 	// Decode and verify the backup.
 	walletBackup, err := DecodeWalletBackup(backupBlob)
 	if err != nil {
-		return 0, fmt.Errorf("failed to decode backup: %w", err)
+		return 0, 0, fmt.Errorf("failed to decode backup: "+
+			"%w", err)
 	}
 
 	log.Infof("Decoded backup version %d with %d assets",
@@ -103,15 +179,99 @@ func ImportBackup(ctx context.Context, backupBlob []byte,
 		ctx, cfg.SpendChecker, walletBackup.Assets,
 	)
 	if err != nil {
-		return 0, fmt.Errorf("failed to check outpoint "+
+		return 0, 0, fmt.Errorf("failed to check outpoint "+
 			"status: %w", err)
 	}
 
-	var numImported uint32
+	// Pre-extract group keys from all available proof data.
+	// For v1 (raw) backups, ProofFileBlob is available. For v2
+	// (compact) backups, StrippedProofFileBlob retains the
+	// GroupKeyReveal (TLV type 25, odd/optional). This
+	// eliminates ordering issues: all group keys are known
+	// before any asset is imported.
+	knownGroupKeys := make(map[asset.SerializedKey]bool)
+	for _, ab := range walletBackup.Assets {
+		switch {
+		case len(ab.ProofFileBlob) > 0:
+			extractGroupKeys(ab.ProofFileBlob, knownGroupKeys)
+		case len(ab.StrippedProofFileBlob) > 0:
+			extractGroupKeys(
+				ab.StrippedProofFileBlob, knownGroupKeys,
+			)
+		}
+	}
+
+	if len(knownGroupKeys) > 0 {
+		log.Infof("Pre-extracted %d group key(s) from "+
+			"backup proof data", len(knownGroupKeys))
+	}
+
+	// Build an augmented GroupVerifier that accepts
+	// pre-extracted group keys alongside the normal DB lookup.
+	// Security is preserved: File.Verify still runs
+	// verifyGroupKeyReveal() on genesis proofs with reveals.
+	origGroupVerifier := cfg.ProofVerifier.GroupVerifier
+	augmentedVerifier := func(gk *btcec.PublicKey) error {
+		if knownGroupKeys[asset.ToSerialized(gk)] {
+			return nil
+		}
+		return origGroupVerifier(gk)
+	}
+
+	// Two verifier contexts: one for pre-verification (data
+	// checks only, no infrastructure dependencies) and one for
+	// the actual import (full verification including chain
+	// backend). Pre-verification catches per-asset data issues
+	// (unknown group keys, bad proofs) which are skippable.
+	// Import verification catches everything including chain
+	// and storage errors which are fatal.
+	//
+	// The pre-verify context uses no-op header verification
+	// and a mock chain lookup so it never hits the chain
+	// backend. The only code path that consumes the chain
+	// lookup is timelock validation, which is disabled via
+	// WithSkipTimeLockValidationForAllProofs.
+	preVerifyCtx := proof.VerifierCtx{
+		HeaderVerifier: func(_ wire.BlockHeader,
+			_ uint32) error {
+
+			return nil
+		},
+		MerkleVerifier:      cfg.ProofVerifier.MerkleVerifier,
+		GroupVerifier:       augmentedVerifier,
+		GroupAnchorVerifier: cfg.ProofVerifier.GroupAnchorVerifier,
+		ChainLookupGen:      proof.MockChainLookup,
+		IgnoreChecker:       lfn.None[proof.IgnoreChecker](),
+	}
+
+	importVCtx := proof.VerifierCtx{
+		HeaderVerifier:      cfg.ProofVerifier.HeaderVerifier,
+		MerkleVerifier:      cfg.ProofVerifier.MerkleVerifier,
+		GroupVerifier:       augmentedVerifier,
+		GroupAnchorVerifier: cfg.ProofVerifier.GroupAnchorVerifier,
+		ChainLookupGen:      cfg.ProofVerifier.ChainLookupGen,
+		IgnoreChecker:       cfg.ProofVerifier.IgnoreChecker,
+	}
+
+	var (
+		numImported  uint32
+		numSkipped   uint32
+		retryIndices []int
+		verifier     proof.BaseVerifier
+	)
 
 	for i, assetBackup := range walletBackup.Assets {
-		log.Debugf("Processing asset %d: outpoint=%v, amount=%d",
-			i, assetBackup.AnchorOutpoint,
+		if assetBackup.Asset == nil ||
+			assetBackup.Asset.ScriptKey.PubKey == nil {
+
+			log.Warnf("Skipping asset %d: nil asset "+
+				"or script key", i)
+			numSkipped++
+			continue
+		}
+
+		log.Debugf("Processing asset %d: outpoint=%v, "+
+			"amount=%d", i, assetBackup.AnchorOutpoint,
 			assetBackup.Asset.Amount)
 
 		// Skip assets whose anchor outpoint has been spent.
@@ -124,8 +284,8 @@ func ImportBackup(ctx context.Context, backupBlob []byte,
 			continue
 		}
 
-		// Check if asset already exists by trying to fetch its
-		// proof.
+		// Check if asset already exists by trying to fetch
+		// its proof. DB errors here are fatal.
 		assetID := assetBackup.Asset.ID()
 		locator := proof.Locator{
 			AssetID:   &assetID,
@@ -135,42 +295,52 @@ func ImportBackup(ctx context.Context, backupBlob []byte,
 
 		_, err := cfg.ProofArchive.FetchProof(ctx, locator)
 		if err == nil {
-			log.Debugf("Asset %d already exists, skipping", i)
+			log.Debugf("Asset %d already exists, "+
+				"skipping", i)
 			continue
 		}
 		if !errors.Is(err, proof.ErrProofNotFound) {
-			return 0, fmt.Errorf("error checking existing "+
-				"asset %d: %w", i, err)
+			return numImported, numSkipped,
+				fmt.Errorf("error checking existing "+
+					"asset %d: %w", i, err)
 		}
 
 		// For v2+ backups, rehydrate the stripped proof by
-		// fetching blockchain data. This reconstructs the full
-		// proof file.
-		if len(assetBackup.StrippedProofFileBlob) > 0 {
+		// fetching blockchain data.
+		if len(assetBackup.StrippedProofFileBlob) > 0 &&
+			len(assetBackup.ProofFileBlob) == 0 {
+
 			hints, err := DecodeFileHints(
 				bytes.NewReader(
 					assetBackup.RehydrationHintsBlob,
 				),
 			)
 			if err != nil {
-				return 0, fmt.Errorf("failed to decode "+
-					"hints for asset %d: %w", i, err)
+				log.Warnf("Skipping asset %d (id=%x):"+
+					" failed to decode hints: %v",
+					i, assetID[:], err)
+				numSkipped++
+				continue
 			}
 
 			fullBlob, err := RehydrateProofFile(
-				ctx, assetBackup.StrippedProofFileBlob,
+				ctx,
+				assetBackup.StrippedProofFileBlob,
 				hints, cfg.ChainQuerier,
 			)
 			if err != nil {
-				return 0, fmt.Errorf("failed to rehydrate "+
-					"proof for asset %d: %w", i, err)
+				log.Warnf("Skipping asset %d (id=%x):"+
+					" failed to rehydrate proof:"+
+					" %v", i, assetID[:], err)
+				numSkipped++
+				continue
 			}
 
 			assetBackup.ProofFileBlob = fullBlob
 		}
 
-		// For v3 optimistic backups, fetch proofs from a universe
-		// server when no proof data is present.
+		// For v3 optimistic backups, fetch proofs from a
+		// universe server when no proof data is present.
 		if len(assetBackup.ProofFileBlob) == 0 &&
 			len(assetBackup.StrippedProofFileBlob) == 0 &&
 			len(walletBackup.FederationURLs) > 0 {
@@ -180,28 +350,52 @@ func ImportBackup(ctx context.Context, backupBlob []byte,
 				assetBackup, cfg.ProofArchive,
 			)
 			if err != nil {
-				return 0, fmt.Errorf("failed to fetch "+
-					"proof from universe for asset "+
-					"%d: %w", i, err)
+				log.Warnf("Skipping asset %d (id=%x):"+
+					" failed to fetch proof from"+
+					" universe: %v",
+					i, assetID[:], err)
+				numSkipped++
+				continue
 			}
 
 			assetBackup.ProofFileBlob = proofBlob
 		}
 
-		// Verify we have a proof blob.
-		if len(assetBackup.ProofFileBlob) == 0 {
-			return 0, fmt.Errorf("asset %d has no proof blob", i)
+		// After rehydration or universe fetch, extract any
+		// group keys from the newly-available proof blob so
+		// that subsequent assets can benefit (v3 ordering).
+		if len(assetBackup.ProofFileBlob) > 0 {
+			extractGroupKeys(
+				assetBackup.ProofFileBlob,
+				knownGroupKeys,
+			)
 		}
 
-		// Register keys BEFORE importing the proof so that when
-		// ImportProofs stores the asset, it can find the existing
-		// key records with full key locator info. This is
-		// essential for the wallet to be able to sign spends
-		// later. The key upserts are idempotent (ON CONFLICT),
-		// so duplicate keys from a re-import are harmless.
+		// Verify we have a proof blob.
+		if len(assetBackup.ProofFileBlob) == 0 {
+			log.Warnf("Skipping asset %d (id=%x): "+
+				"no proof blob available",
+				i, assetID[:])
+			numSkipped++
+			continue
+		}
 
-		// Register the anchor internal key so LND can sign for
-		// the anchor output when spending.
+		// Register keys BEFORE importing the proof so that
+		// when ImportProofs stores the asset, it can find
+		// the existing key records with full key locator
+		// info. This is essential for the wallet to be able
+		// to sign spends later. The key upserts are
+		// idempotent (ON CONFLICT), so duplicate keys from
+		// a re-import are harmless — including for assets
+		// that fail pre-verify and enter the retry pass,
+		// whose keys must already be registered when the
+		// retry succeeds.
+		//
+		// Key registration errors are fatal since they
+		// indicate DB/infrastructure problems.
+
+		// Register the anchor internal key so LND can sign
+		// for the anchor output when spending.
 		if assetBackup.AnchorInternalKeyInfo != nil {
 			info := assetBackup.AnchorInternalKeyInfo
 			anchorKey := keychain.KeyDescriptor{
@@ -213,14 +407,17 @@ func ImportBackup(ctx context.Context, backupBlob []byte,
 				ctx, anchorKey,
 			)
 			if err != nil {
-				return 0, fmt.Errorf("failed to insert "+
-					"anchor internal key for asset "+
-					"%d: %w", i, err)
+				return numImported, numSkipped,
+					fmt.Errorf("failed to insert "+
+						"anchor internal key "+
+						"for asset %d: %w",
+						i, err)
 			}
 		}
 
-		// Register the script key so the wallet can identify the
-		// asset as locally owned and sign virtual transactions.
+		// Register the script key so the wallet can
+		// identify the asset as locally owned and sign
+		// virtual transactions.
 		if assetBackup.ScriptKeyInfo != nil {
 			skInfo := assetBackup.ScriptKeyInfo
 			scriptKey := asset.ScriptKey{
@@ -241,36 +438,135 @@ func ImportBackup(ctx context.Context, backupBlob []byte,
 				ctx, scriptKey, scriptKeyType,
 			)
 			if err != nil {
-				return 0, fmt.Errorf("failed to insert "+
-					"script key for asset %d: %w",
-					i, err)
+				return numImported, numSkipped,
+					fmt.Errorf("failed to insert "+
+						"script key for asset "+
+						"%d: %w", i, err)
 			}
 		}
 
-		// Import the proof blob into the archive. The locator is
-		// derived from the same backup entry as the proof blob,
-		// so the asset ID and script key are guaranteed to be
-		// consistent — a tampered backup cannot register keys
-		// for one asset while importing proof for another.
+		// Pre-verify the proof with a context that skips
+		// infrastructure-dependent checks (chain backend,
+		// ignore checker, timelock validation). This catches
+		// per-asset data issues (bad proof, unknown group
+		// key) which are skippable. The full import step
+		// below re-verifies with the real chain backend;
+		// failures there are fatal.
+		_, err = verifier.Verify(
+			ctx,
+			bytes.NewReader(assetBackup.ProofFileBlob),
+			preVerifyCtx,
+			proof.WithSkipTimeLockValidationForAllProofs(),
+		)
+		if err != nil {
+			// Track ErrGroupKeyUnknown failures for the
+			// retry pass.
+			if errors.Is(err,
+				proof.ErrGroupKeyUnknown) {
+
+				retryIndices = append(
+					retryIndices, i,
+				)
+			}
+
+			log.Warnf("Skipping asset %d (id=%x): "+
+				"verification failed: %v",
+				i, assetID[:], err)
+			numSkipped++
+			continue
+		}
+
+		// Import the verified proof into the archive. The
+		// locator is derived from the same backup entry as
+		// the proof blob, so the asset ID and script key
+		// are guaranteed to be consistent. Errors here are
+		// storage/infrastructure issues — fail fast.
 		err = cfg.ProofArchive.ImportProofs(
-			ctx, cfg.ProofVerifier, false,
+			ctx, importVCtx, false,
 			&proof.AnnotatedProof{
 				Locator: locator,
 				Blob:    assetBackup.ProofFileBlob,
 			},
 		)
 		if err != nil {
-			return 0, fmt.Errorf("failed to import proof "+
-				"for asset %d: %w", i, err)
+			return numImported, numSkipped,
+				fmt.Errorf("failed to import "+
+					"proof for asset %d: %w",
+					i, err)
 		}
 
 		log.Debugf("Successfully imported asset %d", i)
 		numImported++
 	}
 
-	log.Infof("Imported %d assets from backup", numImported)
+	// Retry pass: re-attempt assets that failed specifically
+	// with ErrGroupKeyUnknown. By now, the main loop has
+	// processed all other assets and populated knownGroupKeys
+	// from their proof blobs. This handles v3 optimistic backup
+	// ordering where a grouped asset was processed before the
+	// group anchor.
+	if len(retryIndices) > 0 {
+		log.Infof("Retrying %d asset(s) that failed with "+
+			"group key unknown", len(retryIndices))
+	}
 
-	return numImported, nil
+	for _, idx := range retryIndices {
+		ab := walletBackup.Assets[idx]
+		if ab.Asset == nil ||
+			ab.Asset.ScriptKey.PubKey == nil {
+
+			log.Warnf("Skipping retry asset %d: nil "+
+				"asset or script key", idx)
+			continue
+		}
+
+		retryID := ab.Asset.ID()
+		retryLocator := proof.Locator{
+			AssetID:   &retryID,
+			ScriptKey: *ab.Asset.ScriptKey.PubKey,
+			OutPoint:  &ab.AnchorOutpoint,
+		}
+
+		// Pre-verify with the data-only context, same as
+		// the main loop.
+		_, err := verifier.Verify(
+			ctx,
+			bytes.NewReader(ab.ProofFileBlob),
+			preVerifyCtx,
+			proof.WithSkipTimeLockValidationForAllProofs(),
+		)
+		if err != nil {
+			log.Warnf("Retry verification failed for "+
+				"asset %d (id=%x): %v",
+				idx, retryID[:], err)
+			continue
+		}
+
+		// Import — storage errors are fatal.
+		err = cfg.ProofArchive.ImportProofs(
+			ctx, importVCtx, false,
+			&proof.AnnotatedProof{
+				Locator: retryLocator,
+				Blob:    ab.ProofFileBlob,
+			},
+		)
+		if err != nil {
+			return numImported, numSkipped,
+				fmt.Errorf("failed to import proof "+
+					"for asset %d (retry): %w",
+					idx, err)
+		}
+
+		log.Infof("Retry succeeded for asset %d (id=%x)",
+			idx, retryID[:])
+		numImported++
+		numSkipped--
+	}
+
+	log.Infof("Imported %d assets from backup (%d skipped)",
+		numImported, numSkipped)
+
+	return numImported, numSkipped, nil
 }
 
 // detectSpentOutpoints registers spend notifications for every asset's

--- a/docs/backup.md
+++ b/docs/backup.md
@@ -332,8 +332,36 @@ message ImportAssetsFromBackupRequest {
 
 message ImportAssetsFromBackupResponse {
     uint32 num_imported = 1;  // Number of newly imported assets
+    uint32 num_skipped = 2;   // Number skipped due to errors
 }
 ```
+
+#### Group key handling
+
+Assets with group keys require the importing node to know the
+group key. For backups that include the group anchor asset (the
+asset that created the group), the import process automatically
+extracts the group key from the genesis proof's `GroupKeyReveal`
+before verification. This means:
+
+- **Group anchor present in backup:** import succeeds without
+  prior group key knowledge, for all backup modes (raw, compact,
+  optimistic).
+
+- **Reissuance-only backups:** if the group anchor is no longer
+  active (e.g. it was transferred) and the backup contains only
+  reissued or transferred group-member assets, the importing node
+  must have prior group key knowledge — typically from universe
+  federation sync or a previous import that included the anchor.
+  Without it, these assets are skipped during import.
+
+#### Error handling
+
+Per-asset verification and data-preparation errors are
+non-fatal: the failing asset is skipped (with a server-side
+log warning) and import continues with the remaining assets.
+DB and infrastructure errors remain fatal and abort the import
+immediately.
 
 ### Export flow
 
@@ -361,7 +389,8 @@ flowchart TD
 flowchart TD
     A[ImportAssetsFromBackup] --> B[Decode + verify checksum]
     B --> C[detectSpentOutpoints — concurrent spend check]
-    C --> D[For each asset]
+    C --> X[Pre-extract group keys from proof blobs]
+    X --> D[For each asset]
     D --> E{Outpoint spent?}
     E -->|yes| F[Skip — log warning]
     E -->|no| G{Already exists?}
@@ -375,9 +404,15 @@ flowchart TD
     J2 --> L
     K --> L
     L --> M[Register script key]
-    M --> N[Import proof into archive]
-    N --> O[Increment count]
+    M --> PV{Pre-verify proof}
+    PV -->|fail: group key unknown| RQ[Queue for retry]
+    PV -->|fail: other| S[Skip — log warning]
+    PV -->|pass| N[Import proof into archive]
+    RQ --> D
+    S --> D
+    N --> O[Increment imported]
     O --> D
-    D -->|done| P[Return num_imported]
+    D -->|done| R[Retry group-key-unknown failures]
+    R --> P[Return num_imported + num_skipped]
 ```
 

--- a/itest/backup_test.go
+++ b/itest/backup_test.go
@@ -457,6 +457,289 @@ func assertAssetsMatch(t *harnessTest, expected []*taprpc.Asset,
 	}
 }
 
+// testBackupRestoreGrouped tests that backups containing grouped
+// assets can be imported on a node that has never seen the group
+// key (no federation server, no prior universe sync).
+//
+// This exercises the fix for #2111: the import pre-extracts group
+// keys from GroupKeyReveal in genesis proofs so the GroupVerifier
+// accepts them during proof chain verification.
+//
+// Flow:
+//  1. Alice mints a grouped asset (group anchor) and an
+//     ungrouped asset in one batch
+//  2. Alice exports RAW and COMPACT backups
+//  3. Bob (fresh LND, no federation) imports RAW — both assets
+//     imported, NumSkipped=0
+//  4. Charlie (fresh LND, no federation) imports COMPACT — same
+//  5. Verify asset counts and group key presence on both nodes
+func testBackupRestoreGrouped(t *harnessTest) {
+	ctxb := context.Background()
+	ctxt, cancel := context.WithTimeout(ctxb, defaultWaitTimeout)
+	defer cancel()
+
+	// Mint a grouped asset and an ungrouped asset together.
+	mintReqs := []*mintrpc.MintAssetRequest{
+		{
+			Asset: &mintrpc.MintAsset{
+				AssetType: taprpc.AssetType_NORMAL,
+				Name:      "grouped-backup-anchor",
+				AssetMeta: &taprpc.AssetMeta{
+					Data: []byte("group anchor"),
+				},
+				Amount:          5000,
+				NewGroupedAsset: true,
+			},
+		},
+		{
+			Asset: &mintrpc.MintAsset{
+				AssetType: taprpc.AssetType_NORMAL,
+				Name:      "ungrouped-backup-asset",
+				AssetMeta: &taprpc.AssetMeta{
+					Data: []byte("no group"),
+				},
+				Amount: 1000,
+			},
+		},
+	}
+
+	rpcAssets := MintAssetsConfirmBatch(
+		t.t, t.lndHarness.Miner(), t.tapd, mintReqs,
+	)
+	require.Len(t.t, rpcAssets, 2)
+
+	// Verify Alice has the group.
+	AssertNumGroups(t.t, t.tapd, 1)
+
+	// Export RAW and COMPACT backups.
+	rawBackup, err := t.tapd.ExportAssetWalletBackup(
+		ctxt, &wrpc.ExportAssetWalletBackupRequest{
+			Mode: wrpc.BackupMode_RAW,
+		},
+	)
+	require.NoError(t.t, err)
+
+	compactBackup, err := t.tapd.ExportAssetWalletBackup(
+		ctxt, &wrpc.ExportAssetWalletBackupRequest{
+			Mode: wrpc.BackupMode_COMPACT,
+		},
+	)
+	require.NoError(t.t, err)
+
+	// === Import RAW on Bob (no federation) ===
+	t.Logf("=== Import RAW on Bob (no federation) ===")
+
+	bobLnd := t.lndHarness.NewNode("Bob", lndDefaultArgs)
+	bobTapd := setupTapdHarness(
+		t.t, t, bobLnd, t.universeServer,
+		func(params *tapdHarnessParams) {
+			params.noDefaultUniverseSync = true
+		},
+	)
+	defer func() {
+		require.NoError(t.t, bobTapd.stop(!*noDelete))
+	}()
+
+	bobImport, err := bobTapd.ImportAssetsFromBackup(
+		ctxt, &wrpc.ImportAssetsFromBackupRequest{
+			Backup: rawBackup.Backup,
+		},
+	)
+	require.NoError(t.t, err)
+	require.Equal(t.t, uint32(2), bobImport.NumImported,
+		"both assets should import (grouped + ungrouped)")
+	require.Equal(t.t, uint32(0), bobImport.NumSkipped,
+		"no assets should be skipped")
+
+	bobAssets, err := bobTapd.ListAssets(
+		ctxt, &taprpc.ListAssetRequest{},
+	)
+	require.NoError(t.t, err)
+	assertAssetsMatch(t, rpcAssets, bobAssets.Assets)
+
+	t.Logf("Bob (RAW, no federation): imported %d, "+
+		"skipped %d", bobImport.NumImported,
+		bobImport.NumSkipped)
+
+	// === Import COMPACT on Charlie (no federation) ===
+	t.Logf("=== Import COMPACT on Charlie (no federation) ===")
+
+	charlieLnd := t.lndHarness.NewNode("Charlie", lndDefaultArgs)
+	charlieTapd := setupTapdHarness(
+		t.t, t, charlieLnd, t.universeServer,
+		func(params *tapdHarnessParams) {
+			params.noDefaultUniverseSync = true
+		},
+	)
+	defer func() {
+		require.NoError(t.t, charlieTapd.stop(!*noDelete))
+	}()
+
+	charlieImport, err := charlieTapd.ImportAssetsFromBackup(
+		ctxt, &wrpc.ImportAssetsFromBackupRequest{
+			Backup: compactBackup.Backup,
+		},
+	)
+	require.NoError(t.t, err)
+	require.Equal(t.t, uint32(2), charlieImport.NumImported,
+		"both assets should import (grouped + ungrouped)")
+	require.Equal(t.t, uint32(0), charlieImport.NumSkipped,
+		"no assets should be skipped")
+
+	charlieAssets, err := charlieTapd.ListAssets(
+		ctxt, &taprpc.ListAssetRequest{},
+	)
+	require.NoError(t.t, err)
+	assertAssetsMatch(t, rpcAssets, charlieAssets.Assets)
+
+	t.Logf("Charlie (COMPACT, no federation): imported %d, "+
+		"skipped %d", charlieImport.NumImported,
+		charlieImport.NumSkipped)
+}
+
+// testBackupRestoreOptimistic tests that OPTIMISTIC (v3) backups
+// with grouped assets — including reissuances — can be imported on
+// a node with no federation sync. The proofs are fetched from the
+// universe server via the federation URLs embedded in the backup.
+//
+// The test decodes the backup and swaps the asset order so the
+// reissuance is iterated before the group anchor. This forces
+// the retry pass: the reissuance fails pre-verify with
+// ErrGroupKeyUnknown, then the anchor is processed (populating
+// the group key), and the retry pass resolves the reissuance.
+//
+// Flow:
+//  1. Alice mints a group anchor (batch 1)
+//  2. Alice mints a reissuance into the same group (batch 2)
+//  3. Alice exports an OPTIMISTIC backup
+//  4. Decode, swap asset order, re-encode
+//  5. Bob (fresh LND, no federation sync) imports the reordered
+//     backup
+//  6. Verify all assets imported, none skipped, group key present
+func testBackupRestoreOptimistic(t *harnessTest) {
+	ctxb := context.Background()
+	ctxt, cancel := context.WithTimeout(ctxb, defaultWaitTimeout*2)
+	defer cancel()
+
+	miner := t.lndHarness.Miner()
+
+	// Mint a group anchor.
+	anchorAssets := MintAssetsConfirmBatch(
+		t.t, miner, t.tapd,
+		[]*mintrpc.MintAssetRequest{
+			{
+				Asset: &mintrpc.MintAsset{
+					AssetType: taprpc.AssetType_NORMAL,
+					Name:      "optimistic-anchor",
+					AssetMeta: &taprpc.AssetMeta{
+						Data: []byte("anchor"),
+					},
+					Amount:          5000,
+					NewGroupedAsset: true,
+				},
+			},
+		},
+	)
+	require.Len(t.t, anchorAssets, 1)
+
+	groupKey := anchorAssets[0].AssetGroup.TweakedGroupKey
+	AssertNumGroups(t.t, t.tapd, 1)
+
+	// Mint a reissuance into the same group.
+	reissueAssets := MintAssetsConfirmBatch(
+		t.t, miner, t.tapd,
+		[]*mintrpc.MintAssetRequest{
+			{
+				Asset: &mintrpc.MintAsset{
+					AssetType: taprpc.AssetType_NORMAL,
+					Name:      "optimistic-reissue",
+					AssetMeta: &taprpc.AssetMeta{
+						Data: []byte("reissue"),
+					},
+					Amount:       2000,
+					GroupKey:     groupKey,
+					GroupedAsset: true,
+				},
+			},
+		},
+	)
+	require.Len(t.t, reissueAssets, 1)
+
+	// Still one group, now with two assets.
+	AssertNumGroups(t.t, t.tapd, 1)
+
+	// Export OPTIMISTIC backup.
+	optimisticBackup, err := t.tapd.ExportAssetWalletBackup(
+		ctxt, &wrpc.ExportAssetWalletBackupRequest{
+			Mode: wrpc.BackupMode_OPTIMISTIC,
+		},
+	)
+	require.NoError(t.t, err)
+
+	decoded, err := backup.DecodeWalletBackup(
+		optimisticBackup.Backup,
+	)
+	require.NoError(t.t, err)
+	require.Equal(t.t, backup.BackupVersionOptimistic,
+		decoded.Version)
+	require.NotEmpty(t.t, decoded.FederationURLs)
+
+	// The export orders assets by ascending asset_id, so the
+	// anchor (minted first) is Assets[0] and the reissuance
+	// is Assets[1]. In that order, the main loop processes
+	// the anchor first and the retry pass is never needed.
+	//
+	// To exercise the retry pass, swap the asset order so the
+	// reissuance is processed first. It will fail pre-verify
+	// with ErrGroupKeyUnknown (no prior group key knowledge),
+	// then the anchor is processed (populating the group key),
+	// and finally the retry pass resolves the reissuance.
+	require.Len(t.t, decoded.Assets, 2)
+	decoded.Assets[0], decoded.Assets[1] =
+		decoded.Assets[1], decoded.Assets[0]
+
+	swappedBlob, err := backup.EncodeWalletBackup(decoded)
+	require.NoError(t.t, err)
+
+	// Import the reordered backup on Bob.
+	bobLnd := t.lndHarness.NewNode("Bob", lndDefaultArgs)
+	bobTapd := setupTapdHarness(
+		t.t, t, bobLnd, t.universeServer,
+		func(params *tapdHarnessParams) {
+			params.noDefaultUniverseSync = true
+		},
+	)
+	defer func() {
+		require.NoError(t.t, bobTapd.stop(!*noDelete))
+	}()
+
+	bobImport, err := bobTapd.ImportAssetsFromBackup(
+		ctxt, &wrpc.ImportAssetsFromBackupRequest{
+			Backup: swappedBlob,
+		},
+	)
+	require.NoError(t.t, err)
+	require.Equal(t.t, uint32(2), bobImport.NumImported,
+		"both anchor and reissuance should import")
+	require.Equal(t.t, uint32(0), bobImport.NumSkipped,
+		"no assets should be skipped")
+
+	bobAssets, err := bobTapd.ListAssets(
+		ctxt, &taprpc.ListAssetRequest{},
+	)
+	require.NoError(t.t, err)
+
+	allMinted := append(anchorAssets, reissueAssets...)
+	assertAssetsMatch(t, allMinted, bobAssets.Assets)
+
+	// Verify the group key is present on Bob.
+	AssertNumGroups(t.t, bobTapd, 1)
+
+	t.Logf("Bob (OPTIMISTIC, swapped order): imported %d, "+
+		"skipped %d", bobImport.NumImported,
+		bobImport.NumSkipped)
+}
+
 // formatBytes formats a byte count as a human-readable string.
 func formatBytes(bytes int) string {
 	if bytes < 1024 {

--- a/itest/test_list_on_test.go
+++ b/itest/test_list_on_test.go
@@ -66,6 +66,14 @@ var allTestCases = []*testCase{
 		test: testBackupRestoreTransferred,
 	},
 	{
+		name: "backup restore grouped",
+		test: testBackupRestoreGrouped,
+	},
+	{
+		name: "backup restore optimistic",
+		test: testBackupRestoreOptimistic,
+	},
+	{
 		name: "addresses",
 		test: testAddresses,
 	},

--- a/proof/verifier.go
+++ b/proof/verifier.go
@@ -90,6 +90,11 @@ type verifyOptions struct {
 	// skipTimeLockValidationForFinalProof skips locktime checks for the
 	// final proof in a file.
 	skipTimeLockValidationForFinalProof bool
+
+	// skipTimeLockValidation skips locktime checks for all proofs in a
+	// file. This is used when verifying proofs without access to the
+	// chain backend (e.g. during backup pre-verification).
+	skipTimeLockValidation bool
 }
 
 // defaultVerifyOptions returns a default set of proof verification options.
@@ -110,6 +115,15 @@ func WithSkipChainVerificationForFinalProof() VerifyOption {
 func WithSkipTimeLockValidationForFinalProof() VerifyOption {
 	return func(o *verifyOptions) {
 		o.skipTimeLockValidationForFinalProof = true
+	}
+}
+
+// WithSkipTimeLockValidationForAllProofs skips locktime checks for
+// every proof in the file. Use this when verifying proofs without
+// access to the chain backend.
+func WithSkipTimeLockValidationForAllProofs() VerifyOption {
+	return func(o *verifyOptions) {
+		o.skipTimeLockValidation = true
 	}
 }
 
@@ -1409,6 +1423,16 @@ func (f *File) Verify(ctx context.Context,
 		}
 
 		var proofOpts []ProofVerificationOption
+
+		// Skip timelocks for all proofs if requested.
+		if verifyOpts.skipTimeLockValidation &&
+			assetUsesTimeLock(&decodedProof.Asset) {
+
+			proofOpts = append(
+				proofOpts, WithSkipTimeLockValidation(),
+			)
+		}
+
 		if idx == len(f.proofs)-1 {
 			if verifyOpts.skipChainForFinalProof {
 				proofOpts = append(

--- a/rpcserver/rpcserver.go
+++ b/rpcserver/rpcserver.go
@@ -11444,7 +11444,9 @@ func (r *RPCServer) ImportAssetsFromBackup(ctx context.Context,
 		ProofVerifier: r.ProofVerifierCtx(ctx),
 	}
 
-	numImported, err := backup.ImportBackup(ctx, req.Backup, cfg)
+	numImported, numSkipped, err := backup.ImportBackup(
+		ctx, req.Backup, cfg,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to import backup: %w",
 			err)
@@ -11452,5 +11454,6 @@ func (r *RPCServer) ImportAssetsFromBackup(ctx context.Context,
 
 	return &wrpc.ImportAssetsFromBackupResponse{
 		NumImported: numImported,
+		NumSkipped:  numSkipped,
 	}, nil
 }

--- a/taprpc/assetwalletrpc/assetwallet.pb.go
+++ b/taprpc/assetwalletrpc/assetwallet.pb.go
@@ -1952,7 +1952,12 @@ func (x *ImportAssetsFromBackupRequest) GetBackup() []byte {
 type ImportAssetsFromBackupResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// The number of assets that were successfully imported.
-	NumImported   uint32 `protobuf:"varint,1,opt,name=num_imported,json=numImported,proto3" json:"num_imported,omitempty"`
+	NumImported uint32 `protobuf:"varint,1,opt,name=num_imported,json=numImported,proto3" json:"num_imported,omitempty"`
+	// The number of assets that were skipped due to errors
+	// during import. Details are logged server-side. Skipped
+	// assets may include those with verification failures,
+	// missing proofs, or other per-asset data issues.
+	NumSkipped    uint32 `protobuf:"varint,2,opt,name=num_skipped,json=numSkipped,proto3" json:"num_skipped,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1990,6 +1995,13 @@ func (*ImportAssetsFromBackupResponse) Descriptor() ([]byte, []int) {
 func (x *ImportAssetsFromBackupResponse) GetNumImported() uint32 {
 	if x != nil {
 		return x.NumImported
+	}
+	return 0
+}
+
+func (x *ImportAssetsFromBackupResponse) GetNumSkipped() uint32 {
+	if x != nil {
+		return x.NumSkipped
 	}
 	return 0
 }
@@ -2120,9 +2132,11 @@ const file_assetwalletrpc_assetwallet_proto_rawDesc = "" +
 	"\x1fExportAssetWalletBackupResponse\x12\x16\n" +
 	"\x06backup\x18\x01 \x01(\fR\x06backup\"7\n" +
 	"\x1dImportAssetsFromBackupRequest\x12\x16\n" +
-	"\x06backup\x18\x01 \x01(\fR\x06backup\"C\n" +
+	"\x06backup\x18\x01 \x01(\fR\x06backup\"d\n" +
 	"\x1eImportAssetsFromBackupResponse\x12!\n" +
-	"\fnum_imported\x18\x01 \x01(\rR\vnumImported*k\n" +
+	"\fnum_imported\x18\x01 \x01(\rR\vnumImported\x12\x1f\n" +
+	"\vnum_skipped\x18\x02 \x01(\rR\n" +
+	"numSkipped*k\n" +
 	"\x0eCoinSelectType\x12\x17\n" +
 	"\x13COIN_SELECT_DEFAULT\x10\x00\x12\x1a\n" +
 	"\x16COIN_SELECT_BIP86_ONLY\x10\x01\x12$\n" +

--- a/taprpc/assetwalletrpc/assetwallet.proto
+++ b/taprpc/assetwalletrpc/assetwallet.proto
@@ -601,4 +601,10 @@ message ImportAssetsFromBackupRequest {
 message ImportAssetsFromBackupResponse {
     // The number of assets that were successfully imported.
     uint32 num_imported = 1;
+
+    // The number of assets that were skipped due to errors
+    // during import. Details are logged server-side. Skipped
+    // assets may include those with verification failures,
+    // missing proofs, or other per-asset data issues.
+    uint32 num_skipped = 2;
 }

--- a/taprpc/assetwalletrpc/assetwallet.swagger.json
+++ b/taprpc/assetwalletrpc/assetwallet.swagger.json
@@ -739,6 +739,11 @@
           "type": "integer",
           "format": "int64",
           "description": "The number of assets that were successfully imported."
+        },
+        "num_skipped": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The number of assets that were skipped due to errors\nduring import. Details are logged server-side. Skipped\nassets may include those with verification failures,\nmissing proofs, or other per-asset data issues."
         }
       }
     },


### PR DESCRIPTION
Fixes #2111, with the fix confirmed in e2e tests on a Docker regtest network.

Opus's summary follows: 

> Fix backup import failing with "group key not known" when the importing node has no prior group key knowledge (no federation server, no prior universe sync).
> 
> Root cause: the GroupVerifier callback checks the local DB during proof chain verification, but the group key hasn't been stored yet — it exists in the same proof chain as a GroupKeyReveal on the genesis proof, or in another proof file in the backup.
> 
> Fix: pre-extract group keys from genesis proofs using SparseDecode (works on both raw and stripped proof files), verify the GroupKeyReveal derivation, and augment the GroupVerifier to accept pre-extracted keys. A retry pass handles v3 optimistic backup ordering where a grouped asset is processed before its anchor.
> 
> Also changes error handling so per-asset data/verification errors are skipped instead of aborting the entire import. Pre-verification runs with an infrastructure-free VerifierCtx (no-op HeaderVerifier, no IgnoreChecker, timelock validation skipped) so only proof-data issues are caught as skippable. The full ImportProofs call re-verifies with the real chain backend; failures there are fatal.

