### PR TITLE
build: bump Go version to v1.26.3

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -20,7 +20,7 @@ env:
   # Go needs absolute directories; using the $HOME variable doesn't work here.
   GOPATH: /home/runner/work/go
 
-  GO_VERSION: '1.25.5'
+  GO_VERSION: '1.26.3'
 
   # Number of parallel itest jobs in the matrix and tranches per job.
   # Total tranches = NUM_ITEST_JOBS * ITEST_PARALLELISM.

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,7 @@ defaults:
     shell: bash
 
 env:
-  GO_VERSION: 1.25.5
+  GO_VERSION: 1.26.3
 
 jobs:
   main:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.5-alpine as builder
+FROM golang:1.26.3-alpine as builder
 
 # Force Go to use the cgo based DNS resolver. This is required to ensure DNS
 # queries required to connect to linked containers succeed.

--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ DOCKER_TOOLS = $(DOCKER) run \
   -v $$(pwd):/build taproot-assets-tools
 endif
 
-GO_VERSION = 1.25.5
+GO_VERSION = 1.26.3
 
 GREEN := "\\033[0;32m"
 NC := "\\033[0m"

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.5 as builder
+FROM golang:1.26.3 as builder
 
 WORKDIR /app
 

--- a/docs/examples/basic-portfolio-pilot/Dockerfile
+++ b/docs/examples/basic-portfolio-pilot/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.5-alpine AS builder
+FROM golang:1.26.3-alpine AS builder
 
 RUN apk add --no-cache alpine-sdk make
 

--- a/docs/examples/basic-price-oracle/go.mod
+++ b/docs/examples/basic-price-oracle/go.mod
@@ -1,6 +1,6 @@
 module basic-price-oracle
 
-go 1.25.5
+go 1.26.3
 
 // We want to format raw bytes as hex instead of base64. The forked version
 // allows us to specify that as an option.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/lightninglabs/taproot-assets
 
-go 1.25.5
+go 1.26.3
 
 require (
 	github.com/btcsuite/btcd v0.25.1-0.20260310163610-1c55c7c18179

--- a/make/builder.Dockerfile
+++ b/make/builder.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.5-bookworm@sha256:d9132cce84391efab786495288756d60e1da215b1f94e87860aeefc3d4c45b6d
+FROM golang:1.26.3-bookworm@sha256:386d475a660466863d9f8c766fec64d7fdad3edac2c6a05020c09534d71edb4b
 
 LABEL maintainer="Olaoluwa Osuntokun <laolu@lightning.engineering>"
 

--- a/taprpc/Dockerfile
+++ b/taprpc/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.5-bookworm
+FROM golang:1.26.3-bookworm
 
 RUN apt-get update && apt-get install -y \
   git \

--- a/taprpc/go.mod
+++ b/taprpc/go.mod
@@ -1,6 +1,6 @@
 module github.com/lightninglabs/taproot-assets/taprpc
 
-go 1.25.5
+go 1.26.3
 
 require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.20.0

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.5-bookworm
+FROM golang:1.26.3-bookworm
 
 RUN apt-get update && apt-get install -y git
 ENV GOCACHE=/tmp/build/.cache

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/lightninglabs/taproot-assets/tools
 
-go 1.25.5
+go 1.26.3
 
 require (
 	github.com/btcsuite/btcd v0.24.2


### PR DESCRIPTION
This updates the Go version across CI workflows, Dockerfiles, Makefile, and all go.mod files from v1.25.5 to v1.26.3. The builder.Dockerfile SHA pin is also refreshed.