### PR TITLE
tapfreighter: detect subsequent v2-addr local sends

### DIFF
--- a/docs/release-notes/release-notes-0.8.0.md
+++ b/docs/release-notes/release-notes-0.8.0.md
@@ -111,6 +111,10 @@
   fixes several bugs that could leave minting batches in an inconsistent
   state in the case of a funding, database write, or restart error.
 
+* [PR#2149](https://github.com/lightninglabs/taproot-assets/pull/2149)
+  fixes a bug that caused tapd not to detect subsequent self-sends to
+  V2 addresses.
+
 # New Features
 
 ## Functional Enhancements

--- a/itest/addrs_v2_test.go
+++ b/itest/addrs_v2_test.go
@@ -639,6 +639,64 @@ func testAddressV2WithGroupKeyMultipleRoundTrips(t *harnessTest) {
 	}
 }
 
+// testAddressV2SelfSend exercises repeated self-sends to a single reusable
+// V2 group address on the same node, asserting that each send produces a
+// distinct AddrEvent. Regression coverage for issue #2148, where the
+// second self-send was silently dropped because the per-send unique script
+// key became locally known after the first receive.
+func testAddressV2SelfSend(t *harnessTest) {
+	// Mint a single grouped asset on the only node (t.tapd). The bug
+	// requires the same asset ID across both sends so that
+	// DeriveUniqueScriptKey yields the same derived key each time.
+	mintReq := CopyRequest(issuableAssets[0])
+	mintReq.Asset.Amount = 1000
+
+	tranche := MintAssetsConfirmBatch(
+		t.t, t.lndHarness.Miner(), t.tapd,
+		[]*mintrpc.MintAssetRequest{mintReq},
+	)
+	mintedAsset := tranche[0]
+	groupKey := mintedAsset.AssetGroup.TweakedGroupKey
+
+	// Create a reusable amountless V2 group address on the same node;
+	// this is the self-send case.
+	ctx := context.Background()
+	selfAddr, err := t.tapd.NewAddr(ctx, &taprpc.NewAddrRequest{
+		AddressVersion: addrV2,
+		GroupKey:       groupKey,
+	})
+	require.NoError(t.t, err)
+	t.Logf("Got self group addr: %v", toJSON(t.t, selfAddr))
+
+	// First self-send.
+	_, err = t.tapd.SendAsset(ctx, &taprpc.SendAssetRequest{
+		AddressesWithAmounts: []*taprpc.AddressWithAmount{
+			{
+				TapAddr: selfAddr.Encoded,
+				Amount:  1,
+			},
+		},
+	})
+	require.NoError(t.t, err)
+	MineBlocks(t.t, t.lndHarness.Miner(), 1, 1)
+	AssertAddrEventByStatus(t.t, t.tapd, statusCompleted, 1)
+
+	// Second self-send to the same reusable V2 address. Without the
+	// fix in #2148 this would silently produce no new AddrEvent and
+	// the assertion below would fail.
+	_, err = t.tapd.SendAsset(ctx, &taprpc.SendAssetRequest{
+		AddressesWithAmounts: []*taprpc.AddressWithAmount{
+			{
+				TapAddr: selfAddr.Encoded,
+				Amount:  1,
+			},
+		},
+	})
+	require.NoError(t.t, err)
+	MineBlocks(t.t, t.lndHarness.Miner(), 1, 1)
+	AssertAddrEventByStatus(t.t, t.tapd, statusCompleted, 2)
+}
+
 // testAddressV2WithGroupKeyRestart tests that we can re-try and properly
 // continue the address v2 send process in various scenarios.
 func testAddressV2WithGroupKeyRestart(t *harnessTest) {

--- a/itest/test_list_on_test.go
+++ b/itest/test_list_on_test.go
@@ -468,6 +468,10 @@ var allTestCases = []*testCase{
 		test: testAddressV2WithGroupKeyMultipleRoundTrips,
 	},
 	{
+		name: "address v2 self send",
+		test: testAddressV2SelfSend,
+	},
+	{
 		name: "address v2 with group key restart",
 		test: testAddressV2WithGroupKeyRestart,
 	},

--- a/tapfreighter/interface.go
+++ b/tapfreighter/interface.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"encoding/binary"
 	"fmt"
+	"net/url"
 	"time"
 
 	"github.com/btcsuite/btcd/btcec/v2"
@@ -394,8 +395,15 @@ func (out *TransferOutput) ShouldDeliverProof() (bool, error) {
 	}
 
 	// If this is an output that is going to our own node/wallet, we don't
-	// need to deliver a proof.
-	if out.ScriptKey.TweakedScriptKey != nil && out.ScriptKeyLocal {
+	// need to deliver a proof — the wallet-tx watcher will create the
+	// AddrEvent locally. The exception is V2 (auth-mailbox) sends, where
+	// the SendFragment upload is the only path that produces a
+	// receiver-side AddrEvent, so we must still deliver even when the
+	// recipient script key is local (e.g. a self-send to a reusable V2
+	// address; see issue #2148).
+	localScriptKey := out.ScriptKey.TweakedScriptKey != nil &&
+		out.ScriptKeyLocal
+	if localScriptKey && !out.UsesAuthMailboxCourier() {
 		return false, nil
 	}
 
@@ -409,6 +417,22 @@ func (out *TransferOutput) ShouldDeliverProof() (bool, error) {
 
 	// At this point, we should deliver a proof.
 	return true, nil
+}
+
+// UsesAuthMailboxCourier reports whether the output's proof courier
+// address points at an auth-mailbox server, which is the courier scheme
+// used by V2 (reusable) Taproot Asset addresses.
+func (out *TransferOutput) UsesAuthMailboxCourier() bool {
+	if len(out.ProofCourierAddr) == 0 {
+		return false
+	}
+
+	u, err := url.Parse(string(out.ProofCourierAddr))
+	if err != nil {
+		return false
+	}
+
+	return u.Scheme == proof.AuthMailboxUniRpcCourierType
 }
 
 // AssetID returns the asset ID of the transfer output. This requires the

--- a/tapfreighter/interface_test.go
+++ b/tapfreighter/interface_test.go
@@ -1,0 +1,155 @@
+package tapfreighter
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/lightninglabs/taproot-assets/asset"
+	"github.com/lightninglabs/taproot-assets/fn"
+	"github.com/lightninglabs/taproot-assets/proof"
+	"github.com/stretchr/testify/require"
+)
+
+// TestShouldDeliverProof exercises TransferOutput.ShouldDeliverProof,
+// in particular the V2 self-send case from issue #2148, where the
+// local-script-key shortcut was incorrectly skipping the auth-mailbox
+// SendFragment upload — the only path that creates an AddrEvent for
+// V2 reusable addresses.
+func TestShouldDeliverProof(t *testing.T) {
+	t.Parallel()
+
+	priv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	pubKey := priv.PubKey()
+
+	// A local-script-key output mimicking the result of
+	// asset.DeriveUniqueScriptKey for a V2 send: TweakedScriptKey is
+	// populated, PubKey is set.
+	tweakedLocalKey := asset.ScriptKey{
+		PubKey: pubKey,
+		TweakedScriptKey: &asset.TweakedScriptKey{
+			Type: asset.ScriptKeyUniquePedersen,
+		},
+	}
+
+	// An un-spendable NUMS script key.
+	unspendableKey := asset.ScriptKey{
+		PubKey: asset.NUMSPubKey,
+	}
+
+	// A burn script key + witness pair, so asset.IsBurnKey returns
+	// true.
+	prevID := asset.PrevID{}
+	burnPubKey := asset.DeriveBurnKey(prevID)
+	burnKey := asset.ScriptKey{
+		PubKey: burnPubKey,
+		TweakedScriptKey: &asset.TweakedScriptKey{
+			Type: asset.ScriptKeyBurn,
+		},
+	}
+	burnWitness := asset.Witness{
+		PrevID: &prevID,
+	}
+
+	authmailbox := []byte(
+		proof.AuthMailboxUniRpcCourierType + "://example.org:1234",
+	)
+	universerpc := []byte(
+		proof.UniverseRpcCourierType + "://example.org:1234",
+	)
+
+	cases := []struct {
+		name string
+		out  TransferOutput
+		want bool
+	}{
+		// The regression from issue #2148: V2 self-send (authmailbox
+		// courier + local script key) must still deliver, since the
+		// SendFragment upload is the only way a receiver-side
+		// AddrEvent gets created for V2.
+		{
+			name: "v2 self-send delivers",
+			out: TransferOutput{
+				ScriptKey:        tweakedLocalKey,
+				ScriptKeyLocal:   true,
+				ProofCourierAddr: authmailbox,
+			},
+			want: true,
+		},
+		{
+			name: "v2 remote send delivers",
+			out: TransferOutput{
+				ScriptKey:        tweakedLocalKey,
+				ScriptKeyLocal:   false,
+				ProofCourierAddr: authmailbox,
+			},
+			want: true,
+		},
+		// V0/V1 self-send must keep its existing shortcut: the
+		// wallet-tx watcher creates the event locally, so we don't
+		// need to push a proof.
+		{
+			name: "v0/v1 self-send skips delivery",
+			out: TransferOutput{
+				ScriptKey:        tweakedLocalKey,
+				ScriptKeyLocal:   true,
+				ProofCourierAddr: universerpc,
+			},
+			want: false,
+		},
+		{
+			name: "v0/v1 remote send delivers",
+			out: TransferOutput{
+				ScriptKey:        tweakedLocalKey,
+				ScriptKeyLocal:   false,
+				ProofCourierAddr: universerpc,
+			},
+			want: true,
+		},
+		{
+			name: "unspendable script key skips delivery",
+			out: TransferOutput{
+				ScriptKey:        unspendableKey,
+				ProofCourierAddr: authmailbox,
+			},
+			want: false,
+		},
+		{
+			name: "burn output skips delivery",
+			out: TransferOutput{
+				ScriptKey:        burnKey,
+				ProofCourierAddr: authmailbox,
+				WitnessData:      []asset.Witness{burnWitness},
+			},
+			want: false,
+		},
+		{
+			name: "empty courier addr skips delivery",
+			out: TransferOutput{
+				ScriptKey:      tweakedLocalKey,
+				ScriptKeyLocal: false,
+			},
+			want: false,
+		},
+		{
+			name: "completed delivery skips re-delivery",
+			out: TransferOutput{
+				ScriptKey:             tweakedLocalKey,
+				ScriptKeyLocal:        false,
+				ProofCourierAddr:      authmailbox,
+				ProofDeliveryComplete: fn.Some(true),
+			},
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := tc.out.ShouldDeliverProof()
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}


### PR DESCRIPTION
Fixes #2148, by which tapd failed to pick up *subsequent* sends to a local, reused V2 address. The issue was that such receipts are only registered by an authmailbox upload, but the sender was skipping the delivery because the recipient was local. The fix is just to not skip delivery when the courier type is authmailbox.

I think that the correct solution would arguably be to introduce an address version field to the TransferOutput struct that delivery operates on. Opus talked me out of it for pragmatic reasons (it would be a much more invasive change, payoff is not so obvious given the current fix works just fine, etc. etc.).