### PR TITLE
tapdb: populate group witness from proof during asset import

### DIFF
--- a/docs/release-notes/release-notes-0.8.0.md
+++ b/docs/release-notes/release-notes-0.8.0.md
@@ -94,6 +94,10 @@
   fixes `DecodeAssetPayReq` so `GenesisInfo` is populated consistently,
   including group-key invoice decodes.
 
+* [PR#2115](https://github.com/lightninglabs/taproot-assets/pull/2115)
+  fixes a bug by which grouped assets could remain invisible to
+  ListGroups after import, remaining visible only in ListAssets.
+
 # New Features
 
 ## Functional Enhancements

--- a/tapdb/assets_common.go
+++ b/tapdb/assets_common.go
@@ -242,9 +242,19 @@ func upsertAssetsWithGenesis(ctx context.Context, q UpsertAssetStore,
 				"%w", err)
 		}
 
-		// This asset has as key group, so we'll insert it into the
-		// database. If it doesn't exist, the UPSERT query will still
-		// return the group_id we'll need.
+		// When an asset is deserialized from a proof,
+		// GroupKey.Witness is empty because the wire format
+		// stores the group witness in PrevWitnesses, not in
+		// the GroupKey TLV. Reconstruct it here so
+		// upsertGroupKey can insert the asset_group_witnesses
+		// row that ListGroups depends on.
+		if a.HasGenesisWitnessForGroup() {
+			a.GroupKey.Witness = a.PrevWitnesses[0].TxWitness
+		}
+
+		// This asset has a key group, so we'll insert it
+		// into the database. If it doesn't exist, the UPSERT
+		// query will still return the group_id we'll need.
 		groupWitnessID, err := upsertGroupKey(
 			ctx, a.GroupKey, q, genesisPointID, genAssetID,
 		)


### PR DESCRIPTION
Resolves #2114.

When an asset is deserialized from a proof, GroupKey.Witness is empty because the wire format stores the group witness in the asset's PrevWitnesses, not in the GroupKey TLV field. This caused upsertGroupKey to skip inserting the asset_group_witnesses row, making imported grouped assets invisible to ListGroups and ListBalances(GroupKey: true).

Fix: in upsertAssetsWithGenesis, copy the witness from PrevWitnesses[0].TxWitness into GroupKey.Witness for grouped genesis assets before calling upsertGroupKey. This is the common path for all proof import (backup, universe sync, direct ImportProofs), so the fix applies universally.

Minting is unaffected as it already populates GroupKey.Witness before reaching this code path.