### PR TITLE
tapdb: make mssmt node inserts idempotent

### DIFF
--- a/tapdb/sqlc/mssmt.sql.go
+++ b/tapdb/sqlc/mssmt.sql.go
@@ -244,6 +244,7 @@ const InsertBranch = `-- name: InsertBranch :exec
 INSERT INTO mssmt_nodes (
     hash_key, l_hash_key, r_hash_key, key, value, sum, namespace
 ) VALUES ($1, $2, $3, NULL, NULL, $4, $5)
+ON CONFLICT (hash_key, namespace) DO NOTHING
 `
 
 type InsertBranchParams struct {
@@ -269,6 +270,7 @@ const InsertCompactedLeaf = `-- name: InsertCompactedLeaf :exec
 INSERT INTO mssmt_nodes (
     hash_key, l_hash_key, r_hash_key, key, value, sum, namespace
 ) VALUES ($1, NULL, NULL, $2, $3, $4, $5)
+ON CONFLICT (hash_key, namespace) DO NOTHING
 `
 
 type InsertCompactedLeafParams struct {
@@ -294,6 +296,7 @@ const InsertLeaf = `-- name: InsertLeaf :exec
 INSERT INTO mssmt_nodes (
     hash_key, l_hash_key, r_hash_key, key, value, sum, namespace
 ) VALUES ($1, NULL, NULL, NULL, $2, $3, $4)
+ON CONFLICT (hash_key, namespace) DO NOTHING
 `
 
 type InsertLeafParams struct {

--- a/tapdb/sqlc/queries/mssmt.sql
+++ b/tapdb/sqlc/queries/mssmt.sql
@@ -1,17 +1,20 @@
 -- name: InsertBranch :exec
 INSERT INTO mssmt_nodes (
     hash_key, l_hash_key, r_hash_key, key, value, sum, namespace
-) VALUES ($1, $2, $3, NULL, NULL, $4, $5);
+) VALUES ($1, $2, $3, NULL, NULL, $4, $5)
+ON CONFLICT (hash_key, namespace) DO NOTHING;
 
 -- name: InsertLeaf :exec
 INSERT INTO mssmt_nodes (
     hash_key, l_hash_key, r_hash_key, key, value, sum, namespace
-) VALUES ($1, NULL, NULL, NULL, $2, $3, $4);
+) VALUES ($1, NULL, NULL, NULL, $2, $3, $4)
+ON CONFLICT (hash_key, namespace) DO NOTHING;
 
 -- name: InsertCompactedLeaf :exec
 INSERT INTO mssmt_nodes (
     hash_key, l_hash_key, r_hash_key, key, value, sum, namespace
-) VALUES ($1, NULL, NULL, $2, $3, $4, $5);
+) VALUES ($1, NULL, NULL, $2, $3, $4, $5)
+ON CONFLICT (hash_key, namespace) DO NOTHING;
 
 -- name: FetchChildren :many
 WITH RECURSIVE mssmt_branches_cte (


### PR DESCRIPTION
Fixes #2116.

Add ON CONFLICT (hash_key, namespace) DO NOTHING to InsertBranch, InsertLeaf, and InsertCompactedLeaf. In a Merkle tree, identical hashes guarantee identical content, so ignoring duplicates is correct. This fixes UNIQUE constraint violations when tree operations produce nodes whose hashes already exist in the table.