### PR TITLE
rfqmath: fail UnitsToMilliSatoshi on overflow

### DIFF
--- a/docs/examples/basic-portfolio-pilot/main.go
+++ b/docs/examples/basic-portfolio-pilot/main.go
@@ -340,7 +340,11 @@ func amountIsTransportable(amt uint64,
 			),
 			Scale: 0,
 		}
-		return rfqmath.UnitsToMilliSatoshi(units, rate) != 0
+		mSat, err := rfqmath.UnitsToMilliSatoshi(units, rate)
+		if err != nil {
+			return false
+		}
+		return mSat != 0
 	}
 
 	// Sell: msat → asset units.

--- a/itest/custom_channels/forward_bandwidth_test.go
+++ b/itest/custom_channels/forward_bandwidth_test.go
@@ -181,7 +181,8 @@ func testCustomChannelsForwardBandwidth(ctx context.Context,
 
 	oneUnit := uint64(1)
 	oneUnitFP := rfqmath.NewBigIntFixedPoint(oneUnit, 0)
-	oneUnitMilliSat := rfqmath.UnitsToMilliSatoshi(oneUnitFP, *rate)
+	oneUnitMilliSat, err := rfqmath.UnitsToMilliSatoshi(oneUnitFP, *rate)
+	require.NoError(t.t, err)
 
 	t.Logf("Got quote for %v asset units per BTC", rate)
 	msatPerUnit := float64(oneUnitMilliSat) / float64(oneUnit)

--- a/itest/custom_channels/helpers.go
+++ b/itest/custom_channels/helpers.go
@@ -1105,7 +1105,8 @@ func createAssetInvoice(t *testing.T, dstRfqPeer, dst *itest.IntegratedNode,
 		mSatPerUnit = float64(cfg.msats) / float64(units.ToUint64())
 	} else {
 		assetUnits := rfqmath.NewBigIntFixedPoint(assetAmount, 0)
-		numMSats := rfqmath.UnitsToMilliSatoshi(assetUnits, *rate)
+		numMSats, err := rfqmath.UnitsToMilliSatoshi(assetUnits, *rate)
+		require.NoError(t, err)
 		mSatPerUnit = float64(decodedInvoice.NumMsat) /
 			float64(assetAmount)
 
@@ -2343,7 +2344,8 @@ func createAssetHodlInvoice(t *testing.T, dstRfqPeer,
 	require.NoError(t, err)
 
 	assetUnits := rfqmath.NewBigIntFixedPoint(assetAmount, 0)
-	numMSats := rfqmath.UnitsToMilliSatoshi(assetUnits, *rate)
+	numMSats, err := rfqmath.UnitsToMilliSatoshi(assetUnits, *rate)
+	require.NoError(t, err)
 	mSatPerUnit := float64(decodedInvoice.NumMsat) / float64(assetAmount)
 
 	require.EqualValues(

--- a/rfq/marshal.go
+++ b/rfq/marshal.go
@@ -15,7 +15,8 @@ import (
 // MarshalAcceptedSellQuoteEvent marshals a peer accepted sell quote event to
 // its RPC representation.
 func MarshalAcceptedSellQuoteEvent(
-	event *PeerAcceptedSellQuoteEvent) *rfqrpc.PeerAcceptedSellQuote {
+	event *PeerAcceptedSellQuoteEvent) (*rfqrpc.PeerAcceptedSellQuote,
+	error) {
 
 	return MarshalAcceptedSellQuote(event.SellAccept)
 }
@@ -23,7 +24,7 @@ func MarshalAcceptedSellQuoteEvent(
 // MarshalAcceptedSellQuote marshals a peer accepted sell quote to its RPC
 // representation.
 func MarshalAcceptedSellQuote(
-	accept rfqmsg.SellAccept) *rfqrpc.PeerAcceptedSellQuote {
+	accept rfqmsg.SellAccept) (*rfqrpc.PeerAcceptedSellQuote, error) {
 
 	rpcAssetRate := &rfqrpc.FixedPoint{
 		Coefficient: accept.AssetRate.Rate.Coefficient.String(),
@@ -36,9 +37,13 @@ func MarshalAcceptedSellQuote(
 		accept.Request.PaymentMaxAmt, accept.AssetRate.Rate,
 	)
 
-	minTransportableMSat := rfqmath.MinTransportableMSat(
+	minTransportableMSat, err := rfqmath.MinTransportableMSat(
 		rfqmath.DefaultOnChainHtlcMSat, accept.AssetRate.Rate,
 	)
+	if err != nil {
+		return nil, fmt.Errorf("unable to compute minimum "+
+			"transportable mSat: %w", err)
+	}
 
 	quote := &rfqrpc.PeerAcceptedSellQuote{
 		Peer:                 accept.Peer.String(),
@@ -72,7 +77,7 @@ func MarshalAcceptedSellQuote(
 		},
 	)
 
-	return quote
+	return quote, nil
 }
 
 // MarshalAcceptedBuyQuote marshals a peer accepted buy quote to its RPC
@@ -192,8 +197,13 @@ func NewAddAssetSellOrderResponse(
 
 	switch e := event.(type) {
 	case *PeerAcceptedSellQuoteEvent:
+		acceptedQuote, err := MarshalAcceptedSellQuoteEvent(e)
+		if err != nil {
+			return nil, fmt.Errorf("unable to marshal accepted "+
+				"sell quote: %w", err)
+		}
 		resp.Response = &rfqrpc.AddAssetSellOrderResponse_AcceptedQuote{
-			AcceptedQuote: MarshalAcceptedSellQuoteEvent(e),
+			AcceptedQuote: acceptedQuote,
 		}
 		return resp, nil
 

--- a/rfq/order.go
+++ b/rfq/order.go
@@ -266,9 +266,13 @@ func (c *AssetSalePolicy) CheckHtlcCompliance(_ context.Context,
 	maxAssetAmount := rfqmath.NewBigIntFixedPoint(
 		c.MaxOutboundAssetAmount, 0,
 	)
-	policyMaxOutMsat := rfqmath.UnitsToMilliSatoshi(
+	policyMaxOutMsat, err := rfqmath.UnitsToMilliSatoshi(
 		maxAssetAmount, c.AskAssetRate,
 	)
+	if err != nil {
+		return fmt.Errorf("unable to convert max asset amount to "+
+			"mSat: %w", err)
+	}
 
 	if (c.CurrentAmountMsat + htlc.AmountOutMsat) > policyMaxOutMsat {
 		return fmt.Errorf("HTLC out amount is greater than the policy "+
@@ -518,9 +522,13 @@ func (c *AssetPurchasePolicy) CheckHtlcCompliance(ctx context.Context,
 	// Convert the inbound asset amount to millisatoshis and ensure that the
 	// outgoing HTLC amount is not more than the inbound asset amount.
 	assetAmtFp := new(rfqmath.BigIntFixedPoint).SetIntValue(assetAmt)
-	inboundAmountMSat := rfqmath.UnitsToMilliSatoshi(
+	inboundAmountMSat, err := rfqmath.UnitsToMilliSatoshi(
 		assetAmtFp, c.BidAssetRate,
 	)
+	if err != nil {
+		return fmt.Errorf("unable to convert inbound asset amount to "+
+			"mSat: %w", err)
+	}
 
 	if inboundAmountMSat < htlc.AmountOutMsat {
 		return fmt.Errorf("HTLC out amount is more than inbound "+
@@ -619,9 +627,13 @@ func (c *AssetPurchasePolicy) GenerateInterceptorResponse(
 	htlcAssetAmount := htlcRecord.Amounts.Val.Sum() + roundingCorrection
 
 	assetAmt := rfqmath.NewBigIntFixedPoint(htlcAssetAmount, 0)
-	incomingHtlcMsats := rfqmath.UnitsToMilliSatoshi(
+	incomingHtlcMsats, err := rfqmath.UnitsToMilliSatoshi(
 		assetAmt, c.BidAssetRate,
 	)
+	if err != nil {
+		return nil, fmt.Errorf("unable to convert incoming HTLC "+
+			"asset amount to mSat: %w", err)
+	}
 
 	return &lndclient.InterceptedHtlcResponse{
 		Action:         lndclient.InterceptorActionResumeModified,

--- a/rfq/portfolio_pilot.go
+++ b/rfq/portfolio_pilot.go
@@ -513,14 +513,19 @@ func checkAllConstraints(req rfqmsg.Request,
 // a non-zero result at the given rate. For buy requests (RateBoundCmp
 // == -1), the amount is in asset units and converts to msat. For sell
 // requests (RateBoundCmp == +1), the amount is in msat and converts
-// to asset units.
+// to asset units. An mSat overflow on the buy side is treated as
+// non-transportable.
 func amountIsTransportable(amt uint64,
 	rate rfqmath.BigIntFixedPoint, rateBoundCmp int) bool {
 
 	if rateBoundCmp < 0 {
 		// Buy: asset units → msat.
 		units := rfqmath.NewBigIntFixedPoint(amt, 0)
-		return rfqmath.UnitsToMilliSatoshi(units, rate) != 0
+		mSat, err := rfqmath.UnitsToMilliSatoshi(units, rate)
+		if err != nil {
+			return false
+		}
+		return mSat != 0
 	}
 
 	// Sell: msat → asset units.

--- a/rfqmath/arithmetic.go
+++ b/rfqmath/arithmetic.go
@@ -49,6 +49,10 @@ type Int[N any] interface {
 	// ToUint64 converts the integer to a uint64.
 	ToUint64() uint64
 
+	// ToUint64Checked converts the integer to a uint64, returning false
+	// when the value does not fit in a uint64.
+	ToUint64Checked() (uint64, bool)
+
 	// FromUint64 converts a uint64 to the integer type.
 	FromUint64(uint64) N
 }
@@ -115,6 +119,13 @@ func (b GoInt[T]) FromFloat(f float64) GoInt[T] {
 // ToUint64 converts the integer to a uint64.
 func (b GoInt[T]) ToUint64() uint64 {
 	return uint64(b.value)
+}
+
+// ToUint64Checked converts the integer to a uint64. The bool is always true
+// because GoInt's underlying type is an unsigned integer whose width is at
+// most that of uint64.
+func (b GoInt[T]) ToUint64Checked() (uint64, bool) {
+	return uint64(b.value), true
 }
 
 // FromUint64 converts a uint64 to the integer type.
@@ -226,6 +237,16 @@ func (b BigInt) FromUint64(u uint64) BigInt {
 // ToUint64 converts the integer to a uint64.
 func (b BigInt) ToUint64() uint64 {
 	return b.value.Uint64()
+}
+
+// ToUint64Checked converts the integer to a uint64, returning false when the
+// value does not fit in a uint64. ToUint64 returns the low 64 bits on
+// overflow; this variant reports the truncation instead.
+func (b BigInt) ToUint64Checked() (uint64, bool) {
+	if !b.value.IsUint64() {
+		return 0, false
+	}
+	return b.value.Uint64(), true
 }
 
 // Bytes returns the absolute value of b as a big-endian byte slice.

--- a/rfqmath/convert.go
+++ b/rfqmath/convert.go
@@ -1,6 +1,7 @@
 package rfqmath
 
 import (
+	"errors"
 	"math"
 
 	"github.com/btcsuite/btcd/btcutil"
@@ -8,6 +9,11 @@ import (
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwire"
 )
+
+// ErrMsatOverflow is returned when a computed milli-satoshi amount does not
+// fit in a uint64. Without this signal, lnwire.MilliSatoshi(BigInt.ToUint64())
+// would return the low 64 bits.
+var ErrMsatOverflow = errors.New("rfqmath: mSat amount exceeds uint64")
 
 var (
 	// DefaultOnChainHtlcSat is the default amount that we consider as the
@@ -84,7 +90,7 @@ func MilliSatoshiToUnits[N Int[N]](milliSat lnwire.MilliSatoshi,
 // integer type. For built-in integer types, oneBtcInMilliSat overflows.
 // We should remove the type generic or reformulate.
 func UnitsToMilliSatoshi[N Int[N]](assetUnits,
-	unitsPerBtc FixedPoint[N]) lnwire.MilliSatoshi {
+	unitsPerBtc FixedPoint[N]) (lnwire.MilliSatoshi, error) {
 
 	// We take the max of the target arithmetic scale and the given unit's
 	// scale, which is expected to be the asset's decimal display value.
@@ -109,10 +115,15 @@ func UnitsToMilliSatoshi[N Int[N]](assetUnits,
 
 	amtMsat := amtBTC.Mul(oneBtcInMilliSat)
 
-	// We did the computation in terms of the scaled integers, so no we'll
+	// We did the computation in terms of the scaled integers, so now we'll
 	// go back to a normal mSAT value scaling down to zero (no decimals)
-	// along the way.
-	return lnwire.MilliSatoshi(amtMsat.ScaleTo(0).ToUint64())
+	// along the way. Use the checked conversion so an amtMsat that does
+	// not fit in a uint64 returns an error rather than the low 64 bits.
+	v, ok := amtMsat.ScaleTo(0).ToUint64Checked()
+	if !ok {
+		return 0, ErrMsatOverflow
+	}
+	return lnwire.MilliSatoshi(v), nil
 }
 
 // MinTransportableUnits computes the minimum number of transportable units
@@ -163,14 +174,18 @@ func MinTransportableUnits(dustLimit lnwire.MilliSatoshi,
 // below this value would be uneconomical as the total amount sent would exceed
 // the total invoice amount.
 func MinTransportableMSat(dustLimit lnwire.MilliSatoshi,
-	rate BigIntFixedPoint) lnwire.MilliSatoshi {
+	rate BigIntFixedPoint) (lnwire.MilliSatoshi, error) {
 
 	// We can only transport at least one asset unit in an HTLC. And we
 	// always have to send out an HTLC with a BTC amount of 354 satoshi. So
 	// the minimum amount of milli-satoshi we can transport is 354,000 plus
 	// the milli-satoshi equivalent of a single asset unit.
 	oneAssetUnit := NewBigIntFixedPoint(1, 0)
-	return dustLimit + UnitsToMilliSatoshi(oneAssetUnit, rate)
+	oneUnitMSat, err := UnitsToMilliSatoshi(oneAssetUnit, rate)
+	if err != nil {
+		return 0, err
+	}
+	return dustLimit + oneUnitMSat, nil
 }
 
 // SatsPerAssetToAssetRate converts a satoshis per asset rate to an asset to

--- a/rfqmath/convert_test.go
+++ b/rfqmath/convert_test.go
@@ -129,7 +129,10 @@ func TestConvertFindDecimalDisplayBoundaries(t *testing.T) {
 				Scale:       0,
 			}.ScaleTo(uint8(decDisp))
 
-			mSatPerUsd := UnitsToMilliSatoshi(oneUsd, priceScaled)
+			mSatPerUsd, err := UnitsToMilliSatoshi(
+				oneUsd, priceScaled,
+			)
+			require.NoError(t, err)
 			unitsPerSat := MilliSatoshiToUnits(1000, priceScaled)
 
 			fmt.Printf("decimalDisplay: %d\t\t\t%v units = 1 USD, "+
@@ -466,7 +469,8 @@ func TestConvertMilliSatoshiToUnits(t *testing.T) {
 			units := MilliSatoshiToUnits(tc.invoiceAmount, tc.price)
 			require.Equal(t, tc.expectedUnits, units.ToUint64())
 
-			mSat := UnitsToMilliSatoshi(units, tc.price)
+			mSat, err := UnitsToMilliSatoshi(units, tc.price)
+			require.NoError(t, err)
 
 			diff := tc.invoiceAmount - mSat
 			require.LessOrEqual(t, diff, uint64(2), "mSAT diff")
@@ -477,9 +481,10 @@ func TestConvertMilliSatoshiToUnits(t *testing.T) {
 			minUnits := minUnitsFP.ScaleTo(0).ToUint64()
 			require.Equal(t, tc.expectedMinTransportUnits, minUnits)
 
-			minMSat := MinTransportableMSat(
+			minMSat, err := MinTransportableMSat(
 				DefaultOnChainHtlcMSat, tc.price,
 			)
+			require.NoError(t, err)
 			require.Equal(t, tc.expectedMinTransportMSat, minMSat)
 		})
 	}
@@ -549,14 +554,16 @@ func TestPriceOracleRateExample(t *testing.T) {
 	// equal to 1 dollar. Note that previously we said that
 	// 67,918.90 USD/BTC is equivalent to 1472 satoshi per USD.
 	assetAmount := NewBigIntFixedPoint(10_000, 0)
-	mSat := UnitsToMilliSatoshi(assetAmount, assetUnitsPerBtc)
+	mSat, err := UnitsToMilliSatoshi(assetAmount, assetUnitsPerBtc)
+	require.NoError(t, err)
 	require.EqualValues(t, 1472, mSat.ToSatoshis())
 
 	// The asset amount fixed point can have any scale and does not need to
 	// match the asset's decimal display. This is because the price oracle
 	// returns an asset units per BTC rate and not a dollar per BTC rate.
 	assetAmount = NewBigIntFixedPoint(10_000_000, 3)
-	mSat = UnitsToMilliSatoshi(assetAmount, assetUnitsPerBtc)
+	mSat, err = UnitsToMilliSatoshi(assetAmount, assetUnitsPerBtc)
+	require.NoError(t, err)
 	require.EqualValues(t, 1472, mSat.ToSatoshis())
 }
 
@@ -630,8 +637,14 @@ func TestAssetAmtScaleRedundant(t *testing.T) {
 
 		// Call UnitsToMilliSatoshi with both asset amount fixed-point
 		// numbers.
-		mSat1 := UnitsToMilliSatoshi(assetAmtZeroScale, assetRateFp)
-		mSat2 := UnitsToMilliSatoshi(assetAmtNonZeroScale, assetRateFp)
+		mSat1, err := UnitsToMilliSatoshi(
+			assetAmtZeroScale, assetRateFp,
+		)
+		require.NoError(t, err)
+		mSat2, err := UnitsToMilliSatoshi(
+			assetAmtNonZeroScale, assetRateFp,
+		)
+		require.NoError(t, err)
 
 		require.Equal(t, mSat1, mSat2)
 		require.Greater(t, uint64(mSat1), uint64(0))
@@ -699,9 +712,10 @@ func TestConvertUsdToJpy(t *testing.T) {
 		}.ScaleTo(6)
 
 		// Convert the USD to mSAT.
-		hundredUsdAsMilliSatoshi := UnitsToMilliSatoshi(
+		hundredUsdAsMilliSatoshi, err := UnitsToMilliSatoshi(
 			dollarUnits, tc.usdPrice,
 		)
+		require.NoError(t, err)
 
 		// Convert the mSAT to JPY.
 		usdAmountAsJpy := MilliSatoshiToUnits(
@@ -725,13 +739,15 @@ func TestConvertUsdToJpy(t *testing.T) {
 		_, _, mSatPerUsdUnit := calcLimits[BigInt](
 			tc.usdPrice.ScaleTo(2).ToUint64(), 6,
 		)
-		mSatPerUsd := UnitsToMilliSatoshi(oneUsd, tc.usdPrice)
+		mSatPerUsd, err := UnitsToMilliSatoshi(oneUsd, tc.usdPrice)
+		require.NoError(t, err)
 		usdUnitsPerSat := MilliSatoshiToUnits(1000, tc.usdPrice)
 
 		_, _, mSatPerJpyUnit := calcLimits[BigInt](
 			tc.jpyPrice.ScaleTo(0).ToUint64(), 4,
 		)
-		mSatPerJpy := UnitsToMilliSatoshi(oneJpy, tc.jpyPrice)
+		mSatPerJpy, err := UnitsToMilliSatoshi(oneJpy, tc.jpyPrice)
+		require.NoError(t, err)
 		jpyUnitsPerSat := MilliSatoshiToUnits(1000, tc.jpyPrice)
 
 		fmt.Printf("Satoshi per USD:\t\t\t\t%d\n"+
@@ -783,7 +799,8 @@ func testUnitsToMilliSatoshi[N Int[N]](t *rapid.T) {
 	unitsFP := FixedPointFromUint64[N](units, scale)
 	unitsPerBtcFP := FixedPointFromUint64[N](unitsPerBtc, scale)
 
-	result := UnitsToMilliSatoshi(unitsFP, unitsPerBtcFP)
+	result, err := UnitsToMilliSatoshi(unitsFP, unitsPerBtcFP)
+	require.NoError(t, err)
 
 	// If we recompute the value using pure floats, then we should be
 	// within a margin of error related to the scale: X = (U / Y) * M.
@@ -806,7 +823,8 @@ func testRoundTripConversion[N Int[N]](t *rapid.T) {
 	unitsPerBtcFP := FixedPointFromUint64[N](unitsPerBtc, scale)
 
 	units := MilliSatoshiToUnits(msat, unitsPerBtcFP)
-	msatResult := UnitsToMilliSatoshi(units, unitsPerBtcFP)
+	msatResult, err := UnitsToMilliSatoshi(units, unitsPerBtcFP)
+	require.NoError(t, err)
 
 	// TODO(roasbeef): should it also round up to the nearest sat on the
 	// other end?
@@ -814,6 +832,33 @@ func testRoundTripConversion[N Int[N]](t *rapid.T) {
 
 	// The round trip conversion should preserve the value.
 	require.InDelta(t, uint64(msat), uint64(msatResult), 1)
+}
+
+// TestUnitsToMilliSatoshiOverflow ensures that a rate/units pair whose
+// mSat result exceeds uint64 returns ErrMsatOverflow rather than the low
+// 64 bits.
+func TestUnitsToMilliSatoshiOverflow(t *testing.T) {
+	t.Parallel()
+
+	// A rate of 1 unit/BTC means each asset unit is worth 1e11 mSat.
+	// 1e8 units therefore yields 1e19 mSat, just under 2^64, but past
+	// ~1.8e8 the result overflows.
+	rate := NewBigIntFixedPoint(1, 0)
+
+	// Just below the overflow boundary: 2^64 / 1e11 ≈ 1.844e8 units.
+	safeUnits := NewBigIntFixedPoint(100_000_000, 0)
+	_, err := UnitsToMilliSatoshi(safeUnits, rate)
+	require.NoError(t, err)
+
+	// Comfortably above the overflow boundary.
+	overflowUnits := NewBigIntFixedPoint(1_000_000_000, 0)
+	_, err = UnitsToMilliSatoshi(overflowUnits, rate)
+	require.ErrorIs(t, err, ErrMsatOverflow)
+
+	// Massive units (uint64 max) at the same rate must also be caught.
+	maxUnits := NewBigIntFixedPoint(math.MaxUint64, 0)
+	_, err = UnitsToMilliSatoshi(maxUnits, rate)
+	require.ErrorIs(t, err, ErrMsatOverflow)
 }
 
 // TestConversionMsat tests key invariant properties of the conversion

--- a/rfqmath/fixed_point.go
+++ b/rfqmath/fixed_point.go
@@ -74,6 +74,12 @@ func (f FixedPoint[T]) ToUint64() uint64 {
 	return f.Coefficient.ToUint64()
 }
 
+// ToUint64Checked is the overflow-checked variant of ToUint64. The bool is
+// false when the coefficient does not fit in a uint64.
+func (f FixedPoint[T]) ToUint64Checked() (uint64, bool) {
+	return f.Coefficient.ToUint64Checked()
+}
+
 // ToFloat64 returns a float64 representation of the FixedPoint value.
 func (f FixedPoint[T]) ToFloat64() float64 {
 	floatStr := f.String()

--- a/rpcserver/rpcserver.go
+++ b/rpcserver/rpcserver.go
@@ -9371,10 +9371,19 @@ func (r *RPCServer) QueryPeerAcceptedQuotes(_ context.Context,
 	rpcBuyQuotes := fn.Map(
 		maps.Values(peerAcceptedBuyQuotes), rfq.MarshalAcceptedBuyQuote,
 	)
-	rpcSellQuotes := fn.Map(
-		maps.Values(peerAcceptedSellQuotes),
-		rfq.MarshalAcceptedSellQuote,
+
+	sellQuotes := maps.Values(peerAcceptedSellQuotes)
+	rpcSellQuotes := make(
+		[]*rfqrpc.PeerAcceptedSellQuote, 0, len(sellQuotes),
 	)
+	for _, q := range sellQuotes {
+		rpcQuote, err := rfq.MarshalAcceptedSellQuote(q)
+		if err != nil {
+			return nil, fmt.Errorf("unable to marshal accepted "+
+				"sell quote: %w", err)
+		}
+		rpcSellQuotes = append(rpcSellQuotes, rpcQuote)
+	}
 
 	return &rfqrpc.QueryPeerAcceptedQuotesResponse{
 		BuyQuotes:  rpcBuyQuotes,
@@ -9401,9 +9410,13 @@ func marshallRfqEvent(eventInterface fn.Event) (*rfqrpc.RfqEvent, error) {
 		}, nil
 
 	case *rfq.PeerAcceptedSellQuoteEvent:
-		rpcAcceptedQuote := rfq.MarshalAcceptedSellQuoteEvent(
+		rpcAcceptedQuote, err := rfq.MarshalAcceptedSellQuoteEvent(
 			event,
 		)
+		if err != nil {
+			return nil, fmt.Errorf("unable to marshal accepted "+
+				"sell quote event: %w", err)
+		}
 
 		sellQuoteEvent := &rfqrpc.PeerAcceptedSellQuoteEvent{
 			Timestamp:             uint64(timestamp),
@@ -9831,7 +9844,11 @@ func (r *RPCServer) SendPayment(req *tchrpc.SendPaymentRequest,
 
 		// Calculate the equivalent asset units for the given invoice
 		// amount based on the asset-to-BTC conversion rate.
-		sellOrder := rfq.MarshalAcceptedSellQuote(*quote)
+		sellOrder, err := rfq.MarshalAcceptedSellQuote(*quote)
+		if err != nil {
+			return fmt.Errorf("unable to marshal accepted sell "+
+				"quote: %w", err)
+		}
 
 		// paymentMaxAmt is the maximum amount that the counterparty is
 		// expected to pay. This is the amount that the invoice is
@@ -10157,7 +10174,13 @@ func checkOverpayment(quote *rfqrpc.PeerAcceptedSellQuote,
 	// the override flag.
 	if quote.AssetAmount == 0 {
 		oneUnit := rfqmath.NewBigIntFixedPoint(1, 0)
-		oneUnitAsMSat := rfqmath.UnitsToMilliSatoshi(oneUnit, *rateFP)
+		oneUnitAsMSat, err := rfqmath.UnitsToMilliSatoshi(
+			oneUnit, *rateFP,
+		)
+		if err != nil {
+			return fmt.Errorf("unable to convert one asset unit "+
+				"to mSat: %w", err)
+		}
 		return fmt.Errorf("rejecting payment of %v (invoice amount + "+
 			"user-defined routing fee limit), smallest payable "+
 			"amount with assets is equivalent to %v",
@@ -10776,9 +10799,13 @@ func validateInvoiceAmount(acceptedQuote *rfqrpc.PeerAcceptedBuyQuote,
 		maxFixedUnits := rfqmath.NewBigIntFixedPoint(
 			maxAmt, 0,
 		)
-		maxRoutableMsat := rfqmath.UnitsToMilliSatoshi(
+		maxRoutableMsat, err := rfqmath.UnitsToMilliSatoshi(
 			maxFixedUnits, *askAssetRate,
 		)
+		if err != nil {
+			return 0, fmt.Errorf("unable to convert max routable "+
+				"asset amount to mSat: %w", err)
+		}
 
 		if maxRoutableMsat <= invoiceAmtMsat {
 			return 0, fmt.Errorf("cannot create invoice for %v "+
@@ -10791,9 +10818,13 @@ func validateInvoiceAmount(acceptedQuote *rfqrpc.PeerAcceptedBuyQuote,
 		assetAmount := rfqmath.NewBigIntFixedPoint(invoiceUnits, 0)
 
 		// Calculate the invoice amount in msat.
-		newInvoiceAmtMsat = rfqmath.UnitsToMilliSatoshi(
+		newInvoiceAmtMsat, err = rfqmath.UnitsToMilliSatoshi(
 			assetAmount, *askAssetRate,
 		)
+		if err != nil {
+			return 0, fmt.Errorf("unable to convert invoice "+
+				"asset amount to mSat: %w", err)
+		}
 	}
 
 	// If the invoice is for an asset unit amount smaller than the minimal

--- a/tapchannel/aux_invoice_manager.go
+++ b/tapchannel/aux_invoice_manager.go
@@ -277,7 +277,13 @@ func (s *AuxInvoiceManager) handleInvoiceAccept(ctx context.Context,
 
 	htlcAssetAmount := htlc.Amounts.Val.Sum()
 	totalAssetAmt := rfqmath.NewBigIntFixedPoint(htlcAssetAmount, 0)
-	resp.AmtPaid = rfqmath.UnitsToMilliSatoshi(totalAssetAmt, *assetRate)
+	resp.AmtPaid, err = rfqmath.UnitsToMilliSatoshi(
+		totalAssetAmt, *assetRate,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("unable to convert HTLC asset "+
+			"amount to mSat: %w", err)
+	}
 
 	// If all previously accepted HTLC amounts plus the intercepted HTLC
 	// amount together add up to just about the asset invoice amount, then
@@ -299,9 +305,13 @@ func (s *AuxInvoiceManager) handleInvoiceAccept(ctx context.Context,
 	marginAssetUnits := rfqmath.NewBigIntFixedPoint(
 		allowedMarginAssetUnits, 0,
 	)
-	allowedMarginMSat := rfqmath.UnitsToMilliSatoshi(
+	allowedMarginMSat, err := rfqmath.UnitsToMilliSatoshi(
 		marginAssetUnits, *assetRate,
 	)
+	if err != nil {
+		return nil, fmt.Errorf("unable to convert margin asset "+
+			"units to mSat: %w", err)
+	}
 
 	// Every HTLC makes a roundtrip from msats to units and then back to
 	// msats right here. Above we account for the asset units that may have

--- a/tapchannel/aux_invoice_manager_test.go
+++ b/tapchannel/aux_invoice_manager_test.go
@@ -288,9 +288,10 @@ func (m *mockHtlcModifierProperty) HtlcModifier(ctx context.Context,
 		htlcAssets := htlc.Amounts.Val.Sum()
 		totalAssetAmount := rfqmath.NewBigIntFixedPoint(htlcAssets, 0)
 
-		amtPaid := rfqmath.UnitsToMilliSatoshi(
+		amtPaid, err := rfqmath.UnitsToMilliSatoshi(
 			totalAssetAmount, assetRate,
 		)
+		require.NoError(m.t, err)
 
 		acceptedMsat := lnwire.MilliSatoshi(0)
 		for _, htlc := range r.Invoice.Htlcs {
@@ -302,9 +303,10 @@ func (m *mockHtlcModifierProperty) HtlcModifier(ctx context.Context,
 
 		marginAssetUnits := rfqmath.NewBigIntFixedPoint(marginHtlcs, 0)
 
-		marginMsat := rfqmath.UnitsToMilliSatoshi(
+		marginMsat, err := rfqmath.UnitsToMilliSatoshi(
 			marginAssetUnits, assetRate,
 		)
+		require.NoError(m.t, err)
 
 		totalMsatIn := marginMsat + amtPaid + acceptedMsat + 1
 

--- a/tapchannel/aux_traffic_shaper.go
+++ b/tapchannel/aux_traffic_shaper.go
@@ -402,9 +402,13 @@ func (s *AuxTrafficShaper) paymentBandwidthRFQ(rfqID rfqmsg.ID,
 	// Calculate the local available balance in the local asset unit,
 	// expressed in milli-satoshis.
 	localBalanceFp := rfqmath.NewBigIntFixedPoint(localBalance, 0)
-	availableBalanceMsat := rfqmath.UnitsToMilliSatoshi(
+	availableBalanceMsat, err := rfqmath.UnitsToMilliSatoshi(
 		localBalanceFp, rate.Rate,
 	)
+	if err != nil {
+		return 0, fmt.Errorf("unable to convert local balance to "+
+			"mSat: %w", err)
+	}
 
 	// At this point we have acquired what we need to express the asset
 	// bandwidth expressed in satoshis. Before we return the result, we need

--- a/tapchannel/aux_traffic_shaper_test.go
+++ b/tapchannel/aux_traffic_shaper_test.go
@@ -27,7 +27,8 @@ func TestUnitConversionTolerance(t *testing.T) {
 	t.Logf("Initial amount in asset units: %d", invoiceAmtUnits)
 
 	assetAmountFP := rfqmath.NewBigIntFixedPoint(invoiceAmtUnits, 0)
-	invoiceAmtMsat := rfqmath.UnitsToMilliSatoshi(assetAmountFP, rate)
+	invoiceAmtMsat, err := rfqmath.UnitsToMilliSatoshi(assetAmountFP, rate)
+	require.NoError(t, err)
 
 	t.Logf("Invoice amount in msat: %d", invoiceAmtMsat)
 
@@ -47,22 +48,30 @@ func TestUnitConversionTolerance(t *testing.T) {
 		shardSizeUnit*numHTLCs)
 
 	shardSumFP := rfqmath.NewBigIntFixedPoint(shardSizeUnit*numHTLCs, 0)
-	inboundAmountMSat := rfqmath.UnitsToMilliSatoshi(shardSumFP, rate)
+	inboundAmountMSat, err := rfqmath.UnitsToMilliSatoshi(shardSumFP, rate)
+	require.NoError(t, err)
 
 	t.Logf("Inbound amount in msat: %d", inboundAmountMSat)
 	t.Logf("Total tolerance required in msat: %d",
 		invoiceAmtMsat-inboundAmountMSat)
 
 	marginAssetUnits := rfqmath.NewBigIntFixedPoint(numHTLCs, 0)
-	allowedMarginMSat := rfqmath.UnitsToMilliSatoshi(marginAssetUnits, rate)
+	allowedMarginMSat, err := rfqmath.UnitsToMilliSatoshi(
+		marginAssetUnits, rate,
+	)
+	require.NoError(t, err)
 
 	newMarginAssetUnits := rfqmath.NewBigIntFixedPoint(numHTLCs+1, 0)
-	newAllowedMarginMSat := rfqmath.UnitsToMilliSatoshi(
+	newAllowedMarginMSat, err := rfqmath.UnitsToMilliSatoshi(
 		newMarginAssetUnits, rate,
 	)
+	require.NoError(t, err)
 
-	proposedMargin := rfqmath.UnitsToMilliSatoshi(marginAssetUnits, rate) +
-		lnwire.MilliSatoshi(numHTLCs)
+	proposedMarginMSat, err := rfqmath.UnitsToMilliSatoshi(
+		marginAssetUnits, rate,
+	)
+	require.NoError(t, err)
+	proposedMargin := proposedMarginMSat + lnwire.MilliSatoshi(numHTLCs)
 
 	t.Logf("Old tolerance allowed in msat: %d", allowedMarginMSat)
 	t.Logf("New tolerance allowed in msat: %d", newAllowedMarginMSat)
@@ -87,9 +96,10 @@ func TestUnitConversionToleranceRapid(t *testing.T) {
 		}
 
 		assetAmountFP := rfqmath.NewBigIntFixedPoint(invoiceAmtUnits, 0)
-		invoiceAmtMsat := rfqmath.UnitsToMilliSatoshi(
+		invoiceAmtMsat, err := rfqmath.UnitsToMilliSatoshi(
 			assetAmountFP, rate,
 		)
+		require.NoError(t, err)
 
 		shardSizeMSat := invoiceAmtMsat / lnwire.MilliSatoshi(numHTLCs)
 		shardSizeFP := rfqmath.MilliSatoshiToUnits(shardSizeMSat, rate)
@@ -108,24 +118,29 @@ func TestUnitConversionToleranceRapid(t *testing.T) {
 		// shards. We go up to numHTLCS-1 because we want to add any
 		// leftovers to the last shard.
 		for range numHTLCs - 1 {
-			shardPartialSum := rfqmath.UnitsToMilliSatoshi(
+			shardPartialSum, err := rfqmath.UnitsToMilliSatoshi(
 				shardSizeFP, rate,
 			)
+			require.NoError(t, err)
 
 			inboundAmountMSat += shardPartialSum
 		}
 
 		// Make a single pass over the last shard, which may also carry
 		// the remainder of the payment amt.
-		lastShardMsat = rfqmath.UnitsToMilliSatoshi(lastShardFP, rate)
+		lastShardMsat, err = rfqmath.UnitsToMilliSatoshi(
+			lastShardFP, rate,
+		)
+		require.NoError(t, err)
 		inboundAmountMSat += lastShardMsat
 
 		allowedMarginUnits := rfqmath.NewBigIntFixedPoint(
 			numHTLCs, 0,
 		)
-		marginAmt := rfqmath.UnitsToMilliSatoshi(
+		marginAmt, err := rfqmath.UnitsToMilliSatoshi(
 			allowedMarginUnits, rate,
 		)
+		require.NoError(t, err)
 
 		marginAmt += lnwire.MilliSatoshi(numHTLCs)
 


### PR DESCRIPTION
rfqmath.UnitsToMilliSatoshi previously cast its BigInt result through big.Int.Uint64, which returns the low 64 bits when the value exceeds uint64. This silent narrowing is replaced with an explicit error so callers can react to results that don't fit.
