### PR TITLE
tapchannel+tapfreighter: fix stuck pending xfers after force close

### DIFF
--- a/docs/release-notes/release-notes-0.8.1.md
+++ b/docs/release-notes/release-notes-0.8.1.md
@@ -1,0 +1,65 @@
+# Release Notes
+- [Bug Fixes](#bug-fixes)
+- [New Features](#new-features)
+    - [Functional Enhancements](#functional-enhancements)
+    - [RPC Additions](#rpc-additions)
+    - [tapcli Additions](#tapcli-additions)
+- [Improvements](#improvements)
+    - [Functional Updates](#functional-updates)
+    - [RPC Updates](#rpc-updates)
+    - [tapcli Updates](#tapcli-updates)
+    - [Config Changes](#config-changes)
+    - [Breaking Changes](#breaking-changes)
+    - [Performance Improvements](#performance-improvements)
+    - [Deprecations](#deprecations)
+- [Technical and Architectural Updates](#technical-and-architectural-updates)
+    - [BIP/bLIP Spec Updates](#bipblip-spec-updates)
+    - [Testing](#testing)
+    - [Database](#database)
+    - [Code Health](#code-health)
+    - [Tooling and Documentation](#tooling-and-documentation)
+
+# Bug Fixes
+
+- [PR#2159](https://github.com/lightninglabs/taproot-assets/pull/2159)
+  fixes several failure modes in the handling of force-close sweep
+  transactions that could leave transfers stuck in a pending state.
+
+# New Features
+
+## Functional Enhancements
+
+## RPC Additions
+
+## tapcli Additions
+
+# Improvements
+
+## Functional Updates
+
+## RPC Updates
+
+## tapcli Updates
+
+## Config Changes
+
+## Code Health
+
+## Breaking Changes
+
+## Performance Improvements
+
+## Deprecations
+
+# Technical and Architectural Updates
+
+## BIP/bLIP Spec Updates
+
+## Testing
+
+## Database
+
+## Code Health
+
+## Tooling and Documentation
+

--- a/itest/custom_channels/helpers.go
+++ b/itest/custom_channels/helpers.go
@@ -3281,33 +3281,55 @@ func assertForceCloseSweeps(ctx context.Context,
 
 	t.Logf("Asserting balance on sweeps: %v", timeoutSweeps)
 
-	bobSweeps, err := bob.WalletKitClient.ListSweeps(
-		ctx, &walletrpc.ListSweepsRequest{
-			Verbose: true,
-		},
-	)
-	require.NoError(t.t, err)
-
+	// The sweeper records a sweep in its store only after its own
+	// publish path has completed, which can lag the transaction's
+	// appearance in the mempool (and its confirmation, since we mine
+	// aggressively). So we poll ListSweeps instead of asserting on a
+	// single snapshot.
 	var bobSweepTx *wire.MsgTx
-	for _, sweep := range bobSweeps.GetTransactionDetails().Transactions {
-		for _, tx := range timeoutSweeps {
-			if sweep.TxHash == tx.String() {
+	err = wait.NoError(func() error {
+		bobSweeps, err := bob.WalletKitClient.ListSweeps(
+			ctx, &walletrpc.ListSweepsRequest{
+				Verbose: true,
+			},
+		)
+		if err != nil {
+			return err
+		}
+
+		txns := bobSweeps.GetTransactionDetails().Transactions
+		for _, sweep := range txns {
+			for _, tx := range timeoutSweeps {
+				if sweep.TxHash != tx.String() {
+					continue
+				}
+
 				txBytes, err := hex.DecodeString(
 					sweep.RawTxHex,
 				)
-				require.NoError(t.t, err)
+				if err != nil {
+					return err
+				}
 
 				bobSweepTx = &wire.MsgTx{}
 				err = bobSweepTx.Deserialize(
 					bytes.NewReader(txBytes),
 				)
-				require.NoError(t.t, err)
+				if err != nil {
+					return err
+				}
+
+				return nil
 			}
 		}
-	}
-	require.NotNil(
-		t.t, bobSweepTx, "Bob's sweep transaction not found",
-	)
+
+		if bobSweepTx == nil {
+			return fmt.Errorf("Bob's sweep transaction not found")
+		}
+
+		return nil
+	}, ccShortTimeout)
+	require.NoError(t.t, err)
 
 	// There's always an extra input that pays for the fees. So we can only
 	// count the remainder as HTLC inputs.

--- a/itest/psbt_test.go
+++ b/itest/psbt_test.go
@@ -2893,11 +2893,12 @@ func testPsbtExternalCommit(t *harnessTest) {
 		withLabel(transferLabel),
 	)
 
-	// Assert that the state machine transitions directly to waiting for
-	// tx confirmation, skipping the broadcast state.
+	// Assert that the state machine passes through the broadcast state
+	// without publishing the transaction (broadcast is handled
+	// externally) and moves on to waiting for tx confirmation.
 	require.Eventually(t.t, func() bool {
 		isMatchingState := func(msg *taprpc.SendEvent) bool {
-			lastState := tapfreighter.SendStateStorePreBroadcast
+			lastState := tapfreighter.SendStateBroadcast
 			nextState := tapfreighter.SendStateWaitTxConf
 
 			return msg.SendState == lastState.String() &&

--- a/tapcfg/server.go
+++ b/tapcfg/server.go
@@ -788,6 +788,7 @@ func genServerConfig(cfg *Config, cfgLogger btclog.Logger,
 			GroupVerifier:      groupVerifier,
 			ChainBridge:        chainBridge,
 			IgnoreChecker:      ignoreCheckerOpt,
+			ProofWatcher:       reOrgWatcher,
 		},
 	)
 

--- a/tapchannel/aux_closer.go
+++ b/tapchannel/aux_closer.go
@@ -767,8 +767,17 @@ func shipChannelTxn(txSender tapfreighter.Porter, chanTx *wire.MsgTx,
 		FinalTx:   chanTx,
 	}
 	parcelLabel := fmt.Sprintf("channel-tx-%s", chanTx.TxHash().String())
+
+	// Broadcast (and rebroadcast) of channel transactions is always owned
+	// by lnd: the channel peer flow for cooperative closes, the channel
+	// arbitrator for commitment transactions (which are only ever shipped
+	// here after they confirmed), and the sweeper for force-close sweeps.
+	// The porter therefore only records the transfer and watches for its
+	// confirmation. Publishing here as well would race lnd's own
+	// bookkeeping and, worse, a replaced or conflicted sweep version
+	// would fail the porter's broadcast and strand the transfer.
 	preSignedParcel := tapfreighter.NewPreAnchoredParcel(
-		vPkts, nil, closeAnchor, false, parcelLabel,
+		vPkts, nil, closeAnchor, true, parcelLabel,
 		anchorTxHeightHint,
 	)
 	_, err = txSender.RequestShipment(preSignedParcel)

--- a/tapchannel/aux_sweeper.go
+++ b/tapchannel/aux_sweeper.go
@@ -133,6 +133,11 @@ type AuxSweeperCfg struct {
 	// IgnoreChecker is an optional function that can be used to check if
 	// a proof should be ignored.
 	IgnoreChecker lfn.Option[proof.IgnoreChecker]
+
+	// ProofWatcher is used to watch proofs we import for their anchor
+	// transaction being re-organized out of the chain, so their block
+	// info can be patched once it re-confirms.
+	ProofWatcher proof.Watcher
 }
 
 // AuxSweeper is used to sweep funds from a commitment transaction that has
@@ -1536,6 +1541,109 @@ func importOutputProofs(ctx context.Context, scid lnwire.ShortChannelID,
 	return nil
 }
 
+// materializeAssetOutputs ensures that each of the given commitment outputs
+// exists as an asset in the local database. The (re-anchored) transition
+// proof of each output is appended to its input proof file, which is already
+// present in the local archive, and the result is imported through the multi
+// archiver, which creates the asset row as a side effect. The import is
+// idempotent, so it is safe to call this for outputs that have already been
+// materialized through another path.
+func (a *AuxSweeper) materializeAssetOutputs(ctx context.Context,
+	outputs []*cmsg.AssetOutput) error {
+
+	vCtx := proof.VerifierCtx{
+		HeaderVerifier: a.cfg.HeaderVerifier,
+		MerkleVerifier: proof.DefaultMerkleVerifier,
+		GroupVerifier:  a.cfg.GroupVerifier,
+		ChainLookupGen: a.cfg.ChainBridge,
+		IgnoreChecker:  a.cfg.IgnoreChecker,
+	}
+
+	for _, out := range outputs {
+		outProof := &out.Proof.Val
+
+		locator := proof.Locator{
+			AssetID:   fn.Ptr(outProof.Asset.ID()),
+			ScriptKey: *outProof.Asset.ScriptKey.PubKey,
+			OutPoint:  fn.Ptr(outProof.OutPoint()),
+		}
+
+		// The input proof file (typically that of the funding output)
+		// was imported by importCommitTx, so we can fetch it from the
+		// local archive.
+		proofPrevID, err := outProof.Asset.PrimaryPrevID()
+		if err != nil {
+			return fmt.Errorf("unable to get primary prev ID: %w",
+				err)
+		}
+		prevScriptKey, err := proofPrevID.ScriptKey.ToPubKey()
+		if err != nil {
+			return fmt.Errorf("unable to convert script key to "+
+				"pubkey: %w", err)
+		}
+		prevLocator := proof.Locator{
+			AssetID:   &proofPrevID.ID,
+			ScriptKey: *prevScriptKey,
+			OutPoint:  &proofPrevID.OutPoint,
+		}
+		if outProof.Asset.GroupKey != nil {
+			groupKey := outProof.Asset.GroupKey.GroupPubKey
+			prevLocator.GroupKey = &groupKey
+		}
+
+		prefixProof, err := a.cfg.ProofArchive.FetchProof(
+			ctx, prevLocator,
+		)
+		if err != nil {
+			return fmt.Errorf("unable to fetch input proof file: "+
+				"%w", err)
+		}
+
+		var proofFile proof.File
+		err = proofFile.Decode(bytes.NewReader(prefixProof))
+		if err != nil {
+			return fmt.Errorf("unable to decode input proof "+
+				"file: %w", err)
+		}
+		if err := proofFile.AppendProof(*outProof); err != nil {
+			return fmt.Errorf("unable to append proof: %w", err)
+		}
+
+		var finalProofBuf bytes.Buffer
+		if err := proofFile.Encode(&finalProofBuf); err != nil {
+			return fmt.Errorf("unable to encode proof file: %w",
+				err)
+		}
+
+		log.Infof("Materializing commitment output asset, "+
+			"outpoint=%v, script_key=%x", outProof.OutPoint(),
+			outProof.Asset.ScriptKey.PubKey.SerializeCompressed())
+
+		err = a.cfg.ProofArchive.ImportProofs(
+			ctx, vCtx, false, &proof.AnnotatedProof{
+				Locator: locator,
+				Blob:    finalProofBuf.Bytes(),
+			},
+		)
+		if err != nil {
+			return fmt.Errorf("unable to import proof: %w", err)
+		}
+
+		// Hand the transition proof to the re-org watcher, so its
+		// block info is patched in the archive if the commitment
+		// transaction is re-organized into a different block.
+		err = a.cfg.ProofWatcher.WatchProofs(
+			[]*proof.Proof{outProof},
+			a.cfg.ProofWatcher.DefaultUpdateCallback(),
+		)
+		if err != nil {
+			return fmt.Errorf("unable to watch proof: %w", err)
+		}
+	}
+
+	return nil
+}
+
 // importCommitTx imports the commitment transaction into the wallet. This is
 // called after a force close to ensure that we can properly spend outputs
 // created by the commitment transaction at a later step.
@@ -1953,6 +2061,20 @@ func (a *AuxSweeper) resolveContract(
 		assetOutputs,
 	); err != nil {
 		return lfn.Errf[returnType]("unable to re-anchor asset "+
+			"outputs: %w", err)
+	}
+
+	// With the proofs bound to the confirmed commitment transaction, we
+	// can materialize the outputs we're sweeping as assets in our local
+	// database. We can't rely on the commitment transaction's own transfer
+	// to create these asset rows: its output locality snapshot is taken
+	// when the transfer is stored, which races the per-contract script key
+	// imports above, so outputs whose resolution arrives late would never
+	// be materialized. The porter marks the swept asset as spent when the
+	// sweep transaction confirms and fails the transfer permanently if the
+	// asset row is missing at that point.
+	if err := a.materializeAssetOutputs(ctx, assetOutputs); err != nil {
+		return lfn.Errf[returnType]("unable to materialize asset "+
 			"outputs: %w", err)
 	}
 

--- a/tapdb/assets_store.go
+++ b/tapdb/assets_store.go
@@ -319,6 +319,16 @@ type ActiveAssetsStore interface {
 	// previously unconfirmed as confirmed.
 	ConfirmChainAnchorTx(ctx context.Context, arg AnchorTxConf) error
 
+	// SupersedeConflictingTransfers marks all unconfirmed transfers that
+	// spend the given anchor point as superseded, except for the given
+	// (just confirmed) transfer.
+	SupersedeConflictingTransfers(ctx context.Context,
+		arg sqlc.SupersedeConflictingTransfersParams) (int64, error)
+
+	// QuerySupersededTransferIDs returns the IDs of all transfers that
+	// have been marked as superseded.
+	QuerySupersededTransferIDs(ctx context.Context) ([]int64, error)
+
 	// InsertAssetTransfer inserts a new asset transfer into the DB.
 	InsertAssetTransfer(ctx context.Context,
 		arg NewAssetTransfer) (int64, error)
@@ -3420,6 +3430,33 @@ func (a *AssetStore) LogAnchorTxConfirm(ctx context.Context,
 			}
 		}
 
+		// Any other unconfirmed transfer that claims one of the inputs
+		// just spent can never confirm now: its anchor transaction
+		// conflicts with the one that confirmed (e.g. a fee-bumped
+		// replacement of a sweep transaction). Mark such transfers as
+		// superseded so they're no longer treated as pending and
+		// aren't resumed at startup.
+		for idx := range inputs {
+			anchorPoint := inputs[idx].AnchorPoint
+			numMarked, err := q.SupersedeConflictingTransfers(
+				ctx, sqlc.SupersedeConflictingTransfersParams{
+					ConfirmedTransferID: assetTransfer.ID,
+					AnchorPoint:         anchorPoint,
+				},
+			)
+			if err != nil {
+				return fmt.Errorf("unable to mark conflicting "+
+					"transfers as superseded: %w", err)
+			}
+
+			if numMarked > 0 {
+				log.Infof("Marked %d conflicting transfer(s) "+
+					"as superseded by transfer_id=%d "+
+					"(anchor_txid=%v)", numMarked,
+					assetTransfer.ID, conf.AnchorTXID)
+			}
+		}
+
 		// Now is the time to fetch our outputs and create new assets
 		// for them.
 		outputs, err := q.FetchTransferOutputs(ctx, assetTransfer.ID)
@@ -3856,6 +3893,28 @@ func (a *AssetStore) queryParcelsWithFilters(ctx context.Context,
 		dbTransfers, err := q.QueryAssetTransfers(ctx, transferQuery)
 		if err != nil {
 			return err
+		}
+
+		// When querying for pending transfers, we exclude superseded
+		// ones: another confirmed transfer spent (some of) their
+		// inputs, so their anchor transaction can never confirm. We
+		// filter here rather than in QueryAssetTransfers, as that
+		// query is also executed by programmatic migrations against
+		// historical schema versions that don't have the superseded
+		// column yet.
+		if pendingOnly {
+			supersededIDs, err := q.QuerySupersededTransferIDs(ctx)
+			if err != nil {
+				return fmt.Errorf("unable to query "+
+					"superseded transfers: %w", err)
+			}
+
+			superseded := fn.NewSet(supersededIDs...)
+			dbTransfers = fn.Filter(
+				dbTransfers, func(t AssetTransferRow) bool {
+					return !superseded.Contains(t.ID)
+				},
+			)
 		}
 
 		for idx := range dbTransfers {

--- a/tapdb/migrations.go
+++ b/tapdb/migrations.go
@@ -24,7 +24,7 @@ const (
 	// daemon.
 	//
 	// NOTE: This MUST be updated when a new migration is added.
-	LatestMigrationVersion = 59
+	LatestMigrationVersion = 60
 )
 
 // DatabaseBackend is an interface that contains all methods our different

--- a/tapdb/sqlc/migrations/000060_asset_transfers_superseded.down.sql
+++ b/tapdb/sqlc/migrations/000060_asset_transfers_superseded.down.sql
@@ -1,0 +1,5 @@
+-- Remove the index on the input anchor points.
+DROP INDEX IF EXISTS transfer_inputs_anchor_point_idx;
+
+-- Remove the superseded flag from the asset_transfers table.
+ALTER TABLE asset_transfers DROP COLUMN superseded;

--- a/tapdb/sqlc/migrations/000060_asset_transfers_superseded.up.sql
+++ b/tapdb/sqlc/migrations/000060_asset_transfers_superseded.up.sql
@@ -1,0 +1,10 @@
+-- Add a flag that marks an asset transfer as superseded: another transfer
+-- spending (some of) the same inputs confirmed on-chain, so this transfer's
+-- anchor transaction can never confirm. Superseded transfers are no longer
+-- considered pending and are not resumed at startup.
+ALTER TABLE asset_transfers ADD COLUMN superseded BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- Index the input anchor points, so that finding conflicting transfers at
+-- confirmation time doesn't require a full table scan.
+CREATE INDEX IF NOT EXISTS transfer_inputs_anchor_point_idx
+    ON asset_transfer_inputs (anchor_point);

--- a/tapdb/sqlc/models.go
+++ b/tapdb/sqlc/models.go
@@ -137,6 +137,7 @@ type AssetTransfer struct {
 	TransferTimeUnix      time.Time
 	Label                 sql.NullString
 	SkipAnchorTxBroadcast bool
+	Superseded            bool
 }
 
 type AssetTransferInput struct {

--- a/tapdb/sqlc/querier.go
+++ b/tapdb/sqlc/querier.go
@@ -216,6 +216,7 @@ type Querier interface {
 	QueryPendingSupplyCommitTransition(ctx context.Context, groupKey []byte) (QueryPendingSupplyCommitTransitionRow, error)
 	QueryProofTransferAttempts(ctx context.Context, arg QueryProofTransferAttemptsParams) ([]time.Time, error)
 	QueryStartingSupplyCommitment(ctx context.Context, groupKey []byte) (QueryStartingSupplyCommitmentRow, error)
+	QuerySupersededTransferIDs(ctx context.Context) ([]int64, error)
 	QuerySupplyCommitStateMachine(ctx context.Context, groupKey []byte) (QuerySupplyCommitStateMachineRow, error)
 	QuerySupplyCommitment(ctx context.Context, commitID int64) (QuerySupplyCommitmentRow, error)
 	QuerySupplyCommitmentByOutpoint(ctx context.Context, arg QuerySupplyCommitmentByOutpointParams) (QuerySupplyCommitmentByOutpointRow, error)
@@ -234,6 +235,11 @@ type Querier interface {
 	SetAddrManaged(ctx context.Context, arg SetAddrManagedParams) error
 	SetAssetSpent(ctx context.Context, arg SetAssetSpentParams) (int64, error)
 	SetTransferOutputProofDeliveryStatus(ctx context.Context, arg SetTransferOutputProofDeliveryStatusParams) error
+	// Mark all unconfirmed transfers that spend the given anchor point as
+	// superseded, except for the given (just confirmed) transfer. Once a
+	// conflicting transfer has confirmed on-chain, these transfers' anchor
+	// transactions can never confirm.
+	SupersedeConflictingTransfers(ctx context.Context, arg SupersedeConflictingTransfersParams) (int64, error)
 	UniverseLeaves(ctx context.Context) ([]UniverseLeafe, error)
 	UniverseRoots(ctx context.Context, arg UniverseRootsParams) ([]UniverseRootsRow, error)
 	UpdateBatchGenesisTx(ctx context.Context, arg UpdateBatchGenesisTxParams) error

--- a/tapdb/sqlc/queries/transfers.sql
+++ b/tapdb/sqlc/queries/transfers.sql
@@ -58,6 +58,11 @@ WHERE
         OR sqlc.narg('anchor_tx_hash') IS NULL)
 
     -- Filter for pending transfers only if requested.
+    --
+    -- NOTE: This query is also executed by programmatic migrations against
+    -- historical schema versions, so it MUST NOT reference columns added
+    -- in later migrations (such as transfers.superseded). Superseded
+    -- transfers are filtered out in Go instead.
     AND (
         @pending_transfers_only = true AND
         (
@@ -98,6 +103,31 @@ SELECT input_id, anchor_point, asset_id, script_key, amount
 FROM asset_transfer_inputs inputs
 WHERE transfer_id = $1
 ORDER BY input_id;
+
+-- name: QuerySupersededTransferIDs :many
+SELECT id
+FROM asset_transfers
+WHERE superseded = true;
+
+-- name: SupersedeConflictingTransfers :execrows
+-- Mark all unconfirmed transfers that spend the given anchor point as
+-- superseded, except for the given (just confirmed) transfer. Once a
+-- conflicting transfer has confirmed on-chain, these transfers' anchor
+-- transactions can never confirm.
+UPDATE asset_transfers
+SET superseded = true
+WHERE id != @confirmed_transfer_id
+  AND superseded = false
+  AND id IN (
+      SELECT inputs.transfer_id
+      FROM asset_transfer_inputs inputs
+      WHERE inputs.anchor_point = @anchor_point
+  )
+  AND anchor_txn_id IN (
+      SELECT txns.txn_id
+      FROM chain_txns txns
+      WHERE txns.block_hash IS NULL
+  );
 
 -- name: FetchTransferOutputs :many
 SELECT

--- a/tapdb/sqlc/schemas/generated_schema.sql
+++ b/tapdb/sqlc/schemas/generated_schema.sql
@@ -304,7 +304,7 @@ CREATE TABLE asset_transfers (
     anchor_txn_id BIGINT NOT NULL REFERENCES chain_txns(txn_id),
 
     transfer_time_unix TIMESTAMP NOT NULL
-, label VARCHAR DEFAULT NULL, skip_anchor_tx_broadcast BOOLEAN NOT NULL DEFAULT FALSE);
+, label VARCHAR DEFAULT NULL, skip_anchor_tx_broadcast BOOLEAN NOT NULL DEFAULT FALSE, superseded BOOLEAN NOT NULL DEFAULT FALSE);
 
 CREATE TABLE asset_witnesses (
     witness_id INTEGER PRIMARY KEY,
@@ -1154,6 +1154,9 @@ CREATE TABLE tapscript_roots (
         -- a set of tapLeafs.
         branch_only BOOLEAN NOT NULL DEFAULT FALSE
 );
+
+CREATE INDEX transfer_inputs_anchor_point_idx
+    ON asset_transfer_inputs (anchor_point);
 
 CREATE INDEX transfer_inputs_idx
     ON asset_transfer_inputs (transfer_id);

--- a/tapdb/sqlc/transfers.sql.go
+++ b/tapdb/sqlc/transfers.sql.go
@@ -475,6 +475,11 @@ WHERE
         OR $1 IS NULL)
 
     -- Filter for pending transfers only if requested.
+    --
+    -- NOTE: This query is also executed by programmatic migrations against
+    -- historical schema versions, so it MUST NOT reference columns added
+    -- in later migrations (such as transfers.superseded). Superseded
+    -- transfers are filtered out in Go instead.
     AND (
         $2 = true AND
         (
@@ -729,6 +734,35 @@ func (q *Queries) QueryProofTransferAttempts(ctx context.Context, arg QueryProof
 	return items, nil
 }
 
+const QuerySupersededTransferIDs = `-- name: QuerySupersededTransferIDs :many
+SELECT id
+FROM asset_transfers
+WHERE superseded = true
+`
+
+func (q *Queries) QuerySupersededTransferIDs(ctx context.Context) ([]int64, error) {
+	rows, err := q.db.QueryContext(ctx, QuerySupersededTransferIDs)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []int64
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		items = append(items, id)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const ReAnchorPassiveAssets = `-- name: ReAnchorPassiveAssets :exec
 UPDATE assets
 SET anchor_utxo_id = $1,
@@ -774,4 +808,38 @@ type SetTransferOutputProofDeliveryStatusParams struct {
 func (q *Queries) SetTransferOutputProofDeliveryStatus(ctx context.Context, arg SetTransferOutputProofDeliveryStatusParams) error {
 	_, err := q.db.ExecContext(ctx, SetTransferOutputProofDeliveryStatus, arg.DeliveryComplete, arg.SerializedAnchorOutpoint, arg.Position)
 	return err
+}
+
+const SupersedeConflictingTransfers = `-- name: SupersedeConflictingTransfers :execrows
+UPDATE asset_transfers
+SET superseded = true
+WHERE id != $1
+  AND superseded = false
+  AND id IN (
+      SELECT inputs.transfer_id
+      FROM asset_transfer_inputs inputs
+      WHERE inputs.anchor_point = $2
+  )
+  AND anchor_txn_id IN (
+      SELECT txns.txn_id
+      FROM chain_txns txns
+      WHERE txns.block_hash IS NULL
+  )
+`
+
+type SupersedeConflictingTransfersParams struct {
+	ConfirmedTransferID int64
+	AnchorPoint         []byte
+}
+
+// Mark all unconfirmed transfers that spend the given anchor point as
+// superseded, except for the given (just confirmed) transfer. Once a
+// conflicting transfer has confirmed on-chain, these transfers' anchor
+// transactions can never confirm.
+func (q *Queries) SupersedeConflictingTransfers(ctx context.Context, arg SupersedeConflictingTransfersParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, SupersedeConflictingTransfers, arg.ConfirmedTransferID, arg.AnchorPoint)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
 }

--- a/tapfreighter/chain_porter.go
+++ b/tapfreighter/chain_porter.go
@@ -2115,16 +2115,6 @@ func (p *ChainPorter) stateStep(currentPkg sendPackage) (*sendPackage, error) {
 				"disk: %w", err)
 		}
 
-		// If skip flag is set—bypass anchor broadcast and advance to
-		// the confirmation wait state.
-		if currentPkg.OutboundPkg.SkipAnchorTxBroadcast {
-			log.Info("Skip anchor broadcast flag set; " +
-				"transitioning to WaitTxConf state")
-			currentPkg.SendState = SendStateWaitTxConf
-
-			return &currentPkg, nil
-		}
-
 		// We've logged the state transition to disk, so now we can
 		// move onto the broadcast phase.
 		currentPkg.SendState = SendStateBroadcast
@@ -2143,6 +2133,21 @@ func (p *ChainPorter) stateStep(currentPkg sendPackage) (*sendPackage, error) {
 
 			return nil, fmt.Errorf("unable to import local "+
 				"addresses: %w", err)
+		}
+
+		// If the skip flag is set, another system (the lnd sweeper
+		// for force-close sweeps, the channel arbitrator or peer flow
+		// for commitment and cooperative close transactions, or an
+		// external packager) owns broadcast and rebroadcast of this
+		// transaction. We only record and watch it.
+		if currentPkg.OutboundPkg.SkipAnchorTxBroadcast {
+			log.Infof("Skip anchor broadcast flag set; not "+
+				"publishing txid=%v, transitioning to "+
+				"WaitTxConf state",
+				currentPkg.OutboundPkg.AnchorTx.TxHash())
+			currentPkg.SendState = SendStateWaitTxConf
+
+			return &currentPkg, nil
 		}
 
 		txHash := currentPkg.OutboundPkg.AnchorTx.TxHash()

--- a/tapfreighter/chain_porter.go
+++ b/tapfreighter/chain_porter.go
@@ -36,6 +36,16 @@ const (
 	// we expect a send fragment to be valid for after its claimed outpoint
 	// has been spent. This is roughly equivalent to 90 days.
 	DefaultSendFragmentExpiryDelta = 12_960
+
+	// confRetryDelay is the initial delay before we re-register the
+	// transfer confirmation notification after a failure of the
+	// notification stream. The delay doubles on each successive failure,
+	// up to confRetryDelayMax.
+	confRetryDelay = time.Second
+
+	// confRetryDelayMax is the maximum delay between attempts to
+	// re-register the transfer confirmation notification.
+	confRetryDelayMax = time.Second * 30
 )
 
 // VerifiedProofImporter is used to import verified proofs into the local proof
@@ -413,6 +423,13 @@ func (p *ChainPorter) advanceState(pkg *sendPackage, kit *parcelKit) {
 // waitForTransferTxConf waits for the confirmation of the final transaction
 // within the delta. Once confirmed, the parcel will be marked as delivered on
 // chain, with the goroutine cleaning up its state.
+//
+// The confirmation of the anchor transaction is a fact about the chain that
+// can be re-queried at any time, so a failure of the notification stream
+// doesn't mean the transfer failed, only that we lost our view of the chain
+// for a moment. We therefore re-register the notification on stream errors
+// instead of aborting the parcel, which would otherwise leave the transfer
+// pending forever.
 func (p *ChainPorter) waitForTransferTxConf(pkg *sendPackage) error {
 	outboundPkg := pkg.OutboundPkg
 
@@ -420,51 +437,127 @@ func (p *ChainPorter) waitForTransferTxConf(pkg *sendPackage) error {
 	log.Infof("Waiting for confirmation of transfer_txid=%v", txHash)
 
 	confCtx, confCancel := p.WithCtxQuitNoTimeout()
+	defer confCancel()
+
+	retryDelay := confRetryDelay
+	for attempt := 1; ; attempt++ {
+		confEvent, terminal, err := p.waitForConfEventOnce(
+			confCtx, outboundPkg,
+		)
+		switch {
+		// We received the confirmation event, so we can proceed to
+		// the next state.
+		case confEvent != nil:
+			log.Debugf("Got chain confirmation: %v",
+				confEvent.Tx.TxHash())
+			pkg.TransferTxConfEvent = confEvent
+
+			// If the anchoring tx block hash is given, we'll also
+			// store it in the outbound package.
+			pkg.OutboundPkg.AnchorTxBlockHash = fn.MaybeSome(
+				confEvent.BlockHash,
+			)
+			pkg.OutboundPkg.AnchorTxBlockHeight =
+				confEvent.BlockHeight
+
+			pkg.SendState = SendStateStorePostAnchorTxConf
+
+			return nil
+
+		// We're shutting down, or the context was cancelled; there's
+		// no point in retrying.
+		case terminal:
+			return err
+		}
+
+		// The notification stream failed before delivering a
+		// confirmation event. Wait, then re-register.
+		log.Warnf("Transfer confirmation watcher for txid=%v failed "+
+			"(attempt %d), re-registering in %v: %v", txHash,
+			attempt, retryDelay, err)
+
+		select {
+		case <-time.After(retryDelay):
+		case <-confCtx.Done():
+			// The context is also cancelled on shutdown, in which
+			// case both this and the quit case below are ready at
+			// the same time. Prefer the graceful exit.
+			select {
+			case <-p.Quit:
+				log.Debugf("Skipping TX confirmation, exiting")
+				return nil
+			default:
+			}
+
+			return fmt.Errorf("context done whilst waiting for "+
+				"package tx confirmation of %v", txHash)
+		case <-p.Quit:
+			log.Debugf("Skipping TX confirmation, exiting")
+			return nil
+		}
+
+		retryDelay *= 2
+		if retryDelay > confRetryDelayMax {
+			retryDelay = confRetryDelayMax
+		}
+	}
+}
+
+// waitForConfEventOnce registers a confirmation notification for the parcel's
+// anchor transaction and waits for a single outcome. It returns the
+// confirmation event on success. If the notification stream fails in a way
+// that can be remedied by re-registering, a nil event and terminal=false are
+// returned. Shutdown and context cancellation are terminal.
+func (p *ChainPorter) waitForConfEventOnce(ctx context.Context,
+	outboundPkg *OutboundParcel) (*chainntnfs.TxConfirmation, bool, error) {
+
+	txHash := outboundPkg.AnchorTx.TxHash()
 	confNtfn, errChan, err := p.cfg.ChainBridge.RegisterConfirmationsNtfn(
-		confCtx, &txHash, outboundPkg.AnchorTx.TxOut[0].PkScript, 1,
+		ctx, &txHash, outboundPkg.AnchorTx.TxOut[0].PkScript, 1,
 		outboundPkg.AnchorTxHeightHint, true, nil,
 	)
 	if err != nil {
-		return fmt.Errorf("unable to register for package tx conf: %w",
-			err)
+		// Registration itself failed, which is generally a transient
+		// RPC issue, so we'll have the caller retry.
+		return nil, false, fmt.Errorf("unable to register for package "+
+			"tx conf: %w", err)
 	}
 
-	// Launch a goroutine that'll notify us when the transaction confirms.
-	defer confCancel()
+	// Make sure the registration (and its notification stream) is torn
+	// down once we leave this attempt, whatever the outcome.
+	defer confNtfn.Cancel()
 
-	var confEvent *chainntnfs.TxConfirmation
 	select {
-	case confEvent = <-confNtfn.Confirmed:
-		log.Debugf("Got chain confirmation: %v", confEvent.Tx.TxHash())
-		pkg.TransferTxConfEvent = confEvent
+	case confEvent, ok := <-confNtfn.Confirmed:
+		if !ok || confEvent == nil {
+			return nil, false, fmt.Errorf("confirmation event "+
+				"channel closed for txid=%v", txHash)
+		}
 
-		// If the anchoring tx block hash is given, we'll also store it
-		// in the outbound package.
-		pkg.OutboundPkg.AnchorTxBlockHash = fn.MaybeSome(
-			confEvent.BlockHash,
-		)
-		pkg.OutboundPkg.AnchorTxBlockHeight = confEvent.BlockHeight
-
-		pkg.SendState = SendStateStorePostAnchorTxConf
+		return confEvent, false, nil
 
 	case err := <-errChan:
-		return fmt.Errorf("error whilst waiting for package tx "+
-			"confirmation: %w", err)
+		return nil, false, fmt.Errorf("error whilst waiting for "+
+			"package tx confirmation: %w", err)
 
-	case <-confCtx.Done():
-		log.Debugf("Skipping TX confirmation, context done")
+	case <-ctx.Done():
+		// The context is also cancelled on shutdown, in which case
+		// both this and the quit case below are ready at the same
+		// time. Prefer the graceful exit.
+		select {
+		case <-p.Quit:
+			log.Debugf("Skipping TX confirmation, exiting")
+			return nil, true, nil
+		default:
+		}
+
+		return nil, true, fmt.Errorf("context done whilst waiting "+
+			"for package tx confirmation of %v", txHash)
 
 	case <-p.Quit:
 		log.Debugf("Skipping TX confirmation, exiting")
-		return nil
+		return nil, true, nil
 	}
-
-	if confEvent == nil {
-		return fmt.Errorf("got empty package tx confirmation event " +
-			"in batch")
-	}
-
-	return nil
 }
 
 // storeProofs writes the updated sender and receiver proof files to the proof


### PR DESCRIPTION
I believe this should substantially improve force close handling and (finally) resolve #1888 and #1976.

Previously, the chain porter viewed every transaction announced by lnd's sweeper as an immutable *commitment*, whereas the sweeper views each sweep as an *intent* (viz., "claim these outputs") for which each (replaceable, retryable) transaction is an attempt to satisfy. The result was that any time the sweeper did *not* happen to perform a sweep as an immutable commitment (which is "frequently"), tapd would effectively botch its handling of the force close. I believe this is what caused the relentless plague of flakes described in #1976, as well as the stranded assets described in #1888.

The fix is to properly subordinate the porter to the sweeper, and to adapt its operation to how the sweeper actually works. This is basically to tell the porter:

* If a potential sweep tx fails to confirm, that doesn't mean the abstract sweep "being aimed at" is dead. It is normal for the abstract sweep to occur in another transaction.
* A potential sweep tx is not the actual sweep tx until it confirms, and lnd is the judge of that.
* When a sweep tx confirms, the other potential candidates *will not* confirm.
* Don't try to resolve which commitment outputs are ours until contract resolution time, as we don't have all the necessary information to do so until then.

Of note: with these changes, plus another yet-to-be-PR'd change to lnd, I experienced zero HTLC force close cc-itest errors in a run of 40 (10 of each class).