### PR TITLE
docs: backport v0.8.0 release notes from v0.8 branch

### DIFF
--- a/docs/release-notes/release-notes-0.8.0.md
+++ b/docs/release-notes/release-notes-0.8.0.md
@@ -1,135 +1,50 @@
 # Release Notes
-- [Bug Fixes](#bug-fixes)
+- [Breaking Changes](#breaking-changes)
 - [New Features](#new-features)
     - [Functional Enhancements](#functional-enhancements)
-    - [RPC Additions](#rpc-additions)
     - [tapcli Additions](#tapcli-additions)
+    - [RPC Additions](#rpc-additions)
 - [Improvements](#improvements)
+    - [Bug Fixes](#bug-fixes)
     - [Functional Updates](#functional-updates)
     - [RPC Updates](#rpc-updates)
     - [tapcli Updates](#tapcli-updates)
     - [Config Changes](#config-changes)
-    - [Breaking Changes](#breaking-changes)
-    - [Performance Improvements](#performance-improvements)
-    - [Deprecations](#deprecations)
-- [Technical and Architectural Updates](#technical-and-architectural-updates)
-    - [BIP/bLIP Spec Updates](#bipblip-spec-updates)
-    - [Testing](#testing)
-    - [Database](#database)
-    - [Code Health](#code-health)
-    - [Tooling and Documentation](#tooling-and-documentation)
+- [Tooling and Documentation](#tooling-and-documentation)
 
-# Bug Fixes
+# Breaking Changes
 
-- [PR#1897](https://github.com/lightninglabs/taproot-assets/pull/1897)
-  Fix witness writeback issue when a split commitment is present.
-  `UpdateTxWitness` was mutating a pointer into a copied root asset when a
-  split commitment was present, causing the updated witness to never propagate
-  back into `SplitCommitment.RootAsset`. This left the root witness empty and
-  produced invalid split proofs and transactions.
+- **(RFQ Configuration)**:
+  [PR#1935](https://github.com/lightninglabs/taproot-assets/pull/1935)
+  renames the RFQ configuration option
+  `experimental.rfq.skipacceptquotepricecheck` to
+  `experimental.rfq.skipquoteacceptverify` for improved clarity.
 
-- [PR#1898](https://github.com/lightninglabs/taproot-assets/pull/1898)
-  The funding output proofs are now always imported during force close handling
-  for both channel initiator and responder. Previously, proofs were only
-  imported for the responder, which could lead to issues if the initiator
-  failed to properly import funding proofs after the funding transaction
-  confirmed. This ensures both parties can properly recognize and spend funding
-  outputs regardless of any prior import failures.
+- **(BurnAsset RPC changes)**:
+  via [PR#2062](https://github.com/lightninglabs/taproot-assets/pull/2062),
+  `BurnAssetRequest` now uses an `AssetSpecifier` field to identify the
+  asset to burn, supporting both asset ID and group key. The old `oneof
+  asset` fields (`asset_id`, `asset_id_str`) are deprecated.
+  `BurnAssetResponse` adds a repeated `burn_proofs` field; the singular
+  `burn_proof` field is deprecated.
 
-- [PR#1920](https://github.com/lightninglabs/taproot-assets/pull/1920)
-  addresses a bug in which Neutrino-backed nodes could fail to import
-  transfer proofs for remote-initiated force close transactions if they
-  were not online to see them broadcast.
-
-- [PR#1941](https://github.com/lightninglabs/taproot-assets/pull/1941)
-  `tapgarden` now avoids a full `tapd` shutdown when the `Custodian` encounters
-  non-critical errors during its operation. Errors occurring during proof
-  availability checks, proof retrieval, or initial wallet transaction
-  inspections are now logged instead of being treated as fatal, allowing the
-  daemon to remain operational and continue processing other events.
-
-* [PR#1943](https://github.com/lightninglabs/taproot-assets/pull/1943)
-  addresses a bug in which passive assets would incorrectly be included in
-  channel funding proofs.
-
-* [PR#1990](https://github.com/lightninglabs/taproot-assets/pull/1990)
-  prevents buggy results when comparing quotes encoded using different
-  scales.
-
-* [PR#1985](https://github.com/lightninglabs/taproot-assets/pull/1985)
-  adds a basic health check for TLS cert expiry which allows for more effective
-  autonomous renewals.
-
-* [PR#1991](https://github.com/lightninglabs/taproot-assets/pull/1991)
-  fixes an issue in which asset invoices could be settled in sats if
-  their expiration extended beyond that of the accepted edge node
-  quote (or quotes).
-
-* [PR#2044](https://github.com/lightninglabs/taproot-assets/pull/2044)
-  fixes a bug in `AssertAnchorTimeLocks` that prevented asset-level
-  timelocks from being enforced at the consensus level.
-
-* [PR#2009](https://github.com/lightninglabs/taproot-assets/pull/2009)
-  fixes SCID resolution for asset invoices when the peer-accepted buy
-  quote has expired from memory or the node has restarted. Peer-accepted
-  buy quotes are now persisted to the database and resolved via a 3-tier
-  lookup (active map, LRU cache, DB fallback). On startup, persisted
-  quotes are restored into the active map so payment flows survive
-  restarts.
-
-* [PR#2051](https://github.com/lightninglabs/taproot-assets/pull/2051)
-  persists peer-accepted sell quotes to the database on acceptance and
-  restores them into the active cache on startup, ensuring sell-side
-  payment flows survive restarts.
-
-* [PR#2010](https://github.com/lightninglabs/taproot-assets/pull/2010)
-  fixes an issue that prevented asset roots from being deleted on
-  universes with existing federation sync log entries.
-
-* [PR#2035](https://github.com/lightninglabs/taproot-assets/pull/2035)
-  fixes a bug by which which the connection with an authmailbox server
-  could be lost after encountering a non-graceful error.
-
-* [PR#2039](https://github.com/lightninglabs/taproot-assets/pull/2039)
-  fixes `DecodeAssetPayReq` so `GenesisInfo` is populated consistently,
-  including group-key invoice decodes.
-
-* [PR#2115](https://github.com/lightninglabs/taproot-assets/pull/2115)
-  fixes a bug by which grouped assets could remain invisible to
-  ListGroups after import, remaining visible only in ListAssets.
-
-* [PR#2100](https://github.com/lightninglabs/taproot-assets/pull/2100)
-  fixes inverted sort direction in `AssetRoots`, `AssetLeafKeys`, and
-  `QueryEvents` universe RPCs.
-
-* [PR#2047](https://github.com/lightninglabs/taproot-assets/pull/2047)
-  fixes a bug that affected legacy Postgres-backed universe servers that
-  were upgraded to v0.6.0, by which universe leaf inserts could result in
-  duplicate-key errors.
-
-* [PR#2141](https://github.com/lightninglabs/taproot-assets/pull/2141)
-  fixes several bugs that could leave minting batches in an inconsistent
-  state in the case of a funding, database write, or restart error.
-
-* [PR#2149](https://github.com/lightninglabs/taproot-assets/pull/2149)
-  fixes a bug that caused tapd not to detect subsequent self-sends to
-  V2 addresses.
-
-* [PR#2157](https://github.com/lightninglabs/taproot-assets/pull/2157)
-  fixes a bug that could cause tapd to miss incoming V2-address
-  transfers until restart in the event of a silently-dropped TCP
-  connection.
+- **(Proof cache configuration)**:
+  [PR#1870](https://github.com/lightninglabs/taproot-assets/pull/1870)
+  removes the `universe.multiverse-caches.proofs-per-universe` config
+  option in favour of `universe.multiverse-caches.max-proof-cache-size`,
+  which bounds the proof cache by total memory size rather than proof
+  count. Accepts human-readable values such as `64MB`.
 
 # New Features
 
 ## Functional Enhancements
 
-- [Auth Mailbox Cleanup](https://github.com/lightninglabs/taproot-assets/pull/2020):
-  The auth mailbox server now periodically checks claimed outpoints against the
-  chain and deletes messages whose outpoints have been spent. Receivers can also
-  explicitly remove their own messages via the new `RemoveMessage` RPC. The
-  custodian automatically removes mailbox messages after successfully receiving
-  proofs.
+- [Orphan UTXO Garbage Collection](https://github.com/lightninglabs/taproot-assets/pull/1832):
+  tapd now garbage-collects orphaned UTXOs by sweeping tombstone and
+  burn outputs when executing on-chain transactions. Collection runs
+  on every burn, transfer, or call to `AnchorVirtualPsbts`. Sweeping
+  is enabled by default and can be disabled via the
+  `wallet.disable-sweep-orphan-utxos` config flag.
 
 - [Forwarding History Tracking](https://github.com/lightninglabs/taproot-assets/pull/1921):
   Routing nodes can now track and query historical asset forwarding events.
@@ -138,39 +53,16 @@
   **Note:** For full functionality, it is highly recommended to start LND with
   the `--store-final-htlc-resolutions` flag enabled, which is disabled by default.
 
-- [Limit-Order Constraints](https://github.com/lightninglabs/taproot-assets/pull/2048):
-  RFQ buy and sell orders can now carry explicit limit-price bounds
-  (`asset_rate_limit`) and minimum fill sizes (`asset_min_amt` /
-  `payment_min_amt`). Quotes that violate these constraints are rejected
-  with machine-readable reasons (`RATE_BOUND_MISS`, `MIN_FILL_NOT_MET`).
-  New fields are optional and backward-compatible; constraint validation
-  only activates when they are present.
-
-- [Burn Assets by Group Key](https://github.com/lightninglabs/taproot-assets/pull/2062):
-  Assets can now be burned by specifying a group key instead of a specific
-  asset ID. When burning by group key, the daemon automatically selects
-  and burns units across all issuances in the group, producing multiple
-  burn outputs if needed. The `tapcli assets burn` command now accepts a
-  `--group_key` flag.
-
-- [Execution Policy](https://github.com/lightninglabs/taproot-assets/pull/2049):
-  RFQ buy and sell orders can now specify an execution policy: IOC
-  (Immediate-Or-Cancel, the default) allows partial fills above the
-  minimum, while FOK (Fill-Or-Kill) requires the full requested amount
-  or rejects the quote. FOK viability is checked in `VerifyAcceptQuote`
-  with a new `FOK_NOT_VIABLE` reject code. New fields are optional and
-  backward-compatible.
-
-- [Fill Quantity Negotiation](https://github.com/lightninglabs/taproot-assets/pull/2050):
-  RFQ accept messages now carry an optional fill quantity, allowing
-  the responder to signal the maximum amount it is willing to fill.
-  The negotiated fill caps HTLC policies so forwarding never exceeds
-  the agreed amount.
-
-## Functional Enhancements
+- [PortfolioPilot RPC Service](https://github.com/lightninglabs/taproot-assets/pull/1962):
+  introduces a new RPC service contract that lets operators delegate RFQ
+  orchestration to an external engine, allowing e.g. pricing, hedging,
+  and acceptance policy to live in a single external service rather
+  than being baked into tapd. An external server is wired up via the
+  new `experimental.rfq.portfoliopilotaddress` config option, and a
+  reference implementation is provided under `docs/examples`.
 
 - [Wallet Backup/Restore](https://github.com/lightninglabs/taproot-assets/pull/1980):
-  Add wallet backup and restore functionality with three modes: **raw** (v1)
+  Adds wallet backup and restore functionality with three modes: **raw** (v1)
   exports complete proof files, **compact** (v2) strips blockchain-derivable
   fields from proofs for significantly smaller backups (fields are reconstructed
   from the blockchain on import), and **optimistic** (v3) omits proofs entirely
@@ -182,342 +74,323 @@
   corresponding LND wallet; the backup only covers the Taproot Assets layer.
   See [docs/backup.md](../backup.md) for the full format specification.
 
-## RPC Additions
+- [Auth Mailbox Cleanup](https://github.com/lightninglabs/taproot-assets/pull/2020):
+  The auth mailbox server now periodically checks claimed outpoints against the
+  chain and deletes messages whose outpoints have been spent. Receivers can also
+  explicitly remove their own messages via the new `RemoveMessage` RPC. The
+  custodian automatically removes mailbox messages after successfully receiving
+  proofs.
 
-- [Wallet Backup RPCs](https://github.com/lightninglabs/taproot-assets/pull/1980):
-  Add `ExportAssetWalletBackup` and `ImportAssetsFromBackup` RPCs to the
-  `assetwalletrpc` service. Export accepts a `mode` field (`RAW`, `COMPACT`,
-  `OPTIMISTIC`) for selecting the backup format. Import returns the count of
-  newly imported assets.
+- [Limit-Order Constraints](https://github.com/lightninglabs/taproot-assets/pull/2048):
+  RFQ buy and sell orders can now carry explicit limit-price bounds
+  (`asset_rate_limit`) and minimum fill sizes (`asset_min_amt` /
+  `payment_min_amt`). Quotes that violate these constraints are
+  rejected. New fields are optional and backward-compatible; constraint
+  validation only activates when they are present.
 
-- [PR#1960](https://github.com/lightninglabs/taproot-assets/pull/1960)
-  Add `BakeMacaroon` to mint custom macaroons with scoped permissions.
+- [Execution Policy](https://github.com/lightninglabs/taproot-assets/pull/2049):
+  RFQ buy and sell orders can now specify an execution policy: IOC
+  (Immediate-Or-Cancel, the default) allows partial fills above the
+  minimum, while FOK (Fill-Or-Kill) requires the full requested amount
+  or rejects the quote. New fields are optional and backward-compatible.
 
-- [PR#1962](https://github.com/lightninglabs/taproot-assets/pull/1962)
-  Add the PortfolioPilot RPC service for RFQ quote resolution, verification,
-  and asset rate queries.
+- [Fill Quantity Negotiation](https://github.com/lightninglabs/taproot-assets/pull/2050):
+  RFQ accept messages now carry an optional fill quantity, allowing
+  the responder to signal the maximum amount it is willing to fill.
+  The negotiated fill caps HTLC policies so forwarding never exceeds
+  the agreed amount.
 
-- [PR#2023](https://github.com/lightninglabs/taproot-assets/pull/2023)
-  Add `DeleteAssetLeaf` RPC for removing a single leaf from a universe,
-  identified by universe ID and leaf key (outpoint + script key). When
-  the last leaf is deleted, the entire universe is automatically cleaned
-  up.
-
-- [PR#2014](https://github.com/lightninglabs/taproot-assets/pull/2014)
-  Add `FetchAsset` RPC for fetching assets by asset ID or group key using an
-  `AssetSpecifier`. Supports filters for `include_spent`, `include_leased`,
-  `include_unconfirmed_mints`, `with_witness`, and `script_key_type`.
-
-- [PR#2020](https://github.com/lightninglabs/taproot-assets/pull/2020)
-  Add `RemoveMessage` RPC to the auth mailbox service. Receivers can
-  authenticate with a Schnorr signature to delete their own messages by ID.
-
-- [PR#2048](https://github.com/lightninglabs/taproot-assets/pull/2048):
-  Add `asset_rate_limit` to `AddAssetBuyOrder` and `AddAssetSellOrder`
-  requests. Add `asset_min_amt` to buy orders and `payment_min_amt`
-  to sell orders. Add `asset_rate_limit` and min fill fields to
-  `PortfolioPilot.ResolveRequest` for constraint forwarding. Add
-  `RATE_BOUND_MISS` and `MIN_FILL_NOT_MET` to `QuoteRespStatus`.
-
-- [PR#2049](https://github.com/lightninglabs/taproot-assets/pull/2049):
-  Add `execution_policy` enum (`EXECUTION_POLICY_IOC`,
-  `EXECUTION_POLICY_FOK`) to `AddAssetBuyOrder` and `AddAssetSellOrder`
-  requests, and to `PortfolioPilot.ResolveRequest` for constraint
-  forwarding. Add `FOK_NOT_VIABLE` to `QuoteRespStatus`.
-
-## tapcli Additions
-
-- [Wallet Backup CLI](https://github.com/lightninglabs/taproot-assets/pull/1980):
-  Add `tapcli assets backup export` and `tapcli assets backup import` commands
-  exposing the wallet backup RPCs. Export supports `--mode` (`raw`, `compact`,
-  `optimistic`) and `--output_file` flags. Import reads a backup blob from
-  `--backup_file` and restores assets.
-
-- [PR#1960](https://github.com/lightninglabs/taproot-assets/pull/1960)
-  Add `tapcli bakemacaroon` to bake custom macaroons with offline caveats.
-
-- [PR#2023](https://github.com/lightninglabs/taproot-assets/pull/2023)
-  Add `tapcli universe delete-leaf` to delete a single leaf from a
-  universe by asset ID, outpoint, and script key.
-
-- [PR#2014](https://github.com/lightninglabs/taproot-assets/pull/2014)
-  Add `tapcli assets fetch` command for fetching assets by `--asset_id` or
-  `--group_key`, with optional filter flags.
-
-- [ForwardingHistory RPC](https://github.com/lightninglabs/taproot-assets/pull/1921):
-  New RPC endpoint `rfqrpc.ForwardingHistory` allows querying historical
-  forwarding events with filtering and pagination support. Filters include:
-  timestamp range (min/max), peer public key, asset ID, and asset group key.
+- [Burns Assets by Group Key](https://github.com/lightninglabs/taproot-assets/pull/2062):
+  Assets can now be burned by specifying a group key instead of a specific
+  asset ID. When burning by group key, the daemon automatically selects
+  and burns units across all issuances in the group, producing multiple
+  burn outputs if needed. The `tapcli assets burn` command now accepts a
+  `--group_key` flag.
 
 ## tapcli Additions
 
 - [tapcli rfq forwardinghistory](https://github.com/lightninglabs/taproot-assets/pull/1921):
-  New CLI command `tapcli rfq forwardinghistory` (alias: `f`) to query forwarding event
+  adds `tapcli rfq forwardinghistory` (alias: `f`) to query forwarding event
   history. Supports flags for filtering by timestamp (`--min-timestamp`,
   `--max-timestamp`), peer (`--peer`), asset ID (`--asset-id`), and asset
   group key (`--group-key`). Includes pagination support via `--limit` and
   `--offset` flags.
 
+- [tapcli bakemacaroon](https://github.com/lightninglabs/taproot-assets/pull/1960):
+  adds `tapcli bakemacaroon` to bake custom macaroons with offline caveats.
+
+- [tapcli assets backup](https://github.com/lightninglabs/taproot-assets/pull/1980):
+  adds `tapcli assets backup export` and `tapcli assets backup import` commands
+  exposing the wallet backup RPCs. Export supports `--mode` (`raw`, `compact`,
+  `optimistic`) and `--output_file` flags. Import reads a backup blob from
+  `--backup_file` and restores assets.
+
+- [tapcli assets fetch](https://github.com/lightninglabs/taproot-assets/pull/2014):
+  adds `tapcli assets fetch` command for fetching assets by `--asset_id` or
+  `--group_key`, with optional filter flags.
+
+## RPC Additions
+
+- [Forwarding History](https://github.com/lightninglabs/taproot-assets/pull/1921): PR#1921 adds a new `rfqrpc.ForwardingHistory` RPC endpoint that allows
+  querying historical forwarding events with filtering and pagination
+  support. Filters include: timestamp range (min/max), peer public key,
+  asset ID, and asset group key.
+
+- [BakeMacaroon](https://github.com/lightninglabs/taproot-assets/pull/1960):
+  PR#1960 adds `BakeMacaroon` to mint custom macaroons with scoped permissions.
+
+- [Wallet Backup](https://github.com/lightninglabs/taproot-assets/pull/1980):
+  PR#1980 adds `ExportAssetWalletBackup` and `ImportAssetsFromBackup`
+  RPCs to the `assetwalletrpc` service. Export accepts a `mode` field
+  (`RAW`, `COMPACT`, `OPTIMISTIC`) for selecting the backup format.
+  Import returns the count of newly imported assets.
+
+- [FetchAsset](https://github.com/lightninglabs/taproot-assets/pull/2014):
+  PR#2014 adds the `FetchAsset` RPC for fetching assets by asset
+  ID or group key using an `AssetSpecifier`. Supports filters for
+  `include_spent`, `include_leased`, `include_unconfirmed_mints`,
+  `with_witness`, and `script_key_type`.
+
+- [RemoveMessage](https://github.com/lightninglabs/taproot-assets/pull/2020):
+  PR#2020 adds the `RemoveMessage` RPC to the auth mailbox service.
+  Receivers can authenticate with a Schnorr signature to delete their
+  own messages by ID.
+
+- [Limit Constraints](https://github.com/lightninglabs/taproot-assets/pull/2048):
+  PR#2048 adds `asset_rate_limit` to `AddAssetBuyOrder` and
+  `AddAssetSellOrder` requests. Adds `asset_min_amt` to buy orders and
+  `payment_min_amt` to sell orders. Adds `asset_rate_limit` and min fill
+  fields to `PortfolioPilot.ResolveRequest` for constraint forwarding.
+  Adds `RATE_BOUND_MISS` and `MIN_FILL_NOT_MET` to `QuoteRespStatus`.
+
+- [Execution Policy](https://github.com/lightninglabs/taproot-assets/pull/2049):
+  PR#2049 adds `execution_policy` enum (`EXECUTION_POLICY_IOC`,
+  `EXECUTION_POLICY_FOK`) to `AddAssetBuyOrder` and `AddAssetSellOrder`
+  requests, and to `PortfolioPilot.ResolveRequest` for constraint
+  forwarding. Adds `FOK_NOT_VIABLE` to `QuoteRespStatus`.
+
 # Improvements
+
+## Bug Fixes
+
+- [PR#1898](https://github.com/lightninglabs/taproot-assets/pull/1898)
+  ensures that funding output proofs are now always imported during
+  force close handling for both channel initiator and responder.
+  Previously, proofs were only imported for the responder, which could
+  lead to issues if the initiator failed to properly import funding
+  proofs after the funding transaction confirmed.
+
+* [PR#2009](https://github.com/lightninglabs/taproot-assets/pull/2009)
+  fixes SCID resolution for asset invoices when the peer-accepted buy
+  quote has expired from memory or the node has restarted.
+
+* [PR#2035](https://github.com/lightninglabs/taproot-assets/pull/2035)
+  fixes a bug by which which the connection with an authmailbox server
+  could be lost after encountering a non-graceful error.
+
+* [PR#2039](https://github.com/lightninglabs/taproot-assets/pull/2039)
+  ensures that useful asset information is propagated in payment
+  requests.
+
+* [PR#2044](https://github.com/lightninglabs/taproot-assets/pull/2044)
+  fixes a bug that prevented asset-level timelocks from being enforced
+  at the consensus level.
+
+* [PR#2047](https://github.com/lightninglabs/taproot-assets/pull/2047)
+  fixes a bug that caused duplicate key errors on legacy Postgres-backed
+  universe servers that existed prior to tapd v0.6.0.
+
+* [PR#2051](https://github.com/lightninglabs/taproot-assets/pull/2051)
+  ensures that sell-side payment flows survive restarts.
+
+* [PR#2100](https://github.com/lightninglabs/taproot-assets/pull/2100)
+  fixes inverted sort direction in `AssetRoots`, `AssetLeafKeys`, and
+  `QueryEvents` universe RPCs.
+
+* [PR#2110](https://github.com/lightninglabs/taproot-assets/pull/2110)
+  fixes a corner case in which tapd could hang on shutdown while
+  importing output proofs during a coop close.
+
+* [PR#2115](https://github.com/lightninglabs/taproot-assets/pull/2115)
+  fixes a bug by which grouped assets could remain invisible to
+  ListGroups after import, remaining visible only in ListAssets.
+
+* [PR#2118](https://github.com/lightninglabs/taproot-assets/pull/2118)
+  fixes a bug that made MSSMT node inserts fail to be idempotent under
+  database backends.
+
+* [PR#2119](https://github.com/lightninglabs/taproot-assets/pull/2119)
+  eliminates a panic that could occur when MSSMT branch nodes were copied
+  under database backends.
+
+* [PR#2131](https://github.com/lightninglabs/taproot-assets/pull/2131)
+  fixes a bug that could prevent co-op closes from finalizing if
+  tapd were to restart after close negotiation, but before on-chain
+  confirmation.
+
+* [PR#2141](https://github.com/lightninglabs/taproot-assets/pull/2141)
+  fixes several bugs that could leave minting batches in an
+  inconsistent state in the case of a funding, database write, or
+  restart error.
+
+* [PR#2149](https://github.com/lightninglabs/taproot-assets/pull/2149)
+  fixes a bug that caused tapd not to detect subsequent self-sends
+  to V2 addresses.
+
+* [PR#2157](https://github.com/lightninglabs/taproot-assets/pull/2157)
+  fixes a bug that could cause tapd to miss incoming V2-address
+  transfers until restart in the event of a silently-dropped TCP
+  connection.
 
 ## Functional Updates
 
+- [PR#1775](https://github.com/lightninglabs/taproot-assets/pull/1775)
+  and [PR#2147](https://github.com/lightninglabs/taproot-assets/pull/2147):
+  ensure that RFQ gRPC clients (price oracle, portfolio pilot) now verify TLS
+  certificates by default using the OS root CA list. They share a
+  single `experimental.rfq.tls.*` config namespace for disabling TLS,
+  skipping verification, or specifying custom certificates.
+
+- [PR#1863](https://github.com/lightninglabs/taproot-assets/pull/1863)
+  ensures that RFQ buy/sell accepts are now written to the database
+  `rfq_policies` table whenever a policy is agreed, giving us an audit
+  trail and keeping quotes alive across restarts.
+
 - [PR#1884](https://github.com/lightninglabs/taproot-assets/pull/1884)
-  Introduce pre-broadcast validation state in the ChainPorter state machine.
-  A new `SendStateVerifyPreBroadcast` state performs validation checks on send
-  packages before broadcasting transactions. This validates input proofs and
-  provides infrastructure for additional pre-broadcast checks.
+  introduces pre-broadcast validation state in the ChainPorter state
+  machine. This validates input proofs and provides infrastructure for
+  additional pre-broadcast checks.
 
 - [PR#1904](https://github.com/lightninglabs/taproot-assets/pull/1904)
-  Enforce split root witness validation before broadcasting transactions.
-  Split leaf outputs must now embed a split root that carries a valid witness.
-  Split leaves intentionally keep their own `TxWitness` empty and rely on the
-  embedded root witness for validation. This check prevents invalid split
-  transactions from being broadcast.
+  enforces split root witness validation before broadcasting
+  transactions. This check prevents invalid split transactions from
+  being broadcast.
 
-- [Garbage collection of orphaned UTXOs](https://github.com/lightninglabs/taproot-assets/pull/1832)
-  by sweeping tombstones and burn outputs when executing onchain transactions.
-  Garbage collection will be executed on every burn, transfer or call to
-  `AnchorVirtualPsbts`. Sweeping is enabled by default and can be disabled via
-  the flag `wallet.disable-sweep-orphan-utxos`.
-- [PR](https://github.com/lightninglabs/taproot-assets/pull/1899) tapd now
-  treats HTLC interceptor setup failures as fatal during RFQ subsystem startup.
-  If the RFQ subsystem cannot install its interceptor, tapd shuts down instead
-  of continuing in a degraded state. This ensures that any running tapd
-  instance has a fully functional RFQ pipeline and surfaces configuration or
-  lnd-level conflicts immediately.
-
-- [RFQ buy/sell accepts are now written to the database](https://github.com/lightninglabs/taproot-assets/pull/1863)
-  `rfq_policies` table whenever a policy is agreed, giving us an audit trail
-  and keeping quotes alive across restarts.
-
-- [Improve orphan UTXO sweeping](https://github.com/lightninglabs/taproot-assets/pull/1905):
-  Fixed two issues with fetching orphan UTXOs for sweeping during transaction
-  building:
-  - Added filtering to exclude orphan UTXOs with missing signing information
+- [PR#1905](https://github.com/lightninglabs/taproot-assets/pull/1905):
+  improves orphan UTXO sweeping, fixing two issues with fetching orphan
+  UTXOs for sweeping during transaction building:
+  - Adds filtering to exclude orphan UTXOs with missing signing information
     (KeyFamily=0 and KeyIndex=0). These UTXOs were created in prior versions
     that didn't store this information, causing LND to fail when signing.
-  - Added a limit (`MaxOrphanUTXOs = 20`) to prevent transactions from becoming
+  - Adds a limit (`MaxOrphanUTXOs = 20`) to prevent transactions from becoming
     too large when sweeping many orphan UTXOs at once.
-
-- [PR#2070](https://github.com/lightninglabs/taproot-assets/pull/2070)
-  Non-critical custodian errors are now surfaced to RPC clients subscribed via
-  `SubscribeReceiveEvents`. Errors during proof availability checks, proof
-  retrieval, wallet transaction inspection, and mailbox message handling now
-  publish `AssetReceiveErrorEvent` notifications, allowing clients to monitor
-  and react to failures without requiring log parsing.
-
-- [PR#1775](https://github.com/lightninglabs/taproot-assets/pull/1775):
-  Price oracle connections now verify TLS certificates by
-  default, using the OS root CA list. New config options under
-  `experimental.rfq.priceoracle*` allow disabling TLS, skipping
-  verification, or specifying custom certificates.
 
 - [PR#1978](https://github.com/lightninglabs/taproot-assets/pull/1978)
   also augments price oracle connections with support for macaroon
   authentication. A macaroon path can be specified via the
   `experimental.rfq.priceoraclemacaroonpath` config option.
 
-- [PR#2147](https://github.com/lightninglabs/taproot-assets/pull/2147)
-  extends TLS and macaroon auth to the external portfolio pilot
-  client, and unifies the TLS configuration across both RFQ gRPC
-  clients (price oracle, portfolio pilot) under a single shared
-  `experimental.rfq.tls.*` namespace. The portfolio pilot macaroon
-  path is configured via `experimental.rfq.portfoliopilotmacaroonpath`.
+* [PR#1985](https://github.com/lightninglabs/taproot-assets/pull/1985)
+  adds a basic health check for TLS cert expiry which allows for more effective
+  autonomous renewals.
 
-## RPC Updates
-
-- [PR#2005](https://github.com/lightninglabs/taproot-assets/pull/2005)
-  Add a `node_id` field to `QueryAssetRatesRequest` containing the local
-  node's 33-byte compressed public key. This allows the price oracle to
-  identify which tapd node is querying rates. The field is populated by
-  default and can be disabled via
-  `experimental.rfq.priceoracledisablenodeid`.
-
-- [PR#1766](https://github.com/lightninglabs/taproot-assets/pull/1766):
-  Introduces structured price oracle errors that allow oracles to return
-  specific error codes. Also, adds a new error code that oracles can use
-  to indicate that an asset is unsupported.
-
-- [PR#1841](https://github.com/lightninglabs/taproot-assets/pull/1841): Remove
-  the defaultMacaroonWhitelist map and inline its entries directly
-  into the conditional logic within MacaroonWhitelist. This ensures that
-  access to previously always-available endpoints is now governed by
-  explicit user configuration (read/write/courier), improving permission
-  control and aligning with expected access restrictions.
-
-- [PR#1841](https://github.com/lightninglabs/taproot-assets/pull/1841): Add
-  default RPC permissions for RPC endpoints universerpc.Universe/Info and
-  /authmailboxrpc.Mailbox/MailboxInfo.
-
-- [PR#1915](https://github.com/lightninglabs/taproot-assets/pull/1915)
-  `NewAddr` now registers a custodian subscriber and waits for the address
-  import result (with a timeout) before returning, surfacing mailbox courier
-  import failures instead of racing and returning success early.
-
-- [PR#1995](https://github.com/lightninglabs/taproot-assets/pull/1995)
-  Add pagination support (offset, limit, direction) to the `ListAssets` RPC
-  endpoint.
-
-- [PR#2122](https://github.com/lightninglabs/taproot-assets/pull/2122)
-  Add a `group_key` field to `TransferInput` and `TransferOutput`. Affects `ListTransfers` and the `transfer` field embedded in `SendEvent`.
-
-- [PR#2125](https://github.com/lightninglabs/taproot-assets/pull/2125)
-  Add an `asset_type` field to `TransferInput` and `TransferOutput`.
-  Affects `ListTransfers` and the `transfer` field embedded in
-  `SendEvent`, allowing clients to distinguish grouped fungible assets from
-  grouped collectible assets.
-
-- [PR#2126](https://github.com/lightninglabs/taproot-assets/pull/2126)
-  Add an `asset_type` field to `AssetBurn`. Affects `ListBurns`, allowing
-  clients to distinguish grouped fungible burns from grouped collectible
-  burns.
-
-- [PR#2100](https://github.com/lightninglabs/taproot-assets/pull/2100)
-  Add pagination support (offset, limit, direction) to the `AssetLeaves`
-  RPC endpoint, and add `MaxPageSize` validation to `AssetRoots`.
-  Standardize pagination validation across `AssetRoots`,
-  `AssetLeafKeys`, `AssetLeaves`, and `QueryAssetStats` via a shared
-  `validatePage` helper, and add a `has_more` field to all four
-  response types. Default `limit=0` to `MaxPageSize` instead of
-  `RequestPageSize`.
-
-
-## tapcli Updates
-
-- [PR#1995](https://github.com/lightninglabs/taproot-assets/pull/1995)
-  Add `--limit`, `--offset`, and `--direction` flags to `tapcli assets list`
-  for pagination support. The direction defaults to descending order.
-
-- [PR#2100](https://github.com/lightninglabs/taproot-assets/pull/2100)
-  `tapcli universe leaves` now paginates automatically, fetching all
-  pages instead of silently truncating at 512 results.
-
-## Config Changes
-
-- [PR#1962](https://github.com/lightninglabs/taproot-assets/pull/1962)
-  Add `experimental.rfq.portfoliopilotaddress` to configure an external
-  PortfolioPilot RPC server.
-
-- [PR#1870](https://github.com/lightninglabs/taproot-assets/pull/1870)
-  The `proofs-per-universe` configuration option is removed. New option
-  `max-proof-cache-size` sets the proof cache limit in bytes and accepts
-  human-readable values such as `64MB`.
-
-- [Enable orphan UTXO sweeping by default](https://github.com/lightninglabs/taproot-assets/pull/1905):
-  Orphan UTXO sweeping is now enabled by default. This automatically sweeps
-  tombstone and burn outputs when executing on-chain transactions. Set
-  `wallet.disable-sweep-orphan-utxos` to disable.
-
-- [PR#2020](https://github.com/lightninglabs/taproot-assets/pull/2020)
-  Add `universe.mbox-cleanup-interval` and
-  `universe.mbox-cleanup-check-timeout` to configure periodic cleanup of
-  auth mailbox messages whose claimed outpoints have been spent on chain.
-
-## Breaking Changes
-
-- [PR#1935](https://github.com/lightninglabs/taproot-assets/pull/1935)
-  Renamed the RFQ configuration option `experimental.rfq.skipacceptquotepricecheck`
-  to `experimental.rfq.skipquoteacceptverify` for improved clarity.
-  Update your configuration files to use the new option name.
-
-- [PR#2062](https://github.com/lightninglabs/taproot-assets/pull/2062)
-  `BurnAssetRequest` now uses an `AssetSpecifier` field to identify the
-  asset to burn, supporting both asset ID and group key. The old `oneof
-  asset` fields (`asset_id`, `asset_id_str`) are deprecated.
-  `BurnAssetResponse` adds a repeated `burn_proofs` field; the singular
-  `burn_proof` field is deprecated.
-
-## Performance Improvements
+- [PR#2070](https://github.com/lightninglabs/taproot-assets/pull/2070)
+  ensures that non-critical custodian errors are now surfaced to RPC
+  clients subscribed via `SubscribeReceiveEvents`. Errors during proof
+  availability checks, proof retrieval, wallet transaction inspection,
+  and mailbox message handling now publish `AssetReceiveErrorEvent`
+  notifications, allowing clients to monitor and react to failures
+  without requiring log parsing.
 
 * [PR#2104](https://github.com/lightninglabs/taproot-assets/pull/2104)
-  Dramatically improves block header verification performance during
+  dramatically improves block header verification performance during
   proof receipt. Header verification RPCs are now deduplicated
   and executed in parallel, replacing the previous sequential per-proof
   approach. Benchmarks show a ~7x speedup for files with many unique
   headers.
 
-## Deprecations
+* [PR#2147](https://github.com/lightninglabs/taproot-assets/pull/2147)
+  extends macaroon auth to the portfolio pilot client, configurable via
+  `experimental.rfq.portfoliopilotmacaroonpath`.
 
-# Technical and Architectural Updates
+## RPC Updates
 
-## BIP/bLIP Spec Updates
+- [PR#1766](https://github.com/lightninglabs/taproot-assets/pull/1766):
+  introduces structured price oracle errors that allow oracles to return
+  specific error codes. Also, adds a new error code that oracles can use
+  to indicate that an asset is unsupported.
 
-## Testing
+- [PR#1841](https://github.com/lightninglabs/taproot-assets/pull/1841) removes
+  the defaultMacaroonWhitelist map and inlines its entries directly into
+  the conditional logic within MacaroonWhitelist. This ensures that
+  access to previously always-available endpoints is now governed by
+  explicit user configuration (read/write/courier), improving permission
+  control and aligning with expected access restrictions.
 
-- [PR#2057](https://github.com/lightninglabs/taproot-assets/pull/2057)
-  Integration test harness teardown now performs a full top-level harness stop
-  at suite end, so btcd/lnd/tapd itest processes are cleaned up automatically
-  rather than being left running after test completion.
+- [PR#1841](https://github.com/lightninglabs/taproot-assets/pull/1841) adds
+  default RPC permissions for RPC endpoints universerpc.Universe/Info and
+  /authmailboxrpc.Mailbox/MailboxInfo.
 
-- [Wallet Backup Integration Tests](https://github.com/lightninglabs/taproot-assets/pull/1980):
-  Add two integration tests for wallet backup covering genesis backup/restore,
-  idempotent import, all three backup modes with size comparison, post-restore
-  spendability via multi-hop transfer, and stale backup detection. Also includes
-  unit tests for TLV encoding roundtrips, checksum verification, and proof
-  strip/rehydrate cycles.
+- [PR#1995](https://github.com/lightninglabs/taproot-assets/pull/1995)
+  adds pagination support (offset, limit, direction) to the `ListAssets` RPC
+  endpoint.
+
+- [PR#2100](https://github.com/lightninglabs/taproot-assets/pull/2100)
+  adds pagination support (offset, limit, direction) to the `AssetLeaves`
+  RPC endpoint, and adds `MaxPageSize` validation to `AssetRoots`.
+  Standardizes pagination validation across `AssetRoots`,
+  `AssetLeafKeys`, `AssetLeaves`, and `QueryAssetStats` via a shared
+  `validatePage` helper, and adds a `has_more` field to all four
+  response types. Defaults `limit=0` to `MaxPageSize` instead of
+  `RequestPageSize`.
+
+- [PR#2122](https://github.com/lightninglabs/taproot-assets/pull/2122)
+  adds a `group_key` field to `TransferInput` and `TransferOutput`.
+  Affects `ListTransfers` and the `transfer` field embedded in
+  `SendEvent`.
+
+- [PR#2125](https://github.com/lightninglabs/taproot-assets/pull/2125)
+  adds an `asset_type` field to `TransferInput` and `TransferOutput`.
+  Affects `ListTransfers` and the `transfer` field embedded in
+  `SendEvent`, allowing clients to distinguish grouped fungible assets from
+  grouped collectible assets.
+
+- [PR#2126](https://github.com/lightninglabs/taproot-assets/pull/2126)
+  adds an `asset_type` field to `AssetBurn`. Affects `ListBurns`, allowing
+  clients to distinguish grouped fungible burns from grouped collectible
+  burns.
+
+## tapcli Updates
+
+- [PR#1995](https://github.com/lightninglabs/taproot-assets/pull/1995)
+  adds `--limit`, `--offset`, and `--direction` flags to `tapcli assets list`
+  for pagination support. The direction defaults to descending order.
+
+- [PR#2100](https://github.com/lightninglabs/taproot-assets/pull/2100):
+  `tapcli universe leaves` now paginates automatically, fetching all
+  pages instead of silently truncating at 512 results.
+
+## Config Changes
+
+- [PR#1870](https://github.com/lightninglabs/taproot-assets/pull/1870)
+  removes the `proofs-per-universe` configuration option. A new option
+  `max-proof-cache-size` sets the proof cache limit in bytes and accepts
+  human-readable values such as `64MB`.
+
+- [PR#1905](https://github.com/lightninglabs/taproot-assets/pull/1905)
+  enables orphan UTXO sweeping by default. This automatically sweeps
+  tombstone and burn outputs when executing on-chain transactions. Set
+  `wallet.disable-sweep-orphan-utxos` to disable.
 
 - [PR#1962](https://github.com/lightninglabs/taproot-assets/pull/1962)
-  Add an integration test that exercises the PortfolioPilot RPC flow.
+  adds `experimental.rfq.portfoliopilotaddress` to configure an external
+  PortfolioPilot RPC server.
 
-- [PR#1915](https://github.com/lightninglabs/taproot-assets/pull/1915)
-  Add an integration test that verifies tapd stays running when V2 address
-  creation hits an unreachable mailbox courier with the upfront connection
-  check skipped, ensuring mailbox subscription failures do not crash tapd.
+- [PR#2020](https://github.com/lightninglabs/taproot-assets/pull/2020)
+  adds `universe.mbox-cleanup-interval` and
+  `universe.mbox-cleanup-check-timeout` to configure periodic cleanup of
+  auth mailbox messages whose claimed outpoints have been spent on chain.
 
-- [Forwarding History Integration Test](https://github.com/lightninglabs/taproot-assets/pull/1921):
-  New integration test `testForwardingEventHistory` verifies that forwarding events are
-  properly logged when routing asset payments.
+# Tooling and Documentation
 
-- [PR#2048](https://github.com/lightninglabs/taproot-assets/pull/2048):
-  Add unit, property-based, and integration tests for limit-order
-  constraint fields.
+- [PR#1962](https://github.com/lightninglabs/taproot-assets/pull/1962)
+  adds a basic PortfolioPilot RPC example under `docs/examples`.
 
-- [PR#2049](https://github.com/lightninglabs/taproot-assets/pull/2049):
-  Add unit, property-based, and integration tests for execution policy.
-
-- [PR#2050](https://github.com/lightninglabs/taproot-assets/pull/2050):
-  Add unit and integration tests for fill quantity negotiation,
-  including wire roundtrip, zero-normalisation, fill-vs-constraint
-  validation, sell-side FOK/IOC with fill caps, and responder
-  constraint rejection.
-
-- [PR#2053](https://github.com/lightninglabs/taproot-assets/pull/2053):
-  Add integration test for inline AddInvoice constraint fields
-  and for responder-side constraint validation (rate bound,
-  min fill, FOK/IOC acceptance and rejection across sub-tests).
-  Add sell-side constraint rejection unit tests for
-  TestResolveRequest.
-
-## Database
-
-- [forwards table](https://github.com/lightninglabs/taproot-assets/pull/1921):
-  New database table `forwards` stores historical forwarding events.
-
-- [PR#2023](https://github.com/lightninglabs/taproot-assets/pull/2023)
-  Add `DeleteUniverseLeaf` SQL query for single-leaf deletion from a
-  universe.
-
-- [PR#2050](https://github.com/lightninglabs/taproot-assets/pull/2050)
-  Add `accepted_max_amount` column to the `rfq_policies` table to
-  persist the negotiated fill quantity alongside HTLC policies.
-
-## Code Health
-
-## Tooling and Documentation
-
-- [Wallet Backup Format Spec](https://github.com/lightninglabs/taproot-assets/pull/1980):
-  Add `docs/backup.md` documenting the binary backup format, TLV schema,
+- [PR#1980](https://github.com/lightninglabs/taproot-assets/pull/1980)
+  adds `docs/backup.md` documenting the binary backup format, TLV schema,
   compact strip/rehydrate mechanism, stale detection flow, and RPC interface.
-
-- [PR#1962](https://github.com/lightninglabs/taproot-assets/pull/1962)
-  Add a basic PortfolioPilot RPC example under `docs/examples`.
 
 - [PR#2056](https://github.com/lightninglabs/taproot-assets/pull/2056)
   expands the example portfolio pilot with constraint enforcement,
   configurable fill caps, and live CoinGecko pricing.
 
-- [PR#2138](https://github.com/lightninglabs/taproot-assets/pull/2138)
-  Fix `tapcli:` annotations on `QueryAssetStats` and `QueryEvents` so generated
-  OpenAPI summaries match other RPCs and the public API docs list the correct
-  `tapcli universe stats assets` and `tapcli universe stats events` commands.


### PR DESCRIPTION
The v0.8.0 release notes were substantially revised on the release branch; this just backports them to main for posterity.