### PR TITLE
tapgarden: harden batch funding

### DIFF
--- a/docs/release-notes/release-notes-0.8.0.md
+++ b/docs/release-notes/release-notes-0.8.0.md
@@ -107,6 +107,10 @@
   were upgraded to v0.6.0, by which universe leaf inserts could result in
   duplicate-key errors.
 
+* [PR#2141](https://github.com/lightninglabs/taproot-assets/pull/2141)
+  fixes several bugs that could leave minting batches in an inconsistent
+  state in the case of a funding, database write, or restart error.
+
 # New Features
 
 ## Functional Enhancements

--- a/tapdb/asset_minting.go
+++ b/tapdb/asset_minting.go
@@ -1483,22 +1483,6 @@ func (a *AssetMintingStore) UpdateBatchState(ctx context.Context,
 	})
 }
 
-// CommitBatchTapSibling updates the tapscript sibling of a batch based on the
-// batch key.
-func (a *AssetMintingStore) CommitBatchTapSibling(ctx context.Context,
-	batchKey *btcec.PublicKey, batchSibling *chainhash.Hash) error {
-
-	siblingUpdate := BatchTapSiblingUpdate{
-		RawKey:           batchKey.SerializeCompressed(),
-		TapscriptSibling: batchSibling[:],
-	}
-
-	var writeTxOpts AssetStoreTxOptions
-	return a.db.ExecTx(ctx, &writeTxOpts, func(q PendingAssetStore) error {
-		return q.BindMintingBatchWithTapSibling(ctx, siblingUpdate)
-	})
-}
-
 // encodeOutpoint encodes the outpoint point in Bitcoin wire format, returning
 // the final result.
 func encodeOutpoint(outPoint wire.OutPoint) ([]byte, error) {
@@ -1509,34 +1493,6 @@ func encodeOutpoint(outPoint wire.OutPoint) ([]byte, error) {
 	}
 
 	return b.Bytes(), nil
-}
-
-// CommitBatchTx updates the genesis transaction of a batch based on the batch
-// key.
-func (a *AssetMintingStore) CommitBatchTx(ctx context.Context,
-	batchKey *btcec.PublicKey,
-	genesisPacket tapgarden.FundedMintAnchorPsbt) error {
-
-	genesisOutpoint, err := genesisPacket.GenesisOutpoint().UnwrapOrErr(
-		tapgarden.ErrFundedAnchorPsbtMissingOutpoint,
-	)
-	if err != nil {
-		return err
-	}
-
-	var writeTxOpts AssetStoreTxOptions
-	return a.db.ExecTx(ctx, &writeTxOpts, func(q PendingAssetStore) error {
-		// Insert the batch transaction.
-		err := insertMintAnchorTx(
-			ctx, q, genesisPacket, *batchKey, genesisOutpoint,
-		)
-		if err != nil {
-			return fmt.Errorf("unable to insert mint anchor "+
-				"tx: %w", err)
-		}
-
-		return nil
-	})
 }
 
 // CommitBatchFunding atomically persists the funded genesis transaction

--- a/tapdb/asset_minting.go
+++ b/tapdb/asset_minting.go
@@ -1517,7 +1517,12 @@ func (a *AssetMintingStore) CommitBatchTx(ctx context.Context,
 	batchKey *btcec.PublicKey,
 	genesisPacket tapgarden.FundedMintAnchorPsbt) error {
 
-	genesisOutpoint := genesisPacket.Pkt.UnsignedTx.TxIn[0].PreviousOutPoint
+	genesisOutpoint, err := genesisPacket.GenesisOutpoint().UnwrapOrErr(
+		tapgarden.ErrFundedAnchorPsbtMissingOutpoint,
+	)
+	if err != nil {
+		return err
+	}
 
 	var writeTxOpts AssetStoreTxOptions
 	return a.db.ExecTx(ctx, &writeTxOpts, func(q PendingAssetStore) error {
@@ -1541,7 +1546,12 @@ func (a *AssetMintingStore) CommitBatchFunding(ctx context.Context,
 	batchKey *btcec.PublicKey, batchSibling *chainhash.Hash,
 	genesisPacket tapgarden.FundedMintAnchorPsbt) error {
 
-	genesisOutpoint := genesisPacket.Pkt.UnsignedTx.TxIn[0].PreviousOutPoint
+	genesisOutpoint, err := genesisPacket.GenesisOutpoint().UnwrapOrErr(
+		tapgarden.ErrFundedAnchorPsbtMissingOutpoint,
+	)
+	if err != nil {
+		return err
+	}
 
 	var writeTxOpts AssetStoreTxOptions
 	return a.db.ExecTx(ctx, &writeTxOpts, func(q PendingAssetStore) error {
@@ -1851,7 +1861,12 @@ func (a *AssetMintingStore) AddSproutsToBatch(ctx context.Context,
 
 	sortedAssets := append(anchorAssets, nonAnchorAssets...)
 
-	genesisOutpoint := genesisPacket.Pkt.UnsignedTx.TxIn[0].PreviousOutPoint
+	genesisOutpoint, err := genesisPacket.GenesisOutpoint().UnwrapOrErr(
+		tapgarden.ErrFundedAnchorPsbtMissingOutpoint,
+	)
+	if err != nil {
+		return err
+	}
 
 	rawBatchKey := batchKey.SerializeCompressed()
 

--- a/tapdb/asset_minting.go
+++ b/tapdb/asset_minting.go
@@ -1534,6 +1534,44 @@ func (a *AssetMintingStore) CommitBatchTx(ctx context.Context,
 	})
 }
 
+// CommitBatchFunding atomically persists the funded genesis transaction
+// and the optional tapscript sibling for a batch in a single database
+// transaction.
+func (a *AssetMintingStore) CommitBatchFunding(ctx context.Context,
+	batchKey *btcec.PublicKey, batchSibling *chainhash.Hash,
+	genesisPacket tapgarden.FundedMintAnchorPsbt) error {
+
+	genesisOutpoint := genesisPacket.Pkt.UnsignedTx.TxIn[0].PreviousOutPoint
+
+	var writeTxOpts AssetStoreTxOptions
+	return a.db.ExecTx(ctx, &writeTxOpts, func(q PendingAssetStore) error {
+		if batchSibling != nil {
+			rawKey := batchKey.SerializeCompressed()
+			siblingUpdate := BatchTapSiblingUpdate{
+				RawKey:           rawKey,
+				TapscriptSibling: batchSibling[:],
+			}
+			err := q.BindMintingBatchWithTapSibling(
+				ctx, siblingUpdate,
+			)
+			if err != nil {
+				return fmt.Errorf("unable to bind tap "+
+					"sibling: %w", err)
+			}
+		}
+
+		err := insertMintAnchorTx(
+			ctx, q, genesisPacket, *batchKey, genesisOutpoint,
+		)
+		if err != nil {
+			return fmt.Errorf("unable to insert mint anchor "+
+				"tx: %w", err)
+		}
+
+		return nil
+	})
+}
+
 // FetchDelegationKey fetches the delegation key for the given asset group
 // public key.
 func (a *AssetMintingStore) FetchDelegationKey(ctx context.Context,

--- a/tapgarden/interface.go
+++ b/tapgarden/interface.go
@@ -284,19 +284,6 @@ type MintingStore interface {
 	FetchAssetMeta(ctx context.Context, ID asset.ID) (*proof.MetaReveal,
 		error)
 
-	// CommitBatchTapSibling adds a tapscript sibling to the batch,
-	// specified by the sibling root hash.
-	//
-	// NOTE: The tapscript tree that defines the batch sibling must already
-	// be committed to disk.
-	CommitBatchTapSibling(ctx context.Context, batchKey *btcec.PublicKey,
-		rootHash *chainhash.Hash) error
-
-	// CommitBatchTx adds a funded transaction to the batch, which also sets
-	// the genesis point for the batch.
-	CommitBatchTx(ctx context.Context, batchKey *btcec.PublicKey,
-		genesisTx FundedMintAnchorPsbt) error
-
 	// CommitBatchFunding atomically persists the funded genesis
 	// transaction and the optional tapscript sibling root hash for a
 	// batch in a single transaction. Either both writes succeed or

--- a/tapgarden/interface.go
+++ b/tapgarden/interface.go
@@ -297,6 +297,18 @@ type MintingStore interface {
 	CommitBatchTx(ctx context.Context, batchKey *btcec.PublicKey,
 		genesisTx FundedMintAnchorPsbt) error
 
+	// CommitBatchFunding atomically persists the funded genesis
+	// transaction and the optional tapscript sibling root hash for a
+	// batch in a single transaction. Either both writes succeed or
+	// neither persists, so a partial-failure cannot leave the batch
+	// in an inconsistent on-disk state.
+	//
+	// NOTE: The tapscript tree referenced by rootHash (if non-nil)
+	// must already be committed to disk.
+	CommitBatchFunding(ctx context.Context, batchKey *btcec.PublicKey,
+		rootHash *chainhash.Hash,
+		genesisTx FundedMintAnchorPsbt) error
+
 	// FetchDelegationKey fetches the delegation key for the given asset
 	// group public key.
 	FetchDelegationKey(ctx context.Context,

--- a/tapgarden/planter.go
+++ b/tapgarden/planter.go
@@ -2257,24 +2257,15 @@ func (c *ChainPlanter) fundBatch(ctx context.Context, params FundParams,
 		return err
 	}
 
-	// Persist the sibling and genesis TX first. We only mutate
-	// workingBatch after all persistence has succeeded, so a DB
-	// commit failure leaves the live in-memory batch unchanged.
-	if rootHash != nil {
-		err = c.cfg.Log.CommitBatchTapSibling(
-			ctx, workingBatch.BatchKey.PubKey, rootHash,
-		)
-		if err != nil {
-			return fmt.Errorf("unable to commit tapscript "+
-				"sibling for minting batch %w", err)
-		}
-	}
-
-	err = c.cfg.Log.CommitBatchTx(
-		ctx, workingBatch.BatchKey.PubKey, *mintAnchorTx,
+	// Persist the sibling and genesis TX atomically. Combining
+	// both writes in a single transaction ensures a partial
+	// failure cannot leave the batch with one persisted and the
+	// other absent.
+	err = c.cfg.Log.CommitBatchFunding(
+		ctx, workingBatch.BatchKey.PubKey, rootHash, *mintAnchorTx,
 	)
 	if err != nil {
-		return err
+		return fmt.Errorf("unable to commit batch funding: %w", err)
 	}
 
 	// All persistence succeeded; commit the funding to memory.

--- a/tapgarden/planter.go
+++ b/tapgarden/planter.go
@@ -2675,46 +2675,43 @@ func (c *ChainPlanter) finalizeBatch(params FinalizeParams) (*BatchCaretaker,
 		return nil, fmt.Errorf("unable to store tapscript tree for "+
 			"minting batch: %w", err)
 	}
-	// At this point, we have a non-empty batch, so we'll first finalize it
-	// on disk. This means no further seedlings can be added to this batch.
-	err = freezeMintingBatch(ctx, c.cfg.Log, c.pendingBatch)
-	if err != nil {
-		return nil, err
-	}
-
-	// If the batch already has a funded TX, we can skip funding the batch.
+	// Fund the batch if it hasn't been funded yet. If funding
+	// fails, the batch stays pending so the user can retry.
 	if !c.pendingBatch.IsFunded() {
-		// Fund the batch before starting the caretaker. If funding
-		// fails, we can't start a caretaker for the batch, so we'll
-		// clear the pending batch. The batch will exist on disk for
-		// the user to recreate it if necessary.
-		// TODO(jhb): Don't clear pending batch here
-		err = c.fundBatch(ctx, FundParams(params), c.pendingBatch)
+		err = c.fundBatch(
+			ctx, FundParams(params), c.pendingBatch,
+		)
 		if err != nil {
-			c.pendingBatch = nil
 			return nil, err
 		}
 	}
 
-	// If the batch needs to be sealed, we'll use the default behavior for
-	// generating asset group witnesses. Any custom behavior requires
-	// calling SealBatch() explicitly, before batch finalization.
-	sealedBatch, err := c.sealBatch(ctx, SealParams{}, c.pendingBatch)
+	// If the batch needs to be sealed, we'll use the default
+	// behavior for generating asset group witnesses. Any custom
+	// behavior requires calling SealBatch() explicitly, before
+	// batch finalization.
+	sealedBatch, err := c.sealBatch(
+		ctx, SealParams{}, c.pendingBatch,
+	)
 	if err != nil {
 		if !errors.Is(err, ErrBatchAlreadySealed) {
 			return nil, err
 		}
 	}
 
-	// If seal batch executed successfully, and returned a sealed batch,
-	// then we can update the pending batch.
+	// If seal batch executed successfully, and returned a
+	// sealed batch, then we can update the pending batch.
 	if err == nil && sealedBatch != nil {
 		c.pendingBatch = sealedBatch
 	}
 
-	// Now that the batch has been frozen on disk, we can update the batch
-	// state to frozen before launching a new caretaker state machine for
-	// the batch that'll drive all the seedlings do adulthood.
+	// Now that funding and sealing have succeeded, freeze the
+	// batch on disk and in memory. This means no further
+	// seedlings can be added to this batch.
+	err = freezeMintingBatch(ctx, c.cfg.Log, c.pendingBatch)
+	if err != nil {
+		return nil, err
+	}
 	c.pendingBatch.UpdateState(BatchStateFrozen)
 	caretaker := c.newCaretakerForBatch(c.pendingBatch, feeRate)
 	if err := caretaker.Start(); err != nil {

--- a/tapgarden/planter.go
+++ b/tapgarden/planter.go
@@ -2177,11 +2177,6 @@ func (c *ChainPlanter) fundBatch(ctx context.Context, params FundParams,
 
 	// Update the batch by adding the sibling root hash and genesis TX.
 	updateBatch := func(batch *MintingBatch) error {
-		// Add the batch sibling root hash if present.
-		if rootHash != nil {
-			batch.tapSibling = rootHash
-		}
-
 		// Fund the batch with the specified fee rate.
 		feeRate, err := c.anchorTxFeeRate(ctx, params.FeeRate)
 		if err != nil {
@@ -2220,6 +2215,13 @@ func (c *ChainPlanter) fundBatch(ctx context.Context, params FundParams,
 
 		log.Infof("Funded GenesisPacket for batch: %x", batchKey)
 		batch.GenesisPacket = &mintAnchorTx
+
+		// Now that funding has succeeded, stamp the sibling root
+		// hash onto the batch. Deferring this until after funding
+		// ensures a failed attempt leaves the batch unchanged.
+		if rootHash != nil {
+			batch.tapSibling = rootHash
+		}
 
 		return nil
 	}

--- a/tapgarden/planter.go
+++ b/tapgarden/planter.go
@@ -2175,13 +2175,17 @@ func (c *ChainPlanter) fundBatch(ctx context.Context, params FundParams,
 			"batch: %w", err)
 	}
 
-	// Update the batch by adding the sibling root hash and genesis TX.
-	updateBatch := func(batch *MintingBatch) error {
-		// Fund the batch with the specified fee rate.
+	// computeFunding builds the funded genesis PSBT for a batch
+	// without mutating it. The caller is responsible for applying
+	// the result to the batch only after all persistence has
+	// succeeded, so a failure leaves the batch unchanged.
+	computeFunding := func(batch *MintingBatch) (
+		*FundedMintAnchorPsbt, error) {
+
 		feeRate, err := c.anchorTxFeeRate(ctx, params.FeeRate)
 		if err != nil {
-			return fmt.Errorf("unable to determine anchor TX "+
-				"fee rate: %w", err)
+			return nil, fmt.Errorf("unable to determine anchor "+
+				"TX fee rate: %w", err)
 		}
 
 		batchKey := asset.ToSerialized(batch.BatchKey.PubKey)
@@ -2205,25 +2209,15 @@ func (c *ChainPlanter) fundBatch(ctx context.Context, params FundParams,
 
 		log.Infof("Attempting to fund batch: %x", batchKey)
 		mintAnchorTx, err := fundGenesisPsbt(
-			ctx, c.cfg.ChainParams, c.pendingBatch,
-			walletFundPsbt,
+			ctx, c.cfg.ChainParams, batch, walletFundPsbt,
 		)
 		if err != nil {
-			return fmt.Errorf("unable to fund minting PSBT for "+
-				"batch: %x %w", batchKey[:], err)
+			return nil, fmt.Errorf("unable to fund minting PSBT "+
+				"for batch: %x %w", batchKey[:], err)
 		}
 
 		log.Infof("Funded GenesisPacket for batch: %x", batchKey)
-		batch.GenesisPacket = &mintAnchorTx
-
-		// Now that funding has succeeded, stamp the sibling root
-		// hash onto the batch. Deferring this until after funding
-		// ensures a failed attempt leaves the batch unchanged.
-		if rootHash != nil {
-			batch.tapSibling = rootHash
-		}
-
-		return nil
+		return &mintAnchorTx, nil
 	}
 
 	// If we don't have a batch, we'll create an empty batch before funding
@@ -2234,13 +2228,19 @@ func (c *ChainPlanter) fundBatch(ctx context.Context, params FundParams,
 			return fmt.Errorf("unable to create new batch: %w", err)
 		}
 
-		err = updateBatch(newBatch)
+		mintAnchorTx, err := computeFunding(newBatch)
 		if err != nil {
 			return err
 		}
 
-		// Now that we're done populating parts of the batch, write it
-		// to disk.
+		// Apply the funding to the local batch and commit. If the
+		// commit fails, newBatch is discarded and the planter's
+		// pendingBatch is never assigned.
+		newBatch.GenesisPacket = mintAnchorTx
+		if rootHash != nil {
+			newBatch.tapSibling = rootHash
+		}
+
 		err = c.cfg.Log.CommitMintingBatch(ctx, newBatch)
 		if err != nil {
 			return err
@@ -2250,15 +2250,17 @@ func (c *ChainPlanter) fundBatch(ctx context.Context, params FundParams,
 		return nil
 	}
 
-	// If we already have a batch, we need to attach the optional sibling
-	// root hash and fund the batch.
-	err = updateBatch(workingBatch)
+	// Compute the funded genesis packet for the existing batch
+	// without mutating it yet.
+	mintAnchorTx, err := computeFunding(workingBatch)
 	if err != nil {
 		return err
 	}
 
-	// Write the associated sibling root hash and TX to disk.
-	if workingBatch.tapSibling != nil {
+	// Persist the sibling and genesis TX first. We only mutate
+	// workingBatch after all persistence has succeeded, so a DB
+	// commit failure leaves the live in-memory batch unchanged.
+	if rootHash != nil {
 		err = c.cfg.Log.CommitBatchTapSibling(
 			ctx, workingBatch.BatchKey.PubKey, rootHash,
 		)
@@ -2269,10 +2271,16 @@ func (c *ChainPlanter) fundBatch(ctx context.Context, params FundParams,
 	}
 
 	err = c.cfg.Log.CommitBatchTx(
-		ctx, workingBatch.BatchKey.PubKey, *workingBatch.GenesisPacket,
+		ctx, workingBatch.BatchKey.PubKey, *mintAnchorTx,
 	)
 	if err != nil {
 		return err
+	}
+
+	// All persistence succeeded; commit the funding to memory.
+	workingBatch.GenesisPacket = mintAnchorTx
+	if rootHash != nil {
+		workingBatch.tapSibling = rootHash
 	}
 
 	return nil

--- a/tapgarden/planter_test.go
+++ b/tapgarden/planter_test.go
@@ -1734,6 +1734,83 @@ func testFinalizeWithTapscriptTree(t *mintingTestHarness) {
 	t.assertMintOutputKey(batchWithSibling, siblingHash)
 }
 
+// testFundFailSiblingNotLeaked verifies that when a finalize attempt
+// supplies a tapscript sibling and funding fails, the sibling is not
+// left on the in-memory batch. A subsequent retry that omits the
+// sibling should produce a batch with no sibling.
+func testFundFailSiblingNotLeaked(t *mintingTestHarness) {
+	t.refreshChainPlanter()
+
+	const numSeedlings = 5
+	_ = t.queueInitialBatch(numSeedlings)
+
+	// Build a valid tapscript sibling preimage.
+	sigLockKey := test.RandPubKey(t)
+	hashLockWitness := []byte("foobar")
+	hashLockLeaf := test.ScriptHashLock(t.T, hashLockWitness)
+	sigLeaf := test.ScriptSchnorrSig(t.T, sigLockKey)
+	tapTreePreimage, err := asset.TapTreeNodesFromLeaves(
+		[]txscript.TapLeaf{hashLockLeaf, sigLeaf},
+	)
+	require.NoError(t, err)
+
+	var (
+		wg          sync.WaitGroup
+		respChan    = make(chan *FinalizeBatchResp, 1)
+		finalizeReq = tapgarden.FinalizeParams{
+			SiblingTapTree: fn.Some(*tapTreePreimage),
+		}
+		batchCount = 0
+	)
+
+	// Force fee estimation to fail so that funding fails inside
+	// fundBatch.
+	t.chain.FailFeeEstimatesOnce()
+
+	t.finalizeBatch(&wg, respChan, &finalizeReq)
+	batchCount++
+
+	_, err = fn.RecvOrTimeout(
+		t.chain.FeeEstimateSignal, defaultTimeout,
+	)
+	require.NoError(t, err)
+
+	// The batch should remain pending.
+	t.assertLastBatchState(batchCount, tapgarden.BatchStatePending)
+	t.assertFinalizeBatch(
+		&wg, respChan, "failed to estimate fee",
+	)
+
+	// The pending batch's sibling must not carry over from the
+	// failed attempt.
+	pending, err := t.planter.PendingBatch()
+	require.NoError(t, err)
+	require.NotNil(t, pending)
+	require.Nil(
+		t, pending.TapSibling(),
+		"fundBatch leaked sibling on failed attempt",
+	)
+
+	// Retry without a sibling. The attempt should succeed.
+	t.finalizeBatch(&wg, respChan, nil)
+
+	sendConfNtfn := t.progressCaretaker(false, nil, nil)
+	sendConfNtfn()
+
+	finalBatch := t.assertFinalizeBatch(&wg, respChan, "")
+	require.NotNil(t, finalBatch)
+	require.Nil(
+		t, finalBatch.TapSibling(),
+		"final batch has unexpected sibling",
+	)
+	t.assertNoError()
+	t.assertNoPendingBatch()
+	t.assertNumCaretakersActive(0)
+	t.assertLastBatchState(
+		batchCount, tapgarden.BatchStateFinalized,
+	)
+}
+
 func testFundSealBeforeFinalize(t *mintingTestHarness) {
 	// First, create a new chain planter instance using the supplied test
 	// harness.
@@ -2124,6 +2201,10 @@ var testCases = []mintingStoreTestCase{
 	{
 		name:     "finalize_with_tapscript_tree",
 		testFunc: testFinalizeWithTapscriptTree,
+	},
+	{
+		name:     "fund_fail_sibling_not_leaked",
+		testFunc: testFundFailSiblingNotLeaked,
 	},
 	{
 		name:     "fund_seal_before_finalize",

--- a/tapgarden/planter_test.go
+++ b/tapgarden/planter_test.go
@@ -1811,6 +1811,72 @@ func testFundFailSiblingNotLeaked(t *mintingTestHarness) {
 	)
 }
 
+// testFundBatchFailRetry verifies that when the FundBatch RPC fails
+// partway through (e.g. fee estimation), the batch remains in a
+// retryable state: the pending batch survives, no tapscript sibling
+// from the failed attempt is leaked, and a subsequent FundBatch
+// succeeds.
+func testFundBatchFailRetry(t *mintingTestHarness) {
+	t.refreshChainPlanter()
+
+	const numSeedlings = 5
+	_ = t.queueInitialBatch(numSeedlings)
+
+	// Build a valid tapscript sibling preimage.
+	sigLockKey := test.RandPubKey(t)
+	hashLockWitness := []byte("foobar")
+	hashLockLeaf := test.ScriptHashLock(t.T, hashLockWitness)
+	sigLeaf := test.ScriptSchnorrSig(t.T, sigLockKey)
+	tapTreePreimage, err := asset.TapTreeNodesFromLeaves(
+		[]txscript.TapLeaf{hashLockLeaf, sigLeaf},
+	)
+	require.NoError(t, err)
+
+	var (
+		wg       sync.WaitGroup
+		respChan = make(chan *FundBatchResp, 1)
+		fundReq  = tapgarden.FundParams{
+			SiblingTapTree: fn.Some(*tapTreePreimage),
+		}
+	)
+
+	// Force fee estimation to fail so that FundBatch fails inside
+	// fundBatch.
+	t.chain.FailFeeEstimatesOnce()
+
+	t.fundBatch(&wg, respChan, &fundReq)
+
+	_, err = fn.RecvOrTimeout(
+		t.chain.FeeEstimateSignal, defaultTimeout,
+	)
+	require.NoError(t, err)
+
+	t.assertFundBatch(&wg, respChan, "failed to estimate fee")
+
+	// The pending batch should still exist, unfunded, and with no
+	// leaked sibling from the failed attempt.
+	pending, err := t.planter.PendingBatch()
+	require.NoError(t, err)
+	require.NotNil(t, pending)
+	require.False(t, pending.IsFunded())
+	require.Nil(
+		t, pending.TapSibling(),
+		"fundBatch leaked sibling on failed attempt",
+	)
+
+	// Retry FundBatch without a sibling. The attempt should succeed.
+	retryReq := tapgarden.FundParams{}
+	t.fundBatch(&wg, respChan, &retryReq)
+	t.assertGenesisTxFunded(nil)
+	funded := t.assertFundBatch(&wg, respChan, "")
+	require.NotNil(t, funded)
+	require.True(t, funded.IsFunded())
+	require.Nil(
+		t, funded.TapSibling(),
+		"funded batch has unexpected sibling",
+	)
+}
+
 func testFundSealBeforeFinalize(t *mintingTestHarness) {
 	// First, create a new chain planter instance using the supplied test
 	// harness.
@@ -2205,6 +2271,10 @@ var testCases = []mintingStoreTestCase{
 	{
 		name:     "fund_fail_sibling_not_leaked",
 		testFunc: testFundFailSiblingNotLeaked,
+	},
+	{
+		name:     "fund_batch_fail_retry",
+		testFunc: testFundBatchFailRetry,
 	},
 	{
 		name:     "fund_seal_before_finalize",

--- a/tapgarden/planter_test.go
+++ b/tapgarden/planter_test.go
@@ -601,9 +601,12 @@ func (t *mintingTestHarness) finalizeBatchAssertFrozen(
 		return nil
 	}
 
-	// Check that the batch was frozen and then funded.
-	newBatch := t.assertNewBatchFrozen(existingFrozenBatches)
+	// Funding now happens before freeze, so we must consume the
+	// fund signal first to unblock the finalize goroutine.
 	_ = t.assertGenesisTxFunded(nil)
+
+	// Now check that the batch reached a frozen-or-later state.
+	newBatch := t.assertNewBatchFrozen(existingFrozenBatches)
 
 	// Fetch the batch again after funding.
 	return t.fetchSingleBatch(newBatch.BatchKey.PubKey)
@@ -1479,19 +1482,20 @@ func testMintingCancelFinalize(t *mintingTestHarness) {
 	t.assertNumCaretakersActive(0)
 }
 
-// testFinalizeBatch tests that the planter can recover from caretaker errors
-// successfully when finalizing a batch, and that the planter state is properly
-// reset after successful batch finalization.
+// testFinalizeBatch tests that the planter can recover from funding
+// errors and caretaker errors successfully when finalizing a batch,
+// and that the planter state is properly reset after successful batch
+// finalization.
 func testFinalizeBatch(t *mintingTestHarness) {
-	// First, create a new chain planter instance using the supplied test
-	// harness.
+	// First, create a new chain planter instance using the supplied
+	// test harness.
 	t.refreshChainPlanter()
 
 	// Create an initial batch of 5 seedlings.
 	const numSeedlings = 5
 	_ = t.queueInitialBatch(numSeedlings)
 
-	// Force fee estimation to fail so we crash the caretaker before the
+	// Force fee estimation to fail so funding fails before the
 	// batch can be frozen.
 	t.chain.FailFeeEstimatesOnce()
 
@@ -1502,7 +1506,8 @@ func testFinalizeBatch(t *mintingTestHarness) {
 		batchCount     = 0
 	)
 
-	// Finalize the pending batch to start a caretaker.
+	// Finalize the pending batch. Funding will fail because fee
+	// estimation was set to fail.
 	t.finalizeBatch(&wg, respChan, nil)
 	batchCount++
 
@@ -1511,41 +1516,43 @@ func testFinalizeBatch(t *mintingTestHarness) {
 	)
 	require.NoError(t, err)
 
-	// The planter should fail to finalize the batch, so there should be no
-	// active caretakers nor pending batch.
-	t.assertNoPendingBatch()
+	// The batch should stay pending so the user can retry. No
+	// caretakers should have been started.
 	t.assertNumCaretakersActive(caretakerCount)
-	t.assertLastBatchState(batchCount, tapgarden.BatchStateFrozen)
-	t.assertFinalizeBatch(&wg, respChan, "failed to estimate fee")
+	t.assertLastBatchState(
+		batchCount, tapgarden.BatchStatePending,
+	)
+	t.assertFinalizeBatch(
+		&wg, respChan, "failed to estimate fee",
+	)
 
-	// Queue another batch, reset fee estimation behavior, and set TX
-	// confirmation registration to fail.
-	t.queueInitialBatch(numSeedlings)
+	// Retry finalize on the same batch, but set TX confirmation
+	// registration to fail.
 	t.chain.FailConfOnce()
 
-	// Finalize the pending batch to start a caretaker, and progress the
-	// caretaker to TX confirmation. The finalize call should report no
-	// error, but the caretaker should propagate the confirmation error to
-	// the shared error channel.
+	// The retry should succeed at funding and freezing, but the
+	// caretaker should propagate the confirmation error.
 	t.finalizeBatch(&wg, respChan, nil)
-	batchCount++
 
 	_ = t.progressCaretaker(false, nil, nil)
 	caretakerCount++
 
 	t.assertFinalizeBatch(&wg, respChan, "")
 	caretakerErr := <-t.errChan
-	require.ErrorContains(t, caretakerErr, "error getting confirmation")
+	require.ErrorContains(
+		t, caretakerErr, "error getting confirmation",
+	)
 
-	// The stopped caretaker will still exist but there should be no pending
-	// batch. We will have two batches on disk, including the broadcasted
-	// batch.
+	// The stopped caretaker will still exist but there should
+	// be no pending batch.
 	t.assertNoPendingBatch()
 	t.assertNumCaretakersActive(caretakerCount)
-	t.assertLastBatchState(batchCount, tapgarden.BatchStateBroadcast)
+	t.assertLastBatchState(
+		batchCount, tapgarden.BatchStateBroadcast,
+	)
 
-	// Queue another batch, set TX confirmation to succeed, and set the
-	// confirmation event to be empty.
+	// Queue another batch, set TX confirmation to succeed, and
+	// set the confirmation event to be empty.
 	t.queueInitialBatch(numSeedlings)
 	t.chain.EmptyConfOnce()
 
@@ -1556,30 +1563,38 @@ func testFinalizeBatch(t *mintingTestHarness) {
 	sendConfNtfn := t.progressCaretaker(false, nil, nil)
 	caretakerCount++
 
-	// Trigger the confirmation event, which should cause the caretaker to
-	// fail.
+	// Trigger the confirmation event, which should cause the
+	// caretaker to fail.
 	sendConfNtfn()
 
 	t.assertFinalizeBatch(&wg, respChan, "")
 	caretakerErr = <-t.errChan
-	require.ErrorContains(t, caretakerErr, "got empty confirmation")
+	require.ErrorContains(
+		t, caretakerErr, "got empty confirmation",
+	)
 
-	// The stopped caretaker will still exist but there should be no pending
-	// batch. We will now have three batches on disk.
+	// The stopped caretaker will still exist but there should
+	// be no pending batch.
 	t.assertNoPendingBatch()
 	t.assertNumCaretakersActive(caretakerCount)
-	t.assertLastBatchState(batchCount, tapgarden.BatchStateBroadcast)
+	t.assertLastBatchState(
+		batchCount, tapgarden.BatchStateBroadcast,
+	)
 
-	// If we try to finalize without a pending batch, the finalize call
-	// should return an error.
+	// If we try to finalize without a pending batch, the
+	// finalize call should return an error.
 	t.finalizeBatch(&wg, respChan, nil)
-	t.assertFinalizeBatch(&wg, respChan, "no pending batch")
+	t.assertFinalizeBatch(
+		&wg, respChan, "no pending batch",
+	)
 	t.assertNumCaretakersActive(caretakerCount)
 
-	// Queue another batch and drive the caretaker to a successful minting.
+	// Queue another batch and drive the caretaker to a
+	// successful minting.
 	t.queueInitialBatch(numSeedlings)
 
-	// Use a custom feerate and verify that the TX uses that feerate.
+	// Use a custom feerate and verify that the TX uses that
+	// feerate.
 	manualFeeRate := chainfee.FeePerKwFloor * 2
 	finalizeReq := tapgarden.FinalizeParams{
 		FeeRate: fn.Some(manualFeeRate),
@@ -1587,14 +1602,18 @@ func testFinalizeBatch(t *mintingTestHarness) {
 	t.finalizeBatch(&wg, respChan, &finalizeReq)
 	batchCount++
 
-	sendConfNtfn = t.progressCaretaker(false, nil, &manualFeeRate)
+	sendConfNtfn = t.progressCaretaker(
+		false, nil, &manualFeeRate,
+	)
 	sendConfNtfn()
 
 	t.assertFinalizeBatch(&wg, respChan, "")
 	t.assertNoError()
 	t.assertNoPendingBatch()
 	t.assertNumCaretakersActive(caretakerCount)
-	t.assertLastBatchState(batchCount, tapgarden.BatchStateFinalized)
+	t.assertLastBatchState(
+		batchCount, tapgarden.BatchStateFinalized,
+	)
 }
 
 func testFinalizeWithTapscriptTree(t *mintingTestHarness) {


### PR DESCRIPTION
Resolves #2136. Tested e2e on a docker regtest network with [this script](https://gist.github.com/jtobin/306dbe77782208022bc513891a666d9f).

This is a series of tapgarden fixes, each one targeting an issue exposed by righteously fixing, from first principles, the previous one.

The first issue is what's described in #2136, i.e. that a minting batch could get stuck in FROZEN if finalization failed due to a funding error. The fix here is to freeze only after funding and sealing succeed; a fund failure now leaves the batch PENDING and retryable, with no orphaned state.

The next issue is then exposed during funding retry, in that state is mutated before persistence completes such that an intermediate failure can produce inconsistent state. The fix is to stage the funded PSBT, complete all persistence, and only mutate the in-memory batch after every write succeeds (this also fixes another extant bug by which fundGenesisPsbt is called with the wrong batch reference on restart).

The *next* issue is that the above persistence was non-atomic, in that the batch's tapscript sibling and genesis transaction were written in two separate transactions, such that a partial failure could create inconsistent state. The fix is to write both in a single transaction.

(EDIT: the *next next* fix, resolving the issue pointed out by Gemini, gets rid of a bunch of pre-existing potential nil pointer dereferences.)