### PR TITLE
itest: wait for channel policy gossip in ListInvoices test

### DIFF
--- a/itest/custom_channels/helpers.go
+++ b/itest/custom_channels/helpers.go
@@ -846,6 +846,71 @@ func assertChannelOutboundPolicyKnown(t *testing.T, node *itest.IntegratedNode,
 	require.NoError(t, err)
 }
 
+// assertPeerPolicyKnown asserts that the peer's channel edge policy for the
+// given channel is visible in the viewer's graph. This is the condition that
+// AddInvoice's RFQ hop-hint construction (which runs on the invoice creator
+// and reads the inbound peer's policy) depends on.
+func assertPeerPolicyKnown(t *testing.T, viewer,
+	peer *itest.IntegratedNode, chanPoint *lnrpc.ChannelPoint) {
+
+	targetChanPoint, err := channelPointString(chanPoint)
+	require.NoError(t, err)
+
+	err = wait.NoError(func() error {
+		ctxb := context.Background()
+		ctxt, cancel := context.WithTimeout(ctxb, wait.DefaultTimeout)
+		defer cancel()
+
+		graphResp, err := viewer.DescribeGraph(
+			ctxt, &lnrpc.ChannelGraphRequest{
+				IncludeUnannounced: true,
+			},
+		)
+		if err != nil {
+			return err
+		}
+
+		for _, edge := range graphResp.Edges {
+			if edge.ChanPoint != targetChanPoint {
+				continue
+			}
+
+			switch peer.PubKeyStr {
+			case edge.Node1Pub:
+				if edge.Node1Policy == nil {
+					return fmt.Errorf("channel %v missing "+
+						"policy for %v in %v's graph",
+						targetChanPoint, peer.Cfg.Name,
+						viewer.Cfg.Name)
+				}
+
+				return nil
+
+			case edge.Node2Pub:
+				if edge.Node2Policy == nil {
+					return fmt.Errorf("channel %v missing "+
+						"policy for %v in %v's graph",
+						targetChanPoint, peer.Cfg.Name,
+						viewer.Cfg.Name)
+				}
+
+				return nil
+
+			default:
+				return fmt.Errorf(
+					"channel %v found but peer %v "+
+						"not part of edge",
+					targetChanPoint, peer.Cfg.Name,
+				)
+			}
+		}
+
+		return fmt.Errorf("channel %v not found in %v's graph",
+			targetChanPoint, viewer.Cfg.Name)
+	}, wait.DefaultTimeout)
+	require.NoError(t, err)
+}
+
 // assertChannelKnown asserts that the given channel point is known in the
 // node's graph.
 func assertChannelKnown(t *testing.T, node *itest.IntegratedNode,

--- a/itest/custom_channels/list_asset_rpcs_test.go
+++ b/itest/custom_channels/list_asset_rpcs_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/lightninglabs/taproot-assets/proof"
 	"github.com/lightninglabs/taproot-assets/taprpc/mintrpc"
 	tchrpc "github.com/lightninglabs/taproot-assets/taprpc/tapchannelrpc"
-	fn "github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/lnrpc/invoicesrpc"
 	"github.com/lightningnetwork/lnd/lntest/node"
@@ -100,14 +99,11 @@ func testCustomChannelsListInvoicesAndPayments(_ context.Context,
 	require.NoError(t.t, net.AssertNodeKnown(alice, bob))
 	require.NoError(t.t, net.AssertNodeKnown(bob, alice))
 
-	// Push a small keysend through the channel before Bob creates his
-	// invoice. AddInvoice's RFQ hop-hint construction needs the inbound
-	// channel policy from Alice's side; on a freshly-opened channel that
-	// edge update may not have been gossiped yet, and the keysend forces
-	// both sides to exchange policies.
-	sendAssetKeySendPayment(
-		t.t, alice, bob, 100, assetID, fn.None[int64](),
-	)
+	// AddInvoice runs on Bob and reads Alice's (inbound) policy via
+	// getInboundPolicy when constructing RFQ hop hints. On a freshly-opened
+	// channel that edge update may not have propagated to Bob's graph yet,
+	// so wait for it before proceeding.
+	assertPeerPolicyKnown(t.t, bob, alice, assetChanPoint)
 
 	// Create a plain BTC invoice on Alice. We never settle it, but we use
 	// it later to verify that tapd's ListInvoices filters out invoices
@@ -173,11 +169,10 @@ func testCustomChannelsListInvoicesAndPayments(_ context.Context,
 	waitForAssetChannelHtlcSettlement(t.t, alice, assetChanPoint)
 
 	// -----------------------------------------------------------------
-	// ListInvoices on Bob: Bob has four asset invoices: the warm-up
-	// keysend (auto-generated), the asset invoice we explicitly paid, the
-	// canceled hodl invoice, and the settled hodl invoice above. We locate
-	// the settled invoices by payment hash and verify their decoded asset
-	// metadata.
+	// ListInvoices on Bob: Bob has three asset invoices: the asset
+	// invoice we explicitly paid, the canceled hodl invoice, and the
+	// settled hodl invoice above. We locate the settled invoices by
+	// payment hash and verify their decoded asset metadata.
 	// -----------------------------------------------------------------
 	var bobInvoices *tchrpc.ListInvoicesResponse
 	err = wait.NoError(func() error {
@@ -228,7 +223,7 @@ func testCustomChannelsListInvoicesAndPayments(_ context.Context,
 	}, wait.DefaultTimeout)
 	require.NoError(t.t, err)
 
-	require.Len(t.t, bobInvoices.Invoices, 4)
+	require.Len(t.t, bobInvoices.Invoices, 3)
 	canceledInv := findAssetInvoice(t.t, bobInvoices, canceledHash[:])
 	require.Equal(t.t, lnrpc.Invoice_CANCELED, canceledInv.Invoice.State)
 	require.Empty(t.t, canceledInv.AssetAmounts)
@@ -289,10 +284,10 @@ func testCustomChannelsListInvoicesAndPayments(_ context.Context,
 	require.NotZero(t.t, aliceInvoices.LastIndexOffset)
 
 	// -----------------------------------------------------------------
-	// ListPayments on Alice: Alice has four asset payments, the warm-up
-	// keysend, the settled invoice payment, the canceled hodl payment, and
-	// the settled hodl payment. Include incomplete payments so the failed
-	// canceled hodl payment is returned.
+	// ListPayments on Alice: Alice has three asset payments, the settled
+	// invoice payment, the canceled hodl payment, and the settled hodl
+	// payment. Include incomplete payments so the failed canceled hodl
+	// payment is returned.
 	// -----------------------------------------------------------------
 	var alicePayments *tchrpc.ListPaymentsResponse
 	err = wait.NoError(func() error {
@@ -346,7 +341,7 @@ func testCustomChannelsListInvoicesAndPayments(_ context.Context,
 	}, wait.DefaultTimeout)
 	require.NoError(t.t, err)
 
-	require.Len(t.t, alicePayments.Payments, 4)
+	require.Len(t.t, alicePayments.Payments, 3)
 	canceledPayment := findAssetPayment(
 		t.t, alicePayments, hex.EncodeToString(canceledHash[:]),
 	)

--- a/itest/custom_channels/list_asset_rpcs_test.go
+++ b/itest/custom_channels/list_asset_rpcs_test.go
@@ -58,12 +58,17 @@ func testCustomChannelsListInvoicesAndPayments(_ context.Context,
 	// Mint a grouped asset on Alice (we use a group so we can verify that
 	// the response surfaces the tweaked group key alongside the tranche
 	// asset_id) and open an asset channel from Alice to Bob.
-	groupedAsset := *ccItestAsset
-	groupedAsset.NewGroupedAsset = true
+	groupedAsset := &mintrpc.MintAsset{
+		AssetType:       ccItestAsset.AssetType,
+		Name:            ccItestAsset.Name,
+		AssetMeta:       ccItestAsset.AssetMeta,
+		Amount:          ccItestAsset.Amount,
+		NewGroupedAsset: true,
+	}
 	mintedAssets := itest.MintAssetsConfirmBatch(
 		t.t, net.Miner, asTapd(alice),
 		[]*mintrpc.MintAssetRequest{
-			{Asset: &groupedAsset},
+			{Asset: groupedAsset},
 		},
 	)
 	cents := mintedAssets[0]


### PR DESCRIPTION
Fixes a flake observed in [this CI job](https://github.com/lightninglabs/taproot-assets/actions/runs/28193535578/job/83515488479), and also patches up an errant 'go vet' warning that was present.

Opus's justification for the keysend deletion:

> The keysend was being used as a side-channel to induce policy gossip.  The trouble: it was racing the very gossip it was meant to force — when the keysend fired too early, it failed with INSUFFICIENT_BALANCE (no policy → no route → routing thinks it can't get there → reports as a balance problem). That's the flake you saw on CI.
> 
> The new wait replaces a "fire-and-pray" workaround with a direct read of the exact precondition AddInvoice's getInboundPolicy consults: "Alice's policy is visible in Bob's graph." Once that's true, hop-hint construction will succeed deterministically; we no longer need a payment to force anything.
> 
> What we lost: nothing functional. The keysend wasn't asserting anything, wasn't part of the ListInvoices/ListPayments behavior being tested, and was just creating the auto-generated "warm-up" invoice/payment we then had to compensate for in the count assertions (the 4 → 3 change).  Dropping it actually simplifies the test surface.

