### PR TITLE
chore: bump taprpc, lnd, lnclient versions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,10 +28,10 @@ require (
 	github.com/lib/pq v1.10.9
 	github.com/lightninglabs/aperture v0.4.0
 	github.com/lightninglabs/lightning-node-connect/hashmailrpc v1.0.4-0.20250610182311-2f1d46ef18b7
-	github.com/lightninglabs/lndclient v0.21.0-rc3
+	github.com/lightninglabs/lndclient v0.21.0-1
 	github.com/lightninglabs/neutrino/cache v1.1.3
 	github.com/lightninglabs/taproot-assets/taprpc v1.1.0
-	github.com/lightningnetwork/lnd v0.21.0-beta.rc3
+	github.com/lightningnetwork/lnd v0.21.0-beta
 	github.com/lightningnetwork/lnd/cert v1.2.2
 	github.com/lightningnetwork/lnd/clock v1.1.1
 	github.com/lightningnetwork/lnd/fn/v2 v2.0.9

--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/lightninglabs/lightning-node-connect/hashmailrpc v1.0.4-0.20250610182311-2f1d46ef18b7
 	github.com/lightninglabs/lndclient v0.21.0-rc3
 	github.com/lightninglabs/neutrino/cache v1.1.3
-	github.com/lightninglabs/taproot-assets/taprpc v1.0.9
+	github.com/lightninglabs/taproot-assets/taprpc v1.1.0
 	github.com/lightningnetwork/lnd v0.21.0-beta.rc3
 	github.com/lightningnetwork/lnd/cert v1.2.2
 	github.com/lightningnetwork/lnd/clock v1.1.1
@@ -222,9 +222,6 @@ replace google.golang.org/protobuf => github.com/lightninglabs/protobuf-go-hex-d
 // We are using a fork of the migration library with custom functionality that
 // did not yet make it into the upstream repository.
 replace github.com/golang-migrate/migrate/v4 => github.com/lightninglabs/migrate/v4 v4.18.2-9023d66a-fork-pr-2.0.20251211093704-71c1eef09789
-
-// Note this is a temproary replace and will be removed when taprpc is tagged.
-replace github.com/lightninglabs/taproot-assets/taprpc => ./taprpc
 
 // Needed for healthcheck import.
 replace github.com/prometheus/common => github.com/prometheus/common v0.26.0

--- a/go.sum
+++ b/go.sum
@@ -1113,8 +1113,8 @@ github.com/lightninglabs/lightning-node-connect/hashmailrpc v1.0.4-0.20250610182
 github.com/lightninglabs/lightning-node-connect/hashmailrpc v1.0.4-0.20250610182311-2f1d46ef18b7/go.mod h1:bDnEKRN1u13NFBuy/C+bFLhxA5bfd3clT25y76QY0AM=
 github.com/lightninglabs/lightning-node-connect/mailbox v1.0.2-0.20250610182311-2f1d46ef18b7 h1:EU/pEkszIbIJOHwOr67G9Gjmyy4CUXk6StRi9C26sUw=
 github.com/lightninglabs/lightning-node-connect/mailbox v1.0.2-0.20250610182311-2f1d46ef18b7/go.mod h1:cQA5pybYbERkMlE8j49LITZZozQZIXABbWJLIpMWnus=
-github.com/lightninglabs/lndclient v0.21.0-rc3 h1:QP/dxVKLbD+06HbFIcHnsw8UL1GaMZwLFG/Kq80AtrM=
-github.com/lightninglabs/lndclient v0.21.0-rc3/go.mod h1:/j9vuI2ez+NtHwZtvjQc/3z3oF8g6UnU30/BuiT2ARU=
+github.com/lightninglabs/lndclient v0.21.0-1 h1:NuyccCK7tbMaH7hhqtewcx+qeBel4/RLJrlnQ/lMkkY=
+github.com/lightninglabs/lndclient v0.21.0-1/go.mod h1:RUIcfPr82HrvZr3pu9f8nbD5v6VFbm+KgExqNNp5bE4=
 github.com/lightninglabs/migrate/v4 v4.18.2-9023d66a-fork-pr-2.0.20251211093704-71c1eef09789 h1:7kX7vUgHUazAHcCJ6uzBDa4/2MEGEbMEfa01GtfqmTQ=
 github.com/lightninglabs/migrate/v4 v4.18.2-9023d66a-fork-pr-2.0.20251211093704-71c1eef09789/go.mod h1:99BKpIi6ruaaXRM1A77eqZ+FWPQ3cfRa+ZVy5bmWMaY=
 github.com/lightninglabs/neutrino v0.17.1 h1:lNhgq7ix/N81R6oATroP/kHMzH1qzVVF2dEGcTlN2t4=
@@ -1127,8 +1127,8 @@ github.com/lightninglabs/taproot-assets/taprpc v1.1.0 h1:Oum7ddGygrEaT+NHqpaQI8U
 github.com/lightninglabs/taproot-assets/taprpc v1.1.0/go.mod h1:X7XP753o8xCgjVI2mRu1Tvpyk3k4uybGDMFhpF6IRxI=
 github.com/lightningnetwork/lightning-onion v1.3.0 h1:FqILgHjD6euc/Muo1VOzZ4+XDPuFnw6EYROBq0rR/5c=
 github.com/lightningnetwork/lightning-onion v1.3.0/go.mod h1:nP85zMHG7c0si/eHBbSQpuDCtnIXfSvFrK3tW6YWzmU=
-github.com/lightningnetwork/lnd v0.21.0-beta.rc3 h1:yXsIG+38V5KBxyivaG1Kt5Swk49VZl8AQitbttiisN4=
-github.com/lightningnetwork/lnd v0.21.0-beta.rc3/go.mod h1:HcKq9DyxbVEZXuR28TIyGbIIgAjANCxI+N6dqOnRBAA=
+github.com/lightningnetwork/lnd v0.21.0-beta h1:bDP5UH15E7DVGTztsmBPQLqgyilq5EXDrglvQFmRc3U=
+github.com/lightningnetwork/lnd v0.21.0-beta/go.mod h1:HcKq9DyxbVEZXuR28TIyGbIIgAjANCxI+N6dqOnRBAA=
 github.com/lightningnetwork/lnd/actor v0.0.6 h1:Ge8N2wivARG+27qJBwTlB0vwsypStZYZy8vk4Zl38sU=
 github.com/lightningnetwork/lnd/actor v0.0.6/go.mod h1:YAsoniSbY/cAM9HTVNfZLvt7RI6swDxy6wzPspTcMZg=
 github.com/lightningnetwork/lnd/cert v1.2.2 h1:71YK6hogeJtxSxw2teq3eGeuy4rHGKcFf0d0Uy4qBjI=

--- a/go.sum
+++ b/go.sum
@@ -1123,6 +1123,8 @@ github.com/lightninglabs/neutrino/cache v1.1.3 h1:rgnabC41W+XaPuBTQrdeFjFCCAVKh1
 github.com/lightninglabs/neutrino/cache v1.1.3/go.mod h1:qxkJb+pUxR5p84jl5uIGFCR4dGdFkhNUwMSxw3EUWls=
 github.com/lightninglabs/protobuf-go-hex-display v1.34.2-hex-display h1:w7FM5LH9Z6CpKxl13mS48idsu6F+cEZf0lkyiV+Dq9g=
 github.com/lightninglabs/protobuf-go-hex-display v1.34.2-hex-display/go.mod h1:qYOHts0dSfpeUzUFpOMr/WGzszTmLH+DiWniOlNbLDw=
+github.com/lightninglabs/taproot-assets/taprpc v1.1.0 h1:Oum7ddGygrEaT+NHqpaQI8U6pV5jJUH4hvhezl5y00k=
+github.com/lightninglabs/taproot-assets/taprpc v1.1.0/go.mod h1:X7XP753o8xCgjVI2mRu1Tvpyk3k4uybGDMFhpF6IRxI=
 github.com/lightningnetwork/lightning-onion v1.3.0 h1:FqILgHjD6euc/Muo1VOzZ4+XDPuFnw6EYROBq0rR/5c=
 github.com/lightningnetwork/lightning-onion v1.3.0/go.mod h1:nP85zMHG7c0si/eHBbSQpuDCtnIXfSvFrK3tW6YWzmU=
 github.com/lightningnetwork/lnd v0.21.0-beta.rc3 h1:yXsIG+38V5KBxyivaG1Kt5Swk49VZl8AQitbttiisN4=

--- a/version.go
+++ b/version.go
@@ -42,7 +42,7 @@ const (
 	AppMajor uint = 0
 
 	// AppMinor defines the minor version of this binary.
-	AppMinor uint = 7
+	AppMinor uint = 8
 
 	// AppPatch defines the application patch for this binary.
 	AppPatch uint = 99


### PR DESCRIPTION
.. all supporting a move to lnd v0.21.0-beta:

* taprpc moves to v1.1.0 (and we drop the old 'replace' directive pointing at the taprpc/ subdirectory).
* lnd moves to v0.21.0-beta.
* lndclient moves to v0.21.0-1.

Also changes version.go to use v0.8.99 for the main branch build, per convention.