### PR TITLE
itest: fix timing-sensitive backup flake

### DIFF
--- a/itest/backup_test.go
+++ b/itest/backup_test.go
@@ -475,7 +475,7 @@ func assertAssetsMatch(t *harnessTest, expected []*taprpc.Asset,
 //  5. Verify asset counts and group key presence on both nodes
 func testBackupRestoreGrouped(t *harnessTest) {
 	ctxb := context.Background()
-	ctxt, cancel := context.WithTimeout(ctxb, defaultWaitTimeout)
+	ctxt, cancel := context.WithTimeout(ctxb, defaultWaitTimeout*4)
 	defer cancel()
 
 	// Mint a grouped asset and an ungrouped asset together.


### PR DESCRIPTION
Fixes a flake observed in [this CI job](https://github.com/lightninglabs/taproot-assets/actions/runs/26048448891/job/76579893103).

Simply widens a timeout that otherwise gets racy with some other conditions.

Opus's summary:

> The test calls ImportAssetsFromBackup twice in sequence (Bob with RAW, Charlie with COMPACT). Each call blocks for the full spendCheckTimeout (10s) in backup.detectSpentOutpoints because lnd's chain notifier cannot match the taproot anchor pkScript ("taproot pk script not supported"), so every spend subscription waits out the timeout before the outpoint is treated as unspent. Combined with mint+confirm and two fresh tapd spin-ups, the test's intrinsic floor is right around 30s.
> 
> With ctxt set to defaultWaitTimeout (30s), the parent context can expire while Charlie's import is still inside detectSpentOutpoints. When that happens, the lndclient RegisterSpendNtfn stream is cancelled with DeadlineExceeded and the result is reported as
>
>    spend check error for asset N: rpc error: code = DeadlineExceeded
>    desc = stream terminated by RST_STREAM with error code: CANCEL
> 
> which fails the test at backup_test.go:583.
> 
> Match the existing precedent at line 124 (testBackupRestoreTransferred) and use defaultWaitTimeout*4, leaving ample headroom for CI jitter.