### PR TITLE
authmailbox+proof: enable client gRPC keepalive

### DIFF
--- a/authmailbox/client.go
+++ b/authmailbox/client.go
@@ -20,7 +20,21 @@ import (
 	"github.com/lightningnetwork/lnd/tor"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/keepalive"
 )
+
+// clientKeepalive configures HTTP/2 PING-based liveness on the
+// long-lived authmailbox subscription stream. Without it, a TCP path
+// that silently dies (NAT timeout, stateful firewall idle drop)
+// leaves Recv blocked indefinitely while the server has already torn
+// the subscriber down, and incoming messages are lost until the
+// receiver is restarted. Time/Timeout are chosen to fail fast enough
+// to recover within a minute while staying well above the 5s minimum
+// the server's enforcement policy expects.
+var clientKeepalive = keepalive.ClientParameters{
+	Time:    30 * time.Second,
+	Timeout: 20 * time.Second,
+}
 
 var (
 	// ErrServerShutdown is the error returned if the mailbox server signals
@@ -271,6 +285,8 @@ func getServerDialOpts(insecure, skipTlsVerify bool, proxyAddress,
 
 	// Create a copy of the dial options array.
 	opts := dialOpts
+
+	opts = append(opts, grpc.WithKeepaliveParams(clientKeepalive))
 
 	// There are four options to connect to a mailbox server, either
 	// completely skipping TLS verification, using an insecure (h2c)

--- a/docs/release-notes/release-notes-0.8.0.md
+++ b/docs/release-notes/release-notes-0.8.0.md
@@ -115,6 +115,11 @@
   fixes a bug that caused tapd not to detect subsequent self-sends to
   V2 addresses.
 
+* [PR#2157](https://github.com/lightninglabs/taproot-assets/pull/2157)
+  fixes a bug that could cause tapd to miss incoming V2-address
+  transfers until restart in the event of a silently-dropped TCP
+  connection.
+
 # New Features
 
 ## Functional Enhancements

--- a/proof/courier.go
+++ b/proof/courier.go
@@ -23,8 +23,21 @@ import (
 	"google.golang.org/grpc/codes"
 	grpcconn "google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/status"
 )
+
+// courierKeepalive configures HTTP/2 PING-based liveness on the
+// universe RPC courier connection. Per-call timeouts already bound
+// individual requests, but keepalive lets the underlying ClientConn
+// transition out of READY when the path silently dies, so
+// ensureConnect redials promptly rather than letting the next call
+// wait out its ServiceRequestTimeout. Mirrors authmailbox's
+// clientKeepalive.
+var courierKeepalive = keepalive.ClientParameters{
+	Time:    30 * time.Second,
+	Timeout: 20 * time.Second,
+}
 
 // CourierType is an enum that represents the different proof courier services
 // protocols that are supported.
@@ -316,6 +329,8 @@ func serverDialOpts() ([]grpc.DialOption, error) {
 	tlsConfig := tls.Config{InsecureSkipVerify: true}
 	transportCredentials := credentials.NewTLS(&tlsConfig)
 	opts = append(opts, grpc.WithTransportCredentials(transportCredentials))
+
+	opts = append(opts, grpc.WithKeepaliveParams(courierKeepalive))
 
 	return opts, nil
 }


### PR DESCRIPTION
Adds some basic/sane keepalive config to long-lived authmailbox and proof courier connections, the config being the same as the one used for price oracles. This should prevent the sort of problem described in https://github.com/lightninglabs/taproot-assets/discussions/2155, at least when caused by a silent TCP connection drop.

I originally included a regression test that demonstrated that the problem could indeed be caused by a silent TCP drop, and that the fix resolved it, but it didn't feel necessary to include that in the codebase proper. The config change is simple, and should suffice on its own.