### PR TITLE
rpcserver: expose asset type on transfers

### DIFF
--- a/docs/release-notes/release-notes-0.8.0.md
+++ b/docs/release-notes/release-notes-0.8.0.md
@@ -333,6 +333,12 @@
 - [PR#2122](https://github.com/lightninglabs/taproot-assets/pull/2122)
   Add a `group_key` field to `TransferInput` and `TransferOutput`. Affects `ListTransfers` and the `transfer` field embedded in `SendEvent`.
 
+- [PR#2125](https://github.com/lightninglabs/taproot-assets/pull/2125)
+  Add an `asset_type` field to `TransferInput` and `TransferOutput`.
+  Affects `ListTransfers` and the `transfer` field embedded in
+  `SendEvent`, allowing clients to distinguish grouped fungible assets from
+  grouped collectible assets.
+
 ## tapcli Updates
 
 - [PR#1995](https://github.com/lightninglabs/taproot-assets/pull/1995)
@@ -455,4 +461,3 @@
 - [PR#2056](https://github.com/lightninglabs/taproot-assets/pull/2056)
   expands the example portfolio pilot with constraint enforcement,
   configurable fill caps, and live CoinGecko pricing.
-

--- a/itest/transfer_group_key_test.go
+++ b/itest/transfer_group_key_test.go
@@ -2,50 +2,58 @@ package itest
 
 import (
 	"context"
+	"testing"
+	"time"
 
+	"github.com/lightninglabs/taproot-assets/tapfreighter"
 	"github.com/lightninglabs/taproot-assets/taprpc"
 	"github.com/lightninglabs/taproot-assets/taprpc/mintrpc"
 	"github.com/stretchr/testify/require"
 )
 
-// testTransferGroupKey verifies that the group_key field added to
-// TransferInput and TransferOutput populates correctly across both
-// ListTransfers and SubscribeSendEvents for grouped fungible assets, and
-// stays empty for ungrouped (asset-id only) assets.
+// testTransferGroupKey verifies that transfer inputs and outputs carry enough
+// asset metadata across both ListTransfers and SubscribeSendEvents to identify
+// grouped fungible assets, ungrouped fungible assets, and grouped collectibles.
 //
-// This is the dedicated coverage for the marshal-time group-key resolver
+// This is the dedicated coverage for the marshal-time asset metadata resolver
 // that lives in rpcserver. The bytes carried in group_key must match the
-// asset's tweaked group public key exactly so SDK consumers can reconstruct
-// their user-facing identifier from the transfer alone, without a side
-// query.
+// asset's tweaked group public key exactly, and asset_type must match the
+// asset's genesis type.
 func testTransferGroupKey(t *harnessTest) {
 	ctxb := context.Background()
 
-	// Mint two assets in one batch so the test runs a single confirmation
-	// cycle: a grouped fungible (carries a group key) and an ungrouped
-	// fungible (asset-id only). Reusing the existing fixtures keeps this
-	// test in lock-step with the rest of the suite.
+	// Mint three assets in one batch so the test runs a single confirmation
+	// cycle: a grouped fungible, an ungrouped fungible, and a grouped
+	// collectible. Reusing the existing fixtures keeps this test in
+	// lock-step with the rest of the suite.
 	mintReqs := []*mintrpc.MintAssetRequest{
-		issuableAssets[0], // grouped fungible
-		simpleAssets[0],   // ungrouped fungible
+		issuableAssets[0], // grouped fungible.
+		simpleAssets[0],   // ungrouped fungible.
+		issuableAssets[1], // grouped collectible.
 	}
 	rpcAssets := MintAssetsConfirmBatch(
 		t.t, t.lndHarness.Miner(), t.tapd, mintReqs,
 	)
-	require.Len(t.t, rpcAssets, 2)
+	require.Len(t.t, rpcAssets, 3)
 
 	groupedAsset := rpcAssets[0]
 	ungroupedAsset := rpcAssets[1]
+	collectibleAsset := rpcAssets[2]
 	require.NotNil(t.t, groupedAsset.AssetGroup,
 		"first minted asset must carry a group key")
 	require.Nil(t.t, ungroupedAsset.AssetGroup,
 		"second minted asset must not carry a group key")
+	require.NotNil(t.t, collectibleAsset.AssetGroup,
+		"third minted asset must carry a group key")
 
 	expectedGroupKey := groupedAsset.AssetGroup.TweakedGroupKey
 	require.NotEmpty(t.t, expectedGroupKey)
+	expectedCollectibleGroupKey := collectibleAsset.AssetGroup.
+		TweakedGroupKey
+	require.NotEmpty(t.t, expectedCollectibleGroupKey)
 
-	// Spin up a receiver tapd. One node is enough — both transfers go to
-	// the same recipient.
+	// Spin up a receiver tapd. One node is enough because all transfers go
+	// to the same recipient.
 	bobLnd := t.lndHarness.NewNodeWithCoins("Bob", nil)
 	secondTapd := setupTapdHarness(t.t, t, bobLnd, t.universeServer)
 	defer func() {
@@ -63,13 +71,16 @@ func testTransferGroupKey(t *harnessTest) {
 	require.NoError(t.t, err)
 	AssertAddrCreated(t.t, secondTapd, groupedAsset, groupedAddr)
 
-	groupedSend, _ := sendAssetsToAddr(t, t.tapd, groupedAddr)
+	groupedSend, groupedEvents := sendAssetsToAddr(t, t.tapd, groupedAddr)
 	ConfirmAndAssertOutboundTransfer(
 		t.t, t.lndHarness.Miner(), t.tapd, groupedSend,
 		groupedAsset.AssetGenesis.AssetId,
 		[]uint64{groupedAsset.Amount - sendUnits, sendUnits}, 0, 1,
 	)
 	AssertNonInteractiveRecvComplete(t.t, secondTapd, 1)
+	assertCompletedSendEventAssetMeta(
+		t.t, groupedEvents, expectedGroupKey, taprpc.AssetType_NORMAL,
+	)
 
 	// Send the ungrouped asset.
 	ungroupedAddr, err := secondTapd.NewAddr(ctxb, &taprpc.NewAddrRequest{
@@ -80,48 +91,129 @@ func testTransferGroupKey(t *harnessTest) {
 	require.NoError(t.t, err)
 	AssertAddrCreated(t.t, secondTapd, ungroupedAsset, ungroupedAddr)
 
-	ungroupedSend, _ := sendAssetsToAddr(t, t.tapd, ungroupedAddr)
+	ungroupedSend, ungroupedEvents := sendAssetsToAddr(
+		t, t.tapd, ungroupedAddr,
+	)
 	ConfirmAndAssertOutboundTransfer(
 		t.t, t.lndHarness.Miner(), t.tapd, ungroupedSend,
 		ungroupedAsset.AssetGenesis.AssetId,
 		[]uint64{ungroupedAsset.Amount - sendUnits, sendUnits}, 1, 2,
 	)
 	AssertNonInteractiveRecvComplete(t.t, secondTapd, 2)
+	assertCompletedSendEventAssetMeta(
+		t.t, ungroupedEvents, nil, taprpc.AssetType_NORMAL,
+	)
+
+	// Send the grouped collectible. This is the important ambiguity check:
+	// grouped fungibles and NFT collection items both carry group_key, so
+	// transfer rows must also carry asset_type for SDKs to project them
+	// differently.
+	collectibleAddr, err := secondTapd.NewAddr(
+		ctxb, &taprpc.NewAddrRequest{
+			AssetId:      collectibleAsset.AssetGenesis.AssetId,
+			Amt:          collectibleAsset.Amount,
+			AssetVersion: collectibleAsset.Version,
+		},
+	)
+	require.NoError(t.t, err)
+	AssertAddrCreated(t.t, secondTapd, collectibleAsset, collectibleAddr)
+
+	collectibleSend, collectibleEvents := sendAssetsToAddr(
+		t, t.tapd, collectibleAddr,
+	)
+	ConfirmAndAssertOutboundTransfer(
+		t.t, t.lndHarness.Miner(), t.tapd, collectibleSend,
+		collectibleAsset.AssetGenesis.AssetId,
+		[]uint64{0, collectibleAsset.Amount}, 2, 3,
+	)
+	AssertNonInteractiveRecvComplete(t.t, secondTapd, 3)
+	assertCompletedSendEventAssetMeta(
+		t.t, collectibleEvents, expectedCollectibleGroupKey,
+		taprpc.AssetType_COLLECTIBLE,
+	)
 
 	// ListTransfers must surface group_key populated on every input and
-	// output of the grouped transfer, and empty on the ungrouped one.
+	// output of grouped transfers, empty on the ungrouped one, and
+	// asset_type populated for every transfer.
 	transferResp, err := t.tapd.ListTransfers(
 		ctxb, &taprpc.ListTransfersRequest{},
 	)
 	require.NoError(t.t, err)
-	require.Len(t.t, transferResp.Transfers, 2)
+	require.Len(t.t, transferResp.Transfers, 3)
 
-	// The two transfers come back in chronological order; the grouped
-	// send was issued first.
+	// The transfers come back in chronological order.
 	groupedTransfer := transferResp.Transfers[0]
 	ungroupedTransfer := transferResp.Transfers[1]
+	collectibleTransfer := transferResp.Transfers[2]
 
-	require.NotEmpty(t.t, groupedTransfer.Inputs)
-	for i, in := range groupedTransfer.Inputs {
-		require.Equalf(t.t, expectedGroupKey, in.GroupKey,
-			"grouped transfer input %d missing group_key", i)
-	}
-	require.NotEmpty(t.t, groupedTransfer.Outputs)
-	for i, out := range groupedTransfer.Outputs {
-		require.Equalf(t.t, expectedGroupKey, out.GroupKey,
-			"grouped transfer output %d missing group_key", i)
+	assertTransferAssetMeta(
+		t.t, groupedTransfer, expectedGroupKey, taprpc.AssetType_NORMAL,
+	)
+	assertTransferAssetMeta(
+		t.t, ungroupedTransfer, nil, taprpc.AssetType_NORMAL,
+	)
+	assertTransferAssetMeta(
+		t.t, collectibleTransfer, expectedCollectibleGroupKey,
+		taprpc.AssetType_COLLECTIBLE,
+	)
+}
+
+func assertTransferAssetMeta(t require.TestingT,
+	transfer *taprpc.AssetTransfer, groupKey []byte,
+	assetType taprpc.AssetType) {
+
+	require.NotEmpty(t, transfer.Inputs)
+	for i, in := range transfer.Inputs {
+		require.Equalf(t, groupKey, in.GroupKey,
+			"transfer input %d group_key mismatch", i)
+		require.Equalf(t, assetType, in.AssetType,
+			"transfer input %d asset_type mismatch", i)
 	}
 
-	require.NotEmpty(t.t, ungroupedTransfer.Inputs)
-	for i, in := range ungroupedTransfer.Inputs {
-		require.Emptyf(t.t, in.GroupKey,
-			"ungrouped transfer input %d should not carry "+
-				"group_key, got %x", i, in.GroupKey)
+	require.NotEmpty(t, transfer.Outputs)
+	for i, out := range transfer.Outputs {
+		require.Equalf(t, groupKey, out.GroupKey,
+			"transfer output %d group_key mismatch", i)
+		require.Equalf(t, assetType, out.AssetType,
+			"transfer output %d asset_type mismatch", i)
 	}
-	require.NotEmpty(t.t, ungroupedTransfer.Outputs)
-	for i, out := range ungroupedTransfer.Outputs {
-		require.Emptyf(t.t, out.GroupKey,
-			"ungrouped transfer output %d should not carry "+
-				"group_key, got %x", i, out.GroupKey)
+}
+
+func assertCompletedSendEventAssetMeta(t *testing.T,
+	stream *EventSubscription[*taprpc.SendEvent], groupKey []byte,
+	assetType taprpc.AssetType) {
+
+	success := make(chan struct{})
+	timeout := time.After(defaultWaitTimeout)
+	go func() {
+		select {
+		case <-timeout:
+			t.Logf("assertCompletedSendEventAssetMeta: " +
+				"cancelling stream after timeout")
+			stream.Cancel()
+
+		case <-success:
+		}
+	}()
+
+	expectedStatus := tapfreighter.SendStateWaitTxConf
+	for {
+		event, err := stream.Recv()
+		require.NoError(t, err, "receiving send event")
+		require.Emptyf(t, event.Error, "send event error: %x", event)
+		require.Equal(t, expectedStatus.String(), event.SendState)
+
+		if event.SendState == tapfreighter.SendStateComplete.String() {
+			require.NotNil(t, event.Transfer)
+			assertTransferAssetMeta(
+				t, event.Transfer, groupKey, assetType,
+			)
+
+			stream.Cancel()
+			close(success)
+			return
+		}
+
+		expectedStatus++
 	}
 }

--- a/rpcserver/rpcserver.go
+++ b/rpcserver/rpcserver.go
@@ -1706,7 +1706,7 @@ func (r *RPCServer) ListTransfers(ctx context.Context,
 		Transfers: make([]*taprpc.AssetTransfer, len(parcels)),
 	}
 
-	resolver := newTransferGroupKeyResolver(ctx, r.cfg.TapAddrBook)
+	resolver := newTransferAssetInfoResolver(ctx, r.cfg.TapAddrBook)
 	for idx := range parcels {
 		resp.Transfers[idx], err = marshalOutboundParcel(
 			parcels[idx], resolver,
@@ -2886,7 +2886,7 @@ func (r *RPCServer) AnchorVirtualPsbts(ctx context.Context,
 		return nil, fmt.Errorf("error requesting delivery: %w", err)
 	}
 
-	resolver := newTransferGroupKeyResolver(ctx, r.cfg.TapAddrBook)
+	resolver := newTransferAssetInfoResolver(ctx, r.cfg.TapAddrBook)
 	parcel, err := marshalOutboundParcel(resp, resolver)
 	if err != nil {
 		return nil, fmt.Errorf("error marshaling outbound parcel: %w",
@@ -3385,7 +3385,7 @@ func (r *RPCServer) PublishAndLogTransfer(ctx context.Context,
 		return nil, fmt.Errorf("error requesting delivery: %w", err)
 	}
 
-	resolver := newTransferGroupKeyResolver(ctx, r.cfg.TapAddrBook)
+	resolver := newTransferAssetInfoResolver(ctx, r.cfg.TapAddrBook)
 	parcel, err := marshalOutboundParcel(resp, resolver)
 	if err != nil {
 		return nil, fmt.Errorf("error marshaling outbound parcel: %w",
@@ -3820,7 +3820,7 @@ func (r *RPCServer) SendAsset(ctx context.Context,
 		return nil, err
 	}
 
-	resolver := newTransferGroupKeyResolver(ctx, r.cfg.TapAddrBook)
+	resolver := newTransferAssetInfoResolver(ctx, r.cfg.TapAddrBook)
 	parcel, err := marshalOutboundParcel(resp, resolver)
 	if err != nil {
 		return nil, fmt.Errorf("error marshaling outbound parcel: %w",
@@ -4079,7 +4079,7 @@ func (r *RPCServer) BurnAsset(ctx context.Context,
 		return nil, err
 	}
 
-	resolver := newTransferGroupKeyResolver(ctx, r.cfg.TapAddrBook)
+	resolver := newTransferAssetInfoResolver(ctx, r.cfg.TapAddrBook)
 	parcel, err := marshalOutboundParcel(resp, resolver)
 	if err != nil {
 		return nil, fmt.Errorf("error marshaling outbound parcel: %w",
@@ -4154,44 +4154,55 @@ func marshalRpcBurn(b *tapfreighter.AssetBurn) *taprpc.AssetBurn {
 	}
 }
 
-// transferGroupKeyResolver caches asset_id -> serialized group key lookups so
-// a transfer with N inputs/outputs sharing one asset collapses to one DB
-// query. An empty []byte cached value means "asset has no group" — the
-// resolver distinguishes a genuine miss from a not-yet-fetched entry via map
-// presence. The resolver is safe for concurrent use, so it can also be
-// captured by a SubscribeSendEvents marshaler closure that processes events
-// on the porter's goroutine.
-type transferGroupKeyResolver struct {
+type transferAssetInfo struct {
+	groupKey  []byte
+	assetType asset.Type
+}
+
+// transferAssetInfoResolver caches asset_id -> transfer asset metadata lookups
+// so a transfer with N inputs/outputs sharing one asset collapses to one DB
+// query. A nil groupKey means "asset has no group". The resolver distinguishes
+// a genuine cache miss from a cached ungrouped asset via map presence. The
+// resolver is safe for concurrent use, so it can also be captured by a
+// SubscribeSendEvents marshaler closure that processes events on the porter's
+// goroutine.
+type transferAssetInfoResolver struct {
 	ctx   context.Context
 	addrs *tapdb.TapAddressBook
 
 	mu    sync.RWMutex
-	cache map[asset.ID][]byte
+	cache map[asset.ID]transferAssetInfo
 }
 
-// newTransferGroupKeyResolver builds a resolver bound to ctx and the daemon's
+// newTransferAssetInfoResolver builds a resolver bound to ctx and the daemon's
 // address book. Pass a request-scoped ctx for unary RPCs and a
 // stream-scoped ctx for subscription marshalers.
-func newTransferGroupKeyResolver(ctx context.Context,
-	addrs *tapdb.TapAddressBook) *transferGroupKeyResolver {
+func newTransferAssetInfoResolver(ctx context.Context,
+	addrs *tapdb.TapAddressBook) *transferAssetInfoResolver {
 
-	return &transferGroupKeyResolver{
+	return &transferAssetInfoResolver{
 		ctx:   ctx,
 		addrs: addrs,
-		cache: make(map[asset.ID][]byte),
+		cache: make(map[asset.ID]transferAssetInfo),
 	}
 }
 
-// groupKeyFor returns the compressed serialized group public key for assetID,
-// or an empty slice if the asset has no group. The result is cached for the
-// lifetime of the resolver.
+func defaultTransferAssetInfo() transferAssetInfo {
+	return transferAssetInfo{
+		assetType: asset.Normal,
+	}
+}
+
+// infoFor returns the transfer asset metadata for assetID. The result is
+// cached for the lifetime of the resolver.
 //
 // A daemon that does not know the asset's genesis
-// (address.ErrAssetGroupUnknown) is treated as "no group" rather than a hard
-// error so that ListTransfers stays resilient against gaps in older rows;
-// downstream consumers fall back to asset_id in that case, which preserves
-// the pre-fix behavior.
-func (r *transferGroupKeyResolver) groupKeyFor(id asset.ID) ([]byte, error) {
+// (address.ErrAssetGroupUnknown) is treated as an ungrouped normal asset rather
+// than a hard error so that ListTransfers stays resilient against gaps in older
+// rows.
+func (r *transferAssetInfoResolver) infoFor(id asset.ID) (
+	transferAssetInfo, error) {
+
 	r.mu.RLock()
 	cached, ok := r.cache[id]
 	r.mu.RUnlock()
@@ -4199,58 +4210,64 @@ func (r *transferGroupKeyResolver) groupKeyFor(id asset.ID) ([]byte, error) {
 		return cached, nil
 	}
 
+	defaultInfo := defaultTransferAssetInfo()
 	if r.addrs == nil {
-		r.store(id, nil)
-		return nil, nil
+		r.store(id, defaultInfo)
+		return defaultInfo, nil
 	}
 
 	group, err := r.addrs.QueryAssetGroupByID(r.ctx, id)
 	switch {
 	case errors.Is(err, address.ErrAssetGroupUnknown):
-		r.store(id, nil)
-		return nil, nil
+		r.store(id, defaultInfo)
+		return defaultInfo, nil
 
 	case err != nil:
-		return nil, fmt.Errorf("unable to look up group for asset "+
+		return transferAssetInfo{}, fmt.Errorf("unable to look up "+
+			"asset information for asset "+
 			"%x: %w", id[:], err)
 	}
 
-	if group == nil || group.GroupKey == nil {
-		r.store(id, nil)
-		return nil, nil
+	info := defaultInfo
+	if group != nil && group.Genesis != nil {
+		info.assetType = group.Genesis.Type
 	}
 
-	keyBytes := group.GroupKey.GroupPubKey.SerializeCompressed()
-	r.store(id, keyBytes)
-	return keyBytes, nil
+	if group != nil && group.GroupKey != nil {
+		info.groupKey = group.GroupKey.GroupPubKey.SerializeCompressed()
+	}
+
+	r.store(id, info)
+	return info, nil
 }
 
-func (r *transferGroupKeyResolver) store(id asset.ID, keyBytes []byte) {
+func (r *transferAssetInfoResolver) store(id asset.ID,
+	info transferAssetInfo) {
+
 	r.mu.Lock()
-	r.cache[id] = keyBytes
+	r.cache[id] = info
 	r.mu.Unlock()
 }
 
 // marshalOutboundParcel turns a pending parcel into its RPC counterpart.
 //
 // resolver may be nil; callers that pass nil get a transfer without group_key
-// populated on inputs/outputs (legacy behavior). All in-tree call sites
-// supply a resolver via (*RPCServer).marshalOutboundParcel.
+// populated on inputs/outputs and with asset_type defaulting to NORMAL.
 func marshalOutboundParcel(parcel *tapfreighter.OutboundParcel,
-	resolver *transferGroupKeyResolver) (*taprpc.AssetTransfer, error) {
+	resolver *transferAssetInfoResolver) (*taprpc.AssetTransfer, error) {
 
-	resolveGroupKey := func(id asset.ID) ([]byte, error) {
+	resolveAssetInfo := func(id asset.ID) (transferAssetInfo, error) {
 		if resolver == nil {
-			return nil, nil
+			return defaultTransferAssetInfo(), nil
 		}
-		return resolver.groupKeyFor(id)
+		return resolver.infoFor(id)
 	}
 
 	rpcInputs := make([]*taprpc.TransferInput, len(parcel.Inputs))
 	for idx := range parcel.Inputs {
 		in := parcel.Inputs[idx]
 
-		groupKey, err := resolveGroupKey(in.ID)
+		assetInfo, err := resolveAssetInfo(in.ID)
 		if err != nil {
 			return nil, err
 		}
@@ -4260,7 +4277,8 @@ func marshalOutboundParcel(parcel *tapfreighter.OutboundParcel,
 			AssetId:     in.ID[:],
 			ScriptKey:   in.ScriptKey[:],
 			Amount:      in.Amount,
-			GroupKey:    groupKey,
+			GroupKey:    assetInfo.groupKey,
+			AssetType:   taprpc.AssetType(assetInfo.assetType),
 		}
 	}
 
@@ -4310,7 +4328,7 @@ func marshalOutboundParcel(parcel *tapfreighter.OutboundParcel,
 				"proof: %w", err)
 		}
 
-		groupKey, err := resolveGroupKey(proofAssetID)
+		assetInfo, err := resolveAssetInfo(proofAssetID)
 		if err != nil {
 			return nil, err
 		}
@@ -4333,7 +4351,10 @@ func marshalOutboundParcel(parcel *tapfreighter.OutboundParcel,
 			AssetId:             proofAssetID[:],
 			ProofCourierAddr:    string(out.ProofCourierAddr),
 			TapAddr:             out.TapAddress,
-			GroupKey:            groupKey,
+			GroupKey:            assetInfo.groupKey,
+			AssetType: taprpc.AssetType(
+				assetInfo.assetType,
+			),
 		}
 	}
 
@@ -5499,9 +5520,10 @@ func (r *RPCServer) SubscribeSendEvents(req *taprpc.SubscribeSendEventsRequest,
 	}
 
 	// One resolver instance covers both historical replay and live event
-	// processing for this subscription. Group keys are stable for any given
-	// asset_id so the cache stays correct for the lifetime of the stream.
-	resolver := newTransferGroupKeyResolver(
+	// processing for this subscription. Transfer asset information is
+	// stable for any given asset_id, so the cache stays correct for the
+	// lifetime of the stream.
+	resolver := newTransferAssetInfoResolver(
 		ntfnStream.Context(), r.cfg.TapAddrBook,
 	)
 	marshalEvent := func(event fn.Event) (*taprpc.SendEvent, error) {
@@ -5834,10 +5856,11 @@ func marshallSendAssetEvent(event fn.Event) (*tapdevrpc.SendAssetEvent, error) {
 
 // marshalSendEvent marshals an asset send event into the RPC counterpart.
 //
-// resolver populates the group_key field on any embedded transfer's inputs
-// and outputs. May be nil for callers that do not need group_key populated.
+// resolver populates the group_key and asset_type fields on any embedded
+// transfer's inputs and outputs. It may be nil for callers that do not need
+// enriched transfer metadata.
 func marshalSendEvent(event fn.Event,
-	resolver *transferGroupKeyResolver) (*taprpc.SendEvent, error) {
+	resolver *transferAssetInfoResolver) (*taprpc.SendEvent, error) {
 
 	e, ok := event.(*tapfreighter.AssetSendEvent)
 	if !ok {

--- a/taprpc/assetwalletrpc/assetwallet.swagger.json
+++ b/taprpc/assetwalletrpc/assetwallet.swagger.json
@@ -1113,6 +1113,15 @@
         }
       }
     },
+    "taprpcAssetType": {
+      "type": "string",
+      "enum": [
+        "NORMAL",
+        "COLLECTIBLE"
+      ],
+      "default": "NORMAL",
+      "description": " - NORMAL: Indicates that an asset is capable of being split/merged, with each of the\nunits being fungible, even across a key asset ID boundary (assuming the\nkey group is the same).\n - COLLECTIBLE: Indicates that an asset is a collectible, meaning that each of the other\nitems under the same key group are not fully fungible with each other.\nCollectibles also cannot be split or merged."
+    },
     "taprpcAssetVersion": {
       "type": "string",
       "enum": [
@@ -1272,7 +1281,11 @@
         "group_key": {
           "type": "string",
           "format": "byte",
-          "description": "The group key of the asset that was spent, if the asset belongs to a\ngroup. Empty for assets that are not part of a group. Consumers that\nwant a single user-facing identifier should prefer this field when set\nand fall back to asset_id otherwise."
+          "description": "The group key of the asset that was spent, if the asset belongs to a\ngroup. Empty for assets that are not part of a group."
+        },
+        "asset_type": {
+          "$ref": "#/definitions/taprpcAssetType",
+          "description": "The type of the asset that was spent."
         }
       }
     },
@@ -1345,7 +1358,11 @@
         "group_key": {
           "type": "string",
           "format": "byte",
-          "description": "The group key of the asset that was created in this output, if the\nasset belongs to a group. Empty for assets that are not part of a\ngroup. Consumers that want a single user-facing identifier should\nprefer this field when set and fall back to asset_id otherwise."
+          "description": "The group key of the asset that was created in this output, if the\nasset belongs to a group. Empty for assets that are not part of a\ngroup."
+        },
+        "asset_type": {
+          "$ref": "#/definitions/taprpcAssetType",
+          "description": "The type of the asset that was created in this output."
         }
       }
     },

--- a/taprpc/taprootassets.pb.go
+++ b/taprpc/taprootassets.pb.go
@@ -3408,10 +3408,10 @@ type TransferInput struct {
 	// The amount of the asset that was spent.
 	Amount uint64 `protobuf:"varint,4,opt,name=amount,proto3" json:"amount,omitempty"`
 	// The group key of the asset that was spent, if the asset belongs to a
-	// group. Empty for assets that are not part of a group. Consumers that
-	// want a single user-facing identifier should prefer this field when set
-	// and fall back to asset_id otherwise.
-	GroupKey      []byte `protobuf:"bytes,5,opt,name=group_key,json=groupKey,proto3" json:"group_key,omitempty"`
+	// group. Empty for assets that are not part of a group.
+	GroupKey []byte `protobuf:"bytes,5,opt,name=group_key,json=groupKey,proto3" json:"group_key,omitempty"`
+	// The type of the asset that was spent.
+	AssetType     AssetType `protobuf:"varint,6,opt,name=asset_type,json=assetType,proto3,enum=taprpc.AssetType" json:"asset_type,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -3479,6 +3479,13 @@ func (x *TransferInput) GetGroupKey() []byte {
 		return x.GroupKey
 	}
 	return nil
+}
+
+func (x *TransferInput) GetAssetType() AssetType {
+	if x != nil {
+		return x.AssetType
+	}
+	return AssetType_NORMAL
 }
 
 type TransferOutputAnchor struct {
@@ -3652,9 +3659,10 @@ type TransferOutput struct {
 	TapAddr string `protobuf:"bytes,14,opt,name=tap_addr,json=tapAddr,proto3" json:"tap_addr,omitempty"`
 	// The group key of the asset that was created in this output, if the
 	// asset belongs to a group. Empty for assets that are not part of a
-	// group. Consumers that want a single user-facing identifier should
-	// prefer this field when set and fall back to asset_id otherwise.
-	GroupKey      []byte `protobuf:"bytes,15,opt,name=group_key,json=groupKey,proto3" json:"group_key,omitempty"`
+	// group.
+	GroupKey []byte `protobuf:"bytes,15,opt,name=group_key,json=groupKey,proto3" json:"group_key,omitempty"`
+	// The type of the asset that was created in this output.
+	AssetType     AssetType `protobuf:"varint,16,opt,name=asset_type,json=assetType,proto3,enum=taprpc.AssetType" json:"asset_type,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -3792,6 +3800,13 @@ func (x *TransferOutput) GetGroupKey() []byte {
 		return x.GroupKey
 	}
 	return nil
+}
+
+func (x *TransferOutput) GetAssetType() AssetType {
+	if x != nil {
+		return x.AssetType
+	}
+	return AssetType_NORMAL
 }
 
 type StopRequest struct {
@@ -7679,14 +7694,16 @@ const file_taprootassets_proto_rawDesc = "" +
 	"\x16anchor_tx_block_height\x18\b \x01(\rR\x13anchorTxBlockHeight\x12\x14\n" +
 	"\x05label\x18\t \x01(\tR\x05label\x12\x1b\n" +
 	"\tanchor_tx\x18\n" +
-	" \x01(\fR\banchorTx\"\xa1\x01\n" +
+	" \x01(\fR\banchorTx\"\xd3\x01\n" +
 	"\rTransferInput\x12!\n" +
 	"\fanchor_point\x18\x01 \x01(\tR\vanchorPoint\x12\x19\n" +
 	"\basset_id\x18\x02 \x01(\fR\aassetId\x12\x1d\n" +
 	"\n" +
 	"script_key\x18\x03 \x01(\fR\tscriptKey\x12\x16\n" +
 	"\x06amount\x18\x04 \x01(\x04R\x06amount\x12\x1b\n" +
-	"\tgroup_key\x18\x05 \x01(\fR\bgroupKey\"\xb2\x02\n" +
+	"\tgroup_key\x18\x05 \x01(\fR\bgroupKey\x120\n" +
+	"\n" +
+	"asset_type\x18\x06 \x01(\x0e2\x11.taprpc.AssetTypeR\tassetType\"\xb2\x02\n" +
 	"\x14TransferOutputAnchor\x12\x1a\n" +
 	"\boutpoint\x18\x01 \x01(\tR\boutpoint\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\x03R\x05value\x12!\n" +
@@ -7696,7 +7713,7 @@ const file_taprootassets_proto_rawDesc = "" +
 	"merkleRoot\x12+\n" +
 	"\x11tapscript_sibling\x18\x06 \x01(\fR\x10tapscriptSibling\x12,\n" +
 	"\x12num_passive_assets\x18\a \x01(\rR\x10numPassiveAssets\x12\x1b\n" +
-	"\tpk_script\x18\b \x01(\fR\bpkScript\"\x94\x05\n" +
+	"\tpk_script\x18\b \x01(\fR\bpkScript\"\xc6\x05\n" +
 	"\x0eTransferOutput\x124\n" +
 	"\x06anchor\x18\x01 \x01(\v2\x1c.taprpc.TransferOutputAnchorR\x06anchor\x12\x1d\n" +
 	"\n" +
@@ -7715,7 +7732,9 @@ const file_taprootassets_proto_rawDesc = "" +
 	"\basset_id\x18\f \x01(\fR\aassetId\x12,\n" +
 	"\x12proof_courier_addr\x18\r \x01(\tR\x10proofCourierAddr\x12\x19\n" +
 	"\btap_addr\x18\x0e \x01(\tR\atapAddr\x12\x1b\n" +
-	"\tgroup_key\x18\x0f \x01(\fR\bgroupKey\"\r\n" +
+	"\tgroup_key\x18\x0f \x01(\fR\bgroupKey\x120\n" +
+	"\n" +
+	"asset_type\x18\x10 \x01(\x0e2\x11.taprpc.AssetTypeR\tassetType\"\r\n" +
 	"\vStopRequest\"\x0e\n" +
 	"\fStopResponse\"F\n" +
 	"\x11DebugLevelRequest\x12\x12\n" +
@@ -8232,113 +8251,115 @@ var file_taprootassets_proto_depIdxs = []int32{
 	45,  // 37: taprpc.AssetTransfer.inputs:type_name -> taprpc.TransferInput
 	47,  // 38: taprpc.AssetTransfer.outputs:type_name -> taprpc.TransferOutput
 	43,  // 39: taprpc.AssetTransfer.anchor_tx_block_hash:type_name -> taprpc.ChainHash
-	46,  // 40: taprpc.TransferOutput.anchor:type_name -> taprpc.TransferOutputAnchor
-	3,   // 41: taprpc.TransferOutput.output_type:type_name -> taprpc.OutputType
-	2,   // 42: taprpc.TransferOutput.asset_version:type_name -> taprpc.AssetVersion
-	4,   // 43: taprpc.TransferOutput.proof_delivery_status:type_name -> taprpc.ProofDeliveryStatus
-	0,   // 44: taprpc.Addr.asset_type:type_name -> taprpc.AssetType
-	2,   // 45: taprpc.Addr.asset_version:type_name -> taprpc.AssetVersion
-	5,   // 46: taprpc.Addr.address_version:type_name -> taprpc.AddrVersion
-	52,  // 47: taprpc.QueryAddrResponse.addrs:type_name -> taprpc.Addr
-	57,  // 48: taprpc.NewAddrRequest.script_key:type_name -> taprpc.ScriptKey
-	59,  // 49: taprpc.NewAddrRequest.internal_key:type_name -> taprpc.KeyDescriptor
-	2,   // 50: taprpc.NewAddrRequest.asset_version:type_name -> taprpc.AssetVersion
-	5,   // 51: taprpc.NewAddrRequest.address_version:type_name -> taprpc.AddrVersion
-	6,   // 52: taprpc.ScriptKeyTypeQuery.explicit_type:type_name -> taprpc.ScriptKeyType
-	59,  // 53: taprpc.ScriptKey.key_desc:type_name -> taprpc.KeyDescriptor
-	6,   // 54: taprpc.ScriptKey.type:type_name -> taprpc.ScriptKeyType
-	58,  // 55: taprpc.KeyDescriptor.key_loc:type_name -> taprpc.KeyLocator
-	61,  // 56: taprpc.TapscriptFullTree.all_leaves:type_name -> taprpc.TapLeaf
-	26,  // 57: taprpc.DecodedProof.asset:type_name -> taprpc.Asset
-	10,  // 58: taprpc.DecodedProof.meta_reveal:type_name -> taprpc.AssetMeta
-	24,  // 59: taprpc.DecodedProof.genesis_reveal:type_name -> taprpc.GenesisReveal
-	23,  // 60: taprpc.DecodedProof.group_key_reveal:type_name -> taprpc.GroupKeyReveal
-	65,  // 61: taprpc.VerifyProofResponse.decoded_proof:type_name -> taprpc.DecodedProof
-	65,  // 62: taprpc.DecodeProofResponse.decoded_proof:type_name -> taprpc.DecodedProof
-	103, // 63: taprpc.ExportProofRequest.outpoint:type_name -> taprpc.OutPoint
-	52,  // 64: taprpc.AddrEvent.addr:type_name -> taprpc.Addr
-	7,   // 65: taprpc.AddrEvent.status:type_name -> taprpc.AddrEventStatus
-	7,   // 66: taprpc.AddrReceivesRequest.filter_status:type_name -> taprpc.AddrEventStatus
-	104, // 67: taprpc.AddrReceivesRequest.direction:type_name -> taprpc.SortDirection
-	72,  // 68: taprpc.AddrReceivesResponse.events:type_name -> taprpc.AddrEvent
-	76,  // 69: taprpc.SendAssetRequest.addresses_with_amounts:type_name -> taprpc.AddressWithAmount
-	44,  // 70: taprpc.SendAssetResponse.transfer:type_name -> taprpc.AssetTransfer
-	1,   // 71: taprpc.FetchAssetMetaResponse.type:type_name -> taprpc.AssetMetaType
-	102, // 72: taprpc.FetchAssetMetaResponse.unknown_odd_types:type_name -> taprpc.FetchAssetMetaResponse.UnknownOddTypesEntry
-	11,  // 73: taprpc.BurnAssetRequest.asset_specifier:type_name -> taprpc.AssetSpecifier
-	44,  // 74: taprpc.BurnAssetResponse.burn_transfer:type_name -> taprpc.AssetTransfer
-	65,  // 75: taprpc.BurnAssetResponse.burn_proof:type_name -> taprpc.DecodedProof
-	65,  // 76: taprpc.BurnAssetResponse.burn_proofs:type_name -> taprpc.DecodedProof
-	86,  // 77: taprpc.ListBurnsResponse.burns:type_name -> taprpc.AssetBurn
-	52,  // 78: taprpc.ReceiveEvent.address:type_name -> taprpc.Addr
-	7,   // 79: taprpc.ReceiveEvent.status:type_name -> taprpc.AddrEventStatus
-	9,   // 80: taprpc.SendEvent.parcel_type:type_name -> taprpc.ParcelType
-	52,  // 81: taprpc.SendEvent.addresses:type_name -> taprpc.Addr
-	92,  // 82: taprpc.SendEvent.anchor_transaction:type_name -> taprpc.AnchorTransaction
-	44,  // 83: taprpc.SendEvent.transfer:type_name -> taprpc.AssetTransfer
-	103, // 84: taprpc.AnchorTransaction.lnd_locked_utxos:type_name -> taprpc.OutPoint
-	103, // 85: taprpc.RegisterTransferRequest.outpoint:type_name -> taprpc.OutPoint
-	26,  // 86: taprpc.RegisterTransferResponse.registered_asset:type_name -> taprpc.Asset
-	95,  // 87: taprpc.BakeMacaroonRequest.permissions:type_name -> taprpc.MacaroonPermission
-	31,  // 88: taprpc.ListUtxosResponse.ManagedUtxosEntry.value:type_name -> taprpc.ManagedUtxo
-	35,  // 89: taprpc.ListGroupsResponse.GroupsEntry.value:type_name -> taprpc.GroupedAssets
-	38,  // 90: taprpc.ListBalancesResponse.AssetBalancesEntry.value:type_name -> taprpc.AssetBalance
-	39,  // 91: taprpc.ListBalancesResponse.AssetGroupBalancesEntry.value:type_name -> taprpc.AssetGroupBalance
-	14,  // 92: taprpc.TaprootAssets.ListAssets:input_type -> taprpc.ListAssetRequest
-	12,  // 93: taprpc.TaprootAssets.FetchAsset:input_type -> taprpc.FetchAssetRequest
-	30,  // 94: taprpc.TaprootAssets.ListUtxos:input_type -> taprpc.ListUtxosRequest
-	33,  // 95: taprpc.TaprootAssets.ListGroups:input_type -> taprpc.ListGroupsRequest
-	37,  // 96: taprpc.TaprootAssets.ListBalances:input_type -> taprpc.ListBalancesRequest
-	41,  // 97: taprpc.TaprootAssets.ListTransfers:input_type -> taprpc.ListTransfersRequest
-	48,  // 98: taprpc.TaprootAssets.StopDaemon:input_type -> taprpc.StopRequest
-	50,  // 99: taprpc.TaprootAssets.DebugLevel:input_type -> taprpc.DebugLevelRequest
-	53,  // 100: taprpc.TaprootAssets.QueryAddrs:input_type -> taprpc.QueryAddrRequest
-	55,  // 101: taprpc.TaprootAssets.NewAddr:input_type -> taprpc.NewAddrRequest
-	63,  // 102: taprpc.TaprootAssets.DecodeAddr:input_type -> taprpc.DecodeAddrRequest
-	73,  // 103: taprpc.TaprootAssets.AddrReceives:input_type -> taprpc.AddrReceivesRequest
-	64,  // 104: taprpc.TaprootAssets.VerifyProof:input_type -> taprpc.ProofFile
-	67,  // 105: taprpc.TaprootAssets.DecodeProof:input_type -> taprpc.DecodeProofRequest
-	69,  // 106: taprpc.TaprootAssets.ExportProof:input_type -> taprpc.ExportProofRequest
-	70,  // 107: taprpc.TaprootAssets.UnpackProofFile:input_type -> taprpc.UnpackProofFileRequest
-	75,  // 108: taprpc.TaprootAssets.SendAsset:input_type -> taprpc.SendAssetRequest
-	83,  // 109: taprpc.TaprootAssets.BurnAsset:input_type -> taprpc.BurnAssetRequest
-	85,  // 110: taprpc.TaprootAssets.ListBurns:input_type -> taprpc.ListBurnsRequest
-	79,  // 111: taprpc.TaprootAssets.GetInfo:input_type -> taprpc.GetInfoRequest
-	96,  // 112: taprpc.TaprootAssets.BakeMacaroon:input_type -> taprpc.BakeMacaroonRequest
-	81,  // 113: taprpc.TaprootAssets.FetchAssetMeta:input_type -> taprpc.FetchAssetMetaRequest
-	88,  // 114: taprpc.TaprootAssets.SubscribeReceiveEvents:input_type -> taprpc.SubscribeReceiveEventsRequest
-	90,  // 115: taprpc.TaprootAssets.SubscribeSendEvents:input_type -> taprpc.SubscribeSendEventsRequest
-	93,  // 116: taprpc.TaprootAssets.RegisterTransfer:input_type -> taprpc.RegisterTransferRequest
-	29,  // 117: taprpc.TaprootAssets.ListAssets:output_type -> taprpc.ListAssetResponse
-	13,  // 118: taprpc.TaprootAssets.FetchAsset:output_type -> taprpc.FetchAssetResponse
-	32,  // 119: taprpc.TaprootAssets.ListUtxos:output_type -> taprpc.ListUtxosResponse
-	36,  // 120: taprpc.TaprootAssets.ListGroups:output_type -> taprpc.ListGroupsResponse
-	40,  // 121: taprpc.TaprootAssets.ListBalances:output_type -> taprpc.ListBalancesResponse
-	42,  // 122: taprpc.TaprootAssets.ListTransfers:output_type -> taprpc.ListTransfersResponse
-	49,  // 123: taprpc.TaprootAssets.StopDaemon:output_type -> taprpc.StopResponse
-	51,  // 124: taprpc.TaprootAssets.DebugLevel:output_type -> taprpc.DebugLevelResponse
-	54,  // 125: taprpc.TaprootAssets.QueryAddrs:output_type -> taprpc.QueryAddrResponse
-	52,  // 126: taprpc.TaprootAssets.NewAddr:output_type -> taprpc.Addr
-	52,  // 127: taprpc.TaprootAssets.DecodeAddr:output_type -> taprpc.Addr
-	74,  // 128: taprpc.TaprootAssets.AddrReceives:output_type -> taprpc.AddrReceivesResponse
-	66,  // 129: taprpc.TaprootAssets.VerifyProof:output_type -> taprpc.VerifyProofResponse
-	68,  // 130: taprpc.TaprootAssets.DecodeProof:output_type -> taprpc.DecodeProofResponse
-	64,  // 131: taprpc.TaprootAssets.ExportProof:output_type -> taprpc.ProofFile
-	71,  // 132: taprpc.TaprootAssets.UnpackProofFile:output_type -> taprpc.UnpackProofFileResponse
-	78,  // 133: taprpc.TaprootAssets.SendAsset:output_type -> taprpc.SendAssetResponse
-	84,  // 134: taprpc.TaprootAssets.BurnAsset:output_type -> taprpc.BurnAssetResponse
-	87,  // 135: taprpc.TaprootAssets.ListBurns:output_type -> taprpc.ListBurnsResponse
-	80,  // 136: taprpc.TaprootAssets.GetInfo:output_type -> taprpc.GetInfoResponse
-	97,  // 137: taprpc.TaprootAssets.BakeMacaroon:output_type -> taprpc.BakeMacaroonResponse
-	82,  // 138: taprpc.TaprootAssets.FetchAssetMeta:output_type -> taprpc.FetchAssetMetaResponse
-	89,  // 139: taprpc.TaprootAssets.SubscribeReceiveEvents:output_type -> taprpc.ReceiveEvent
-	91,  // 140: taprpc.TaprootAssets.SubscribeSendEvents:output_type -> taprpc.SendEvent
-	94,  // 141: taprpc.TaprootAssets.RegisterTransfer:output_type -> taprpc.RegisterTransferResponse
-	117, // [117:142] is the sub-list for method output_type
-	92,  // [92:117] is the sub-list for method input_type
-	92,  // [92:92] is the sub-list for extension type_name
-	92,  // [92:92] is the sub-list for extension extendee
-	0,   // [0:92] is the sub-list for field type_name
+	0,   // 40: taprpc.TransferInput.asset_type:type_name -> taprpc.AssetType
+	46,  // 41: taprpc.TransferOutput.anchor:type_name -> taprpc.TransferOutputAnchor
+	3,   // 42: taprpc.TransferOutput.output_type:type_name -> taprpc.OutputType
+	2,   // 43: taprpc.TransferOutput.asset_version:type_name -> taprpc.AssetVersion
+	4,   // 44: taprpc.TransferOutput.proof_delivery_status:type_name -> taprpc.ProofDeliveryStatus
+	0,   // 45: taprpc.TransferOutput.asset_type:type_name -> taprpc.AssetType
+	0,   // 46: taprpc.Addr.asset_type:type_name -> taprpc.AssetType
+	2,   // 47: taprpc.Addr.asset_version:type_name -> taprpc.AssetVersion
+	5,   // 48: taprpc.Addr.address_version:type_name -> taprpc.AddrVersion
+	52,  // 49: taprpc.QueryAddrResponse.addrs:type_name -> taprpc.Addr
+	57,  // 50: taprpc.NewAddrRequest.script_key:type_name -> taprpc.ScriptKey
+	59,  // 51: taprpc.NewAddrRequest.internal_key:type_name -> taprpc.KeyDescriptor
+	2,   // 52: taprpc.NewAddrRequest.asset_version:type_name -> taprpc.AssetVersion
+	5,   // 53: taprpc.NewAddrRequest.address_version:type_name -> taprpc.AddrVersion
+	6,   // 54: taprpc.ScriptKeyTypeQuery.explicit_type:type_name -> taprpc.ScriptKeyType
+	59,  // 55: taprpc.ScriptKey.key_desc:type_name -> taprpc.KeyDescriptor
+	6,   // 56: taprpc.ScriptKey.type:type_name -> taprpc.ScriptKeyType
+	58,  // 57: taprpc.KeyDescriptor.key_loc:type_name -> taprpc.KeyLocator
+	61,  // 58: taprpc.TapscriptFullTree.all_leaves:type_name -> taprpc.TapLeaf
+	26,  // 59: taprpc.DecodedProof.asset:type_name -> taprpc.Asset
+	10,  // 60: taprpc.DecodedProof.meta_reveal:type_name -> taprpc.AssetMeta
+	24,  // 61: taprpc.DecodedProof.genesis_reveal:type_name -> taprpc.GenesisReveal
+	23,  // 62: taprpc.DecodedProof.group_key_reveal:type_name -> taprpc.GroupKeyReveal
+	65,  // 63: taprpc.VerifyProofResponse.decoded_proof:type_name -> taprpc.DecodedProof
+	65,  // 64: taprpc.DecodeProofResponse.decoded_proof:type_name -> taprpc.DecodedProof
+	103, // 65: taprpc.ExportProofRequest.outpoint:type_name -> taprpc.OutPoint
+	52,  // 66: taprpc.AddrEvent.addr:type_name -> taprpc.Addr
+	7,   // 67: taprpc.AddrEvent.status:type_name -> taprpc.AddrEventStatus
+	7,   // 68: taprpc.AddrReceivesRequest.filter_status:type_name -> taprpc.AddrEventStatus
+	104, // 69: taprpc.AddrReceivesRequest.direction:type_name -> taprpc.SortDirection
+	72,  // 70: taprpc.AddrReceivesResponse.events:type_name -> taprpc.AddrEvent
+	76,  // 71: taprpc.SendAssetRequest.addresses_with_amounts:type_name -> taprpc.AddressWithAmount
+	44,  // 72: taprpc.SendAssetResponse.transfer:type_name -> taprpc.AssetTransfer
+	1,   // 73: taprpc.FetchAssetMetaResponse.type:type_name -> taprpc.AssetMetaType
+	102, // 74: taprpc.FetchAssetMetaResponse.unknown_odd_types:type_name -> taprpc.FetchAssetMetaResponse.UnknownOddTypesEntry
+	11,  // 75: taprpc.BurnAssetRequest.asset_specifier:type_name -> taprpc.AssetSpecifier
+	44,  // 76: taprpc.BurnAssetResponse.burn_transfer:type_name -> taprpc.AssetTransfer
+	65,  // 77: taprpc.BurnAssetResponse.burn_proof:type_name -> taprpc.DecodedProof
+	65,  // 78: taprpc.BurnAssetResponse.burn_proofs:type_name -> taprpc.DecodedProof
+	86,  // 79: taprpc.ListBurnsResponse.burns:type_name -> taprpc.AssetBurn
+	52,  // 80: taprpc.ReceiveEvent.address:type_name -> taprpc.Addr
+	7,   // 81: taprpc.ReceiveEvent.status:type_name -> taprpc.AddrEventStatus
+	9,   // 82: taprpc.SendEvent.parcel_type:type_name -> taprpc.ParcelType
+	52,  // 83: taprpc.SendEvent.addresses:type_name -> taprpc.Addr
+	92,  // 84: taprpc.SendEvent.anchor_transaction:type_name -> taprpc.AnchorTransaction
+	44,  // 85: taprpc.SendEvent.transfer:type_name -> taprpc.AssetTransfer
+	103, // 86: taprpc.AnchorTransaction.lnd_locked_utxos:type_name -> taprpc.OutPoint
+	103, // 87: taprpc.RegisterTransferRequest.outpoint:type_name -> taprpc.OutPoint
+	26,  // 88: taprpc.RegisterTransferResponse.registered_asset:type_name -> taprpc.Asset
+	95,  // 89: taprpc.BakeMacaroonRequest.permissions:type_name -> taprpc.MacaroonPermission
+	31,  // 90: taprpc.ListUtxosResponse.ManagedUtxosEntry.value:type_name -> taprpc.ManagedUtxo
+	35,  // 91: taprpc.ListGroupsResponse.GroupsEntry.value:type_name -> taprpc.GroupedAssets
+	38,  // 92: taprpc.ListBalancesResponse.AssetBalancesEntry.value:type_name -> taprpc.AssetBalance
+	39,  // 93: taprpc.ListBalancesResponse.AssetGroupBalancesEntry.value:type_name -> taprpc.AssetGroupBalance
+	14,  // 94: taprpc.TaprootAssets.ListAssets:input_type -> taprpc.ListAssetRequest
+	12,  // 95: taprpc.TaprootAssets.FetchAsset:input_type -> taprpc.FetchAssetRequest
+	30,  // 96: taprpc.TaprootAssets.ListUtxos:input_type -> taprpc.ListUtxosRequest
+	33,  // 97: taprpc.TaprootAssets.ListGroups:input_type -> taprpc.ListGroupsRequest
+	37,  // 98: taprpc.TaprootAssets.ListBalances:input_type -> taprpc.ListBalancesRequest
+	41,  // 99: taprpc.TaprootAssets.ListTransfers:input_type -> taprpc.ListTransfersRequest
+	48,  // 100: taprpc.TaprootAssets.StopDaemon:input_type -> taprpc.StopRequest
+	50,  // 101: taprpc.TaprootAssets.DebugLevel:input_type -> taprpc.DebugLevelRequest
+	53,  // 102: taprpc.TaprootAssets.QueryAddrs:input_type -> taprpc.QueryAddrRequest
+	55,  // 103: taprpc.TaprootAssets.NewAddr:input_type -> taprpc.NewAddrRequest
+	63,  // 104: taprpc.TaprootAssets.DecodeAddr:input_type -> taprpc.DecodeAddrRequest
+	73,  // 105: taprpc.TaprootAssets.AddrReceives:input_type -> taprpc.AddrReceivesRequest
+	64,  // 106: taprpc.TaprootAssets.VerifyProof:input_type -> taprpc.ProofFile
+	67,  // 107: taprpc.TaprootAssets.DecodeProof:input_type -> taprpc.DecodeProofRequest
+	69,  // 108: taprpc.TaprootAssets.ExportProof:input_type -> taprpc.ExportProofRequest
+	70,  // 109: taprpc.TaprootAssets.UnpackProofFile:input_type -> taprpc.UnpackProofFileRequest
+	75,  // 110: taprpc.TaprootAssets.SendAsset:input_type -> taprpc.SendAssetRequest
+	83,  // 111: taprpc.TaprootAssets.BurnAsset:input_type -> taprpc.BurnAssetRequest
+	85,  // 112: taprpc.TaprootAssets.ListBurns:input_type -> taprpc.ListBurnsRequest
+	79,  // 113: taprpc.TaprootAssets.GetInfo:input_type -> taprpc.GetInfoRequest
+	96,  // 114: taprpc.TaprootAssets.BakeMacaroon:input_type -> taprpc.BakeMacaroonRequest
+	81,  // 115: taprpc.TaprootAssets.FetchAssetMeta:input_type -> taprpc.FetchAssetMetaRequest
+	88,  // 116: taprpc.TaprootAssets.SubscribeReceiveEvents:input_type -> taprpc.SubscribeReceiveEventsRequest
+	90,  // 117: taprpc.TaprootAssets.SubscribeSendEvents:input_type -> taprpc.SubscribeSendEventsRequest
+	93,  // 118: taprpc.TaprootAssets.RegisterTransfer:input_type -> taprpc.RegisterTransferRequest
+	29,  // 119: taprpc.TaprootAssets.ListAssets:output_type -> taprpc.ListAssetResponse
+	13,  // 120: taprpc.TaprootAssets.FetchAsset:output_type -> taprpc.FetchAssetResponse
+	32,  // 121: taprpc.TaprootAssets.ListUtxos:output_type -> taprpc.ListUtxosResponse
+	36,  // 122: taprpc.TaprootAssets.ListGroups:output_type -> taprpc.ListGroupsResponse
+	40,  // 123: taprpc.TaprootAssets.ListBalances:output_type -> taprpc.ListBalancesResponse
+	42,  // 124: taprpc.TaprootAssets.ListTransfers:output_type -> taprpc.ListTransfersResponse
+	49,  // 125: taprpc.TaprootAssets.StopDaemon:output_type -> taprpc.StopResponse
+	51,  // 126: taprpc.TaprootAssets.DebugLevel:output_type -> taprpc.DebugLevelResponse
+	54,  // 127: taprpc.TaprootAssets.QueryAddrs:output_type -> taprpc.QueryAddrResponse
+	52,  // 128: taprpc.TaprootAssets.NewAddr:output_type -> taprpc.Addr
+	52,  // 129: taprpc.TaprootAssets.DecodeAddr:output_type -> taprpc.Addr
+	74,  // 130: taprpc.TaprootAssets.AddrReceives:output_type -> taprpc.AddrReceivesResponse
+	66,  // 131: taprpc.TaprootAssets.VerifyProof:output_type -> taprpc.VerifyProofResponse
+	68,  // 132: taprpc.TaprootAssets.DecodeProof:output_type -> taprpc.DecodeProofResponse
+	64,  // 133: taprpc.TaprootAssets.ExportProof:output_type -> taprpc.ProofFile
+	71,  // 134: taprpc.TaprootAssets.UnpackProofFile:output_type -> taprpc.UnpackProofFileResponse
+	78,  // 135: taprpc.TaprootAssets.SendAsset:output_type -> taprpc.SendAssetResponse
+	84,  // 136: taprpc.TaprootAssets.BurnAsset:output_type -> taprpc.BurnAssetResponse
+	87,  // 137: taprpc.TaprootAssets.ListBurns:output_type -> taprpc.ListBurnsResponse
+	80,  // 138: taprpc.TaprootAssets.GetInfo:output_type -> taprpc.GetInfoResponse
+	97,  // 139: taprpc.TaprootAssets.BakeMacaroon:output_type -> taprpc.BakeMacaroonResponse
+	82,  // 140: taprpc.TaprootAssets.FetchAssetMeta:output_type -> taprpc.FetchAssetMetaResponse
+	89,  // 141: taprpc.TaprootAssets.SubscribeReceiveEvents:output_type -> taprpc.ReceiveEvent
+	91,  // 142: taprpc.TaprootAssets.SubscribeSendEvents:output_type -> taprpc.SendEvent
+	94,  // 143: taprpc.TaprootAssets.RegisterTransfer:output_type -> taprpc.RegisterTransferResponse
+	119, // [119:144] is the sub-list for method output_type
+	94,  // [94:119] is the sub-list for method input_type
+	94,  // [94:94] is the sub-list for extension type_name
+	94,  // [94:94] is the sub-list for extension extendee
+	0,   // [0:94] is the sub-list for field type_name
 }
 
 func init() { file_taprootassets_proto_init() }

--- a/taprpc/taprootassets.proto
+++ b/taprpc/taprootassets.proto
@@ -940,10 +940,11 @@ message TransferInput {
     uint64 amount = 4;
 
     // The group key of the asset that was spent, if the asset belongs to a
-    // group. Empty for assets that are not part of a group. Consumers that
-    // want a single user-facing identifier should prefer this field when set
-    // and fall back to asset_id otherwise.
+    // group. Empty for assets that are not part of a group.
     bytes group_key = 5;
+
+    // The type of the asset that was spent.
+    AssetType asset_type = 6;
 }
 
 message TransferOutputAnchor {
@@ -1081,9 +1082,11 @@ message TransferOutput {
 
     // The group key of the asset that was created in this output, if the
     // asset belongs to a group. Empty for assets that are not part of a
-    // group. Consumers that want a single user-facing identifier should
-    // prefer this field when set and fall back to asset_id otherwise.
+    // group.
     bytes group_key = 15;
+
+    // The type of the asset that was created in this output.
+    AssetType asset_type = 16;
 }
 
 message StopRequest {

--- a/taprpc/taprootassets.swagger.json
+++ b/taprpc/taprootassets.swagger.json
@@ -3147,7 +3147,11 @@
         "group_key": {
           "type": "string",
           "format": "byte",
-          "description": "The group key of the asset that was spent, if the asset belongs to a\ngroup. Empty for assets that are not part of a group. Consumers that\nwant a single user-facing identifier should prefer this field when set\nand fall back to asset_id otherwise."
+          "description": "The group key of the asset that was spent, if the asset belongs to a\ngroup. Empty for assets that are not part of a group."
+        },
+        "asset_type": {
+          "$ref": "#/definitions/taprpcAssetType",
+          "description": "The type of the asset that was spent."
         }
       }
     },
@@ -3220,7 +3224,11 @@
         "group_key": {
           "type": "string",
           "format": "byte",
-          "description": "The group key of the asset that was created in this output, if the\nasset belongs to a group. Empty for assets that are not part of a\ngroup. Consumers that want a single user-facing identifier should\nprefer this field when set and fall back to asset_id otherwise."
+          "description": "The group key of the asset that was created in this output, if the\nasset belongs to a group. Empty for assets that are not part of a\ngroup."
+        },
+        "asset_type": {
+          "$ref": "#/definitions/taprpcAssetType",
+          "description": "The type of the asset that was created in this output."
         }
       }
     },


### PR DESCRIPTION
## Changes

- add `asset_type` to `TransferInput` and `TransferOutput`
- populate transfer `group_key` and `asset_type` from shared asset metadata resolution in list/send/burn/event paths
- extend the transfer metadata itest across grouped fungible, ungrouped fungible, and grouped collectible sends
- add a release note for the RPC response fields

## Notes

This lets SDK clients distinguish grouped fungibles from NFT collection items without a resolver. Both can carry `group_key`, but only collectibles should keep their item asset ID as the high-level NFT handle.

For ungrouped fixed-supply fungibles, transfers now return `asset_type = NORMAL` with no `group_key`