### PR TITLE
Add `ListPayments` / `ListInvoices` RPC

### DIFF
--- a/docs/release-notes/release-notes-0.8.1.md
+++ b/docs/release-notes/release-notes-0.8.1.md
@@ -31,6 +31,15 @@
 
 ## RPC Additions
 
+- [PR#2150](https://github.com/lightninglabs/taproot-assets/pull/2150)
+  Add `ListInvoices` and `ListPayments` RPCs to the `TaprootAssetChannels`
+  service. Each request embeds the corresponding `lnrpc` list request so
+  callers pass the same arguments they would pass to lnd. Responses embed
+  the full `lnrpc.Invoice` / `lnrpc.Payment` alongside an `AssetAmount`
+  summary (`asset_id`, `amount`, and tweaked `group_key`) decoded from
+  the HTLCs' custom records. Results are filtered to records that involve
+  a Taproot Asset; lnd's pagination offsets are passed through unchanged.
+
 ## tapcli Additions
 
 # Improvements

--- a/go.mod
+++ b/go.mod
@@ -225,3 +225,6 @@ replace github.com/golang-migrate/migrate/v4 => github.com/lightninglabs/migrate
 
 // Needed for healthcheck import.
 replace github.com/prometheus/common => github.com/prometheus/common v0.26.0
+
+// Note this is a temporary replace and will be removed when taprpc is tagged.
+replace github.com/lightninglabs/taproot-assets/taprpc => ./taprpc

--- a/go.sum
+++ b/go.sum
@@ -1123,8 +1123,6 @@ github.com/lightninglabs/neutrino/cache v1.1.3 h1:rgnabC41W+XaPuBTQrdeFjFCCAVKh1
 github.com/lightninglabs/neutrino/cache v1.1.3/go.mod h1:qxkJb+pUxR5p84jl5uIGFCR4dGdFkhNUwMSxw3EUWls=
 github.com/lightninglabs/protobuf-go-hex-display v1.34.2-hex-display h1:w7FM5LH9Z6CpKxl13mS48idsu6F+cEZf0lkyiV+Dq9g=
 github.com/lightninglabs/protobuf-go-hex-display v1.34.2-hex-display/go.mod h1:qYOHts0dSfpeUzUFpOMr/WGzszTmLH+DiWniOlNbLDw=
-github.com/lightninglabs/taproot-assets/taprpc v1.1.0 h1:Oum7ddGygrEaT+NHqpaQI8U6pV5jJUH4hvhezl5y00k=
-github.com/lightninglabs/taproot-assets/taprpc v1.1.0/go.mod h1:X7XP753o8xCgjVI2mRu1Tvpyk3k4uybGDMFhpF6IRxI=
 github.com/lightningnetwork/lightning-onion v1.3.0 h1:FqILgHjD6euc/Muo1VOzZ4+XDPuFnw6EYROBq0rR/5c=
 github.com/lightningnetwork/lightning-onion v1.3.0/go.mod h1:nP85zMHG7c0si/eHBbSQpuDCtnIXfSvFrK3tW6YWzmU=
 github.com/lightningnetwork/lnd v0.21.0-beta h1:bDP5UH15E7DVGTztsmBPQLqgyilq5EXDrglvQFmRc3U=

--- a/itest/custom_channels/custom_channels_test.go
+++ b/itest/custom_channels/custom_channels_test.go
@@ -127,6 +127,10 @@ var testCases = []*ccTestCase{
 		name: "restart coop close",
 		test: testCustomChannelsRestartCoopClose,
 	},
+	{
+		name: "list invoices and payments",
+		test: testCustomChannelsListInvoicesAndPayments,
+	},
 }
 
 // TestCustomChannels is the main entry point for running custom channel

--- a/itest/custom_channels/list_asset_rpcs_test.go
+++ b/itest/custom_channels/list_asset_rpcs_test.go
@@ -1,0 +1,462 @@
+//go:build itest
+
+package custom_channels
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"fmt"
+	"slices"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/lightninglabs/taproot-assets/itest"
+	"github.com/lightninglabs/taproot-assets/proof"
+	"github.com/lightninglabs/taproot-assets/taprpc/mintrpc"
+	tchrpc "github.com/lightninglabs/taproot-assets/taprpc/tapchannelrpc"
+	fn "github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/lightningnetwork/lnd/lnrpc"
+	"github.com/lightningnetwork/lnd/lnrpc/invoicesrpc"
+	"github.com/lightningnetwork/lnd/lntest/node"
+	"github.com/lightningnetwork/lnd/lntest/port"
+	"github.com/lightningnetwork/lnd/lntest/wait"
+	"github.com/stretchr/testify/require"
+)
+
+// testCustomChannelsListInvoicesAndPayments asserts that tapd's ListInvoices
+// and ListPayments RPCs return the expected asset-aware view of invoices and
+// payments, filter out records that don't involve any asset, and pass
+// pagination offsets through from lnd.
+//
+//nolint:lll
+func testCustomChannelsListInvoicesAndPayments(_ context.Context,
+	net *itest.IntegratedNetworkHarness, t *ccHarnessTest) {
+
+	lndArgs := slices.Clone(lndArgsTemplate)
+	tapdArgs := slices.Clone(tapdArgsTemplate)
+
+	// We use Alice as the proof courier. But in order for Alice to also
+	// use itself, we need to define its port upfront.
+	alicePort := port.NextAvailablePort()
+	tapdArgs = append(tapdArgs, fmt.Sprintf(
+		"--proofcourieraddr=%s://%s",
+		proof.UniverseRpcCourierType,
+		fmt.Sprintf(node.ListenerFormat, alicePort),
+	))
+
+	aliceLndArgs := slices.Clone(lndArgs)
+	aliceLndArgs = append(aliceLndArgs, fmt.Sprintf(
+		"--rpclisten=127.0.0.1:%d", alicePort,
+	))
+	alice := net.NewNode("Alice", aliceLndArgs, tapdArgs)
+	bob := net.NewNode("Bob", lndArgs, tapdArgs)
+
+	nodes := []*itest.IntegratedNode{alice, bob}
+	connectAllNodes(t.t, net, nodes)
+	fundAllNodes(t.t, net, nodes)
+
+	// Mint a grouped asset on Alice (we use a group so we can verify that
+	// the response surfaces the tweaked group key alongside the tranche
+	// asset_id) and open an asset channel from Alice to Bob.
+	groupedAsset := *ccItestAsset
+	groupedAsset.NewGroupedAsset = true
+	mintedAssets := itest.MintAssetsConfirmBatch(
+		t.t, net.Miner, asTapd(alice),
+		[]*mintrpc.MintAssetRequest{
+			{Asset: &groupedAsset},
+		},
+	)
+	cents := mintedAssets[0]
+	assetID := cents.AssetGenesis.AssetId
+	require.NotNil(t.t, cents.AssetGroup)
+	expectedGroupKey := cents.AssetGroup.TweakedGroupKey
+
+	t.Logf("Minted %d lightning cents, syncing universes...", cents.Amount)
+	syncUniverses(t.t, alice, bob)
+
+	ctx := context.Background()
+	t.Logf("Opening asset channel...")
+	assetFundResp, err := asTapd(alice).FundChannel(
+		ctx, &tchrpc.FundChannelRequest{
+			AssetAmount:        fundingAmount,
+			AssetId:            assetID,
+			PeerPubkey:         bob.PubKey[:],
+			FeeRateSatPerVbyte: 5,
+		},
+	)
+	require.NoError(t.t, err)
+
+	assetChanPoint := &lnrpc.ChannelPoint{
+		OutputIndex: uint32(assetFundResp.OutputIndex),
+		FundingTxid: &lnrpc.ChannelPoint_FundingTxidStr{
+			FundingTxidStr: assetFundResp.Txid,
+		},
+	}
+
+	// With the channel open, mine a block to confirm it.
+	mineBlocks(t, net, 6, 1)
+
+	require.NoError(t.t, net.AssertNodeKnown(alice, bob))
+	require.NoError(t.t, net.AssertNodeKnown(bob, alice))
+
+	// Push a small keysend through the channel before Bob creates his
+	// invoice. AddInvoice's RFQ hop-hint construction needs the inbound
+	// channel policy from Alice's side; on a freshly-opened channel that
+	// edge update may not have been gossiped yet, and the keysend forces
+	// both sides to exchange policies.
+	sendAssetKeySendPayment(
+		t.t, alice, bob, 100, assetID, fn.None[int64](),
+	)
+
+	// Create a plain BTC invoice on Alice. We never settle it, but we use
+	// it later to verify that tapd's ListInvoices filters out invoices
+	// that don't involve any asset.
+	btcInvoice := createNormalInvoice(t.t, alice, btcutil.Amount(1234))
+	require.NotEmpty(t.t, btcInvoice.RHash)
+
+	// Create and pay an asset invoice on Bob.
+	const assetInvoiceAmount = 1_500
+	invoiceResp := createAssetInvoice(
+		t.t, alice, bob, assetInvoiceAmount, assetID,
+	)
+	sentUnits, _ := payInvoiceWithAssets(
+		t.t, alice, bob, invoiceResp.PaymentRequest, assetID,
+	)
+	require.NotZero(t.t, sentUnits)
+	t.Logf("Paid asset invoice: %d units sent", sentUnits)
+
+	waitForAssetChannelHtlcSettlement(t.t, alice, assetChanPoint)
+
+	// Create an asset hodl invoice, send an HTLC to it, then cancel it.
+	// ListInvoices should still include the invoice as asset-related, but
+	// should not count the canceled HTLC's asset amount as delivered.
+	const canceledAssetInvoiceAmount = 750
+	canceledInvoice := createAssetHodlInvoice(
+		t.t, alice, bob, canceledAssetInvoiceAmount, assetID,
+	)
+	payInvoiceWithAssets(
+		t.t, alice, bob, canceledInvoice.payReq, assetID,
+		withFailure(lnrpc.Payment_IN_FLIGHT, failureNone),
+	)
+
+	canceledHash := canceledInvoice.preimage.Hash()
+	_, err = bob.InvoicesClient.CancelInvoice(
+		ctx, &invoicesrpc.CancelInvoiceMsg{
+			PaymentHash: canceledHash[:],
+		},
+	)
+	require.NoError(t.t, err)
+	assertNumHtlcsAll(t.t, 0, alice, bob)
+
+	// Create another asset hodl invoice and settle it explicitly. This
+	// exercises the same hodl invoice code path as the canceled case above,
+	// but verifies that settled HTLC amounts are still reported by
+	// ListInvoices.
+	const settledHodlInvoiceAmount = 900
+	settledHodlInvoice := createAssetHodlInvoice(
+		t.t, alice, bob, settledHodlInvoiceAmount, assetID,
+	)
+	settledHodlUnits, _ := payInvoiceWithAssets(
+		t.t, alice, bob, settledHodlInvoice.payReq, assetID,
+		withFailure(lnrpc.Payment_IN_FLIGHT, failureNone),
+	)
+	require.NotZero(t.t, settledHodlUnits)
+
+	settledHodlHash := settledHodlInvoice.preimage.Hash()
+	_, err = bob.InvoicesClient.SettleInvoice(
+		ctx, &invoicesrpc.SettleInvoiceMsg{
+			Preimage: settledHodlInvoice.preimage[:],
+		},
+	)
+	require.NoError(t.t, err)
+	waitForAssetChannelHtlcSettlement(t.t, alice, assetChanPoint)
+
+	// -----------------------------------------------------------------
+	// ListInvoices on Bob: Bob has four asset invoices: the warm-up
+	// keysend (auto-generated), the asset invoice we explicitly paid, the
+	// canceled hodl invoice, and the settled hodl invoice above. We locate
+	// the settled invoices by payment hash and verify their decoded asset
+	// metadata.
+	// -----------------------------------------------------------------
+	var bobInvoices *tchrpc.ListInvoicesResponse
+	err = wait.NoError(func() error {
+		var err error
+		bobInvoices, err = asTapd(bob).ListInvoices(
+			ctx, &tchrpc.ListInvoicesRequest{
+				Request: &lnrpc.ListInvoiceRequest{
+					NumMaxInvoices: 100,
+				},
+			},
+		)
+		if err != nil {
+			return err
+		}
+
+		canceledInv := findAssetInvoiceOptional(
+			bobInvoices, canceledHash[:],
+		)
+		if canceledInv == nil {
+			return fmt.Errorf("canceled asset invoice not listed")
+		}
+		if canceledInv.Invoice.State != lnrpc.Invoice_CANCELED {
+			return fmt.Errorf("invoice state is %v, want %v",
+				canceledInv.Invoice.State, lnrpc.Invoice_CANCELED)
+		}
+		if len(canceledInv.AssetAmounts) != 0 {
+			return fmt.Errorf("canceled invoice has asset amounts: %v",
+				canceledInv.AssetAmounts)
+		}
+
+		settledHodlInv := findAssetInvoiceOptional(
+			bobInvoices, settledHodlHash[:],
+		)
+		if settledHodlInv == nil {
+			return fmt.Errorf("settled hodl asset invoice not listed")
+		}
+		if settledHodlInv.Invoice.State != lnrpc.Invoice_SETTLED {
+			return fmt.Errorf("invoice state is %v, want %v",
+				settledHodlInv.Invoice.State,
+				lnrpc.Invoice_SETTLED)
+		}
+		if len(settledHodlInv.AssetAmounts) != 1 {
+			return fmt.Errorf("settled hodl invoice has %d asset "+
+				"amounts, want 1", len(settledHodlInv.AssetAmounts))
+		}
+
+		return nil
+	}, wait.DefaultTimeout)
+	require.NoError(t.t, err)
+
+	require.Len(t.t, bobInvoices.Invoices, 4)
+	canceledInv := findAssetInvoice(t.t, bobInvoices, canceledHash[:])
+	require.Equal(t.t, lnrpc.Invoice_CANCELED, canceledInv.Invoice.State)
+	require.Empty(t.t, canceledInv.AssetAmounts)
+	require.NotEmpty(t.t, canceledInv.Invoice.Htlcs)
+	for _, htlc := range canceledInv.Invoice.Htlcs {
+		require.Equal(
+			t.t, lnrpc.InvoiceHTLCState_CANCELED, htlc.State,
+		)
+	}
+
+	settledHodlInv := findAssetInvoice(
+		t.t, bobInvoices, settledHodlHash[:],
+	)
+	require.Equal(t.t, lnrpc.Invoice_SETTLED, settledHodlInv.Invoice.State)
+	require.Len(t.t, settledHodlInv.AssetAmounts, 1)
+	require.Equal(t.t, assetID, settledHodlInv.AssetAmounts[0].AssetId)
+	require.Equal(
+		t.t, settledHodlUnits, settledHodlInv.AssetAmounts[0].Amount,
+	)
+	require.Equal(
+		t.t, expectedGroupKey, settledHodlInv.AssetAmounts[0].GroupKey,
+	)
+	require.NotEmpty(t.t, settledHodlInv.Invoice.Htlcs)
+	for _, htlc := range settledHodlInv.Invoice.Htlcs {
+		require.Equal(t.t, lnrpc.InvoiceHTLCState_SETTLED, htlc.State)
+	}
+
+	assetInv := findAssetInvoice(t.t, bobInvoices, invoiceResp.RHash)
+	require.NotNil(t.t, assetInv.Invoice)
+	require.Len(t.t, assetInv.AssetAmounts, 1)
+	require.Equal(t.t, assetID, assetInv.AssetAmounts[0].AssetId)
+	require.Equal(
+		t.t, sentUnits, assetInv.AssetAmounts[0].Amount,
+	)
+	require.Equal(
+		t.t, expectedGroupKey, assetInv.AssetAmounts[0].GroupKey,
+	)
+
+	// Pagination offsets must come straight from lnd.
+	require.NotZero(t.t, bobInvoices.LastIndexOffset)
+
+	// -----------------------------------------------------------------
+	// ListInvoices on Alice: she only has the BTC invoice, which must be
+	// filtered out (no asset HTLCs).
+	// -----------------------------------------------------------------
+	aliceInvoices, err := asTapd(alice).ListInvoices(
+		ctx, &tchrpc.ListInvoicesRequest{
+			Request: &lnrpc.ListInvoiceRequest{
+				NumMaxInvoices: 100,
+			},
+		},
+	)
+	require.NoError(t.t, err)
+	require.Empty(t.t, aliceInvoices.Invoices)
+
+	// Even though no asset invoices were returned, the BTC invoice in
+	// lnd's DB advances the offset, so we expect it to be non-zero.
+	require.NotZero(t.t, aliceInvoices.LastIndexOffset)
+
+	// -----------------------------------------------------------------
+	// ListPayments on Alice: Alice has four asset payments, the warm-up
+	// keysend, the settled invoice payment, the canceled hodl payment, and
+	// the settled hodl payment. Include incomplete payments so the failed
+	// canceled hodl payment is returned.
+	// -----------------------------------------------------------------
+	var alicePayments *tchrpc.ListPaymentsResponse
+	err = wait.NoError(func() error {
+		var err error
+		alicePayments, err = asTapd(alice).ListPayments(
+			ctx, &tchrpc.ListPaymentsRequest{
+				Request: &lnrpc.ListPaymentsRequest{
+					MaxPayments:       100,
+					IncludeIncomplete: true,
+				},
+			},
+		)
+		if err != nil {
+			return err
+		}
+
+		canceledPayment := findAssetPaymentOptional(
+			alicePayments, hex.EncodeToString(canceledHash[:]),
+		)
+		if canceledPayment == nil {
+			return fmt.Errorf("canceled asset payment not listed")
+		}
+		if canceledPayment.Payment.Status != lnrpc.Payment_FAILED {
+			return fmt.Errorf("payment state is %v, want %v",
+				canceledPayment.Payment.Status,
+				lnrpc.Payment_FAILED)
+		}
+		if len(canceledPayment.AssetAmounts) != 0 {
+			return fmt.Errorf("failed payment has asset amounts: %v",
+				canceledPayment.AssetAmounts)
+		}
+
+		settledHodlPayment := findAssetPaymentOptional(
+			alicePayments, hex.EncodeToString(settledHodlHash[:]),
+		)
+		if settledHodlPayment == nil {
+			return fmt.Errorf("settled hodl asset payment not listed")
+		}
+		if settledHodlPayment.Payment.Status != lnrpc.Payment_SUCCEEDED {
+			return fmt.Errorf("payment state is %v, want %v",
+				settledHodlPayment.Payment.Status,
+				lnrpc.Payment_SUCCEEDED)
+		}
+		if len(settledHodlPayment.AssetAmounts) != 1 {
+			return fmt.Errorf("settled hodl payment has %d asset "+
+				"amounts, want 1",
+				len(settledHodlPayment.AssetAmounts))
+		}
+
+		return nil
+	}, wait.DefaultTimeout)
+	require.NoError(t.t, err)
+
+	require.Len(t.t, alicePayments.Payments, 4)
+	canceledPayment := findAssetPayment(
+		t.t, alicePayments, hex.EncodeToString(canceledHash[:]),
+	)
+	require.Equal(t.t, lnrpc.Payment_FAILED, canceledPayment.Payment.Status)
+	require.Empty(t.t, canceledPayment.AssetAmounts)
+
+	settledHodlPayment := findAssetPayment(
+		t.t, alicePayments, hex.EncodeToString(settledHodlHash[:]),
+	)
+	require.Equal(t.t, lnrpc.Payment_SUCCEEDED, settledHodlPayment.Payment.Status)
+	require.Len(t.t, settledHodlPayment.AssetAmounts, 1)
+	require.Equal(
+		t.t, assetID, settledHodlPayment.AssetAmounts[0].AssetId,
+	)
+	require.Equal(
+		t.t, settledHodlUnits,
+		settledHodlPayment.AssetAmounts[0].Amount,
+	)
+	require.Equal(
+		t.t, expectedGroupKey,
+		settledHodlPayment.AssetAmounts[0].GroupKey,
+	)
+
+	wantHash := hex.EncodeToString(invoiceResp.RHash)
+	assetPay := findAssetPayment(t.t, alicePayments, wantHash)
+	require.NotNil(t.t, assetPay.Payment)
+	require.Len(t.t, assetPay.AssetAmounts, 1)
+	require.Equal(t.t, assetID, assetPay.AssetAmounts[0].AssetId)
+	require.Equal(
+		t.t, sentUnits, assetPay.AssetAmounts[0].Amount,
+	)
+	require.Equal(
+		t.t, expectedGroupKey, assetPay.AssetAmounts[0].GroupKey,
+	)
+
+	require.NotZero(t.t, alicePayments.LastIndexOffset)
+
+	// -----------------------------------------------------------------
+	// ListPayments on Bob: he hasn't sent anything, so the result must
+	// be empty.
+	// -----------------------------------------------------------------
+	bobPayments, err := asTapd(bob).ListPayments(
+		ctx, &tchrpc.ListPaymentsRequest{
+			Request: &lnrpc.ListPaymentsRequest{
+				MaxPayments: 100,
+			},
+		},
+	)
+	require.NoError(t.t, err)
+	require.Empty(t.t, bobPayments.Payments)
+}
+
+// findAssetInvoiceOptional locates the asset invoice with the given r_hash in
+// the response, returning nil if none is found.
+func findAssetInvoiceOptional(resp *tchrpc.ListInvoicesResponse,
+	rHash []byte) *tchrpc.AssetInvoice {
+
+	for _, inv := range resp.Invoices {
+		if inv.Invoice != nil && bytes.Equal(inv.Invoice.RHash, rHash) {
+			return inv
+		}
+	}
+
+	return nil
+}
+
+// findAssetInvoice locates the asset invoice with the given r_hash in the
+// response, failing the test if none is found.
+func findAssetInvoice(t *testing.T, resp *tchrpc.ListInvoicesResponse,
+	rHash []byte) *tchrpc.AssetInvoice {
+
+	t.Helper()
+	inv := findAssetInvoiceOptional(resp, rHash)
+	if inv != nil {
+		return inv
+	}
+
+	require.Failf(t, "asset invoice not found",
+		"no asset invoice with r_hash %x in %d results", rHash,
+		len(resp.Invoices))
+	return nil
+}
+
+// findAssetPaymentOptional locates the asset payment with the given
+// hex-encoded payment_hash in the response, returning nil if none is found.
+func findAssetPaymentOptional(resp *tchrpc.ListPaymentsResponse,
+	hash string) *tchrpc.AssetPayment {
+
+	for _, p := range resp.Payments {
+		if p.Payment != nil && p.Payment.PaymentHash == hash {
+			return p
+		}
+	}
+
+	return nil
+}
+
+// findAssetPayment locates the asset payment with the given hex-encoded
+// payment_hash in the response, failing the test if none is found.
+func findAssetPayment(t *testing.T, resp *tchrpc.ListPaymentsResponse,
+	hash string) *tchrpc.AssetPayment {
+
+	t.Helper()
+	p := findAssetPaymentOptional(resp, hash)
+	if p != nil {
+		return p
+	}
+
+	require.Failf(t, "asset payment not found",
+		"no asset payment with hash %s in %d results", hash,
+		len(resp.Payments))
+	return nil
+}

--- a/rpcserver/rpcserver.go
+++ b/rpcserver/rpcserver.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -10596,6 +10597,402 @@ func (r *RPCServer) AddInvoice(ctx context.Context,
 		AcceptedBuyQuote: expensiveQuote,
 		InvoiceResult:    invoiceResp,
 	}, nil
+}
+
+// ListInvoices is a wrapper around lnd's lnrpc.ListInvoices method that only
+// returns invoices that involve at least one Taproot Asset. The full lnd
+// invoice is returned along with the decoded asset amounts that the invoice's
+// HTLCs carry.
+func (r *RPCServer) ListInvoices(ctx context.Context,
+	req *tchrpc.ListInvoicesRequest) (*tchrpc.ListInvoicesResponse, error) {
+
+	lndReq := req.GetRequest()
+	if lndReq == nil {
+		lndReq = &lnrpc.ListInvoiceRequest{}
+	}
+
+	rpcCtx, _, rawClient := r.cfg.Lnd.Client.RawClientWithMacAuth(ctx)
+	resp, err := rawClient.ListInvoices(rpcCtx, lndReq)
+	if err != nil {
+		return nil, fmt.Errorf("error listing invoices: %w", err)
+	}
+
+	lookup := newAssetGroupLookup(ctx, r.cfg.AddrBook)
+
+	assetInvoices := make([]*tchrpc.AssetInvoice, 0, len(resp.Invoices))
+	for _, invoice := range resp.Invoices {
+		amounts, isAsset, err := assetAmountsFromInvoice(invoice)
+		if err != nil {
+			return nil, fmt.Errorf("error decoding asset "+
+				"amounts from invoice %x: %w",
+				invoice.GetRHash(), err)
+		}
+
+		// Asset-only: skip invoices that don't carry any asset HTLCs.
+		if !isAsset {
+			continue
+		}
+
+		assetInvoices = append(assetInvoices, &tchrpc.AssetInvoice{
+			Invoice:      invoice,
+			AssetAmounts: marshalAssetAmounts(amounts, lookup),
+		})
+	}
+
+	return &tchrpc.ListInvoicesResponse{
+		Invoices:         assetInvoices,
+		FirstIndexOffset: resp.FirstIndexOffset,
+		LastIndexOffset:  resp.LastIndexOffset,
+	}, nil
+}
+
+// ListPayments is a wrapper around lnd's lnrpc.ListPayments method that only
+// returns payments that involve at least one Taproot Asset. The full lnd
+// payment is returned along with the decoded asset amounts that the payment's
+// HTLCs carry.
+func (r *RPCServer) ListPayments(ctx context.Context,
+	req *tchrpc.ListPaymentsRequest) (*tchrpc.ListPaymentsResponse, error) {
+
+	lndReq := req.GetRequest()
+	if lndReq == nil {
+		lndReq = &lnrpc.ListPaymentsRequest{}
+	}
+
+	rpcCtx, _, rawClient := r.cfg.Lnd.Client.RawClientWithMacAuth(ctx)
+	resp, err := rawClient.ListPayments(rpcCtx, lndReq)
+	if err != nil {
+		return nil, fmt.Errorf("error listing payments: %w", err)
+	}
+
+	lookup := newAssetGroupLookup(ctx, r.cfg.AddrBook)
+
+	assetPayments := make([]*tchrpc.AssetPayment, 0, len(resp.Payments))
+	for _, payment := range resp.Payments {
+		amounts, isAsset, err := assetAmountsFromPayment(payment)
+		if err != nil {
+			return nil, fmt.Errorf("error decoding asset "+
+				"amounts from payment %s: %w",
+				payment.GetPaymentHash(), err)
+		}
+
+		// Asset-only: skip payments that don't carry any asset HTLCs.
+		if !isAsset {
+			continue
+		}
+
+		assetPayments = append(assetPayments, &tchrpc.AssetPayment{
+			Payment:      payment,
+			AssetAmounts: marshalAssetAmounts(amounts, lookup),
+		})
+	}
+
+	return &tchrpc.ListPaymentsResponse{
+		Payments:         assetPayments,
+		FirstIndexOffset: resp.FirstIndexOffset,
+		LastIndexOffset:  resp.LastIndexOffset,
+	}, nil
+}
+
+// assetAmountsFromInvoice extracts the per-asset amounts carried by an
+// invoice's settled HTLCs, aggregated across all settled HTLCs. The second
+// return value tells whether the invoice involves any asset at all (i.e. has at
+// least one HTLC carrying asset custom records).
+func assetAmountsFromInvoice(invoice *lnrpc.Invoice) (map[asset.ID]uint64, bool,
+	error) {
+
+	if invoice == nil {
+		return nil, false, fmt.Errorf("nil invoice in lnd response")
+	}
+
+	amounts := make(map[asset.ID]uint64)
+	isAsset := false
+
+	for idx, htlc := range invoice.Htlcs {
+		if htlc == nil {
+			return nil, false, fmt.Errorf("nil HTLC at index "+
+				"%d in invoice %x", idx, invoice.RHash)
+		}
+
+		// We read the raw wire custom records of the HTLC (unlike
+		// the custom_channel_data field, these are never rewritten
+		// into JSON by lnd's aux data parser).
+		balances, err := assetBalancesFromCustomRecords(
+			htlc.CustomRecords,
+		)
+		if err != nil {
+			return nil, false, err
+		}
+
+		if balances == nil {
+			continue
+		}
+
+		isAsset = true
+
+		// Only settled HTLCs delivered assets to the invoice.
+		// Accepted HTLCs are still pending, and canceled HTLCs moved
+		// nothing.
+		if htlc.State == lnrpc.InvoiceHTLCState_SETTLED {
+			mergeAssetBalances(amounts, balances)
+		}
+	}
+
+	return amounts, isAsset, nil
+}
+
+// assetAmountsFromPayment extracts the per-asset amounts carried by a payment,
+// aggregated across all non-failed HTLC attempts. The second return value
+// indicates whether the payment involves any asset at all.
+func assetAmountsFromPayment(payment *lnrpc.Payment) (map[asset.ID]uint64, bool,
+	error) {
+
+	if payment == nil {
+		return nil, false, fmt.Errorf("nil payment in lnd response")
+	}
+
+	amounts := make(map[asset.ID]uint64)
+	isAsset := false
+
+	// The payment-level first hop custom records mark a payment as an asset
+	// payment even when no HTLC succeeded (e.g. fully failed payments), or
+	// for invoice payments where the per-shard amount is only available on
+	// the individual route.
+	firstHop := lnwire.CustomRecords(payment.FirstHopCustomRecords)
+	if rfqmsg.HasAssetHTLCCustomRecords(firstHop) {
+		isAsset = true
+	}
+
+	for idx, htlc := range payment.Htlcs {
+		if htlc == nil {
+			return nil, false, fmt.Errorf("nil HTLC attempt at "+
+				"index %d in payment %s", idx,
+				payment.PaymentHash)
+		}
+
+		if htlc.Route == nil {
+			continue
+		}
+
+		balances, err := assetBalancesFromRouteData(
+			htlc.Route.CustomChannelData,
+		)
+		if err != nil {
+			return nil, false, err
+		}
+
+		if balances == nil {
+			continue
+		}
+
+		isAsset = true
+
+		// Only attempts that are in-flight or have succeeded (still)
+		// carry assets; failed attempts moved nothing.
+		if htlc.Status != lnrpc.HTLCAttempt_FAILED {
+			mergeAssetBalances(amounts, balances)
+		}
+	}
+
+	return amounts, isAsset, nil
+}
+
+// assetBalancesFromCustomRecords extracts the asset balances carried in the
+// given wire custom records. It returns nil (without error) if the records
+// don't carry asset HTLC data.
+func assetBalancesFromCustomRecords(records map[uint64][]byte) (
+	map[asset.ID]uint64, error) {
+
+	customRecords := lnwire.CustomRecords(records)
+	if !rfqmsg.HasAssetHTLCCustomRecords(customRecords) {
+		return nil, nil
+	}
+
+	htlc, err := rfqmsg.HtlcFromCustomRecords(customRecords)
+	if err != nil {
+		return nil, fmt.Errorf("unable to decode asset HTLC from "+
+			"custom records: %w", err)
+	}
+
+	return balancesToMap(htlc.Balances()), nil
+}
+
+// assetBalancesFromRouteData extracts asset balances from the custom channel
+// data of a payment route. Depending on whether lnd had an aux data parser
+// configured when marshalling the payment, this blob is either the raw TLV
+// encoding of the HTLC's custom records or its JSON representation. Both forms
+// are handled here. It returns nil (without error) if the blob is empty.
+func assetBalancesFromRouteData(customChannelData []byte) (map[asset.ID]uint64,
+	error) {
+
+	if len(customChannelData) == 0 {
+		return nil, nil
+	}
+
+	// If lnd's aux data parser already converted the blob to JSON, it
+	// starts with a '{'. Otherwise we expect the raw TLV encoding, whose
+	// first byte is a BigSize-encoded record type well above the JSON brace
+	// byte value.
+	trimmed := bytes.TrimSpace(customChannelData)
+	if len(trimmed) > 0 && trimmed[0] == '{' {
+		var jsonHtlc rfqmsg.JsonHtlc
+		if err := json.Unmarshal(trimmed, &jsonHtlc); err != nil {
+			return nil, fmt.Errorf("unable to decode asset HTLC "+
+				"JSON: %w", err)
+		}
+
+		return balancesFromJSON(jsonHtlc)
+	}
+
+	htlc, err := rfqmsg.DecodeHtlc(customChannelData)
+	if err != nil {
+		return nil, fmt.Errorf("unable to decode asset HTLC from "+
+			"route data: %w", err)
+	}
+
+	return balancesToMap(htlc.Balances()), nil
+}
+
+// balancesToMap aggregates a list of asset balances into a map keyed by asset
+// ID, summing the amounts of duplicate asset IDs.
+func balancesToMap(balances []*rfqmsg.AssetBalance) map[asset.ID]uint64 {
+	out := make(map[asset.ID]uint64, len(balances))
+	for _, balance := range balances {
+		out[balance.AssetID.Val] += balance.Amount.Val
+	}
+
+	return out
+}
+
+// balancesFromJSON aggregates the balances of a JSON-encoded HTLC into a map
+// keyed by asset ID.
+func balancesFromJSON(jsonHtlc rfqmsg.JsonHtlc) (map[asset.ID]uint64, error) {
+	out := make(map[asset.ID]uint64, len(jsonHtlc.Balances))
+	for _, tranche := range jsonHtlc.Balances {
+		if tranche == nil {
+			return nil, fmt.Errorf("nil balance tranche in HTLC " +
+				"JSON")
+		}
+
+		idBytes, err := hex.DecodeString(tranche.AssetID)
+		if err != nil {
+			return nil, fmt.Errorf("invalid asset ID in HTLC "+
+				"JSON: %w", err)
+		}
+
+		// Reject anything that isn't a full asset ID so a short or
+		// truncated hex string can't collide with a real ID after
+		// zero-padding through copy().
+		if len(idBytes) != sha256.Size {
+			return nil, fmt.Errorf("asset ID in HTLC JSON has "+
+				"wrong length: expected %d bytes, got %d",
+				sha256.Size, len(idBytes))
+		}
+
+		var id asset.ID
+		copy(id[:], idBytes)
+		out[id] += tranche.Amount
+	}
+
+	return out, nil
+}
+
+// mergeAssetBalances adds the amounts of src into dst, keyed by asset ID.
+func mergeAssetBalances(dst, src map[asset.ID]uint64) {
+	for id, amount := range src {
+		dst[id] += amount
+	}
+}
+
+// marshalAssetAmounts converts a map of aggregated asset amounts into the RPC
+// representation, ordered deterministically by asset ID. The group key for
+// each tranche is filled in opportunistically via the lookup; assets unknown
+// to this tapd are still returned, just without a group key. Returns nil for
+// an empty map.
+func marshalAssetAmounts(amounts map[asset.ID]uint64,
+	lookup *assetGroupLookup) []*tchrpc.AssetAmount {
+
+	if len(amounts) == 0 {
+		return nil
+	}
+
+	ids := make([]asset.ID, 0, len(amounts))
+	for id := range amounts {
+		ids = append(ids, id)
+	}
+	sort.Slice(ids, func(i, j int) bool {
+		return bytes.Compare(ids[i][:], ids[j][:]) < 0
+	})
+
+	out := make([]*tchrpc.AssetAmount, len(ids))
+	for idx := range ids {
+		id := ids[idx]
+		out[idx] = &tchrpc.AssetAmount{
+			AssetId:  id[:],
+			Amount:   amounts[id],
+			GroupKey: lookup.groupKey(id),
+		}
+	}
+
+	return out
+}
+
+// assetGroupLookup resolves tranche asset IDs to the tweaked group key of the
+// group they belong to. It caches results per call so an MPP payment with N
+// HTLCs over the same asset only triggers a single DB round trip. A nil
+// AddrBook is tolerated (group key always resolves to nil) so the helper can
+// be exercised in unit tests without a wired-up server.
+type assetGroupLookup struct {
+	ctx      context.Context
+	addrBook *address.Book
+	cache    map[asset.ID][]byte
+}
+
+// newAssetGroupLookup constructs an empty assetGroupLookup bound to the given
+// context and address book. A nil address book is tolerated; in that mode
+// every group key resolves to nil (useful for unit tests that don't wire up
+// a real server).
+func newAssetGroupLookup(ctx context.Context,
+	addrBook *address.Book) *assetGroupLookup {
+
+	return &assetGroupLookup{
+		ctx:      ctx,
+		addrBook: addrBook,
+		cache:    make(map[asset.ID][]byte),
+	}
+}
+
+// groupKey returns the compressed tweaked group key that the given asset
+// tranche belongs to, or nil if the tranche has no group, the asset isn't
+// known to this tapd, or no address book is configured. Errors are logged
+// and swallowed: a list RPC should never fail because of opportunistic
+// metadata enrichment.
+func (l *assetGroupLookup) groupKey(id asset.ID) []byte {
+	if gk, ok := l.cache[id]; ok {
+		return gk
+	}
+
+	if l.addrBook == nil {
+		l.cache[id] = nil
+		return nil
+	}
+
+	info, err := l.addrBook.QueryAssetInfo(
+		l.ctx, asset.NewSpecifierFromId(id),
+	)
+	if err != nil {
+		rpcsLog.Debugf("list rpc: unable to query asset info for "+
+			"asset_id %x: %v", id[:], err)
+		l.cache[id] = nil
+		return nil
+	}
+
+	var gk []byte
+	if info.GroupKey != nil {
+		gk = info.GroupKey.GroupPubKey.SerializeCompressed()
+	}
+	l.cache[id] = gk
+
+	return gk
 }
 
 // calculateAssetMaxAmount calculates the max units to be placed in the invoice

--- a/taprpc/perms.go
+++ b/taprpc/perms.go
@@ -343,6 +343,14 @@ var (
 			Entity: "channels",
 			Action: "read",
 		}},
+		"/tapchannelrpc.TaprootAssetChannels/ListInvoices": {{
+			Entity: "channels",
+			Action: "read",
+		}},
+		"/tapchannelrpc.TaprootAssetChannels/ListPayments": {{
+			Entity: "channels",
+			Action: "read",
+		}},
 		"/tapchannelrpc.TaprootAssetChannels/EncodeCustomRecords": {
 			// This RPC is completely stateless and doesn't require
 			// any permissions to use.

--- a/taprpc/tapchannelrpc/tapchannel.pb.go
+++ b/taprpc/tapchannelrpc/tapchannel.pb.go
@@ -1062,6 +1062,419 @@ func (x *AssetPayReqResponse) GetPayReq() *lnrpc.PayReq {
 	return nil
 }
 
+type AssetAmount struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The asset ID (genesis ID of the tranche) the amount refers to.
+	AssetId []byte `protobuf:"bytes,1,opt,name=asset_id,json=assetId,proto3" json:"asset_id,omitempty"`
+	// The amount, expressed in units of the asset identified by asset_id.
+	Amount uint64 `protobuf:"varint,2,opt,name=amount,proto3" json:"amount,omitempty"`
+	// The tweaked group key the asset belongs to, in compressed form. Empty
+	// for assets that aren't part of a group, or whose group is unknown to
+	// this tapd instance. Populated so callers that work in terms of group
+	// keys (e.g. wallets backing a fungible group of tranches) don't need a
+	// separate lookup per result.
+	GroupKey      []byte `protobuf:"bytes,3,opt,name=group_key,json=groupKey,proto3" json:"group_key,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AssetAmount) Reset() {
+	*x = AssetAmount{}
+	mi := &file_tapchannelrpc_tapchannel_proto_msgTypes[13]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AssetAmount) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AssetAmount) ProtoMessage() {}
+
+func (x *AssetAmount) ProtoReflect() protoreflect.Message {
+	mi := &file_tapchannelrpc_tapchannel_proto_msgTypes[13]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AssetAmount.ProtoReflect.Descriptor instead.
+func (*AssetAmount) Descriptor() ([]byte, []int) {
+	return file_tapchannelrpc_tapchannel_proto_rawDescGZIP(), []int{13}
+}
+
+func (x *AssetAmount) GetAssetId() []byte {
+	if x != nil {
+		return x.AssetId
+	}
+	return nil
+}
+
+func (x *AssetAmount) GetAmount() uint64 {
+	if x != nil {
+		return x.Amount
+	}
+	return 0
+}
+
+func (x *AssetAmount) GetGroupKey() []byte {
+	if x != nil {
+		return x.GroupKey
+	}
+	return nil
+}
+
+type ListInvoicesRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The standard lnd invoice listing request. All fields behave the same way
+	// as they do for lnd's lnrpc.ListInvoices RPC method (see the API docs at
+	// https://lightning.engineering/api-docs/api/lnd/lightning/list-invoices
+	// for more details). Pagination is performed by lnd over all invoices; the
+	// returned set is then filtered down to only those that involve assets, so
+	// a page may contain fewer asset invoices than the requested maximum.
+	Request       *lnrpc.ListInvoiceRequest `protobuf:"bytes,1,opt,name=request,proto3" json:"request,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListInvoicesRequest) Reset() {
+	*x = ListInvoicesRequest{}
+	mi := &file_tapchannelrpc_tapchannel_proto_msgTypes[14]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListInvoicesRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListInvoicesRequest) ProtoMessage() {}
+
+func (x *ListInvoicesRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_tapchannelrpc_tapchannel_proto_msgTypes[14]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListInvoicesRequest.ProtoReflect.Descriptor instead.
+func (*ListInvoicesRequest) Descriptor() ([]byte, []int) {
+	return file_tapchannelrpc_tapchannel_proto_rawDescGZIP(), []int{14}
+}
+
+func (x *ListInvoicesRequest) GetRequest() *lnrpc.ListInvoiceRequest {
+	if x != nil {
+		return x.Request
+	}
+	return nil
+}
+
+type AssetInvoice struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The full lnd invoice, including any custom channel data on its HTLCs.
+	Invoice *lnrpc.Invoice `protobuf:"bytes,1,opt,name=invoice,proto3" json:"invoice,omitempty"`
+	// The asset amounts carried by the invoice's HTLCs, aggregated per asset
+	// ID across all of the invoice's HTLCs. Empty for invoices that have not
+	// been (partially) settled with assets yet.
+	AssetAmounts  []*AssetAmount `protobuf:"bytes,2,rep,name=asset_amounts,json=assetAmounts,proto3" json:"asset_amounts,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AssetInvoice) Reset() {
+	*x = AssetInvoice{}
+	mi := &file_tapchannelrpc_tapchannel_proto_msgTypes[15]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AssetInvoice) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AssetInvoice) ProtoMessage() {}
+
+func (x *AssetInvoice) ProtoReflect() protoreflect.Message {
+	mi := &file_tapchannelrpc_tapchannel_proto_msgTypes[15]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AssetInvoice.ProtoReflect.Descriptor instead.
+func (*AssetInvoice) Descriptor() ([]byte, []int) {
+	return file_tapchannelrpc_tapchannel_proto_rawDescGZIP(), []int{15}
+}
+
+func (x *AssetInvoice) GetInvoice() *lnrpc.Invoice {
+	if x != nil {
+		return x.Invoice
+	}
+	return nil
+}
+
+func (x *AssetInvoice) GetAssetAmounts() []*AssetAmount {
+	if x != nil {
+		return x.AssetAmounts
+	}
+	return nil
+}
+
+type ListInvoicesResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The list of asset invoices that matched the request.
+	Invoices []*AssetInvoice `protobuf:"bytes,1,rep,name=invoices,proto3" json:"invoices,omitempty"`
+	// The index of the last item in the set of returned invoices. This can be
+	// used to seek further, pagination style. Mirrors the value returned by
+	// lnd's lnrpc.ListInvoices.
+	LastIndexOffset uint64 `protobuf:"varint,2,opt,name=last_index_offset,json=lastIndexOffset,proto3" json:"last_index_offset,omitempty"`
+	// The index of the first item in the set of returned invoices. This can be
+	// used to seek backwards, pagination style. Mirrors the value returned by
+	// lnd's lnrpc.ListInvoices.
+	FirstIndexOffset uint64 `protobuf:"varint,3,opt,name=first_index_offset,json=firstIndexOffset,proto3" json:"first_index_offset,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
+}
+
+func (x *ListInvoicesResponse) Reset() {
+	*x = ListInvoicesResponse{}
+	mi := &file_tapchannelrpc_tapchannel_proto_msgTypes[16]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListInvoicesResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListInvoicesResponse) ProtoMessage() {}
+
+func (x *ListInvoicesResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_tapchannelrpc_tapchannel_proto_msgTypes[16]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListInvoicesResponse.ProtoReflect.Descriptor instead.
+func (*ListInvoicesResponse) Descriptor() ([]byte, []int) {
+	return file_tapchannelrpc_tapchannel_proto_rawDescGZIP(), []int{16}
+}
+
+func (x *ListInvoicesResponse) GetInvoices() []*AssetInvoice {
+	if x != nil {
+		return x.Invoices
+	}
+	return nil
+}
+
+func (x *ListInvoicesResponse) GetLastIndexOffset() uint64 {
+	if x != nil {
+		return x.LastIndexOffset
+	}
+	return 0
+}
+
+func (x *ListInvoicesResponse) GetFirstIndexOffset() uint64 {
+	if x != nil {
+		return x.FirstIndexOffset
+	}
+	return 0
+}
+
+type ListPaymentsRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The standard lnd payment listing request. All fields behave the same way
+	// as they do for lnd's lnrpc.ListPayments RPC method (see the API docs at
+	// https://lightning.engineering/api-docs/api/lnd/lightning/list-payments
+	// for more details). Pagination is performed by lnd over all payments; the
+	// returned set is then filtered down to only those that involve assets, so
+	// a page may contain fewer asset payments than the requested maximum.
+	Request       *lnrpc.ListPaymentsRequest `protobuf:"bytes,1,opt,name=request,proto3" json:"request,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListPaymentsRequest) Reset() {
+	*x = ListPaymentsRequest{}
+	mi := &file_tapchannelrpc_tapchannel_proto_msgTypes[17]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListPaymentsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListPaymentsRequest) ProtoMessage() {}
+
+func (x *ListPaymentsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_tapchannelrpc_tapchannel_proto_msgTypes[17]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListPaymentsRequest.ProtoReflect.Descriptor instead.
+func (*ListPaymentsRequest) Descriptor() ([]byte, []int) {
+	return file_tapchannelrpc_tapchannel_proto_rawDescGZIP(), []int{17}
+}
+
+func (x *ListPaymentsRequest) GetRequest() *lnrpc.ListPaymentsRequest {
+	if x != nil {
+		return x.Request
+	}
+	return nil
+}
+
+type AssetPayment struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The full lnd payment, including any custom channel data on its HTLCs.
+	Payment *lnrpc.Payment `protobuf:"bytes,1,opt,name=payment,proto3" json:"payment,omitempty"`
+	// The asset amounts carried by the payment, aggregated per asset ID across
+	// all non-failed HTLC attempts. Empty for payments that did not (yet) move
+	// any assets.
+	AssetAmounts  []*AssetAmount `protobuf:"bytes,2,rep,name=asset_amounts,json=assetAmounts,proto3" json:"asset_amounts,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AssetPayment) Reset() {
+	*x = AssetPayment{}
+	mi := &file_tapchannelrpc_tapchannel_proto_msgTypes[18]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AssetPayment) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AssetPayment) ProtoMessage() {}
+
+func (x *AssetPayment) ProtoReflect() protoreflect.Message {
+	mi := &file_tapchannelrpc_tapchannel_proto_msgTypes[18]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AssetPayment.ProtoReflect.Descriptor instead.
+func (*AssetPayment) Descriptor() ([]byte, []int) {
+	return file_tapchannelrpc_tapchannel_proto_rawDescGZIP(), []int{18}
+}
+
+func (x *AssetPayment) GetPayment() *lnrpc.Payment {
+	if x != nil {
+		return x.Payment
+	}
+	return nil
+}
+
+func (x *AssetPayment) GetAssetAmounts() []*AssetAmount {
+	if x != nil {
+		return x.AssetAmounts
+	}
+	return nil
+}
+
+type ListPaymentsResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The list of asset payments that matched the request.
+	Payments []*AssetPayment `protobuf:"bytes,1,rep,name=payments,proto3" json:"payments,omitempty"`
+	// The index of the first item in the set of returned payments. This can be
+	// used to seek backwards, pagination style. Mirrors the value returned by
+	// lnd's lnrpc.ListPayments.
+	FirstIndexOffset uint64 `protobuf:"varint,2,opt,name=first_index_offset,json=firstIndexOffset,proto3" json:"first_index_offset,omitempty"`
+	// The index of the last item in the set of returned payments. This can be
+	// used to seek further, pagination style. Mirrors the value returned by
+	// lnd's lnrpc.ListPayments.
+	LastIndexOffset uint64 `protobuf:"varint,3,opt,name=last_index_offset,json=lastIndexOffset,proto3" json:"last_index_offset,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
+}
+
+func (x *ListPaymentsResponse) Reset() {
+	*x = ListPaymentsResponse{}
+	mi := &file_tapchannelrpc_tapchannel_proto_msgTypes[19]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListPaymentsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListPaymentsResponse) ProtoMessage() {}
+
+func (x *ListPaymentsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_tapchannelrpc_tapchannel_proto_msgTypes[19]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListPaymentsResponse.ProtoReflect.Descriptor instead.
+func (*ListPaymentsResponse) Descriptor() ([]byte, []int) {
+	return file_tapchannelrpc_tapchannel_proto_rawDescGZIP(), []int{19}
+}
+
+func (x *ListPaymentsResponse) GetPayments() []*AssetPayment {
+	if x != nil {
+		return x.Payments
+	}
+	return nil
+}
+
+func (x *ListPaymentsResponse) GetFirstIndexOffset() uint64 {
+	if x != nil {
+		return x.FirstIndexOffset
+	}
+	return 0
+}
+
+func (x *ListPaymentsResponse) GetLastIndexOffset() uint64 {
+	if x != nil {
+		return x.LastIndexOffset
+	}
+	return 0
+}
+
 var File_tapchannelrpc_tapchannel_proto protoreflect.FileDescriptor
 
 const file_tapchannelrpc_tapchannel_proto_rawDesc = "" +
@@ -1139,14 +1552,38 @@ const file_tapchannelrpc_tapchannel_proto_rawDesc = "" +
 	"\vasset_group\x18\x03 \x01(\v2\x12.taprpc.AssetGroupR\n" +
 	"assetGroup\x126\n" +
 	"\fgenesis_info\x18\x04 \x01(\v2\x13.taprpc.GenesisInfoR\vgenesisInfo\x12&\n" +
-	"\apay_req\x18\x05 \x01(\v2\r.lnrpc.PayReqR\x06payReq2\xdf\x03\n" +
+	"\apay_req\x18\x05 \x01(\v2\r.lnrpc.PayReqR\x06payReq\"]\n" +
+	"\vAssetAmount\x12\x19\n" +
+	"\basset_id\x18\x01 \x01(\fR\aassetId\x12\x16\n" +
+	"\x06amount\x18\x02 \x01(\x04R\x06amount\x12\x1b\n" +
+	"\tgroup_key\x18\x03 \x01(\fR\bgroupKey\"J\n" +
+	"\x13ListInvoicesRequest\x123\n" +
+	"\arequest\x18\x01 \x01(\v2\x19.lnrpc.ListInvoiceRequestR\arequest\"y\n" +
+	"\fAssetInvoice\x12(\n" +
+	"\ainvoice\x18\x01 \x01(\v2\x0e.lnrpc.InvoiceR\ainvoice\x12?\n" +
+	"\rasset_amounts\x18\x02 \x03(\v2\x1a.tapchannelrpc.AssetAmountR\fassetAmounts\"\xa9\x01\n" +
+	"\x14ListInvoicesResponse\x127\n" +
+	"\binvoices\x18\x01 \x03(\v2\x1b.tapchannelrpc.AssetInvoiceR\binvoices\x12*\n" +
+	"\x11last_index_offset\x18\x02 \x01(\x04R\x0flastIndexOffset\x12,\n" +
+	"\x12first_index_offset\x18\x03 \x01(\x04R\x10firstIndexOffset\"K\n" +
+	"\x13ListPaymentsRequest\x124\n" +
+	"\arequest\x18\x01 \x01(\v2\x1a.lnrpc.ListPaymentsRequestR\arequest\"y\n" +
+	"\fAssetPayment\x12(\n" +
+	"\apayment\x18\x01 \x01(\v2\x0e.lnrpc.PaymentR\apayment\x12?\n" +
+	"\rasset_amounts\x18\x02 \x03(\v2\x1a.tapchannelrpc.AssetAmountR\fassetAmounts\"\xa9\x01\n" +
+	"\x14ListPaymentsResponse\x127\n" +
+	"\bpayments\x18\x01 \x03(\v2\x1b.tapchannelrpc.AssetPaymentR\bpayments\x12,\n" +
+	"\x12first_index_offset\x18\x02 \x01(\x04R\x10firstIndexOffset\x12*\n" +
+	"\x11last_index_offset\x18\x03 \x01(\x04R\x0flastIndexOffset2\x91\x05\n" +
 	"\x14TaprootAssetChannels\x12T\n" +
 	"\vFundChannel\x12!.tapchannelrpc.FundChannelRequest\x1a\".tapchannelrpc.FundChannelResponse\x12q\n" +
 	"\x13EncodeCustomRecords\x12).tapchannelrpc.EncodeCustomRecordsRequest\x1a*.tapchannelrpc.EncodeCustomRecordsResponse\"\x03\x88\x02\x01\x12V\n" +
 	"\vSendPayment\x12!.tapchannelrpc.SendPaymentRequest\x1a\".tapchannelrpc.SendPaymentResponse0\x01\x12Q\n" +
 	"\n" +
 	"AddInvoice\x12 .tapchannelrpc.AddInvoiceRequest\x1a!.tapchannelrpc.AddInvoiceResponse\x12S\n" +
-	"\x11DecodeAssetPayReq\x12\x1a.tapchannelrpc.AssetPayReq\x1a\".tapchannelrpc.AssetPayReqResponseB>Z<github.com/lightninglabs/taproot-assets/taprpc/tapchannelrpcb\x06proto3"
+	"\x11DecodeAssetPayReq\x12\x1a.tapchannelrpc.AssetPayReq\x1a\".tapchannelrpc.AssetPayReqResponse\x12W\n" +
+	"\fListInvoices\x12\".tapchannelrpc.ListInvoicesRequest\x1a#.tapchannelrpc.ListInvoicesResponse\x12W\n" +
+	"\fListPayments\x12\".tapchannelrpc.ListPaymentsRequest\x1a#.tapchannelrpc.ListPaymentsResponseB>Z<github.com/lightninglabs/taproot-assets/taprpc/tapchannelrpcb\x06proto3"
 
 var (
 	file_tapchannelrpc_tapchannel_proto_rawDescOnce sync.Once
@@ -1160,7 +1597,7 @@ func file_tapchannelrpc_tapchannel_proto_rawDescGZIP() []byte {
 	return file_tapchannelrpc_tapchannel_proto_rawDescData
 }
 
-var file_tapchannelrpc_tapchannel_proto_msgTypes = make([]protoimpl.MessageInfo, 15)
+var file_tapchannelrpc_tapchannel_proto_msgTypes = make([]protoimpl.MessageInfo, 22)
 var file_tapchannelrpc_tapchannel_proto_goTypes = []any{
 	(*FundChannelRequest)(nil),           // 0: tapchannelrpc.FundChannelRequest
 	(*FundChannelResponse)(nil),          // 1: tapchannelrpc.FundChannelResponse
@@ -1175,55 +1612,76 @@ var file_tapchannelrpc_tapchannel_proto_goTypes = []any{
 	(*AddInvoiceResponse)(nil),           // 10: tapchannelrpc.AddInvoiceResponse
 	(*AssetPayReq)(nil),                  // 11: tapchannelrpc.AssetPayReq
 	(*AssetPayReqResponse)(nil),          // 12: tapchannelrpc.AssetPayReqResponse
-	nil,                                  // 13: tapchannelrpc.RouterSendPaymentData.AssetAmountsEntry
-	nil,                                  // 14: tapchannelrpc.EncodeCustomRecordsResponse.CustomRecordsEntry
-	(*routerrpc.SendPaymentRequest)(nil), // 15: routerrpc.SendPaymentRequest
-	(*rfqrpc.PeerAcceptedSellQuote)(nil), // 16: rfqrpc.PeerAcceptedSellQuote
-	(*lnrpc.Payment)(nil),                // 17: lnrpc.Payment
-	(*lnrpc.Invoice)(nil),                // 18: lnrpc.Invoice
-	(*rfqrpc.FixedPoint)(nil),            // 19: rfqrpc.FixedPoint
-	(rfqrpc.ExecutionPolicy)(0),          // 20: rfqrpc.ExecutionPolicy
-	(*rfqrpc.PeerAcceptedBuyQuote)(nil),  // 21: rfqrpc.PeerAcceptedBuyQuote
-	(*lnrpc.AddInvoiceResponse)(nil),     // 22: lnrpc.AddInvoiceResponse
-	(*taprpc.DecimalDisplay)(nil),        // 23: taprpc.DecimalDisplay
-	(*taprpc.AssetGroup)(nil),            // 24: taprpc.AssetGroup
-	(*taprpc.GenesisInfo)(nil),           // 25: taprpc.GenesisInfo
-	(*lnrpc.PayReq)(nil),                 // 26: lnrpc.PayReq
+	(*AssetAmount)(nil),                  // 13: tapchannelrpc.AssetAmount
+	(*ListInvoicesRequest)(nil),          // 14: tapchannelrpc.ListInvoicesRequest
+	(*AssetInvoice)(nil),                 // 15: tapchannelrpc.AssetInvoice
+	(*ListInvoicesResponse)(nil),         // 16: tapchannelrpc.ListInvoicesResponse
+	(*ListPaymentsRequest)(nil),          // 17: tapchannelrpc.ListPaymentsRequest
+	(*AssetPayment)(nil),                 // 18: tapchannelrpc.AssetPayment
+	(*ListPaymentsResponse)(nil),         // 19: tapchannelrpc.ListPaymentsResponse
+	nil,                                  // 20: tapchannelrpc.RouterSendPaymentData.AssetAmountsEntry
+	nil,                                  // 21: tapchannelrpc.EncodeCustomRecordsResponse.CustomRecordsEntry
+	(*routerrpc.SendPaymentRequest)(nil), // 22: routerrpc.SendPaymentRequest
+	(*rfqrpc.PeerAcceptedSellQuote)(nil), // 23: rfqrpc.PeerAcceptedSellQuote
+	(*lnrpc.Payment)(nil),                // 24: lnrpc.Payment
+	(*lnrpc.Invoice)(nil),                // 25: lnrpc.Invoice
+	(*rfqrpc.FixedPoint)(nil),            // 26: rfqrpc.FixedPoint
+	(rfqrpc.ExecutionPolicy)(0),          // 27: rfqrpc.ExecutionPolicy
+	(*rfqrpc.PeerAcceptedBuyQuote)(nil),  // 28: rfqrpc.PeerAcceptedBuyQuote
+	(*lnrpc.AddInvoiceResponse)(nil),     // 29: lnrpc.AddInvoiceResponse
+	(*taprpc.DecimalDisplay)(nil),        // 30: taprpc.DecimalDisplay
+	(*taprpc.AssetGroup)(nil),            // 31: taprpc.AssetGroup
+	(*taprpc.GenesisInfo)(nil),           // 32: taprpc.GenesisInfo
+	(*lnrpc.PayReq)(nil),                 // 33: lnrpc.PayReq
+	(*lnrpc.ListInvoiceRequest)(nil),     // 34: lnrpc.ListInvoiceRequest
+	(*lnrpc.ListPaymentsRequest)(nil),    // 35: lnrpc.ListPaymentsRequest
 }
 var file_tapchannelrpc_tapchannel_proto_depIdxs = []int32{
-	13, // 0: tapchannelrpc.RouterSendPaymentData.asset_amounts:type_name -> tapchannelrpc.RouterSendPaymentData.AssetAmountsEntry
+	20, // 0: tapchannelrpc.RouterSendPaymentData.asset_amounts:type_name -> tapchannelrpc.RouterSendPaymentData.AssetAmountsEntry
 	2,  // 1: tapchannelrpc.EncodeCustomRecordsRequest.router_send_payment:type_name -> tapchannelrpc.RouterSendPaymentData
-	14, // 2: tapchannelrpc.EncodeCustomRecordsResponse.custom_records:type_name -> tapchannelrpc.EncodeCustomRecordsResponse.CustomRecordsEntry
-	15, // 3: tapchannelrpc.SendPaymentRequest.payment_request:type_name -> routerrpc.SendPaymentRequest
-	16, // 4: tapchannelrpc.AcceptedSellQuotes.accepted_sell_orders:type_name -> rfqrpc.PeerAcceptedSellQuote
-	16, // 5: tapchannelrpc.SendPaymentResponse.accepted_sell_order:type_name -> rfqrpc.PeerAcceptedSellQuote
+	21, // 2: tapchannelrpc.EncodeCustomRecordsResponse.custom_records:type_name -> tapchannelrpc.EncodeCustomRecordsResponse.CustomRecordsEntry
+	22, // 3: tapchannelrpc.SendPaymentRequest.payment_request:type_name -> routerrpc.SendPaymentRequest
+	23, // 4: tapchannelrpc.AcceptedSellQuotes.accepted_sell_orders:type_name -> rfqrpc.PeerAcceptedSellQuote
+	23, // 5: tapchannelrpc.SendPaymentResponse.accepted_sell_order:type_name -> rfqrpc.PeerAcceptedSellQuote
 	6,  // 6: tapchannelrpc.SendPaymentResponse.accepted_sell_orders:type_name -> tapchannelrpc.AcceptedSellQuotes
-	17, // 7: tapchannelrpc.SendPaymentResponse.payment_result:type_name -> lnrpc.Payment
-	18, // 8: tapchannelrpc.AddInvoiceRequest.invoice_request:type_name -> lnrpc.Invoice
+	24, // 7: tapchannelrpc.SendPaymentResponse.payment_result:type_name -> lnrpc.Payment
+	25, // 8: tapchannelrpc.AddInvoiceRequest.invoice_request:type_name -> lnrpc.Invoice
 	8,  // 9: tapchannelrpc.AddInvoiceRequest.hodl_invoice:type_name -> tapchannelrpc.HodlInvoice
-	19, // 10: tapchannelrpc.AddInvoiceRequest.asset_rate_limit:type_name -> rfqrpc.FixedPoint
-	20, // 11: tapchannelrpc.AddInvoiceRequest.execution_policy:type_name -> rfqrpc.ExecutionPolicy
-	21, // 12: tapchannelrpc.AddInvoiceResponse.accepted_buy_quote:type_name -> rfqrpc.PeerAcceptedBuyQuote
-	22, // 13: tapchannelrpc.AddInvoiceResponse.invoice_result:type_name -> lnrpc.AddInvoiceResponse
-	23, // 14: tapchannelrpc.AssetPayReqResponse.decimal_display:type_name -> taprpc.DecimalDisplay
-	24, // 15: tapchannelrpc.AssetPayReqResponse.asset_group:type_name -> taprpc.AssetGroup
-	25, // 16: tapchannelrpc.AssetPayReqResponse.genesis_info:type_name -> taprpc.GenesisInfo
-	26, // 17: tapchannelrpc.AssetPayReqResponse.pay_req:type_name -> lnrpc.PayReq
-	0,  // 18: tapchannelrpc.TaprootAssetChannels.FundChannel:input_type -> tapchannelrpc.FundChannelRequest
-	3,  // 19: tapchannelrpc.TaprootAssetChannels.EncodeCustomRecords:input_type -> tapchannelrpc.EncodeCustomRecordsRequest
-	5,  // 20: tapchannelrpc.TaprootAssetChannels.SendPayment:input_type -> tapchannelrpc.SendPaymentRequest
-	9,  // 21: tapchannelrpc.TaprootAssetChannels.AddInvoice:input_type -> tapchannelrpc.AddInvoiceRequest
-	11, // 22: tapchannelrpc.TaprootAssetChannels.DecodeAssetPayReq:input_type -> tapchannelrpc.AssetPayReq
-	1,  // 23: tapchannelrpc.TaprootAssetChannels.FundChannel:output_type -> tapchannelrpc.FundChannelResponse
-	4,  // 24: tapchannelrpc.TaprootAssetChannels.EncodeCustomRecords:output_type -> tapchannelrpc.EncodeCustomRecordsResponse
-	7,  // 25: tapchannelrpc.TaprootAssetChannels.SendPayment:output_type -> tapchannelrpc.SendPaymentResponse
-	10, // 26: tapchannelrpc.TaprootAssetChannels.AddInvoice:output_type -> tapchannelrpc.AddInvoiceResponse
-	12, // 27: tapchannelrpc.TaprootAssetChannels.DecodeAssetPayReq:output_type -> tapchannelrpc.AssetPayReqResponse
-	23, // [23:28] is the sub-list for method output_type
-	18, // [18:23] is the sub-list for method input_type
-	18, // [18:18] is the sub-list for extension type_name
-	18, // [18:18] is the sub-list for extension extendee
-	0,  // [0:18] is the sub-list for field type_name
+	26, // 10: tapchannelrpc.AddInvoiceRequest.asset_rate_limit:type_name -> rfqrpc.FixedPoint
+	27, // 11: tapchannelrpc.AddInvoiceRequest.execution_policy:type_name -> rfqrpc.ExecutionPolicy
+	28, // 12: tapchannelrpc.AddInvoiceResponse.accepted_buy_quote:type_name -> rfqrpc.PeerAcceptedBuyQuote
+	29, // 13: tapchannelrpc.AddInvoiceResponse.invoice_result:type_name -> lnrpc.AddInvoiceResponse
+	30, // 14: tapchannelrpc.AssetPayReqResponse.decimal_display:type_name -> taprpc.DecimalDisplay
+	31, // 15: tapchannelrpc.AssetPayReqResponse.asset_group:type_name -> taprpc.AssetGroup
+	32, // 16: tapchannelrpc.AssetPayReqResponse.genesis_info:type_name -> taprpc.GenesisInfo
+	33, // 17: tapchannelrpc.AssetPayReqResponse.pay_req:type_name -> lnrpc.PayReq
+	34, // 18: tapchannelrpc.ListInvoicesRequest.request:type_name -> lnrpc.ListInvoiceRequest
+	25, // 19: tapchannelrpc.AssetInvoice.invoice:type_name -> lnrpc.Invoice
+	13, // 20: tapchannelrpc.AssetInvoice.asset_amounts:type_name -> tapchannelrpc.AssetAmount
+	15, // 21: tapchannelrpc.ListInvoicesResponse.invoices:type_name -> tapchannelrpc.AssetInvoice
+	35, // 22: tapchannelrpc.ListPaymentsRequest.request:type_name -> lnrpc.ListPaymentsRequest
+	24, // 23: tapchannelrpc.AssetPayment.payment:type_name -> lnrpc.Payment
+	13, // 24: tapchannelrpc.AssetPayment.asset_amounts:type_name -> tapchannelrpc.AssetAmount
+	18, // 25: tapchannelrpc.ListPaymentsResponse.payments:type_name -> tapchannelrpc.AssetPayment
+	0,  // 26: tapchannelrpc.TaprootAssetChannels.FundChannel:input_type -> tapchannelrpc.FundChannelRequest
+	3,  // 27: tapchannelrpc.TaprootAssetChannels.EncodeCustomRecords:input_type -> tapchannelrpc.EncodeCustomRecordsRequest
+	5,  // 28: tapchannelrpc.TaprootAssetChannels.SendPayment:input_type -> tapchannelrpc.SendPaymentRequest
+	9,  // 29: tapchannelrpc.TaprootAssetChannels.AddInvoice:input_type -> tapchannelrpc.AddInvoiceRequest
+	11, // 30: tapchannelrpc.TaprootAssetChannels.DecodeAssetPayReq:input_type -> tapchannelrpc.AssetPayReq
+	14, // 31: tapchannelrpc.TaprootAssetChannels.ListInvoices:input_type -> tapchannelrpc.ListInvoicesRequest
+	17, // 32: tapchannelrpc.TaprootAssetChannels.ListPayments:input_type -> tapchannelrpc.ListPaymentsRequest
+	1,  // 33: tapchannelrpc.TaprootAssetChannels.FundChannel:output_type -> tapchannelrpc.FundChannelResponse
+	4,  // 34: tapchannelrpc.TaprootAssetChannels.EncodeCustomRecords:output_type -> tapchannelrpc.EncodeCustomRecordsResponse
+	7,  // 35: tapchannelrpc.TaprootAssetChannels.SendPayment:output_type -> tapchannelrpc.SendPaymentResponse
+	10, // 36: tapchannelrpc.TaprootAssetChannels.AddInvoice:output_type -> tapchannelrpc.AddInvoiceResponse
+	12, // 37: tapchannelrpc.TaprootAssetChannels.DecodeAssetPayReq:output_type -> tapchannelrpc.AssetPayReqResponse
+	16, // 38: tapchannelrpc.TaprootAssetChannels.ListInvoices:output_type -> tapchannelrpc.ListInvoicesResponse
+	19, // 39: tapchannelrpc.TaprootAssetChannels.ListPayments:output_type -> tapchannelrpc.ListPaymentsResponse
+	33, // [33:40] is the sub-list for method output_type
+	26, // [26:33] is the sub-list for method input_type
+	26, // [26:26] is the sub-list for extension type_name
+	26, // [26:26] is the sub-list for extension extendee
+	0,  // [0:26] is the sub-list for field type_name
 }
 
 func init() { file_tapchannelrpc_tapchannel_proto_init() }
@@ -1246,7 +1704,7 @@ func file_tapchannelrpc_tapchannel_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_tapchannelrpc_tapchannel_proto_rawDesc), len(file_tapchannelrpc_tapchannel_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   15,
+			NumMessages:   22,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/taprpc/tapchannelrpc/tapchannel.pb.gw.go
+++ b/taprpc/tapchannelrpc/tapchannel.pb.gw.go
@@ -156,6 +156,58 @@ func local_request_TaprootAssetChannels_DecodeAssetPayReq_0(ctx context.Context,
 
 }
 
+func request_TaprootAssetChannels_ListInvoices_0(ctx context.Context, marshaler runtime.Marshaler, client TaprootAssetChannelsClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq ListInvoicesRequest
+	var metadata runtime.ServerMetadata
+
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	msg, err := client.ListInvoices(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
+}
+
+func local_request_TaprootAssetChannels_ListInvoices_0(ctx context.Context, marshaler runtime.Marshaler, server TaprootAssetChannelsServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq ListInvoicesRequest
+	var metadata runtime.ServerMetadata
+
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	msg, err := server.ListInvoices(ctx, &protoReq)
+	return msg, metadata, err
+
+}
+
+func request_TaprootAssetChannels_ListPayments_0(ctx context.Context, marshaler runtime.Marshaler, client TaprootAssetChannelsClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq ListPaymentsRequest
+	var metadata runtime.ServerMetadata
+
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	msg, err := client.ListPayments(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
+}
+
+func local_request_TaprootAssetChannels_ListPayments_0(ctx context.Context, marshaler runtime.Marshaler, server TaprootAssetChannelsServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq ListPaymentsRequest
+	var metadata runtime.ServerMetadata
+
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	msg, err := server.ListPayments(ctx, &protoReq)
+	return msg, metadata, err
+
+}
+
 // RegisterTaprootAssetChannelsHandlerServer registers the http handlers for service TaprootAssetChannels to "mux".
 // UnaryRPC     :call TaprootAssetChannelsServer directly.
 // StreamingRPC :currently unsupported pending https://github.com/grpc/grpc-go/issues/906.
@@ -266,6 +318,56 @@ func RegisterTaprootAssetChannelsHandlerServer(ctx context.Context, mux *runtime
 		}
 
 		forward_TaprootAssetChannels_DecodeAssetPayReq_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("POST", pattern_TaprootAssetChannels_ListInvoices_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		var err error
+		var annotatedContext context.Context
+		annotatedContext, err = runtime.AnnotateIncomingContext(ctx, mux, req, "/tapchannelrpc.TaprootAssetChannels/ListInvoices", runtime.WithHTTPPathPattern("/v1/taproot-assets/channels/invoices"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_TaprootAssetChannels_ListInvoices_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_TaprootAssetChannels_ListInvoices_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("POST", pattern_TaprootAssetChannels_ListPayments_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		var err error
+		var annotatedContext context.Context
+		annotatedContext, err = runtime.AnnotateIncomingContext(ctx, mux, req, "/tapchannelrpc.TaprootAssetChannels/ListPayments", runtime.WithHTTPPathPattern("/v1/taproot-assets/channels/payments"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_TaprootAssetChannels_ListPayments_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_TaprootAssetChannels_ListPayments_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 
 	})
 
@@ -420,6 +522,50 @@ func RegisterTaprootAssetChannelsHandlerClient(ctx context.Context, mux *runtime
 
 	})
 
+	mux.Handle("POST", pattern_TaprootAssetChannels_ListInvoices_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		var err error
+		var annotatedContext context.Context
+		annotatedContext, err = runtime.AnnotateContext(ctx, mux, req, "/tapchannelrpc.TaprootAssetChannels/ListInvoices", runtime.WithHTTPPathPattern("/v1/taproot-assets/channels/invoices"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_TaprootAssetChannels_ListInvoices_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_TaprootAssetChannels_ListInvoices_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("POST", pattern_TaprootAssetChannels_ListPayments_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		var err error
+		var annotatedContext context.Context
+		annotatedContext, err = runtime.AnnotateContext(ctx, mux, req, "/tapchannelrpc.TaprootAssetChannels/ListPayments", runtime.WithHTTPPathPattern("/v1/taproot-assets/channels/payments"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_TaprootAssetChannels_ListPayments_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_TaprootAssetChannels_ListPayments_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
 	return nil
 }
 
@@ -433,6 +579,10 @@ var (
 	pattern_TaprootAssetChannels_AddInvoice_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"v1", "taproot-assets", "channels", "invoice"}, ""))
 
 	pattern_TaprootAssetChannels_DecodeAssetPayReq_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3, 2, 4}, []string{"v1", "taproot-assets", "channels", "invoice", "decode"}, ""))
+
+	pattern_TaprootAssetChannels_ListInvoices_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"v1", "taproot-assets", "channels", "invoices"}, ""))
+
+	pattern_TaprootAssetChannels_ListPayments_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"v1", "taproot-assets", "channels", "payments"}, ""))
 )
 
 var (
@@ -445,4 +595,8 @@ var (
 	forward_TaprootAssetChannels_AddInvoice_0 = runtime.ForwardResponseMessage
 
 	forward_TaprootAssetChannels_DecodeAssetPayReq_0 = runtime.ForwardResponseMessage
+
+	forward_TaprootAssetChannels_ListInvoices_0 = runtime.ForwardResponseMessage
+
+	forward_TaprootAssetChannels_ListPayments_0 = runtime.ForwardResponseMessage
 )

--- a/taprpc/tapchannelrpc/tapchannel.proto
+++ b/taprpc/tapchannelrpc/tapchannel.proto
@@ -52,6 +52,26 @@ service TaprootAssetChannels {
     units along side the normal information.
     */
     rpc DecodeAssetPayReq (AssetPayReq) returns (AssetPayReqResponse);
+
+    /* litcli: `ln listinvoices`
+    ListInvoices is a wrapper around lnd's lnrpc.ListInvoices method that only
+    returns invoices that involve at least one Taproot Asset. The full lnd
+    invoice is returned along with the decoded asset amounts that the invoice's
+    HTLCs carry, so that callers don't need to parse the custom channel data
+    themselves. All request fields behave the same way as they do for lnd's
+    lnrpc.ListInvoices RPC method.
+    */
+    rpc ListInvoices (ListInvoicesRequest) returns (ListInvoicesResponse);
+
+    /* litcli: `ln listpayments`
+    ListPayments is a wrapper around lnd's lnrpc.ListPayments method that only
+    returns payments that involve at least one Taproot Asset. The full lnd
+    payment is returned along with the decoded asset amounts that the payment's
+    HTLCs carry, so that callers don't need to parse the custom channel data
+    themselves. All request fields behave the same way as they do for lnd's
+    lnrpc.ListPayments RPC method.
+    */
+    rpc ListPayments (ListPaymentsRequest) returns (ListPaymentsResponse);
 }
 
 message FundChannelRequest {
@@ -318,4 +338,89 @@ message AssetPayReqResponse {
 
     // The normal decoded payment request.
     lnrpc.PayReq pay_req = 5;
+}
+
+message AssetAmount {
+    // The asset ID (genesis ID of the tranche) the amount refers to.
+    bytes asset_id = 1;
+
+    // The amount, expressed in units of the asset identified by asset_id.
+    uint64 amount = 2;
+
+    // The tweaked group key the asset belongs to, in compressed form. Empty
+    // for assets that aren't part of a group, or whose group is unknown to
+    // this tapd instance. Populated so callers that work in terms of group
+    // keys (e.g. wallets backing a fungible group of tranches) don't need a
+    // separate lookup per result.
+    bytes group_key = 3;
+}
+
+message ListInvoicesRequest {
+    // The standard lnd invoice listing request. All fields behave the same way
+    // as they do for lnd's lnrpc.ListInvoices RPC method (see the API docs at
+    // https://lightning.engineering/api-docs/api/lnd/lightning/list-invoices
+    // for more details). Pagination is performed by lnd over all invoices; the
+    // returned set is then filtered down to only those that involve assets, so
+    // a page may contain fewer asset invoices than the requested maximum.
+    lnrpc.ListInvoiceRequest request = 1;
+}
+
+message AssetInvoice {
+    // The full lnd invoice, including any custom channel data on its HTLCs.
+    lnrpc.Invoice invoice = 1;
+
+    // The asset amounts carried by the invoice's HTLCs, aggregated per asset
+    // ID across all of the invoice's HTLCs. Empty for invoices that have not
+    // been (partially) settled with assets yet.
+    repeated AssetAmount asset_amounts = 2;
+}
+
+message ListInvoicesResponse {
+    // The list of asset invoices that matched the request.
+    repeated AssetInvoice invoices = 1;
+
+    // The index of the last item in the set of returned invoices. This can be
+    // used to seek further, pagination style. Mirrors the value returned by
+    // lnd's lnrpc.ListInvoices.
+    uint64 last_index_offset = 2;
+
+    // The index of the first item in the set of returned invoices. This can be
+    // used to seek backwards, pagination style. Mirrors the value returned by
+    // lnd's lnrpc.ListInvoices.
+    uint64 first_index_offset = 3;
+}
+
+message ListPaymentsRequest {
+    // The standard lnd payment listing request. All fields behave the same way
+    // as they do for lnd's lnrpc.ListPayments RPC method (see the API docs at
+    // https://lightning.engineering/api-docs/api/lnd/lightning/list-payments
+    // for more details). Pagination is performed by lnd over all payments; the
+    // returned set is then filtered down to only those that involve assets, so
+    // a page may contain fewer asset payments than the requested maximum.
+    lnrpc.ListPaymentsRequest request = 1;
+}
+
+message AssetPayment {
+    // The full lnd payment, including any custom channel data on its HTLCs.
+    lnrpc.Payment payment = 1;
+
+    // The asset amounts carried by the payment, aggregated per asset ID across
+    // all non-failed HTLC attempts. Empty for payments that did not (yet) move
+    // any assets.
+    repeated AssetAmount asset_amounts = 2;
+}
+
+message ListPaymentsResponse {
+    // The list of asset payments that matched the request.
+    repeated AssetPayment payments = 1;
+
+    // The index of the first item in the set of returned payments. This can be
+    // used to seek backwards, pagination style. Mirrors the value returned by
+    // lnd's lnrpc.ListPayments.
+    uint64 first_index_offset = 2;
+
+    // The index of the last item in the set of returned payments. This can be
+    // used to seek further, pagination style. Mirrors the value returned by
+    // lnd's lnrpc.ListPayments.
+    uint64 last_index_offset = 3;
 }

--- a/taprpc/tapchannelrpc/tapchannel.swagger.json
+++ b/taprpc/tapchannelrpc/tapchannel.swagger.json
@@ -148,6 +148,72 @@
         ]
       }
     },
+    "/v1/taproot-assets/channels/invoices": {
+      "post": {
+        "summary": "litcli: `ln listinvoices`\nListInvoices is a wrapper around lnd's lnrpc.ListInvoices method that only\nreturns invoices that involve at least one Taproot Asset. The full lnd\ninvoice is returned along with the decoded asset amounts that the invoice's\nHTLCs carry, so that callers don't need to parse the custom channel data\nthemselves. All request fields behave the same way as they do for lnd's\nlnrpc.ListInvoices RPC method.",
+        "operationId": "TaprootAssetChannels_ListInvoices",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/tapchannelrpcListInvoicesResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/tapchannelrpcListInvoicesRequest"
+            }
+          }
+        ],
+        "tags": [
+          "TaprootAssetChannels"
+        ]
+      }
+    },
+    "/v1/taproot-assets/channels/payments": {
+      "post": {
+        "summary": "litcli: `ln listpayments`\nListPayments is a wrapper around lnd's lnrpc.ListPayments method that only\nreturns payments that involve at least one Taproot Asset. The full lnd\npayment is returned along with the decoded asset amounts that the payment's\nHTLCs carry, so that callers don't need to parse the custom channel data\nthemselves. All request fields behave the same way as they do for lnd's\nlnrpc.ListPayments RPC method.",
+        "operationId": "TaprootAssetChannels_ListPayments",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/tapchannelrpcListPaymentsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/tapchannelrpcListPaymentsRequest"
+            }
+          }
+        ],
+        "tags": [
+          "TaprootAssetChannels"
+        ]
+      }
+    },
     "/v1/taproot-assets/channels/send-payment": {
       "post": {
         "summary": "litcli: `ln sendpayment`\nSendPayment is a wrapper around lnd's routerrpc.SendPaymentV2 RPC method\nwith asset specific parameters. It allows RPC users to send asset keysend\npayments (direct payments) or payments to an invoice with a specified asset\namount.",
@@ -997,6 +1063,80 @@
       ],
       "default": "ACCEPTED"
     },
+    "lnrpcListInvoiceRequest": {
+      "type": "object",
+      "properties": {
+        "pending_only": {
+          "type": "boolean",
+          "description": "If set, only invoices that are not settled and not canceled will be returned\nin the response."
+        },
+        "index_offset": {
+          "type": "string",
+          "format": "uint64",
+          "description": "The index of an invoice that will be used as either the start or end of a\nquery to determine which invoices should be returned in the response."
+        },
+        "num_max_invoices": {
+          "type": "string",
+          "format": "uint64",
+          "description": "The max number of invoices to return in the response to this query."
+        },
+        "reversed": {
+          "type": "boolean",
+          "description": "If set, the invoices returned will result from seeking backwards from the\nspecified index offset. This can be used to paginate backwards."
+        },
+        "creation_date_start": {
+          "type": "string",
+          "format": "uint64",
+          "description": "If set, returns all invoices with a creation date greater than or equal\nto it. Measured in seconds since the unix epoch."
+        },
+        "creation_date_end": {
+          "type": "string",
+          "format": "uint64",
+          "description": "If set, returns all invoices with a creation date less than or equal to\nit. Measured in seconds since the unix epoch."
+        }
+      }
+    },
+    "lnrpcListPaymentsRequest": {
+      "type": "object",
+      "properties": {
+        "include_incomplete": {
+          "type": "boolean",
+          "description": "If true, then return payments that have not yet fully completed. This means\nthat pending payments, as well as failed payments will show up if this\nfield is set to true. This flag doesn't change the meaning of the indices,\nwhich are tied to individual payments."
+        },
+        "index_offset": {
+          "type": "string",
+          "format": "uint64",
+          "description": "The index of a payment that will be used as either the start or end of a\nquery to determine which payments should be returned in the response. The\nindex_offset is exclusive. In the case of a zero index_offset, the query\nwill start with the oldest payment when paginating forwards, or will end\nwith the most recent payment when paginating backwards."
+        },
+        "max_payments": {
+          "type": "string",
+          "format": "uint64",
+          "description": "The maximal number of payments returned in the response to this query."
+        },
+        "reversed": {
+          "type": "boolean",
+          "description": "If set, the payments returned will result from seeking backwards from the\nspecified index offset. This can be used to paginate backwards. The order\nof the returned payments is always oldest first (ascending index order)."
+        },
+        "count_total_payments": {
+          "type": "boolean",
+          "description": "If set, all payments (complete and incomplete, independent of the\nmax_payments parameter) will be counted. Note that setting this to true will\nincrease the run time of the call significantly on systems that have a lot\nof payments, as all of them have to be iterated through to be counted."
+        },
+        "creation_date_start": {
+          "type": "string",
+          "format": "uint64",
+          "description": "If set, returns all payments with a creation date greater than or equal\nto it. Measured in seconds since the unix epoch."
+        },
+        "creation_date_end": {
+          "type": "string",
+          "format": "uint64",
+          "description": "If set, returns all payments with a creation date less than or equal to\nit. Measured in seconds since the unix epoch."
+        },
+        "omit_hops": {
+          "type": "boolean",
+          "description": "If set, omit hop-level route data for HTLC attempts to reduce query\ncost and response size."
+        }
+      }
+    },
     "lnrpcMPPRecord": {
       "type": "object",
       "properties": {
@@ -1616,6 +1756,43 @@
         }
       }
     },
+    "tapchannelrpcAssetAmount": {
+      "type": "object",
+      "properties": {
+        "asset_id": {
+          "type": "string",
+          "format": "byte",
+          "description": "The asset ID (genesis ID of the tranche) the amount refers to."
+        },
+        "amount": {
+          "type": "string",
+          "format": "uint64",
+          "description": "The amount, expressed in units of the asset identified by asset_id."
+        },
+        "group_key": {
+          "type": "string",
+          "format": "byte",
+          "description": "The tweaked group key the asset belongs to, in compressed form. Empty\nfor assets that aren't part of a group, or whose group is unknown to\nthis tapd instance. Populated so callers that work in terms of group\nkeys (e.g. wallets backing a fungible group of tranches) don't need a\nseparate lookup per result."
+        }
+      }
+    },
+    "tapchannelrpcAssetInvoice": {
+      "type": "object",
+      "properties": {
+        "invoice": {
+          "$ref": "#/definitions/lnrpcInvoice",
+          "description": "The full lnd invoice, including any custom channel data on its HTLCs."
+        },
+        "asset_amounts": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/tapchannelrpcAssetAmount"
+          },
+          "description": "The asset amounts carried by the invoice's HTLCs, aggregated per asset\nID across all of the invoice's HTLCs. Empty for invoices that have not\nbeen (partially) settled with assets yet."
+        }
+      }
+    },
     "tapchannelrpcAssetPayReq": {
       "type": "object",
       "properties": {
@@ -1662,6 +1839,23 @@
         "pay_req": {
           "$ref": "#/definitions/lnrpcPayReq",
           "description": "The normal decoded payment request."
+        }
+      }
+    },
+    "tapchannelrpcAssetPayment": {
+      "type": "object",
+      "properties": {
+        "payment": {
+          "$ref": "#/definitions/lnrpcPayment",
+          "description": "The full lnd payment, including any custom channel data on its HTLCs."
+        },
+        "asset_amounts": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/tapchannelrpcAssetAmount"
+          },
+          "description": "The asset amounts carried by the payment, aggregated per asset ID across\nall non-failed HTLC attempts. Empty for payments that did not (yet) move\nany assets."
         }
       }
     },
@@ -1743,6 +1937,70 @@
           "type": "string",
           "format": "byte",
           "description": "The payment hash of the HODL invoice to be created."
+        }
+      }
+    },
+    "tapchannelrpcListInvoicesRequest": {
+      "type": "object",
+      "properties": {
+        "request": {
+          "$ref": "#/definitions/lnrpcListInvoiceRequest",
+          "description": "The standard lnd invoice listing request. All fields behave the same way\nas they do for lnd's lnrpc.ListInvoices RPC method (see the API docs at\nhttps://lightning.engineering/api-docs/api/lnd/lightning/list-invoices\nfor more details). Pagination is performed by lnd over all invoices; the\nreturned set is then filtered down to only those that involve assets, so\na page may contain fewer asset invoices than the requested maximum."
+        }
+      }
+    },
+    "tapchannelrpcListInvoicesResponse": {
+      "type": "object",
+      "properties": {
+        "invoices": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/tapchannelrpcAssetInvoice"
+          },
+          "description": "The list of asset invoices that matched the request."
+        },
+        "last_index_offset": {
+          "type": "string",
+          "format": "uint64",
+          "description": "The index of the last item in the set of returned invoices. This can be\nused to seek further, pagination style. Mirrors the value returned by\nlnd's lnrpc.ListInvoices."
+        },
+        "first_index_offset": {
+          "type": "string",
+          "format": "uint64",
+          "description": "The index of the first item in the set of returned invoices. This can be\nused to seek backwards, pagination style. Mirrors the value returned by\nlnd's lnrpc.ListInvoices."
+        }
+      }
+    },
+    "tapchannelrpcListPaymentsRequest": {
+      "type": "object",
+      "properties": {
+        "request": {
+          "$ref": "#/definitions/lnrpcListPaymentsRequest",
+          "description": "The standard lnd payment listing request. All fields behave the same way\nas they do for lnd's lnrpc.ListPayments RPC method (see the API docs at\nhttps://lightning.engineering/api-docs/api/lnd/lightning/list-payments\nfor more details). Pagination is performed by lnd over all payments; the\nreturned set is then filtered down to only those that involve assets, so\na page may contain fewer asset payments than the requested maximum."
+        }
+      }
+    },
+    "tapchannelrpcListPaymentsResponse": {
+      "type": "object",
+      "properties": {
+        "payments": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/tapchannelrpcAssetPayment"
+          },
+          "description": "The list of asset payments that matched the request."
+        },
+        "first_index_offset": {
+          "type": "string",
+          "format": "uint64",
+          "description": "The index of the first item in the set of returned payments. This can be\nused to seek backwards, pagination style. Mirrors the value returned by\nlnd's lnrpc.ListPayments."
+        },
+        "last_index_offset": {
+          "type": "string",
+          "format": "uint64",
+          "description": "The index of the last item in the set of returned payments. This can be\nused to seek further, pagination style. Mirrors the value returned by\nlnd's lnrpc.ListPayments."
         }
       }
     },

--- a/taprpc/tapchannelrpc/tapchannel.yaml
+++ b/taprpc/tapchannelrpc/tapchannel.yaml
@@ -18,3 +18,9 @@ http:
     - selector: tapchannelrpc.TaprootAssetChannels.DecodeAssetPayReq
       post: "/v1/taproot-assets/channels/invoice/decode"
       body: "*"
+    - selector: tapchannelrpc.TaprootAssetChannels.ListInvoices
+      post: "/v1/taproot-assets/channels/invoices"
+      body: "*"
+    - selector: tapchannelrpc.TaprootAssetChannels.ListPayments
+      post: "/v1/taproot-assets/channels/payments"
+      body: "*"

--- a/taprpc/tapchannelrpc/tapchannel_grpc.pb.go
+++ b/taprpc/tapchannelrpc/tapchannel_grpc.pb.go
@@ -49,6 +49,22 @@ type TaprootAssetChannelsClient interface {
 	// asset ID or group key and returns the invoice amount expressed in asset
 	// units along side the normal information.
 	DecodeAssetPayReq(ctx context.Context, in *AssetPayReq, opts ...grpc.CallOption) (*AssetPayReqResponse, error)
+	// litcli: `ln listinvoices`
+	// ListInvoices is a wrapper around lnd's lnrpc.ListInvoices method that only
+	// returns invoices that involve at least one Taproot Asset. The full lnd
+	// invoice is returned along with the decoded asset amounts that the invoice's
+	// HTLCs carry, so that callers don't need to parse the custom channel data
+	// themselves. All request fields behave the same way as they do for lnd's
+	// lnrpc.ListInvoices RPC method.
+	ListInvoices(ctx context.Context, in *ListInvoicesRequest, opts ...grpc.CallOption) (*ListInvoicesResponse, error)
+	// litcli: `ln listpayments`
+	// ListPayments is a wrapper around lnd's lnrpc.ListPayments method that only
+	// returns payments that involve at least one Taproot Asset. The full lnd
+	// payment is returned along with the decoded asset amounts that the payment's
+	// HTLCs carry, so that callers don't need to parse the custom channel data
+	// themselves. All request fields behave the same way as they do for lnd's
+	// lnrpc.ListPayments RPC method.
+	ListPayments(ctx context.Context, in *ListPaymentsRequest, opts ...grpc.CallOption) (*ListPaymentsResponse, error)
 }
 
 type taprootAssetChannelsClient struct {
@@ -128,6 +144,24 @@ func (c *taprootAssetChannelsClient) DecodeAssetPayReq(ctx context.Context, in *
 	return out, nil
 }
 
+func (c *taprootAssetChannelsClient) ListInvoices(ctx context.Context, in *ListInvoicesRequest, opts ...grpc.CallOption) (*ListInvoicesResponse, error) {
+	out := new(ListInvoicesResponse)
+	err := c.cc.Invoke(ctx, "/tapchannelrpc.TaprootAssetChannels/ListInvoices", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *taprootAssetChannelsClient) ListPayments(ctx context.Context, in *ListPaymentsRequest, opts ...grpc.CallOption) (*ListPaymentsResponse, error) {
+	out := new(ListPaymentsResponse)
+	err := c.cc.Invoke(ctx, "/tapchannelrpc.TaprootAssetChannels/ListPayments", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // TaprootAssetChannelsServer is the server API for TaprootAssetChannels service.
 // All implementations must embed UnimplementedTaprootAssetChannelsServer
 // for forward compatibility
@@ -163,6 +197,22 @@ type TaprootAssetChannelsServer interface {
 	// asset ID or group key and returns the invoice amount expressed in asset
 	// units along side the normal information.
 	DecodeAssetPayReq(context.Context, *AssetPayReq) (*AssetPayReqResponse, error)
+	// litcli: `ln listinvoices`
+	// ListInvoices is a wrapper around lnd's lnrpc.ListInvoices method that only
+	// returns invoices that involve at least one Taproot Asset. The full lnd
+	// invoice is returned along with the decoded asset amounts that the invoice's
+	// HTLCs carry, so that callers don't need to parse the custom channel data
+	// themselves. All request fields behave the same way as they do for lnd's
+	// lnrpc.ListInvoices RPC method.
+	ListInvoices(context.Context, *ListInvoicesRequest) (*ListInvoicesResponse, error)
+	// litcli: `ln listpayments`
+	// ListPayments is a wrapper around lnd's lnrpc.ListPayments method that only
+	// returns payments that involve at least one Taproot Asset. The full lnd
+	// payment is returned along with the decoded asset amounts that the payment's
+	// HTLCs carry, so that callers don't need to parse the custom channel data
+	// themselves. All request fields behave the same way as they do for lnd's
+	// lnrpc.ListPayments RPC method.
+	ListPayments(context.Context, *ListPaymentsRequest) (*ListPaymentsResponse, error)
 	mustEmbedUnimplementedTaprootAssetChannelsServer()
 }
 
@@ -184,6 +234,12 @@ func (UnimplementedTaprootAssetChannelsServer) AddInvoice(context.Context, *AddI
 }
 func (UnimplementedTaprootAssetChannelsServer) DecodeAssetPayReq(context.Context, *AssetPayReq) (*AssetPayReqResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method DecodeAssetPayReq not implemented")
+}
+func (UnimplementedTaprootAssetChannelsServer) ListInvoices(context.Context, *ListInvoicesRequest) (*ListInvoicesResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ListInvoices not implemented")
+}
+func (UnimplementedTaprootAssetChannelsServer) ListPayments(context.Context, *ListPaymentsRequest) (*ListPaymentsResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ListPayments not implemented")
 }
 func (UnimplementedTaprootAssetChannelsServer) mustEmbedUnimplementedTaprootAssetChannelsServer() {}
 
@@ -291,6 +347,42 @@ func _TaprootAssetChannels_DecodeAssetPayReq_Handler(srv interface{}, ctx contex
 	return interceptor(ctx, in, info, handler)
 }
 
+func _TaprootAssetChannels_ListInvoices_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ListInvoicesRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(TaprootAssetChannelsServer).ListInvoices(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/tapchannelrpc.TaprootAssetChannels/ListInvoices",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(TaprootAssetChannelsServer).ListInvoices(ctx, req.(*ListInvoicesRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _TaprootAssetChannels_ListPayments_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ListPaymentsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(TaprootAssetChannelsServer).ListPayments(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/tapchannelrpc.TaprootAssetChannels/ListPayments",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(TaprootAssetChannelsServer).ListPayments(ctx, req.(*ListPaymentsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // TaprootAssetChannels_ServiceDesc is the grpc.ServiceDesc for TaprootAssetChannels service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -313,6 +405,14 @@ var TaprootAssetChannels_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "DecodeAssetPayReq",
 			Handler:    _TaprootAssetChannels_DecodeAssetPayReq_Handler,
+		},
+		{
+			MethodName: "ListInvoices",
+			Handler:    _TaprootAssetChannels_ListInvoices_Handler,
+		},
+		{
+			MethodName: "ListPayments",
+			Handler:    _TaprootAssetChannels_ListPayments_Handler,
 		},
 	},
 	Streams: []grpc.StreamDesc{

--- a/taprpc/tapchannelrpc/taprootassetchannels.pb.json.go
+++ b/taprpc/tapchannelrpc/taprootassetchannels.pb.json.go
@@ -162,4 +162,54 @@ func RegisterTaprootAssetChannelsJSONCallbacks(registry map[string]func(ctx cont
 		}
 		callback(string(respBytes), nil)
 	}
+
+	registry["tapchannelrpc.TaprootAssetChannels.ListInvoices"] = func(ctx context.Context,
+		conn *grpc.ClientConn, reqJSON string, callback func(string, error)) {
+
+		req := &ListInvoicesRequest{}
+		err := marshaler.Unmarshal([]byte(reqJSON), req)
+		if err != nil {
+			callback("", err)
+			return
+		}
+
+		client := NewTaprootAssetChannelsClient(conn)
+		resp, err := client.ListInvoices(ctx, req)
+		if err != nil {
+			callback("", err)
+			return
+		}
+
+		respBytes, err := marshaler.Marshal(resp)
+		if err != nil {
+			callback("", err)
+			return
+		}
+		callback(string(respBytes), nil)
+	}
+
+	registry["tapchannelrpc.TaprootAssetChannels.ListPayments"] = func(ctx context.Context,
+		conn *grpc.ClientConn, reqJSON string, callback func(string, error)) {
+
+		req := &ListPaymentsRequest{}
+		err := marshaler.Unmarshal([]byte(reqJSON), req)
+		if err != nil {
+			callback("", err)
+			return
+		}
+
+		client := NewTaprootAssetChannelsClient(conn)
+		resp, err := client.ListPayments(ctx, req)
+		if err != nil {
+			callback("", err)
+			return
+		}
+
+		respBytes, err := marshaler.Marshal(resp)
+		if err != nil {
+			callback("", err)
+			return
+		}
+		callback(string(respBytes), nil)
+	}
 }


### PR DESCRIPTION
## Description

Adds asset-aware `ListInvoices` and `ListPayments` RPCs to the TaprootAssetChannels service. Each request embeds the corresponding lnrpc list request, callers pass the same arguments they'd pass to lnd and each response item embeds the full `lnrpc.Invoice` / `lnrpc.Payment` alongside a repeated `AssetAmount` summary (asset_id, amount, and the tweaked group_key available) decoded from the HTLCs' custom records.

Results are filtered to records that actually involve a Taproot Asset; pagination offsets are passed through unchanged from lnd. Decode failures error out the whole RPC rather than silently dropping records, so corrupted data surfaces loudly. Unit tests cover the aggregation, binary-vs-JSON route decoding, error propagation, and length-validated asset IDs; a new custom-channels itest exercises the full flow end-to-end against a grouped asset.

Closes #2142 