### PR TITLE
Fixing QueryAssetStats CLI docs missing from API docs

### DIFF
--- a/docs/release-notes/release-notes-0.8.0.md
+++ b/docs/release-notes/release-notes-0.8.0.md
@@ -491,3 +491,8 @@
 - [PR#2056](https://github.com/lightninglabs/taproot-assets/pull/2056)
   expands the example portfolio pilot with constraint enforcement,
   configurable fill caps, and live CoinGecko pricing.
+
+- [PR#2138](https://github.com/lightninglabs/taproot-assets/pull/2138)
+  Fix `tapcli:` annotations on `QueryAssetStats` and `QueryEvents` so generated
+  OpenAPI summaries match other RPCs and the public API docs list the correct
+  `tapcli universe stats assets` and `tapcli universe stats events` commands.

--- a/taprpc/universerpc/universe.proto
+++ b/taprpc/universerpc/universe.proto
@@ -137,7 +137,7 @@ service Universe {
     */
     rpc UniverseStats (StatsRequest) returns (StatsResponse);
 
-    /* tapcli `universe stats assets`
+    /* tapcli: `universe stats assets`
     QueryAssetStats returns a set of statistics for a given set of assets.
     Stats can be queried for all assets, or based on the: asset ID, name, or
     asset type. Pagination is supported via the offset and limit params.
@@ -145,7 +145,7 @@ service Universe {
     */
     rpc QueryAssetStats (AssetStatsQuery) returns (UniverseAssetStats);
 
-    /* tapcli `universe stats events`
+    /* tapcli: `universe stats events`
     QueryEvents returns the number of sync and proof events for a given time
     period, grouped by day.
     */

--- a/taprpc/universerpc/universe.swagger.json
+++ b/taprpc/universerpc/universe.swagger.json
@@ -1360,7 +1360,7 @@
     },
     "/v1/taproot-assets/universe/stats/assets": {
       "get": {
-        "summary": "tapcli `universe stats assets`\nQueryAssetStats returns a set of statistics for a given set of assets.\nStats can be queried for all assets, or based on the: asset ID, name, or\nasset type. Pagination is supported via the offset and limit params.\nResults can also be sorted based on any of the main query params.",
+        "summary": "tapcli: `universe stats assets`\nQueryAssetStats returns a set of statistics for a given set of assets.\nStats can be queried for all assets, or based on the: asset ID, name, or\nasset type. Pagination is supported via the offset and limit params.\nResults can also be sorted based on any of the main query params.",
         "operationId": "Universe_QueryAssetStats",
         "responses": {
           "200": {
@@ -1459,7 +1459,7 @@
     },
     "/v1/taproot-assets/universe/stats/events": {
       "get": {
-        "summary": "tapcli `universe stats events`\nQueryEvents returns the number of sync and proof events for a given time\nperiod, grouped by day.",
+        "summary": "tapcli: `universe stats events`\nQueryEvents returns the number of sync and proof events for a given time\nperiod, grouped by day.",
         "operationId": "Universe_QueryEvents",
         "responses": {
           "200": {

--- a/taprpc/universerpc/universe_grpc.pb.go
+++ b/taprpc/universerpc/universe_grpc.pb.go
@@ -104,13 +104,13 @@ type UniverseClient interface {
 	// of the Universe. Stats returned include: total number of syncs, total
 	// number of proofs, and total number of known assets.
 	UniverseStats(ctx context.Context, in *StatsRequest, opts ...grpc.CallOption) (*StatsResponse, error)
-	// tapcli `universe stats assets`
+	// tapcli: `universe stats assets`
 	// QueryAssetStats returns a set of statistics for a given set of assets.
 	// Stats can be queried for all assets, or based on the: asset ID, name, or
 	// asset type. Pagination is supported via the offset and limit params.
 	// Results can also be sorted based on any of the main query params.
 	QueryAssetStats(ctx context.Context, in *AssetStatsQuery, opts ...grpc.CallOption) (*UniverseAssetStats, error)
-	// tapcli `universe stats events`
+	// tapcli: `universe stats events`
 	// QueryEvents returns the number of sync and proof events for a given time
 	// period, grouped by day.
 	QueryEvents(ctx context.Context, in *QueryEventsRequest, opts ...grpc.CallOption) (*QueryEventsResponse, error)
@@ -469,13 +469,13 @@ type UniverseServer interface {
 	// of the Universe. Stats returned include: total number of syncs, total
 	// number of proofs, and total number of known assets.
 	UniverseStats(context.Context, *StatsRequest) (*StatsResponse, error)
-	// tapcli `universe stats assets`
+	// tapcli: `universe stats assets`
 	// QueryAssetStats returns a set of statistics for a given set of assets.
 	// Stats can be queried for all assets, or based on the: asset ID, name, or
 	// asset type. Pagination is supported via the offset and limit params.
 	// Results can also be sorted based on any of the main query params.
 	QueryAssetStats(context.Context, *AssetStatsQuery) (*UniverseAssetStats, error)
-	// tapcli `universe stats events`
+	// tapcli: `universe stats events`
 	// QueryEvents returns the number of sync and proof events for a given time
 	// period, grouped by day.
 	QueryEvents(context.Context, *QueryEventsRequest) (*QueryEventsResponse, error)


### PR DESCRIPTION
Should close #1767 