### PR TITLE
tapdb+mssmt: run tests against registered db backends (redux)

### DIFF
--- a/mssmt/tree_test.go
+++ b/mssmt/tree_test.go
@@ -39,25 +39,22 @@ func genTestStores(t *testing.T) map[string]makeTestTreeStoreFunc {
 	constructors := make(map[string]makeTestTreeStoreFunc)
 
 	for _, driver := range mssmt.RegisteredTreeStores() {
-		var makeFunc makeTestTreeStoreFunc
-		if driver.Name == "sqlite3" {
-			makeFunc = func() (mssmt.TreeStore, error) {
-				dbFileName := filepath.Join(
-					t.TempDir(), "tmp.db",
-				)
+		driver := driver
+		constructors[driver.Name] = func() (mssmt.TreeStore, error) {
+			dbFileName := filepath.Join(
+				t.TempDir(), "tmp.db",
+			)
 
-				treeStore, err := driver.New(dbFileName, "test")
-				if err != nil {
-					return nil, fmt.Errorf("unable to "+
-						"create new sqlite tree "+
-						"store: %w", err)
-				}
-
-				return treeStore, nil
+			treeStore, err := driver.New(
+				dbFileName, "test", t,
+			)
+			if err != nil {
+				return nil, fmt.Errorf("unable to create "+
+					"new tree store: %w", err)
 			}
-		}
 
-		constructors[driver.Name] = makeFunc
+			return treeStore, nil
+		}
 	}
 
 	constructors["default"] = func() (mssmt.TreeStore, error) {

--- a/mssmt/tree_test.go
+++ b/mssmt/tree_test.go
@@ -615,10 +615,18 @@ func testBatchDeletion(t *testing.T, leaves []treeLeaf, tree mssmt.Tree) {
 	err = tree.DeleteAllNodes(ctx)
 	require.NoError(t, err)
 
+	// Backends differ on the post-DeleteAllNodes stale state: some
+	// error with "node not found"; others walk through the empty
+	// tree and return an empty leaf. Either result confirms the
+	// inserted leaves are no longer retrievable.
 	for _, item := range leaves {
 		emptyLeaf, err := tree.Get(ctx, item.key)
-		require.Nil(t, emptyLeaf)
-		require.ErrorContains(t, err, "node not found")
+		if err != nil {
+			require.ErrorContains(t, err, "node not found")
+			require.Nil(t, emptyLeaf)
+			continue
+		}
+		require.True(t, emptyLeaf.IsEmpty())
 	}
 
 	err = tree.DeleteRoot(ctx)

--- a/tapdb/sqlutils_test.go
+++ b/tapdb/sqlutils_test.go
@@ -298,13 +298,6 @@ func newDbHandleFromDb(t *testing.T, db *BaseDB) *DbHandler {
 	}
 }
 
-// NewDbHandleFromPath creates a new database store handle given a database file
-// path.
-func NewDbHandleFromPath(t *testing.T, dbPath string) *DbHandler {
-	db := NewTestDbHandleFromPath(t, dbPath)
-	return newDbHandleFromDb(t, db.BaseDB)
-}
-
 // NewDbHandle creates a new database store handle.
 func NewDbHandle(t *testing.T) *DbHandler {
 	// Create a new test database with the default database file path.

--- a/tapdb/test_postgres.go
+++ b/tapdb/test_postgres.go
@@ -3,22 +3,77 @@
 package tapdb
 
 import (
+	"database/sql"
+	"fmt"
 	"testing"
+
+	"github.com/lightninglabs/taproot-assets/mssmt"
 )
 
-// NewTestDB is a helper function that creates a Postgres database for testing.
+func init() {
+	driver := mssmt.TreeStoreDriver{
+		Name: "postgres",
+		New: func(args ...any) (mssmt.TreeStore,
+			error) {
+
+			if len(args) < 3 {
+				return nil, fmt.Errorf("invalid "+
+					"number of arguments: "+
+					"want 3, got %d",
+					len(args))
+			}
+
+			namespace, ok := args[1].(string)
+			if !ok {
+				return nil, fmt.Errorf("invalid "+
+					"namespace: want string, "+
+					"got %T", args[1])
+			}
+			t, ok := args[2].(testing.TB)
+			if !ok {
+				return nil, fmt.Errorf("invalid "+
+					"testing.TB: got %T",
+					args[2])
+			}
+
+			sqlDB := NewTestPostgresDB(t)
+
+			txCreator := func(tx *sql.Tx) TreeStore {
+				return sqlDB.WithTx(tx)
+			}
+			treeDB := NewTransactionExecutor(
+				sqlDB, txCreator,
+			)
+
+			return NewTaprootAssetTreeStore(
+				treeDB, namespace,
+			), nil
+		},
+	}
+	if err := mssmt.RegisterTreeStore(&driver); err != nil {
+		panic(fmt.Errorf("failed to register tree "+
+			"store db=postgres: %v", err))
+	}
+}
+
+// NewTestDB is a helper function that creates a Postgres database
+// for testing.
 func NewTestDB(t testing.TB) *PostgresStore {
 	return NewTestPostgresDB(t)
 }
 
-// NewTestDbHandleFromPath is a helper function that creates a new handle to an
-// existing SQLite database for testing.
-func NewTestDbHandleFromPath(t testing.TB, dbPath string) *PostgresStore {
+// NewTestDbHandleFromPath is a helper function that creates a new
+// handle to an existing Postgres database for testing.
+func NewTestDbHandleFromPath(t testing.TB,
+	dbPath string) *PostgresStore {
+
 	return NewTestPostgresDB(t)
 }
 
-// NewTestDBWithVersion is a helper function that creates a Postgres database
-// for testing and migrates it to the given version.
-func NewTestDBWithVersion(t testing.TB, version uint) *PostgresStore {
+// NewTestDBWithVersion is a helper function that creates a Postgres
+// database for testing and migrates it to the given version.
+func NewTestDBWithVersion(t testing.TB,
+	version uint) *PostgresStore {
+
 	return NewTestPostgresDBWithVersion(t, version)
 }

--- a/tapdb/test_sqlite.go
+++ b/tapdb/test_sqlite.go
@@ -3,22 +3,85 @@
 package tapdb
 
 import (
+	"database/sql"
+	"fmt"
 	"testing"
+
+	"github.com/lightninglabs/taproot-assets/mssmt"
 )
 
-// NewTestDB is a helper function that creates an SQLite database for testing.
+func init() {
+	driver := mssmt.TreeStoreDriver{
+		Name: "sqlite3",
+		New: func(args ...any) (mssmt.TreeStore,
+			error) {
+
+			if len(args) < 3 {
+				return nil, fmt.Errorf("invalid "+
+					"number of arguments: "+
+					"want 3, got %d",
+					len(args))
+			}
+
+			dbPath, ok := args[0].(string)
+			if !ok {
+				return nil, fmt.Errorf("invalid "+
+					"db path: want string, "+
+					"got %T", args[0])
+			}
+			namespace, ok := args[1].(string)
+			if !ok {
+				return nil, fmt.Errorf("invalid "+
+					"namespace: want string, "+
+					"got %T", args[1])
+			}
+			t, ok := args[2].(testing.TB)
+			if !ok {
+				return nil, fmt.Errorf("invalid "+
+					"testing.TB: got %T",
+					args[2])
+			}
+
+			sqlDB := NewTestSqliteDbHandleFromPath(
+				t, dbPath,
+			)
+
+			txCreator := func(tx *sql.Tx) TreeStore {
+				return sqlDB.WithTx(tx)
+			}
+			treeDB := NewTransactionExecutor(
+				sqlDB, txCreator,
+			)
+
+			return NewTaprootAssetTreeStore(
+				treeDB, namespace,
+			), nil
+		},
+	}
+	if err := mssmt.RegisterTreeStore(&driver); err != nil {
+		panic(fmt.Errorf("failed to register tree "+
+			"store db=sqlite3: %v", err))
+	}
+}
+
+// NewTestDB is a helper function that creates an SQLite database
+// for testing.
 func NewTestDB(t testing.TB) *SqliteStore {
 	return NewTestSqliteDB(t)
 }
 
-// NewTestDbHandleFromPath is a helper function that creates a new handle to an
-// existing SQLite database for testing.
-func NewTestDbHandleFromPath(t testing.TB, dbPath string) *SqliteStore {
+// NewTestDbHandleFromPath is a helper function that creates a new
+// handle to an existing SQLite database for testing.
+func NewTestDbHandleFromPath(t testing.TB,
+	dbPath string) *SqliteStore {
+
 	return NewTestSqliteDbHandleFromPath(t, dbPath)
 }
 
-// NewTestDBWithVersion is a helper function that creates an SQLite database for
-// testing and migrates it to the given version.
-func NewTestDBWithVersion(t testing.TB, version uint) *SqliteStore {
+// NewTestDBWithVersion is a helper function that creates an SQLite
+// database for testing and migrates it to the given version.
+func NewTestDBWithVersion(t testing.TB,
+	version uint) *SqliteStore {
+
 	return NewTestSqliteDBWithVersion(t, version)
 }


### PR DESCRIPTION
Replaces #770.

The mssmt unit tests use a driver registration pattern to discover tree store backends. Previously, no backend was ever registered, so only the default in-memory store was used.

These two commits wire up the SQL backends so the unit tests actually exercise them. Each build-tag-gated file now registers a tree store driver during initialization, and we construct a store for every registered driver.

This immediately surfaced #2116: the insert queries for mssmt_nodes aren't idempotent, so tests that produce duplicate node hashes fail against SQL backends (e.g. sqlite3, postgres). Those tests always passed before because they were only running against the in-memory store.