### PR TITLE
mssmt: guard nil children in BranchNode.Copy

### DIFF
--- a/mssmt/node.go
+++ b/mssmt/node.go
@@ -275,10 +275,22 @@ func (n *BranchNode) Copy() Node {
 		*sumCopy = *n.sum
 	}
 
+	var leftCopy, rightCopy Node
+	if n.Left != nil {
+		leftCopy = NewComputedNode(
+			n.Left.NodeHash(), n.Left.NodeSum(),
+		)
+	}
+	if n.Right != nil {
+		rightCopy = NewComputedNode(
+			n.Right.NodeHash(), n.Right.NodeSum(),
+		)
+	}
+
 	return &BranchNode{
 		nodeHash: nodeHashCopy,
-		Left:     NewComputedNode(n.Left.NodeHash(), n.Left.NodeSum()),
-		Right:    NewComputedNode(n.Right.NodeHash(), n.Right.NodeSum()),
+		Left:     leftCopy,
+		Right:    rightCopy,
 		sum:      sumCopy,
 	}
 }


### PR DESCRIPTION
(This was sussed out by #2117, which will require the fix in order for its CI to pass.)

An MS-SMT's BranchNode, which always has two children (it's a branch), has two valid representations:

1) a full branch, with children materialised, as produced by the in-memory Golang store via pointer traversal, and
2) a so-called "computed branch," with hash/sum precomputed, but children not *yet* computed (i.e. they're in the database, or certainly should be, but we haven't fetched them yet), as produced by the SQL backends via one-level-at-a-time fetch.

Copy() should handle both, but previously it assumed the full branch / in-memory representation and dereferenced children unconditionally. That caused panics when using e.g. sqlite3 and postgres backends for the tree store, since the children in the computed branch representation are always nil.

The fix is to just do an explicit nil check, dereferencing child nodes only if they're non-nil. This ensures the BranchNode is faithfully copied, whatever its representation (if we're copying a computed branch, the copy will also be a computed branch).