### PR TITLE
rfq: enforce nonzero asset rates on quote accept

### DIFF
--- a/rfq/manager.go
+++ b/rfq/manager.go
@@ -1383,7 +1383,7 @@ func EstimateAssetUnits(ctx context.Context, oracle PriceOracle,
 	// used as a divisor in downstream conversion arithmetic and
 	// must be non-zero.
 	rate := oracleRes.AssetRate.Rate
-	if rate.Coefficient.ToUint64() == 0 {
+	if rate.Coefficient.IsZero() {
 		return 0, fmt.Errorf("oracle returned empty asset rate")
 	}
 

--- a/rfq/manager.go
+++ b/rfq/manager.go
@@ -1379,11 +1379,11 @@ func EstimateAssetUnits(ctx context.Context, oracle PriceOracle,
 			oracleRes.Err.Error())
 	}
 
-	// Ensure the oracle returned a usable rate. A zero-valued
-	// BigIntFixedPoint has a nil coefficient, which would panic
-	// in downstream arithmetic.
+	// Ensure the oracle returned a usable rate. The coefficient is
+	// used as a divisor in downstream conversion arithmetic and
+	// must be non-zero.
 	rate := oracleRes.AssetRate.Rate
-	if rate.Coefficient == (rfqmath.BigInt{}) {
+	if rate.Coefficient.ToUint64() == 0 {
 		return 0, fmt.Errorf("oracle returned empty asset rate")
 	}
 

--- a/rfq/oracle.go
+++ b/rfq/oracle.go
@@ -360,7 +360,7 @@ func (r *RpcPriceOracle) QuerySellPrice(ctx context.Context,
 			return nil, err
 		}
 
-		if rate.Coefficient.ToUint64() == 0 {
+		if rate.Coefficient.IsZero() {
 			return nil, fmt.Errorf("asset rate unspecified")
 		}
 
@@ -501,7 +501,7 @@ func (r *RpcPriceOracle) QueryBuyPrice(ctx context.Context,
 			return nil, err
 		}
 
-		if rate.Coefficient.ToUint64() == 0 {
+		if rate.Coefficient.IsZero() {
 			return nil, fmt.Errorf("asset rate unspecified")
 		}
 

--- a/rfqmath/arithmetic.go
+++ b/rfqmath/arithmetic.go
@@ -256,6 +256,16 @@ func (b BigInt) Equals(other BigInt) bool {
 	return b.value.Cmp(other.value) == 0
 }
 
+// IsZero returns true if the integer is numerically zero. An
+// uninitialised BigInt (nil internal value) is treated as zero,
+// matching the zero-value semantics of the struct.
+func (b BigInt) IsZero() bool {
+	if b.value == nil {
+		return true
+	}
+	return b.value.Sign() == 0
+}
+
 // Gt returns true if the integer is greater than the other integer.
 func (b BigInt) Gt(other BigInt) bool {
 	return b.value.Cmp(other.value) == 1

--- a/rfqmath/arithmetic_test.go
+++ b/rfqmath/arithmetic_test.go
@@ -2,6 +2,7 @@ package rfqmath
 
 import (
 	"math"
+	"math/big"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -275,6 +276,26 @@ func TestArithmeticGoIntConstructor(t *testing.T) {
 	val := uint64(123)
 	a := NewGoInt[uint64](val)
 	require.Equal(t, val, a.value)
+}
+
+// TestBigIntIsZero tests that IsZero correctly identifies numerically
+// zero BigInts, including the zero-value struct and large coefficients
+// whose low 64 bits truncate to zero.
+func TestBigIntIsZero(t *testing.T) {
+	t.Parallel()
+
+	require.True(t, BigInt{}.IsZero(),
+		"zero-value BigInt should be zero")
+	require.True(t, NewBigIntFromUint64(0).IsZero(),
+		"BigInt constructed from 0 should be zero")
+	require.False(t, NewBigIntFromUint64(1).IsZero(),
+		"BigInt of 1 should not be zero")
+
+	// 2^64 has zero low 64 bits but is numerically non-zero; the
+	// ToUint64-based check would incorrectly flag this as zero.
+	twoPow64 := NewBigInt(new(big.Int).Lsh(big.NewInt(1), 64))
+	require.False(t, twoPow64.IsZero(),
+		"2^64 should not be flagged as zero")
 }
 
 // TestArithmeticIntConstructor tests the NewInt constructor for the BigInt.

--- a/rfqmsg/accept.go
+++ b/rfqmsg/accept.go
@@ -149,6 +149,21 @@ func (m *acceptWireMsgData) Validate() error {
 		return fmt.Errorf("expiry must be set to a future time")
 	}
 
+	// Both rate coefficients are used as divisors during conversion
+	// between asset units and milli-satoshis, so they must be
+	// non-zero.
+	inRate := m.InAssetRate.Val.IntoBigIntFixedPoint()
+	if inRate.Coefficient.ToUint64() == 0 {
+		return fmt.Errorf("in-asset rate coefficient must be " +
+			"non-zero")
+	}
+
+	outRate := m.OutAssetRate.Val.IntoBigIntFixedPoint()
+	if outRate.Coefficient.ToUint64() == 0 {
+		return fmt.Errorf("out-asset rate coefficient must be " +
+			"non-zero")
+	}
+
 	return nil
 }
 

--- a/rfqmsg/accept.go
+++ b/rfqmsg/accept.go
@@ -153,13 +153,13 @@ func (m *acceptWireMsgData) Validate() error {
 	// between asset units and milli-satoshis, so they must be
 	// non-zero.
 	inRate := m.InAssetRate.Val.IntoBigIntFixedPoint()
-	if inRate.Coefficient.ToUint64() == 0 {
+	if inRate.Coefficient.IsZero() {
 		return fmt.Errorf("in-asset rate coefficient must be " +
 			"non-zero")
 	}
 
 	outRate := m.OutAssetRate.Val.IntoBigIntFixedPoint()
-	if outRate.Coefficient.ToUint64() == 0 {
+	if outRate.Coefficient.IsZero() {
 		return fmt.Errorf("out-asset rate coefficient must be " +
 			"non-zero")
 	}

--- a/rfqmsg/accept_test.go
+++ b/rfqmsg/accept_test.go
@@ -131,6 +131,74 @@ func TestAcceptMsgDataEncodeDecode(t *testing.T) {
 		})
 	}
 
+	// Verify that Validate rejects a zero-coefficient asset rate.
+	t.Run("zero in-asset rate rejected", func(tt *testing.T) {
+		zeroRate := NewTlvFixedPointFromUint64(0, 0)
+		bad := acceptEncodeDecodeTC{
+			version:      V1,
+			id:           id,
+			expiry:       expiry,
+			sig:          randSig,
+			inAssetRate:  zeroRate,
+			outAssetRate: outAssetRate,
+		}
+		msgData := bad.MsgData()
+		err := msgData.Validate()
+		require.ErrorContains(tt, err, "in-asset rate")
+	})
+
+	t.Run("zero out-asset rate rejected", func(tt *testing.T) {
+		zeroRate := NewTlvFixedPointFromUint64(0, 0)
+		bad := acceptEncodeDecodeTC{
+			version:      V1,
+			id:           id,
+			expiry:       expiry,
+			sig:          randSig,
+			inAssetRate:  inAssetRate,
+			outAssetRate: zeroRate,
+		}
+		msgData := bad.MsgData()
+		err := msgData.Validate()
+		require.ErrorContains(tt, err, "out-asset rate")
+	})
+
+	// Validate after a wire round-trip must still reject a zero
+	// rate. Empty coefficient bytes decode to an allocated BigInt
+	// of value zero, so the rejection cannot rely on struct
+	// equality with a zero-value BigInt.
+	t.Run("decoded zero in-asset rate rejected", func(tt *testing.T) {
+		zeroRate := NewTlvFixedPointFromUint64(0, 0)
+		bad := acceptEncodeDecodeTC{
+			version:      V1,
+			id:           id,
+			expiry:       expiry,
+			sig:          randSig,
+			inAssetRate:  zeroRate,
+			outAssetRate: outAssetRate,
+		}
+		msgData := bad.MsgData()
+
+		// Bypass Encode (which itself calls Validate) by
+		// serialising the records directly.
+		var buf bytes.Buffer
+		records := []tlv.Record{
+			msgData.Version.Record(),
+			msgData.ID.Record(),
+			msgData.Expiry.Record(),
+			msgData.Sig.Record(),
+			msgData.InAssetRate.Record(),
+			msgData.OutAssetRate.Record(),
+		}
+		tlv.SortRecords(records)
+		stream, err := tlv.NewStream(records...)
+		require.NoError(tt, err)
+		require.NoError(tt, stream.Encode(&buf))
+
+		var decoded acceptWireMsgData
+		require.NoError(tt, decoded.Decode(&buf))
+		require.ErrorContains(tt, decoded.Validate(), "in-asset rate")
+	})
+
 	// Verify that a zero fill value on the wire is normalised to
 	// None during decode.
 	t.Run("zero max in-asset normalised to None", func(tt *testing.T) {


### PR DESCRIPTION
Patches acceptWireMsgData.Validate() to reject zero-coeff asset rates, per spec. Also replaces an ineffective struct-equality guard on an oracle response rate with the `ToUint64() == 0` pattern already used in rfq/oracle.go.