### PR TITLE
rfqmsg: bind incoming Accept to original Request peer

### DIFF
--- a/rfqmsg/accept.go
+++ b/rfqmsg/accept.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/lightninglabs/taproot-assets/fn"
+	"github.com/lightningnetwork/lnd/routing/route"
 	"github.com/lightningnetwork/lnd/tlv"
 )
 
@@ -277,16 +278,39 @@ func NewIncomingAcceptFromWire(wireMsg WireMessage,
 	}
 
 	// Use the corresponding request to determine the type of accept
-	// message.
+	// message. The wire-level sender must match the peer the original
+	// Request was sent to, so that an Accept is only ever associated
+	// with the session it belongs to.
 	switch typedRequest := request.(type) {
 	case *BuyRequest:
+		if typedRequest.MsgPeer() != wireMsg.Peer {
+			return nil, peerMismatchErr(
+				wireMsg.Peer, typedRequest.MsgPeer(),
+				msgData.ID.Val,
+			)
+		}
 		return newBuyAcceptFromWireMsg(wireMsg, msgData, *typedRequest)
 	case *SellRequest:
+		if typedRequest.MsgPeer() != wireMsg.Peer {
+			return nil, peerMismatchErr(
+				wireMsg.Peer, typedRequest.MsgPeer(),
+				msgData.ID.Val,
+			)
+		}
 		return newSellAcceptFromWireMsg(wireMsg, msgData, *typedRequest)
 	default:
 		return nil, fmt.Errorf("unknown request type for incoming "+
 			"accept message: %T", request)
 	}
+}
+
+// peerMismatchErr returns an error indicating that the wire-level
+// sender of an incoming response does not match the peer the original
+// Request was sent to.
+func peerMismatchErr(wirePeer, reqPeer route.Vertex, id ID) error {
+	return fmt.Errorf("incoming response peer %x does not match "+
+		"original request peer %x for ID %s",
+		wirePeer[:], reqPeer[:], id.String())
 }
 
 // Accept represents an RFQ quote accept message.

--- a/rfqmsg/accept_test.go
+++ b/rfqmsg/accept_test.go
@@ -5,7 +5,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/lightninglabs/taproot-assets/asset"
+	"github.com/lightninglabs/taproot-assets/fn"
 	"github.com/lightninglabs/taproot-assets/internal/test"
+	"github.com/lightninglabs/taproot-assets/rfqmath"
+	"github.com/lightningnetwork/lnd/routing/route"
 	"github.com/lightningnetwork/lnd/tlv"
 	"github.com/stretchr/testify/require"
 )
@@ -159,5 +163,74 @@ func TestAcceptMsgDataEncodeDecode(t *testing.T) {
 
 		// Zero should have been normalised away.
 		require.True(tt, decoded.MaxInAsset.IsNone())
+	})
+}
+
+// buildBuyAcceptWire constructs a wire-encoded buy Accept message
+// originating from sender, in response to request.
+func buildBuyAcceptWire(t *testing.T, sender route.Vertex,
+	request BuyRequest) WireMessage {
+
+	t.Helper()
+
+	rate := rfqmath.NewBigIntFixedPoint(42_000, 0)
+	assetRate := NewAssetRate(rate, time.Now().Add(time.Hour))
+	accept := NewBuyAcceptFromRequest(request, assetRate, fn.None[uint64]())
+
+	msgData, err := newAcceptWireMsgDataFromBuy(*accept)
+	require.NoError(t, err)
+
+	data, err := msgData.Bytes()
+	require.NoError(t, err)
+
+	return WireMessage{
+		Peer:    sender,
+		MsgType: MsgTypeAccept,
+		Data:    data,
+	}
+}
+
+// TestIncomingAcceptPeerBinding verifies that
+// NewIncomingAcceptFromWire only accepts an Accept whose wire-level
+// sender matches the peer the original Request was sent to.
+func TestIncomingAcceptPeerBinding(t *testing.T) {
+	t.Parallel()
+
+	requestPeer := route.Vertex{0x01}
+	otherPeer := route.Vertex{0x02}
+	spec := asset.NewSpecifierFromId(asset.ID{0xAA})
+
+	request, err := NewBuyRequest(
+		requestPeer, spec, 100, fn.None[uint64](),
+		fn.None[rfqmath.BigIntFixedPoint](),
+		fn.None[AssetRate](), "",
+		fn.None[ExecutionPolicy](),
+	)
+	require.NoError(t, err)
+
+	lookup := func(id ID) (OutgoingMsg, bool) {
+		if id != request.ID {
+			return nil, false
+		}
+		return request, true
+	}
+
+	t.Run("matching peer accepted", func(tt *testing.T) {
+		wire := buildBuyAcceptWire(tt, requestPeer, *request)
+
+		msg, err := NewIncomingAcceptFromWire(wire, lookup)
+		require.NoError(tt, err)
+
+		ba, ok := msg.(*BuyAccept)
+		require.True(tt, ok)
+		require.Equal(tt, requestPeer, ba.Peer)
+	})
+
+	t.Run("mismatched peer rejected", func(tt *testing.T) {
+		wire := buildBuyAcceptWire(tt, otherPeer, *request)
+
+		_, err := NewIncomingAcceptFromWire(wire, lookup)
+		require.ErrorContains(tt, err, "does not match original "+
+			"request peer")
 	})
 }

--- a/rfqmsg/messages.go
+++ b/rfqmsg/messages.go
@@ -248,7 +248,7 @@ func NewIncomingMsgFromWire(wireMsg WireMessage,
 	case MsgTypeAccept:
 		return NewIncomingAcceptFromWire(wireMsg, sessionLookup)
 	case MsgTypeReject:
-		return NewQuoteRejectFromWireMsg(wireMsg)
+		return NewQuoteRejectFromWireMsg(wireMsg, sessionLookup)
 	default:
 		return nil, ErrUnknownMessageType
 	}

--- a/rfqmsg/reject.go
+++ b/rfqmsg/reject.go
@@ -246,7 +246,12 @@ func NewReject(peer route.Vertex, requestId ID,
 }
 
 // NewQuoteRejectFromWireMsg instantiates a new instance from a wire message.
-func NewQuoteRejectFromWireMsg(wireMsg WireMessage) (*Reject, error) {
+// The session lookup is used to bind the incoming Reject to the peer the
+// original Request was sent to, so that an unsolicited or spoofed Reject
+// cannot terminate a session that belongs to a different counterparty.
+func NewQuoteRejectFromWireMsg(wireMsg WireMessage,
+	sessionLookup SessionLookup) (*Reject, error) {
+
 	// Ensure that the message type is a reject message.
 	if wireMsg.MsgType != MsgTypeReject {
 		return nil, fmt.Errorf("unable to create a reject message "+
@@ -265,6 +270,39 @@ func NewQuoteRejectFromWireMsg(wireMsg WireMessage) (*Reject, error) {
 	if msgData.Version.Val != latestRejectVersion {
 		return nil, fmt.Errorf("unsupported reject message version: %d",
 			msgData.Version.Val)
+	}
+
+	if sessionLookup == nil {
+		return nil, fmt.Errorf("RFQ session lookup function is " +
+			"required")
+	}
+
+	request, found := sessionLookup(msgData.ID.Val)
+	if !found {
+		return nil, fmt.Errorf("no outgoing request found for "+
+			"incoming reject message: %s", msgData.ID.Val.String())
+	}
+
+	// The wire-level sender must match the peer the original Request
+	// was sent to.
+	switch typedRequest := request.(type) {
+	case *BuyRequest:
+		if typedRequest.MsgPeer() != wireMsg.Peer {
+			return nil, peerMismatchErr(
+				wireMsg.Peer, typedRequest.MsgPeer(),
+				msgData.ID.Val,
+			)
+		}
+	case *SellRequest:
+		if typedRequest.MsgPeer() != wireMsg.Peer {
+			return nil, peerMismatchErr(
+				wireMsg.Peer, typedRequest.MsgPeer(),
+				msgData.ID.Val,
+			)
+		}
+	default:
+		return nil, fmt.Errorf("unknown request type for incoming "+
+			"reject message: %T", request)
 	}
 
 	return &Reject{

--- a/rfqmsg/reject_test.go
+++ b/rfqmsg/reject_test.go
@@ -4,7 +4,10 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/lightninglabs/taproot-assets/asset"
+	"github.com/lightninglabs/taproot-assets/fn"
 	"github.com/lightninglabs/taproot-assets/internal/test"
+	"github.com/lightninglabs/taproot-assets/rfqmath"
 	"github.com/lightningnetwork/lnd/routing/route"
 	"github.com/stretchr/testify/require"
 )
@@ -76,4 +79,73 @@ func TestRejectEncodeDecode(t *testing.T) {
 			)
 		})
 	}
+}
+
+// buildRejectWire constructs a wire-encoded Reject message originating
+// from sender, in response to a request with the given ID.
+func buildRejectWire(t *testing.T, sender route.Vertex, id ID) WireMessage {
+	t.Helper()
+
+	reject := NewReject(sender, id, ErrPriceOracleUnavailable)
+
+	data, err := reject.rejectWireMsgData.Bytes()
+	require.NoError(t, err)
+
+	return WireMessage{
+		Peer:    sender,
+		MsgType: MsgTypeReject,
+		Data:    data,
+	}
+}
+
+// TestIncomingRejectPeerBinding verifies that NewQuoteRejectFromWireMsg
+// only accepts a Reject whose wire-level sender matches the peer the
+// original Request was sent to.
+func TestIncomingRejectPeerBinding(t *testing.T) {
+	t.Parallel()
+
+	requestPeer := route.Vertex{0x01}
+	otherPeer := route.Vertex{0x02}
+	spec := asset.NewSpecifierFromId(asset.ID{0xAA})
+
+	request, err := NewBuyRequest(
+		requestPeer, spec, 100, fn.None[uint64](),
+		fn.None[rfqmath.BigIntFixedPoint](),
+		fn.None[AssetRate](), "",
+		fn.None[ExecutionPolicy](),
+	)
+	require.NoError(t, err)
+
+	lookup := func(id ID) (OutgoingMsg, bool) {
+		if id != request.ID {
+			return nil, false
+		}
+		return request, true
+	}
+
+	t.Run("matching peer accepted", func(tt *testing.T) {
+		wire := buildRejectWire(tt, requestPeer, request.ID)
+
+		reject, err := NewQuoteRejectFromWireMsg(wire, lookup)
+		require.NoError(tt, err)
+		require.Equal(tt, requestPeer, reject.Peer)
+	})
+
+	t.Run("mismatched peer rejected", func(tt *testing.T) {
+		wire := buildRejectWire(tt, otherPeer, request.ID)
+
+		_, err := NewQuoteRejectFromWireMsg(wire, lookup)
+		require.ErrorContains(tt, err, "does not match original "+
+			"request peer")
+	})
+
+	t.Run("missing session rejected", func(tt *testing.T) {
+		var unknownID ID
+		copy(unknownID[:], []byte{0xFF})
+
+		wire := buildRejectWire(tt, requestPeer, unknownID)
+
+		_, err := NewQuoteRejectFromWireMsg(wire, lookup)
+		require.ErrorContains(tt, err, "no outgoing request found")
+	})
 }


### PR DESCRIPTION
Previously, NewIncomingAcceptFromWire associated an Accept with a session purely by the session ID carried in the message, without checking that the wire-level sender was the same peer the original Request had been sent to.

The fix is to cross-check wireMsg.Peer against the Request's peer recorded at session open, and return an error on mismatch, so an Accept is only ever associated with the session it actually belongs to.