### PR TITLE
tapchannel: fix immediate force-close proof sync and sweep anchoring

### DIFF
--- a/tapchannel/aux_funding_controller.go
+++ b/tapchannel/aux_funding_controller.go
@@ -585,7 +585,36 @@ func newCommitBlobAndLeaves(pendingFunding *pendingAssetFunding,
 		localAssets = chanAssets
 	}
 
+	// Compute the initial BTC balances so the funding-time allocations
+	// sort into the same output order as the real commitment transaction
+	// produced at force-close. If these are left at zero, the asset proofs
+	// can anchor at the wrong index and fail re-anchor at force close.
+	commitFee := pendingFunding.feeRate.FeeForWeight(
+		lnwallet.CommitWeight(lndOpenChan.ChanType),
+	)
+	commitReserve := commitFee
+	if lndOpenChan.ChanType.HasAnchors() {
+		commitReserve += 2 * lnwallet.AnchorSize
+	}
+
+	capacityMSat := lnwire.NewMSatFromSatoshis(lndOpenChan.Capacity)
+	pushMSat := lnwire.NewMSatFromSatoshis(pendingFunding.pushAmt)
+	reserveMSat := lnwire.NewMSatFromSatoshis(commitReserve)
+	if capacityMSat < reserveMSat+pushMSat {
+		return nil, lnwallet.CommitAuxLeaves{}, fmt.Errorf("invalid "+
+			"initial balances: capacity=%v push=%v reserve=%v",
+			lndOpenChan.Capacity, pendingFunding.pushAmt,
+			commitReserve)
+	}
+
 	var localSatBalance, remoteSatBalance lnwire.MilliSatoshi
+	if pendingFunding.initiator {
+		localSatBalance = capacityMSat - reserveMSat - pushMSat
+		remoteSatBalance = pushMSat
+	} else {
+		localSatBalance = pushMSat
+		remoteSatBalance = capacityMSat - reserveMSat - pushMSat
+	}
 
 	// We don't have a real prev state at this point, the leaf creator only
 	// needs the sum of the remote+local assets, so we'll populate that.

--- a/tapchannel/aux_sweeper.go
+++ b/tapchannel/aux_sweeper.go
@@ -1173,71 +1173,116 @@ func reanchorAssetOutputs(ctx context.Context,
 	return nil
 }
 
-// anchorOutputAllocations is a helper function that creates a set of
-// allocations for the anchor outputs. We'll use this later to create the proper
-// exclusion proofs.
-func anchorOutputAllocations(
-	keyRing *lnwallet.CommitmentKeyRing) lfn.Result[[]*tapsend.Allocation] {
+// commitOutputAllocations builds NoAssets allocations for the actual pure-BTC
+// outputs of the real commitment transaction. This lets force-close exclusion
+// proofs match the transaction that is on chain instead of assuming the first
+// two outputs are always anchors.
+func commitOutputAllocations(req lnwallet.ResolutionReq,
+	vPackets []*tappsbt.VPacket) lfn.Result[[]*tapsend.Allocation] {
 
-	anchorAlloc := func(
-		k *btcec.PublicKey) lfn.Result[*tapsend.Allocation] {
+	if req.CommitTx == nil {
+		return lfn.Err[[]*tapsend.Allocation](
+			fmt.Errorf("commit tx not set"),
+		)
+	}
 
-		anchorTree, err := input.NewAnchorScriptTree(k)
-		if err != nil {
-			return lfn.Err[*tapsend.Allocation](err)
+	assetOutputs := make(map[uint32]struct{})
+	for _, vPkt := range vPackets {
+		for _, vOut := range vPkt.Outputs {
+			assetOutputs[vOut.AnchorOutputIndex] = struct{}{}
+		}
+	}
+
+	findOutputIndex := func(pkScript []byte) (uint32, bool) {
+		for idx, txOut := range req.CommitTx.TxOut {
+			if bytes.Equal(txOut.PkScript, pkScript) {
+				return uint32(idx), true
+			}
 		}
 
-		sibling, scriptTree, err := LeavesFromTapscriptScriptTree(
-			anchorTree,
+		return 0, false
+	}
+
+	newNoAssetAlloc := func(desc input.ScriptDescriptor) (
+		*tapsend.Allocation, error) {
+
+		sibling, scriptTree, err := LeavesFromTapscriptScriptTree(desc)
+		if err != nil {
+			return nil, err
+		}
+
+		pkScript, err := txscript.PayToTaprootScript(
+			scriptTree.TaprootKey,
 		)
 		if err != nil {
-			return lfn.Err[*tapsend.Allocation](err)
+			return nil, err
 		}
 
-		return lfn.Ok(&tapsend.Allocation{
-			Type:           tapsend.AllocationTypeNoAssets,
-			Amount:         0,
-			BtcAmount:      lnwallet.AnchorSize,
+		outputIndex, ok := findOutputIndex(pkScript)
+		if !ok {
+			return nil, nil
+		}
+		if _, hasAssets := assetOutputs[outputIndex]; hasAssets {
+			return nil, nil
+		}
+
+		return &tapsend.Allocation{
+			Type:        tapsend.AllocationTypeNoAssets,
+			OutputIndex: outputIndex,
+			BtcAmount: btcutil.Amount(
+				req.CommitTx.TxOut[outputIndex].Value,
+			),
 			InternalKey:    scriptTree.InternalKey,
 			NonAssetLeaves: sibling,
 			SortTaprootKeyBytes: schnorr.SerializePubKey(
 				scriptTree.TaprootKey,
 			),
-		})
+		}, nil
 	}
 
-	localAnchor := anchorAlloc(keyRing.ToLocalKey)
-	remoteAnchor := anchorAlloc(keyRing.ToRemoteKey)
-
-	type resultType = lfn.Result[[]*tapsend.Allocation]
-	sortAnchor := func(a1, a2 *tapsend.Allocation) resultType {
-		// Before we return the anchors, we'll make sure that
-		// they end up in the right sort order.
-		scriptCompare := bytes.Compare(
-			a1.SortTaprootKeyBytes, a2.SortTaprootKeyBytes,
-		)
-
-		if scriptCompare < 0 {
-			a1.OutputIndex = 0
-			a2.OutputIndex = 1
-		} else {
-			a2.OutputIndex = 0
-			a1.OutputIndex = 1
-		}
-
-		return lfn.Ok([]*tapsend.Allocation{a1, a2})
-	}
-
-	return lfn.FlatMapResult(
-		localAnchor, func(a1 *tapsend.Allocation) resultType {
-			return lfn.FlatMapResult(
-				remoteAnchor,
-				func(a2 *tapsend.Allocation) resultType {
-					return sortAnchor(a1, a2)
-				},
-			)
-		},
+	toLocalTree, err := input.NewLocalCommitScriptTree(
+		req.CsvDelay, req.KeyRing.ToLocalKey, req.KeyRing.RevocationKey,
+		input.NoneTapLeaf(),
 	)
+	if err != nil {
+		return lfn.Err[[]*tapsend.Allocation](err)
+	}
+
+	toRemoteTree, err := input.NewRemoteCommitScriptTree(
+		req.KeyRing.ToRemoteKey, input.NoneTapLeaf(),
+	)
+	if err != nil {
+		return lfn.Err[[]*tapsend.Allocation](err)
+	}
+
+	localAnchorTree, err := input.NewAnchorScriptTree(
+		req.KeyRing.ToLocalKey,
+	)
+	if err != nil {
+		return lfn.Err[[]*tapsend.Allocation](err)
+	}
+
+	remoteAnchorTree, err := input.NewAnchorScriptTree(
+		req.KeyRing.ToRemoteKey,
+	)
+	if err != nil {
+		return lfn.Err[[]*tapsend.Allocation](err)
+	}
+
+	allocations := make([]*tapsend.Allocation, 0, 4)
+	for _, desc := range []input.ScriptDescriptor{
+		toLocalTree, toRemoteTree, localAnchorTree, remoteAnchorTree,
+	} {
+		alloc, err := newNoAssetAlloc(desc)
+		if err != nil {
+			return lfn.Err[[]*tapsend.Allocation](err)
+		}
+		if alloc != nil {
+			allocations = append(allocations, alloc)
+		}
+	}
+
+	return lfn.Ok(allocations)
 }
 
 // remoteCommitScriptKey creates the script key for the remote commitment
@@ -1799,9 +1844,14 @@ func (a *AuxSweeper) importCommitTx(req lnwallet.ResolutionReq,
 			"commitments: %w", err)
 	}
 
-	// With the output commitments known, we can regenerate the proof suffix
-	// for each vPkt.
-	anchorAllocations, err := anchorOutputAllocations(req.KeyRing).Unpack()
+	// With the output commitments known, we can regenerate the proof
+	// suffix for each vPkt. Recompute the non-asset allocations from the
+	// real commit tx outputs so the exclusion proofs line up with what's
+	// actually on chain, regardless of whether this is a symmetric or an
+	// asymmetric commitment.
+	anchorAllocations, err := commitOutputAllocations(
+		req, vPackets,
+	).Unpack()
 	if err != nil {
 		return fmt.Errorf("unable to create anchor "+
 			"allocations: %w", err)


### PR DESCRIPTION
## Description

This PR fixes immediate post-funding (N=0) force-close recovery by correctly re-syncing active vPacket outputs with re-anchored proofs when anchor indices are stale, and hardens anchor resolution to return explicit errors instead of panicking on out-of-range indices.

~It also adds an integration test that force-closes right after funding confirmation and verifies the swept assets remain spendable via an onward transfer to a third node.~

~Depends on https://github.com/lightningnetwork/lnd/pull/10804~

These last parts of the PR now moved to https://github.com/lightninglabs/taproot-assets/pull/2177