### PR TITLE
multi: add group_key to TransferInput and TransferOutput

### DIFF
--- a/docs/release-notes/release-notes-0.8.0.md
+++ b/docs/release-notes/release-notes-0.8.0.md
@@ -330,6 +330,9 @@
   Add pagination support (offset, limit, direction) to the `ListAssets` RPC
   endpoint.
 
+- [PR#2122](https://github.com/lightninglabs/taproot-assets/pull/2122)
+  Add a `group_key` field to `TransferInput` and `TransferOutput`. Affects `ListTransfers` and the `transfer` field embedded in `SendEvent`.
+
 ## tapcli Updates
 
 - [PR#1995](https://github.com/lightninglabs/taproot-assets/pull/1995)

--- a/itest/test_list_on_test.go
+++ b/itest/test_list_on_test.go
@@ -467,6 +467,10 @@ var allTestCases = []*testCase{
 		name: "address v2 import fails without courier",
 		test: testAddressV2ImportFailsWithoutCourier,
 	},
+	{
+		name: "transfer group key",
+		test: testTransferGroupKey,
+	},
 }
 
 var optionalTestCases = []*testCase{

--- a/itest/transfer_group_key_test.go
+++ b/itest/transfer_group_key_test.go
@@ -1,0 +1,127 @@
+package itest
+
+import (
+	"context"
+
+	"github.com/lightninglabs/taproot-assets/taprpc"
+	"github.com/lightninglabs/taproot-assets/taprpc/mintrpc"
+	"github.com/stretchr/testify/require"
+)
+
+// testTransferGroupKey verifies that the group_key field added to
+// TransferInput and TransferOutput populates correctly across both
+// ListTransfers and SubscribeSendEvents for grouped fungible assets, and
+// stays empty for ungrouped (asset-id only) assets.
+//
+// This is the dedicated coverage for the marshal-time group-key resolver
+// that lives in rpcserver. The bytes carried in group_key must match the
+// asset's tweaked group public key exactly so SDK consumers can reconstruct
+// their user-facing identifier from the transfer alone, without a side
+// query.
+func testTransferGroupKey(t *harnessTest) {
+	ctxb := context.Background()
+
+	// Mint two assets in one batch so the test runs a single confirmation
+	// cycle: a grouped fungible (carries a group key) and an ungrouped
+	// fungible (asset-id only). Reusing the existing fixtures keeps this
+	// test in lock-step with the rest of the suite.
+	mintReqs := []*mintrpc.MintAssetRequest{
+		issuableAssets[0], // grouped fungible
+		simpleAssets[0],   // ungrouped fungible
+	}
+	rpcAssets := MintAssetsConfirmBatch(
+		t.t, t.lndHarness.Miner(), t.tapd, mintReqs,
+	)
+	require.Len(t.t, rpcAssets, 2)
+
+	groupedAsset := rpcAssets[0]
+	ungroupedAsset := rpcAssets[1]
+	require.NotNil(t.t, groupedAsset.AssetGroup,
+		"first minted asset must carry a group key")
+	require.Nil(t.t, ungroupedAsset.AssetGroup,
+		"second minted asset must not carry a group key")
+
+	expectedGroupKey := groupedAsset.AssetGroup.TweakedGroupKey
+	require.NotEmpty(t.t, expectedGroupKey)
+
+	// Spin up a receiver tapd. One node is enough — both transfers go to
+	// the same recipient.
+	bobLnd := t.lndHarness.NewNodeWithCoins("Bob", nil)
+	secondTapd := setupTapdHarness(t.t, t, bobLnd, t.universeServer)
+	defer func() {
+		require.NoError(t.t, secondTapd.stop(!*noDelete))
+	}()
+
+	const sendUnits = 100
+
+	// Send the grouped asset.
+	groupedAddr, err := secondTapd.NewAddr(ctxb, &taprpc.NewAddrRequest{
+		AssetId:      groupedAsset.AssetGenesis.AssetId,
+		Amt:          sendUnits,
+		AssetVersion: groupedAsset.Version,
+	})
+	require.NoError(t.t, err)
+	AssertAddrCreated(t.t, secondTapd, groupedAsset, groupedAddr)
+
+	groupedSend, _ := sendAssetsToAddr(t, t.tapd, groupedAddr)
+	ConfirmAndAssertOutboundTransfer(
+		t.t, t.lndHarness.Miner(), t.tapd, groupedSend,
+		groupedAsset.AssetGenesis.AssetId,
+		[]uint64{groupedAsset.Amount - sendUnits, sendUnits}, 0, 1,
+	)
+	AssertNonInteractiveRecvComplete(t.t, secondTapd, 1)
+
+	// Send the ungrouped asset.
+	ungroupedAddr, err := secondTapd.NewAddr(ctxb, &taprpc.NewAddrRequest{
+		AssetId:      ungroupedAsset.AssetGenesis.AssetId,
+		Amt:          sendUnits,
+		AssetVersion: ungroupedAsset.Version,
+	})
+	require.NoError(t.t, err)
+	AssertAddrCreated(t.t, secondTapd, ungroupedAsset, ungroupedAddr)
+
+	ungroupedSend, _ := sendAssetsToAddr(t, t.tapd, ungroupedAddr)
+	ConfirmAndAssertOutboundTransfer(
+		t.t, t.lndHarness.Miner(), t.tapd, ungroupedSend,
+		ungroupedAsset.AssetGenesis.AssetId,
+		[]uint64{ungroupedAsset.Amount - sendUnits, sendUnits}, 1, 2,
+	)
+	AssertNonInteractiveRecvComplete(t.t, secondTapd, 2)
+
+	// ListTransfers must surface group_key populated on every input and
+	// output of the grouped transfer, and empty on the ungrouped one.
+	transferResp, err := t.tapd.ListTransfers(
+		ctxb, &taprpc.ListTransfersRequest{},
+	)
+	require.NoError(t.t, err)
+	require.Len(t.t, transferResp.Transfers, 2)
+
+	// The two transfers come back in chronological order; the grouped
+	// send was issued first.
+	groupedTransfer := transferResp.Transfers[0]
+	ungroupedTransfer := transferResp.Transfers[1]
+
+	require.NotEmpty(t.t, groupedTransfer.Inputs)
+	for i, in := range groupedTransfer.Inputs {
+		require.Equalf(t.t, expectedGroupKey, in.GroupKey,
+			"grouped transfer input %d missing group_key", i)
+	}
+	require.NotEmpty(t.t, groupedTransfer.Outputs)
+	for i, out := range groupedTransfer.Outputs {
+		require.Equalf(t.t, expectedGroupKey, out.GroupKey,
+			"grouped transfer output %d missing group_key", i)
+	}
+
+	require.NotEmpty(t.t, ungroupedTransfer.Inputs)
+	for i, in := range ungroupedTransfer.Inputs {
+		require.Emptyf(t.t, in.GroupKey,
+			"ungrouped transfer input %d should not carry "+
+				"group_key, got %x", i, in.GroupKey)
+	}
+	require.NotEmpty(t.t, ungroupedTransfer.Outputs)
+	for i, out := range ungroupedTransfer.Outputs {
+		require.Emptyf(t.t, out.GroupKey,
+			"ungrouped transfer output %d should not carry "+
+				"group_key, got %x", i, out.GroupKey)
+	}
+}

--- a/rpcserver/rpcserver.go
+++ b/rpcserver/rpcserver.go
@@ -1706,8 +1706,11 @@ func (r *RPCServer) ListTransfers(ctx context.Context,
 		Transfers: make([]*taprpc.AssetTransfer, len(parcels)),
 	}
 
+	resolver := newTransferGroupKeyResolver(ctx, r.cfg.TapAddrBook)
 	for idx := range parcels {
-		resp.Transfers[idx], err = marshalOutboundParcel(parcels[idx])
+		resp.Transfers[idx], err = marshalOutboundParcel(
+			parcels[idx], resolver,
+		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to marshal parcel: %w",
 				err)
@@ -2883,7 +2886,8 @@ func (r *RPCServer) AnchorVirtualPsbts(ctx context.Context,
 		return nil, fmt.Errorf("error requesting delivery: %w", err)
 	}
 
-	parcel, err := marshalOutboundParcel(resp)
+	resolver := newTransferGroupKeyResolver(ctx, r.cfg.TapAddrBook)
+	parcel, err := marshalOutboundParcel(resp, resolver)
 	if err != nil {
 		return nil, fmt.Errorf("error marshaling outbound parcel: %w",
 			err)
@@ -3381,7 +3385,8 @@ func (r *RPCServer) PublishAndLogTransfer(ctx context.Context,
 		return nil, fmt.Errorf("error requesting delivery: %w", err)
 	}
 
-	parcel, err := marshalOutboundParcel(resp)
+	resolver := newTransferGroupKeyResolver(ctx, r.cfg.TapAddrBook)
+	parcel, err := marshalOutboundParcel(resp, resolver)
 	if err != nil {
 		return nil, fmt.Errorf("error marshaling outbound parcel: %w",
 			err)
@@ -3815,7 +3820,8 @@ func (r *RPCServer) SendAsset(ctx context.Context,
 		return nil, err
 	}
 
-	parcel, err := marshalOutboundParcel(resp)
+	resolver := newTransferGroupKeyResolver(ctx, r.cfg.TapAddrBook)
+	parcel, err := marshalOutboundParcel(resp, resolver)
 	if err != nil {
 		return nil, fmt.Errorf("error marshaling outbound parcel: %w",
 			err)
@@ -4073,7 +4079,8 @@ func (r *RPCServer) BurnAsset(ctx context.Context,
 		return nil, err
 	}
 
-	parcel, err := marshalOutboundParcel(resp)
+	resolver := newTransferGroupKeyResolver(ctx, r.cfg.TapAddrBook)
+	parcel, err := marshalOutboundParcel(resp, resolver)
 	if err != nil {
 		return nil, fmt.Errorf("error marshaling outbound parcel: %w",
 			err)
@@ -4147,19 +4154,113 @@ func marshalRpcBurn(b *tapfreighter.AssetBurn) *taprpc.AssetBurn {
 	}
 }
 
+// transferGroupKeyResolver caches asset_id -> serialized group key lookups so
+// a transfer with N inputs/outputs sharing one asset collapses to one DB
+// query. An empty []byte cached value means "asset has no group" — the
+// resolver distinguishes a genuine miss from a not-yet-fetched entry via map
+// presence. The resolver is safe for concurrent use, so it can also be
+// captured by a SubscribeSendEvents marshaler closure that processes events
+// on the porter's goroutine.
+type transferGroupKeyResolver struct {
+	ctx   context.Context
+	addrs *tapdb.TapAddressBook
+
+	mu    sync.RWMutex
+	cache map[asset.ID][]byte
+}
+
+// newTransferGroupKeyResolver builds a resolver bound to ctx and the daemon's
+// address book. Pass a request-scoped ctx for unary RPCs and a
+// stream-scoped ctx for subscription marshalers.
+func newTransferGroupKeyResolver(ctx context.Context,
+	addrs *tapdb.TapAddressBook) *transferGroupKeyResolver {
+
+	return &transferGroupKeyResolver{
+		ctx:   ctx,
+		addrs: addrs,
+		cache: make(map[asset.ID][]byte),
+	}
+}
+
+// groupKeyFor returns the compressed serialized group public key for assetID,
+// or an empty slice if the asset has no group. The result is cached for the
+// lifetime of the resolver.
+//
+// A daemon that does not know the asset's genesis
+// (address.ErrAssetGroupUnknown) is treated as "no group" rather than a hard
+// error so that ListTransfers stays resilient against gaps in older rows;
+// downstream consumers fall back to asset_id in that case, which preserves
+// the pre-fix behavior.
+func (r *transferGroupKeyResolver) groupKeyFor(id asset.ID) ([]byte, error) {
+	r.mu.RLock()
+	cached, ok := r.cache[id]
+	r.mu.RUnlock()
+	if ok {
+		return cached, nil
+	}
+
+	if r.addrs == nil {
+		r.store(id, nil)
+		return nil, nil
+	}
+
+	group, err := r.addrs.QueryAssetGroupByID(r.ctx, id)
+	switch {
+	case errors.Is(err, address.ErrAssetGroupUnknown):
+		r.store(id, nil)
+		return nil, nil
+
+	case err != nil:
+		return nil, fmt.Errorf("unable to look up group for asset "+
+			"%x: %w", id[:], err)
+	}
+
+	if group == nil || group.GroupKey == nil {
+		r.store(id, nil)
+		return nil, nil
+	}
+
+	keyBytes := group.GroupKey.GroupPubKey.SerializeCompressed()
+	r.store(id, keyBytes)
+	return keyBytes, nil
+}
+
+func (r *transferGroupKeyResolver) store(id asset.ID, keyBytes []byte) {
+	r.mu.Lock()
+	r.cache[id] = keyBytes
+	r.mu.Unlock()
+}
+
 // marshalOutboundParcel turns a pending parcel into its RPC counterpart.
-func marshalOutboundParcel(
-	parcel *tapfreighter.OutboundParcel) (*taprpc.AssetTransfer,
-	error) {
+//
+// resolver may be nil; callers that pass nil get a transfer without group_key
+// populated on inputs/outputs (legacy behavior). All in-tree call sites
+// supply a resolver via (*RPCServer).marshalOutboundParcel.
+func marshalOutboundParcel(parcel *tapfreighter.OutboundParcel,
+	resolver *transferGroupKeyResolver) (*taprpc.AssetTransfer, error) {
+
+	resolveGroupKey := func(id asset.ID) ([]byte, error) {
+		if resolver == nil {
+			return nil, nil
+		}
+		return resolver.groupKeyFor(id)
+	}
 
 	rpcInputs := make([]*taprpc.TransferInput, len(parcel.Inputs))
 	for idx := range parcel.Inputs {
 		in := parcel.Inputs[idx]
+
+		groupKey, err := resolveGroupKey(in.ID)
+		if err != nil {
+			return nil, err
+		}
+
 		rpcInputs[idx] = &taprpc.TransferInput{
 			AnchorPoint: in.OutPoint.String(),
 			AssetId:     in.ID[:],
 			ScriptKey:   in.ScriptKey[:],
 			Amount:      in.Amount,
+			GroupKey:    groupKey,
 		}
 	}
 
@@ -4209,6 +4310,11 @@ func marshalOutboundParcel(
 				"proof: %w", err)
 		}
 
+		groupKey, err := resolveGroupKey(proofAssetID)
+		if err != nil {
+			return nil, err
+		}
+
 		// Marshall the proof delivery status.
 		proofDeliveryStatus := marshalOutputProofDeliveryStatus(out)
 
@@ -4227,6 +4333,7 @@ func marshalOutboundParcel(
 			AssetId:             proofAssetID[:],
 			ProofCourierAddr:    string(out.ProofCourierAddr),
 			TapAddr:             out.TapAddress,
+			GroupKey:            groupKey,
 		}
 	}
 
@@ -5391,6 +5498,16 @@ func (r *RPCServer) SubscribeSendEvents(req *taprpc.SubscribeSendEventsRequest,
 		targetScriptKey = fn.MaybeSome(scriptKey)
 	}
 
+	// One resolver instance covers both historical replay and live event
+	// processing for this subscription. Group keys are stable for any given
+	// asset_id so the cache stays correct for the lifetime of the stream.
+	resolver := newTransferGroupKeyResolver(
+		ntfnStream.Context(), r.cfg.TapAddrBook,
+	)
+	marshalEvent := func(event fn.Event) (*taprpc.SendEvent, error) {
+		return marshalSendEvent(event, resolver)
+	}
+
 	// If a start timestamp is provided, first send historical events.
 	if req.StartTimestamp > 0 {
 		// Convert microseconds to time.Time
@@ -5441,7 +5558,7 @@ func (r *RPCServer) SubscribeSendEvents(req *taprpc.SubscribeSendEventsRequest,
 			// Since we already filtered at the database level, we
 			// can directly send all events. Marshal and send the
 			// event.
-			rpcEvent, err := marshalSendEvent(event)
+			rpcEvent, err := marshalEvent(event)
 			if err != nil {
 				rpcsLog.Errorf("Failed to marshal historical "+
 					"send event: %v", err)
@@ -5479,7 +5596,7 @@ func (r *RPCServer) SubscribeSendEvents(req *taprpc.SubscribeSendEventsRequest,
 	}
 
 	return handleEvents[bool, *taprpc.SendEvent](
-		r.cfg.ChainPorter, ntfnStream, marshalSendEvent, shouldNotify,
+		r.cfg.ChainPorter, ntfnStream, marshalEvent, shouldNotify,
 		r.quit, false,
 	)
 }
@@ -5716,7 +5833,12 @@ func marshallSendAssetEvent(event fn.Event) (*tapdevrpc.SendAssetEvent, error) {
 }
 
 // marshalSendEvent marshals an asset send event into the RPC counterpart.
-func marshalSendEvent(event fn.Event) (*taprpc.SendEvent, error) {
+//
+// resolver populates the group_key field on any embedded transfer's inputs
+// and outputs. May be nil for callers that do not need group_key populated.
+func marshalSendEvent(event fn.Event,
+	resolver *transferGroupKeyResolver) (*taprpc.SendEvent, error) {
+
 	e, ok := event.(*tapfreighter.AssetSendEvent)
 	if !ok {
 		return nil, fmt.Errorf("invalid event type: %T", event)
@@ -5831,7 +5953,9 @@ func marshalSendEvent(event fn.Event) (*taprpc.SendEvent, error) {
 	}
 
 	if e.Transfer != nil {
-		result.Transfer, err = marshalOutboundParcel(e.Transfer)
+		result.Transfer, err = marshalOutboundParcel(
+			e.Transfer, resolver,
+		)
 		if err != nil {
 			return nil, fmt.Errorf("error marshaling transfer: %w",
 				err)

--- a/taprpc/assetwalletrpc/assetwallet.swagger.json
+++ b/taprpc/assetwalletrpc/assetwallet.swagger.json
@@ -1268,6 +1268,11 @@
           "type": "string",
           "format": "uint64",
           "description": "The amount of the asset that was spent."
+        },
+        "group_key": {
+          "type": "string",
+          "format": "byte",
+          "description": "The group key of the asset that was spent, if the asset belongs to a\ngroup. Empty for assets that are not part of a group. Consumers that\nwant a single user-facing identifier should prefer this field when set\nand fall back to asset_id otherwise."
         }
       }
     },
@@ -1336,6 +1341,11 @@
         "tap_addr": {
           "type": "string",
           "description": "The Taproot Asset address that was used to create the output. This is\nonly set for new outputs for tapd versions that support the address V2\nformat. For older versions, this field will be empty."
+        },
+        "group_key": {
+          "type": "string",
+          "format": "byte",
+          "description": "The group key of the asset that was created in this output, if the\nasset belongs to a group. Empty for assets that are not part of a\ngroup. Consumers that want a single user-facing identifier should\nprefer this field when set and fall back to asset_id otherwise."
         }
       }
     },

--- a/taprpc/taprootassets.pb.go
+++ b/taprpc/taprootassets.pb.go
@@ -3406,7 +3406,12 @@ type TransferInput struct {
 	// The script key of the asset that was spent.
 	ScriptKey []byte `protobuf:"bytes,3,opt,name=script_key,json=scriptKey,proto3" json:"script_key,omitempty"`
 	// The amount of the asset that was spent.
-	Amount        uint64 `protobuf:"varint,4,opt,name=amount,proto3" json:"amount,omitempty"`
+	Amount uint64 `protobuf:"varint,4,opt,name=amount,proto3" json:"amount,omitempty"`
+	// The group key of the asset that was spent, if the asset belongs to a
+	// group. Empty for assets that are not part of a group. Consumers that
+	// want a single user-facing identifier should prefer this field when set
+	// and fall back to asset_id otherwise.
+	GroupKey      []byte `protobuf:"bytes,5,opt,name=group_key,json=groupKey,proto3" json:"group_key,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -3467,6 +3472,13 @@ func (x *TransferInput) GetAmount() uint64 {
 		return x.Amount
 	}
 	return 0
+}
+
+func (x *TransferInput) GetGroupKey() []byte {
+	if x != nil {
+		return x.GroupKey
+	}
+	return nil
 }
 
 type TransferOutputAnchor struct {
@@ -3637,7 +3649,12 @@ type TransferOutput struct {
 	// The Taproot Asset address that was used to create the output. This is
 	// only set for new outputs for tapd versions that support the address V2
 	// format. For older versions, this field will be empty.
-	TapAddr       string `protobuf:"bytes,14,opt,name=tap_addr,json=tapAddr,proto3" json:"tap_addr,omitempty"`
+	TapAddr string `protobuf:"bytes,14,opt,name=tap_addr,json=tapAddr,proto3" json:"tap_addr,omitempty"`
+	// The group key of the asset that was created in this output, if the
+	// asset belongs to a group. Empty for assets that are not part of a
+	// group. Consumers that want a single user-facing identifier should
+	// prefer this field when set and fall back to asset_id otherwise.
+	GroupKey      []byte `protobuf:"bytes,15,opt,name=group_key,json=groupKey,proto3" json:"group_key,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -3768,6 +3785,13 @@ func (x *TransferOutput) GetTapAddr() string {
 		return x.TapAddr
 	}
 	return ""
+}
+
+func (x *TransferOutput) GetGroupKey() []byte {
+	if x != nil {
+		return x.GroupKey
+	}
+	return nil
 }
 
 type StopRequest struct {
@@ -7655,13 +7679,14 @@ const file_taprootassets_proto_rawDesc = "" +
 	"\x16anchor_tx_block_height\x18\b \x01(\rR\x13anchorTxBlockHeight\x12\x14\n" +
 	"\x05label\x18\t \x01(\tR\x05label\x12\x1b\n" +
 	"\tanchor_tx\x18\n" +
-	" \x01(\fR\banchorTx\"\x84\x01\n" +
+	" \x01(\fR\banchorTx\"\xa1\x01\n" +
 	"\rTransferInput\x12!\n" +
 	"\fanchor_point\x18\x01 \x01(\tR\vanchorPoint\x12\x19\n" +
 	"\basset_id\x18\x02 \x01(\fR\aassetId\x12\x1d\n" +
 	"\n" +
 	"script_key\x18\x03 \x01(\fR\tscriptKey\x12\x16\n" +
-	"\x06amount\x18\x04 \x01(\x04R\x06amount\"\xb2\x02\n" +
+	"\x06amount\x18\x04 \x01(\x04R\x06amount\x12\x1b\n" +
+	"\tgroup_key\x18\x05 \x01(\fR\bgroupKey\"\xb2\x02\n" +
 	"\x14TransferOutputAnchor\x12\x1a\n" +
 	"\boutpoint\x18\x01 \x01(\tR\boutpoint\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\x03R\x05value\x12!\n" +
@@ -7671,7 +7696,7 @@ const file_taprootassets_proto_rawDesc = "" +
 	"merkleRoot\x12+\n" +
 	"\x11tapscript_sibling\x18\x06 \x01(\fR\x10tapscriptSibling\x12,\n" +
 	"\x12num_passive_assets\x18\a \x01(\rR\x10numPassiveAssets\x12\x1b\n" +
-	"\tpk_script\x18\b \x01(\fR\bpkScript\"\xf7\x04\n" +
+	"\tpk_script\x18\b \x01(\fR\bpkScript\"\x94\x05\n" +
 	"\x0eTransferOutput\x124\n" +
 	"\x06anchor\x18\x01 \x01(\v2\x1c.taprpc.TransferOutputAnchorR\x06anchor\x12\x1d\n" +
 	"\n" +
@@ -7689,7 +7714,8 @@ const file_taprootassets_proto_rawDesc = "" +
 	"\x15proof_delivery_status\x18\v \x01(\x0e2\x1b.taprpc.ProofDeliveryStatusR\x13proofDeliveryStatus\x12\x19\n" +
 	"\basset_id\x18\f \x01(\fR\aassetId\x12,\n" +
 	"\x12proof_courier_addr\x18\r \x01(\tR\x10proofCourierAddr\x12\x19\n" +
-	"\btap_addr\x18\x0e \x01(\tR\atapAddr\"\r\n" +
+	"\btap_addr\x18\x0e \x01(\tR\atapAddr\x12\x1b\n" +
+	"\tgroup_key\x18\x0f \x01(\fR\bgroupKey\"\r\n" +
 	"\vStopRequest\"\x0e\n" +
 	"\fStopResponse\"F\n" +
 	"\x11DebugLevelRequest\x12\x12\n" +

--- a/taprpc/taprootassets.proto
+++ b/taprpc/taprootassets.proto
@@ -938,6 +938,12 @@ message TransferInput {
 
     // The amount of the asset that was spent.
     uint64 amount = 4;
+
+    // The group key of the asset that was spent, if the asset belongs to a
+    // group. Empty for assets that are not part of a group. Consumers that
+    // want a single user-facing identifier should prefer this field when set
+    // and fall back to asset_id otherwise.
+    bytes group_key = 5;
 }
 
 message TransferOutputAnchor {
@@ -1072,6 +1078,12 @@ message TransferOutput {
     // only set for new outputs for tapd versions that support the address V2
     // format. For older versions, this field will be empty.
     string tap_addr = 14;
+
+    // The group key of the asset that was created in this output, if the
+    // asset belongs to a group. Empty for assets that are not part of a
+    // group. Consumers that want a single user-facing identifier should
+    // prefer this field when set and fall back to asset_id otherwise.
+    bytes group_key = 15;
 }
 
 message StopRequest {

--- a/taprpc/taprootassets.swagger.json
+++ b/taprpc/taprootassets.swagger.json
@@ -3143,6 +3143,11 @@
           "type": "string",
           "format": "uint64",
           "description": "The amount of the asset that was spent."
+        },
+        "group_key": {
+          "type": "string",
+          "format": "byte",
+          "description": "The group key of the asset that was spent, if the asset belongs to a\ngroup. Empty for assets that are not part of a group. Consumers that\nwant a single user-facing identifier should prefer this field when set\nand fall back to asset_id otherwise."
         }
       }
     },
@@ -3211,6 +3216,11 @@
         "tap_addr": {
           "type": "string",
           "description": "The Taproot Asset address that was used to create the output. This is\nonly set for new outputs for tapd versions that support the address V2\nformat. For older versions, this field will be empty."
+        },
+        "group_key": {
+          "type": "string",
+          "format": "byte",
+          "description": "The group key of the asset that was created in this output, if the\nasset belongs to a group. Empty for assets that are not part of a\ngroup. Consumers that want a single user-facing identifier should\nprefer this field when set and fall back to asset_id otherwise."
         }
       }
     },


### PR DESCRIPTION
## Summary

- Adds an optional `group_key` field to `TransferInput` and `TransferOutput` in `taprpc/taprootassets.proto` so consumers can identify the user-facing asset (group key for grouped fungibles, asset ID otherwise) without a side query.
- Populates the new field at marshal time in `rpcserver.marshalOutboundParcel` via `FetchGroupByGenesis`, with a per-call cache so a transfer with N inputs/outputs sharing one asset collapses to one DB query.
- Threads the same resolver through `marshalSendEvent` so `SubscribeSendEvents` benefits without an RPC-per-event lookup.
- Treats `address.ErrAssetGroupUnknown` as "no group" rather than a hard error so `ListTransfers` stays resilient against gaps in older rows; consumers fall back to `asset_id` in that case (same effective behavior as today).

`SendEvent.transfer` benefits automatically because it embeds `AssetTransfer`. `ReceiveEvent` already had what it needs via the embedded `Addr`, no change there. The change is additive: empty `bytes` ≡ "no group key" (proto3 default), older clients ignore the new field, newer clients see the empty default on responses from older daemons.

Closes #2121.