### PR TITLE
rpcserver: gate Universe RPC calls until the server is ready

### DIFF
--- a/rpcserver/readiness_test.go
+++ b/rpcserver/readiness_test.go
@@ -1,0 +1,232 @@
+package rpcserver
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/time/rate"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// captureRegistrar is a grpc.ServiceRegistrar that records the last
+// ServiceDesc it was asked to register, so a test can reach in and invoke the
+// (possibly wrapped) method handlers directly.
+type captureRegistrar struct {
+	desc *grpc.ServiceDesc
+	impl interface{}
+}
+
+// RegisterService records the descriptor and implementation.
+//
+// NOTE: This is part of the grpc.ServiceRegistrar interface.
+func (c *captureRegistrar) RegisterService(desc *grpc.ServiceDesc,
+	impl interface{}) {
+
+	c.desc = desc
+	c.impl = impl
+}
+
+// markReady flips the server's ready flag, mimicking what Start does once all
+// dependencies are wired up.
+func markReady(r *RPCServer) {
+	atomic.StoreInt32(&r.ready, 1)
+}
+
+// requireUnavailable asserts that the passed error is a gRPC Unavailable
+// status error.
+func requireUnavailable(t *testing.T, err error) {
+	t.Helper()
+
+	require.Error(t, err)
+	require.Equal(t, codes.Unavailable, status.Code(err))
+}
+
+// TestCheckReady asserts that checkReady gates calls on the ready flag,
+// returning an Unavailable status error until the server is marked ready.
+func TestCheckReady(t *testing.T) {
+	t.Parallel()
+
+	r := NewRPCServer()
+
+	// A freshly constructed server has not started, so the gate is closed.
+	requireUnavailable(t, r.checkReady())
+
+	// Once we flip the ready flag, the gate opens and the check is a noop.
+	markReady(r)
+	require.NoError(t, r.checkReady())
+}
+
+// TestReadyGatedRegistrarGatesHandlers asserts that every unary handler
+// registered through the readyGatedRegistrar is wrapped with the readiness
+// gate: before the server is ready the underlying handler is never reached and
+// the call fails with Unavailable, and after it is ready the call dispatches
+// through to the real handler.
+func TestReadyGatedRegistrarGatesHandlers(t *testing.T) {
+	t.Parallel()
+
+	r := NewRPCServer()
+
+	// The underlying handler records whether it ran and returns a sentinel
+	// value so we can tell a real dispatch apart from a gated rejection.
+	var handlerCalls int32
+	const sentinel = "dispatched"
+	innerHandler := func(_ interface{}, _ context.Context,
+		_ func(interface{}) error,
+		_ grpc.UnaryServerInterceptor) (interface{}, error) {
+
+		atomic.AddInt32(&handlerCalls, 1)
+		return sentinel, nil
+	}
+
+	// Register a one-method service through the gated registrar.
+	capture := &captureRegistrar{}
+	gated := newReadyGatedRegistrar(capture, r)
+	desc := &grpc.ServiceDesc{
+		ServiceName: "test.Service",
+		HandlerType: (*interface{})(nil),
+		Methods: []grpc.MethodDesc{
+			{
+				MethodName: "Method",
+				Handler:    innerHandler,
+			},
+		},
+	}
+	gated.RegisterService(desc, r)
+
+	require.NotNil(t, capture.desc)
+	require.Len(t, capture.desc.Methods, 1)
+
+	invoke := func() (interface{}, error) {
+		return capture.desc.Methods[0].Handler(
+			r, context.Background(), nil, nil,
+		)
+	}
+
+	// Before the server is ready, the gate rejects the call and the
+	// underlying handler is never reached.
+	resp, err := invoke()
+	requireUnavailable(t, err)
+	require.Nil(t, resp)
+	require.Equal(t, int32(0), atomic.LoadInt32(&handlerCalls))
+
+	// After the server is ready, the call dispatches through to the real
+	// handler.
+	markReady(r)
+	resp, err = invoke()
+	require.NoError(t, err)
+	require.Equal(t, sentinel, resp)
+	require.Equal(t, int32(1), atomic.LoadInt32(&handlerCalls))
+}
+
+// TestReadyGatedRegistrarDoesNotMutateDesc asserts that the gated registrar
+// wraps handlers on a copy of the ServiceDesc, leaving the caller's
+// (package-level, process-shared) descriptor untouched.
+func TestReadyGatedRegistrarDoesNotMutateDesc(t *testing.T) {
+	t.Parallel()
+
+	r := NewRPCServer()
+
+	var origCalled bool
+	origHandler := func(_ interface{}, _ context.Context,
+		_ func(interface{}) error,
+		_ grpc.UnaryServerInterceptor) (interface{}, error) {
+
+		origCalled = true
+		return nil, nil
+	}
+
+	desc := &grpc.ServiceDesc{
+		ServiceName: "test.Service",
+		Methods: []grpc.MethodDesc{
+			{MethodName: "Method", Handler: origHandler},
+		},
+	}
+
+	capture := &captureRegistrar{}
+	newReadyGatedRegistrar(capture, r).RegisterService(desc, r)
+
+	// The original descriptor must still point at the original handler, and
+	// the registrar must have handed the underlying server a different,
+	// wrapped descriptor.
+	require.NotSame(t, desc, capture.desc)
+	_, err := desc.Methods[0].Handler(r, context.Background(), nil, nil)
+	require.NoError(t, err)
+	require.True(t, origCalled)
+}
+
+// TestReadinessGateConcurrent exercises the gate from many goroutines while the
+// ready flag is flipped, asserting (under -race) that publishing readiness via
+// the atomic store is free of data races and that a gated handler never reaches
+// the underlying handler before the flag is set.
+func TestReadinessGateConcurrent(t *testing.T) {
+	t.Parallel()
+
+	r := NewRPCServer()
+
+	// The underlying handler dereferences the rate limiter, exactly like
+	// the real Universe handlers do. This is the original crash site: if
+	// the gate ever dispatches before the limiter is wired up, this
+	// panics on a nil pointer (and, lacking the atomic barrier, the race
+	// detector flags the read against the limiter write in the main
+	// goroutine).
+	innerHandler := func(_ interface{}, _ context.Context,
+		_ func(interface{}) error,
+		_ grpc.UnaryServerInterceptor) (interface{}, error) {
+
+		_ = r.proofQueryRateLimiter.Limit()
+		return nil, nil
+	}
+
+	capture := &captureRegistrar{}
+	desc := &grpc.ServiceDesc{
+		ServiceName: "test.Service",
+		Methods: []grpc.MethodDesc{
+			{MethodName: "Method", Handler: innerHandler},
+		},
+	}
+	newReadyGatedRegistrar(capture, r).RegisterService(desc, r)
+	handler := capture.desc.Methods[0].Handler
+
+	// Track how the calls resolved so we can assert on the main goroutine,
+	// since testify's FailNow is not safe to call from a spawned goroutine.
+	var dispatched, gated int32
+
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			// Either the gate rejects us (server not ready yet) or
+			// we dispatch after ready; both are valid, but we must
+			// never panic or trip the race detector.
+			_, err := handler(r, context.Background(), nil, nil)
+			switch {
+			case err == nil:
+				atomic.AddInt32(&dispatched, 1)
+			case status.Code(err) == codes.Unavailable:
+				atomic.AddInt32(&gated, 1)
+			default:
+				atomic.AddInt32(&gated, -1000)
+			}
+		}()
+	}
+
+	// Concurrently mark the server ready, just as Start would. The rate
+	// limiter must be initialized before the flag is set so that any
+	// handler observing ready also observes a non-nil limiter.
+	r.proofQueryRateLimiter = rate.NewLimiter(rate.Inf, 1)
+	markReady(r)
+
+	wg.Wait()
+
+	// Every call must have resolved to either a clean dispatch or an
+	// Unavailable rejection; no call may have produced any other error.
+	require.Equal(t, int32(50), dispatched+gated)
+	require.GreaterOrEqual(t, gated, int32(0))
+}

--- a/rpcserver/rpcserver.go
+++ b/rpcserver/rpcserver.go
@@ -265,8 +265,10 @@ func (r *RPCServer) Stop() error {
 
 	rpcsLog.Infof("Stopping Taproot Assets RPC Server")
 
-	// Flip the ready flag back off so that any call racing with shutdown is
+	// Flip the ready flag back off so that any call arriving after Stop is
 	// rejected with Unavailable rather than reaching a tearing-down server.
+	// In-flight calls that already passed the gate are not affected and
+	// finish against the tearing-down state on their own.
 	atomic.StoreInt32(&r.ready, 0)
 
 	close(r.quit)
@@ -315,8 +317,8 @@ func (r *RPCServer) checkReady() error {
 	}
 
 	return status.Error(
-		codes.Unavailable, "tapd is starting up, the RPC server is "+
-			"not yet ready to accept requests",
+		codes.Unavailable,
+		"the RPC server is not ready to accept requests",
 	)
 }
 

--- a/rpcserver/rpcserver.go
+++ b/rpcserver/rpcserver.go
@@ -80,6 +80,8 @@ import (
 	"golang.org/x/exp/maps"
 	"golang.org/x/time/rate"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 var (
@@ -207,6 +209,13 @@ type RPCServer struct {
 
 	proofQueryRateLimiter *rate.Limiter
 
+	// ready is an atomic flag that is set to 1 once Start has finished
+	// wiring up the server's dependencies (config, rate limiter, etc.). It
+	// gates the Universe RPC surface so that calls arriving before the
+	// server is fully initialized are rejected cleanly instead of panicking
+	// on a half-built server. See checkReady and readyGatedRegistrar.
+	ready int32
+
 	quit chan struct{}
 	wg   sync.WaitGroup
 }
@@ -236,6 +245,12 @@ func (r *RPCServer) Start(cfg *tapconfig.Config) error {
 		r.cfg.UniverseQueriesPerSecond, r.cfg.UniverseQueriesBurst,
 	)
 
+	// All of our dependencies are now wired up, so we can flip the ready
+	// flag. This must happen last: the atomic store also acts as the
+	// release barrier that publishes the writes above (config, rate
+	// limiter) to any handler goroutine that observes ready via checkReady.
+	atomic.StoreInt32(&r.ready, 1)
+
 	rpcsLog.Infof("Starting Taproot Assets RPC Server")
 
 	return nil
@@ -249,6 +264,10 @@ func (r *RPCServer) Stop() error {
 	}
 
 	rpcsLog.Infof("Stopping Taproot Assets RPC Server")
+
+	// Flip the ready flag back off so that any call racing with shutdown is
+	// rejected with Unavailable rather than reaching a tearing-down server.
+	atomic.StoreInt32(&r.ready, 0)
 
 	close(r.quit)
 
@@ -268,10 +287,95 @@ func (r *RPCServer) RegisterWithGrpcServer(
 	mintrpc.RegisterMintServer(registrar, r)
 	rfqrpc.RegisterRfqServer(registrar, r)
 	tchrpc.RegisterTaprootAssetChannelsServer(registrar, r)
-	unirpc.RegisterUniverseServer(registrar, r)
+
+	// The Universe service is reachable without a macaroon when public
+	// access is enabled, and in litd's integrated mode it is registered
+	// directly onto lnd's gRPC server. That means a Universe call can land
+	// on a handler before Start has wired up the server's dependencies,
+	// dereferencing a nil config or rate limiter and panicking the whole
+	// process. We register it through a gate that rejects calls with
+	// Unavailable until the server is ready, rather than gating each
+	// handler individually.
+	unirpc.RegisterUniverseServer(newReadyGatedRegistrar(registrar, r), r)
+
 	tapdevrpc.RegisterGrpcServer(registrar, r)
 
 	return nil
+}
+
+// checkReady returns a gRPC Unavailable error if the RPC server has not yet
+// finished starting up. Once Start has completed wiring up the server's
+// dependencies, this is a noop. It is the per-call equivalent of the rpcState
+// interceptor used in standalone mode, but works in litd's integrated mode
+// too, where tapd's handlers run under lnd's interceptor chain and so never see
+// tapd's own state interceptor.
+func (r *RPCServer) checkReady() error {
+	if atomic.LoadInt32(&r.ready) == 1 {
+		return nil
+	}
+
+	return status.Error(
+		codes.Unavailable, "tapd is starting up, the RPC server is "+
+			"not yet ready to accept requests",
+	)
+}
+
+// readyGatedRegistrar wraps a grpc.ServiceRegistrar so that every unary method
+// of a registered service is guarded by a readiness check. Calls that arrive
+// before the gate opens are rejected with the gate's error instead of reaching
+// a half-initialized handler.
+type readyGatedRegistrar struct {
+	grpc.ServiceRegistrar
+
+	gate func() error
+}
+
+// newReadyGatedRegistrar wraps the passed registrar so that all services
+// registered through it have their unary handlers gated on the RPC server's
+// readiness.
+func newReadyGatedRegistrar(registrar grpc.ServiceRegistrar,
+	r *RPCServer) *readyGatedRegistrar {
+
+	return &readyGatedRegistrar{
+		ServiceRegistrar: registrar,
+		gate:             r.checkReady,
+	}
+}
+
+// RegisterService wraps each of the service's unary method handlers with the
+// readiness gate before delegating to the underlying registrar.
+//
+// NOTE: This is part of the grpc.ServiceRegistrar interface.
+func (g *readyGatedRegistrar) RegisterService(desc *grpc.ServiceDesc,
+	impl interface{}) {
+
+	// Copy the descriptor so we don't mutate the package-level ServiceDesc
+	// shared by every server in the process.
+	gated := *desc
+	gated.Methods = make([]grpc.MethodDesc, len(desc.Methods))
+
+	for i, method := range desc.Methods {
+		// Capture the original handler for this method so the closure
+		// below dispatches to the right one.
+		handler := method.Handler
+
+		gated.Methods[i] = grpc.MethodDesc{
+			MethodName: method.MethodName,
+			Handler: func(srv interface{}, ctx context.Context,
+				dec func(interface{}) error,
+				interceptor grpc.UnaryServerInterceptor) (
+				interface{}, error) {
+
+				if err := g.gate(); err != nil {
+					return nil, err
+				}
+
+				return handler(srv, ctx, dec, interceptor)
+			},
+		}
+	}
+
+	g.ServiceRegistrar.RegisterService(&gated, impl)
 }
 
 // RegisterWithRestProxy registers the RPC server with the given rest proxy.


### PR DESCRIPTION
In this PR, we fix a nil pointer panic that can take down `litd` during
startup when tapd runs as an integrated subserver. The crash shows up as a
`SIGSEGV` inside `AssetRoots`, with the offending frame being a call into a
nil `proofQueryRateLimiter`:

```
rate.(*Limiter).WaitN(0x0, ...)
taproot-assets.(*rpcServer).AssetRoots(...) rpcserver.go:6209
...
lnd/rpcperms.(*InterceptorChain).MacaroonUnaryServerInterceptor(...)
universerpc._Universe_AssetRoots_Handler(...)
panic: runtime error: invalid memory address or nil pointer dereference
```

## What's actually going wrong

The limiter is only wired up in `RPCServer.Start`, so a Universe call that
lands before `Start` runs hits a nil limiter (and a nil `cfg` one line
later in `AssetRoots`). The question is how a call gets through that early
in the first place.

In standalone mode it can't. There, tapd owns its gRPC server and installs
its own `rpcperms` interceptor chain, whose `rpcState` interceptor bounces
every call with `ErrWaitingToStart` until `SetRPCActive` fires, and that
only happens after `Start` has already run. So tapd has exactly the "reject
calls until the server is up" mechanism you'd want, and it's an interceptor.

In litd's integrated mode that interceptor isn't in the path. tapd
registers its Universe service directly onto lnd's gRPC server (via
`RegisterGrpcSubserver`), so the handlers run under _lnd's_ interceptor
chain, not tapd's. You can see this in the stack trace: the only `rpcperms`
frames are `lnd/rpcperms`. lnd's state interceptor only knows about lnd's
own readiness, and lnd goes RPC-active as soon as its wallet is unlocked,
which can be well before the bundled tapd has finished starting. A client
hitting lnd's gRPC port in that window sails straight into the tapd handler.

litd does have a readiness gate of its own (`rpcProxy.checkSubSystemStarted`
-> `statusMgr.IsSystemReady`, returning `Unavailable`), but it only runs on
requests that go through litd's `rpcProxy`. A call that arrives on lnd's
port directly never touches it. The Universe service is especially exposed
here because it's reachable with no macaroon at all when public access is
enabled, which is exactly the kind of public universe deployment where this
was hit.

So the fix can't live in litd's proxy, and it can't be a tapd interceptor
either, since in subserver mode tapd doesn't own the server it's registered
on. It has to be something that travels with the handlers regardless of who
owns the gRPC server.

## The fix

In this PR, we add a readiness gate at the registration boundary, which is
the one chokepoint both modes share (`RegisterWithGrpcServer`). We flip an
atomic `ready` flag at the very end of `Start`, after `cfg` and the rate
limiter are in place. The atomic store does double duty as the release
barrier that publishes those writes to any handler goroutine that later
observes the flag, so a handler that sees `ready == 1` is guaranteed to see
a fully wired server.

We then register the Universe service through a small `readyGatedRegistrar`
that wraps each unary handler with a `checkReady` call, returning a clean
`codes.Unavailable` until the gate opens. Wrapping at registration covers
all 25 Universe methods at once instead of touching each handler, and it
works the same whether tapd owns the gRPC server or lnd does. The wrapper
copies the `ServiceDesc` so it never mutates the process-shared package-level
descriptor. The flag is also cleared in `Stop`, so a call racing with
shutdown gets `Unavailable` rather than a tearing-down server.

## Testing

The tests cover the gate reporting `Unavailable` until ready, the wrapped
registrar rejecting early calls and dispatching afterwards, and the wrapper
leaving the caller's shared `ServiceDesc` untouched. There's also a
concurrent test that hammers a gated handler from many goroutines while the
ready flag flips, with the handler dereferencing the rate limiter exactly
like the real Universe handlers do. Run under `-race`, it reproduces the
original nil deref when the gate is removed and confirms the atomic flag
correctly publishes the limiter once readiness is observed.

See each commit message for a detailed description w.r.t the incremental
changes.
