### PR TITLE
build: walk back minimum Go language version to 1.25.10

### DIFF
--- a/docs/examples/basic-price-oracle/go.mod
+++ b/docs/examples/basic-price-oracle/go.mod
@@ -1,6 +1,6 @@
 module basic-price-oracle
 
-go 1.26.3
+go 1.25.10
 
 // We want to format raw bytes as hex instead of base64. The forked version
 // allows us to specify that as an option.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/lightninglabs/taproot-assets
 
-go 1.26.3
+go 1.25.10
 
 require (
 	github.com/btcsuite/btcd v0.25.1-0.20260310163610-1c55c7c18179

--- a/taprpc/go.mod
+++ b/taprpc/go.mod
@@ -1,6 +1,6 @@
 module github.com/lightninglabs/taproot-assets/taprpc
 
-go 1.26.3
+go 1.25.10
 
 require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.20.0

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/lightninglabs/taproot-assets/tools
 
-go 1.26.3
+go 1.25.10
 
 require (
 	github.com/btcsuite/btcd v0.24.2


### PR DESCRIPTION
The previous bump in 905924f1 raised the minimum language version declared in go.mod files alongside the build toolchain. Only the toolchain (CI, Makefile, Dockerfiles) needs to be on 1.26.3; the minimum language version should remain at 1.25.10, mirroring lnd v0.21.0-beta.