### PR TITLE
tapdb: evict all cached proofs for a universe on leaf write

### DIFF
--- a/docs/release-notes/release-notes-0.8.1.md
+++ b/docs/release-notes/release-notes-0.8.1.md
@@ -25,6 +25,10 @@
   fixes several failure modes in the handling of force-close sweep
   transactions that could leave transfers stuck in a pending state.
 
+- [PR#2180](https://github.com/lightninglabs/taproot-assets/pull/2180)
+  fixes a proof cache issue that could cause universe sync to fail for
+  groups receiving new issuances.
+
 # New Features
 
 ## Functional Enhancements

--- a/tapdb/multiverse.go
+++ b/tapdb/multiverse.go
@@ -836,9 +836,13 @@ func (b *MultiverseStore) UpsertProofLeaf(ctx context.Context,
 	uniProof.MultiverseRoot = multiverseRoot
 	uniProof.MultiverseInclusionProof = multiverseProof
 
-	// Invalidate the cache since we just updated the root.
+	// Invalidate the cache since we just updated the root. Every
+	// previously cached proof under this universe embeds the
+	// UniverseRoot at the time it was fetched; inserting a new leaf
+	// changes the root, so all sibling entries are now stale and
+	// must be evicted, not just the one we wrote.
 	b.rootNodeCache.wipeCache()
-	b.proofCache.RemoveLeafKeyProofs(id, key)
+	b.proofCache.RemoveUniverseProofs(id)
 	b.leafKeysCache.wipeCache(id.String())
 	b.syncerCache.addOrReplace(universe.Root{
 		ID:        id,
@@ -948,20 +952,21 @@ func (b *MultiverseStore) UpsertProofLeafBatch(ctx context.Context,
 		})
 	}
 
-	// Invalidate the root node cache for all the assets we just inserted.
-	idsToDelete := fn.NewSet(
-		fn.Map(items, func(item *universe.Item) universeIDKey {
-			return item.ID.String()
-		})...,
-	)
-
-	for id := range idsToDelete {
-		b.leafKeysCache.wipeCache(id)
-	}
-
+	// Invalidate the root node cache for all the assets we just
+	// inserted. Each insert changes the root of its universe tree,
+	// which invalidates the UniverseRoot snapshot embedded in every
+	// previously cached proof under that universe, so we evict by
+	// universe id rather than per leaf key.
+	seenIDs := make(map[universeIDKey]struct{}, len(items))
 	for idx := range items {
-		item := items[idx]
-		b.proofCache.RemoveLeafKeyProofs(item.ID, item.Key)
+		idStr := items[idx].ID.String()
+		if _, ok := seenIDs[idStr]; ok {
+			continue
+		}
+		seenIDs[idStr] = struct{}{}
+
+		b.leafKeysCache.wipeCache(idStr)
+		b.proofCache.RemoveUniverseProofs(items[idx].ID)
 	}
 
 	return nil
@@ -1070,9 +1075,12 @@ func (b *MultiverseStore) DeleteProofLeaf(ctx context.Context,
 		return "", dbErr
 	}
 
-	// Invalidate caches.
+	// Invalidate caches. Deleting any leaf changes the root of the
+	// universe tree, so every previously cached proof under this id
+	// now embeds a stale UniverseRoot and must be evicted, not just
+	// the entry for the leaf we deleted.
 	b.rootNodeCache.wipeCache()
-	b.proofCache.RemoveLeafKeyProofs(id, key)
+	b.proofCache.RemoveUniverseProofs(id)
 	b.leafKeysCache.wipeCache(id.String())
 	b.syncerCache.remove(id.Key())
 

--- a/tapdb/multiverse_cache.go
+++ b/tapdb/multiverse_cache.go
@@ -136,9 +136,13 @@ func (c *cachedProofs) Size() (uint64, error) {
 // newProofCache creates a new leaf proof cache.
 //
 // nolint: lll
-func newProofCache(totalCacheBytesSize uint64) *lru.Cache[UniverseProofKey, *cachedProofs] {
+func newProofCache(totalCacheBytesSize uint64,
+	onDelete lru.OnDeleteCallback[UniverseProofKey, *cachedProofs],
+) *lru.Cache[UniverseProofKey, *cachedProofs] {
+
 	return lru.NewCache[UniverseProofKey, *cachedProofs](
 		totalCacheBytesSize,
+		lru.WithDeleteCallback(onDelete),
 	)
 }
 
@@ -171,6 +175,22 @@ type universeProofCache struct {
 	// maxCacheByteSize is the maximum size of the cache in bytes.
 	maxCacheByteSize uint64
 
+	// writeMu serializes all write paths (insertProofs,
+	// RemoveLeafKeyProofs, RemoveUniverseProofs) so that the LRU and
+	// the byID secondary index stay coherent. The LRU's delete
+	// callback runs synchronously during the cache op that triggered
+	// it, on the same goroutine, so the callback inherits this lock
+	// and can mutate byID without taking it itself. Read paths
+	// (fetchProof) do not take writeMu.
+	writeMu sync.Mutex
+
+	// byID maps a universe id key to the set of leaf-key suffixes
+	// that are currently cached under that id. It is the secondary
+	// index that makes RemoveUniverseProofs O(k) in the number of
+	// cached leaves for the affected universe rather than O(N) in
+	// the total cache size.
+	byID map[universe.IdentifierKey]map[[32]byte]struct{}
+
 	// cache is the LRU cache for the proofs themselves.
 	cache *lru.Cache[UniverseProofKey, *cachedProofs]
 
@@ -179,23 +199,44 @@ type universeProofCache struct {
 
 // newUniverseProofCache creates a new proof cache.
 func newUniverseProofCache(maxCacheByteSize uint64) *universeProofCache {
-	cache := newProofCache(maxCacheByteSize)
+	p := &universeProofCache{
+		maxCacheByteSize: maxCacheByteSize,
+		byID: make(
+			map[universe.IdentifierKey]map[[32]byte]struct{},
+		),
+	}
+
+	// onDelete keeps the byID secondary index in sync with the LRU.
+	// It is invoked by the LRU for both explicit deletes and
+	// capacity evictions, synchronously on the caller's goroutine.
+	// Every write path holds writeMu before calling cache.Put or
+	// cache.Delete, so this callback never needs to lock byID
+	// itself.
+	onDelete := func(key UniverseProofKey, _ *cachedProofs) {
+		set, ok := p.byID[key.uniIDKey]
+		if !ok {
+			return
+		}
+
+		delete(set, key.leafKeyBytes)
+		if len(set) == 0 {
+			delete(p.byID, key.uniIDKey)
+		}
+	}
+
+	p.cache = newProofCache(maxCacheByteSize, onDelete)
 
 	// Formulate a callback function that returns the cache size in a
 	// human-readable format. This will be called by the cache logger to get
 	// the current cache size.
 	cacheSizeLogStr := func() string {
-		return humanize.Bytes(cache.Size())
+		return humanize.Bytes(p.cache.Size())
 	}
-	cacheLogger := newCacheLogger(
+	p.cacheLogger = newCacheLogger(
 		"universe_proofs", withCacheSizeFunc(cacheSizeLogStr),
 	)
 
-	return &universeProofCache{
-		maxCacheByteSize: maxCacheByteSize,
-		cache:            cache,
-		cacheLogger:      cacheLogger,
-	}
+	return p
 }
 
 // fetchProof reads the cached proof for the given ID and leaf key.
@@ -223,11 +264,27 @@ func (p *universeProofCache) insertProofs(id universe.Identifier,
 	log.Debugf("Storing proof(s) in cache (universe_id=%v, leaf_key=%v, "+
 		"count=%d)", id.StringForLog(), leafKey, len(proofs))
 
+	p.writeMu.Lock()
+	defer p.writeMu.Unlock()
+
 	proofVal := newCachedProofs(proofs)
 	if _, err := p.cache.Put(uniProofKey, &proofVal); err != nil {
 		log.Errorf("Unable to insert proof into universe proof "+
 			"cache: %v", err)
+		return
 	}
+
+	// Record the new entry in the secondary index. cache.Put above
+	// may have evicted older entries to make room; their onDelete
+	// callbacks ran synchronously under writeMu and already pruned
+	// byID, so the only mutation we need to make here is for the
+	// key we just inserted.
+	set, ok := p.byID[uniProofKey.uniIDKey]
+	if !ok {
+		set = make(map[[32]byte]struct{})
+		p.byID[uniProofKey.uniIDKey] = set
+	}
+	set[uniProofKey.leafKeyBytes] = struct{}{}
 }
 
 // RemoveUniverseProofs deletes all the proofs for the given universe ID.
@@ -235,15 +292,30 @@ func (p *universeProofCache) RemoveUniverseProofs(id universe.Identifier) {
 	log.Debugf("Removing universe proofs (universe_id=%s)",
 		id.StringForLog())
 
+	p.writeMu.Lock()
+	defer p.writeMu.Unlock()
+
 	targetIDKey := id.Key()
-	p.cache.Range(
-		func(key UniverseProofKey, proofs *cachedProofs) bool {
-			if key.uniIDKey == targetIDKey {
-				p.cache.Delete(key)
-			}
-			return true
-		},
-	)
+	set, ok := p.byID[targetIDKey]
+	if !ok {
+		return
+	}
+
+	// Snapshot the leaf keys before deleting, since each cache.Delete
+	// fires the onDelete callback which mutates byID[targetIDKey];
+	// iterating the map directly while it's being modified would be
+	// unsafe.
+	leafKeys := make([][32]byte, 0, len(set))
+	for lk := range set {
+		leafKeys = append(leafKeys, lk)
+	}
+
+	for _, lk := range leafKeys {
+		p.cache.Delete(UniverseProofKey{
+			uniIDKey:     targetIDKey,
+			leafKeyBytes: lk,
+		})
+	}
 }
 
 // RemoveLeafKeyProofs deletes all the proofs for the given universe ID and leaf
@@ -253,6 +325,9 @@ func (p *universeProofCache) RemoveLeafKeyProofs(id universe.Identifier,
 
 	log.Debugf("Removing leaf key proofs (universe_id=%s, leaf_key=%v)",
 		id.StringForLog(), leafKey)
+
+	p.writeMu.Lock()
+	defer p.writeMu.Unlock()
 
 	targetCacheKey := NewUniverseProofKey(id, leafKey)
 	p.cache.Delete(targetCacheKey)

--- a/tapdb/multiverse_cache_test.go
+++ b/tapdb/multiverse_cache_test.go
@@ -334,6 +334,97 @@ func TestUniverseProofCache(t *testing.T) {
 			t, humanize.Bytes(0), cache.cacheLogger.cacheSize(),
 		)
 	})
+
+	t.Run("secondary index stays in sync", func(t *testing.T) {
+		// Validate the byID secondary index against the LRU's
+		// own contents across the operations that mutate it:
+		// explicit removes (leaf and universe), capacity-driven
+		// evictions, and replace-in-place. The index is what
+		// makes RemoveUniverseProofs O(k) instead of O(N), so a
+		// drift between it and the LRU would silently regress
+		// to phantom entries or to leaves that escape eviction.
+		baseProofs := newTestUniverseProofs(t, 1)
+		proofSize := proofCacheEntrySize(t, baseProofs)
+		cache := newUniverseProofCache(proofSize * 2)
+
+		id1 := randUniverseID(t, false)
+		id2 := randUniverseID(t, false)
+		key1 := randLeafKey(t)
+		key2 := randLeafKey(t)
+		key3 := randLeafKey(t)
+
+		assertIndexMatchesCache := func() {
+			t.Helper()
+			cached := make(
+				map[UniverseProofKey]struct{},
+				cache.cache.Len(),
+			)
+			cache.cache.Range(
+				func(k UniverseProofKey,
+					_ *cachedProofs) bool {
+
+					cached[k] = struct{}{}
+					return true
+				},
+			)
+
+			var indexed int
+			for idKey, set := range cache.byID {
+				require.NotEmpty(
+					t, set, "empty per-id set "+
+						"should have been pruned",
+				)
+				for lk := range set {
+					indexed++
+					key := UniverseProofKey{
+						uniIDKey:     idKey,
+						leafKeyBytes: lk,
+					}
+					_, ok := cached[key]
+					require.True(t, ok,
+						"index has phantom "+
+							"entry for %v", key)
+				}
+			}
+			require.Equal(
+				t, len(cached), indexed,
+				"index missing entries present in LRU",
+			)
+		}
+
+		// Two inserts under id1 fill the cache to capacity.
+		cache.insertProofs(id1, key1, cloneProofSlice(baseProofs))
+		cache.insertProofs(id1, key2, cloneProofSlice(baseProofs))
+		assertIndexMatchesCache()
+
+		// A third insert under id2 evicts key1 (LRU tail). The
+		// onDelete callback must prune key1 from byID[id1].
+		cache.insertProofs(id2, key3, cloneProofSlice(baseProofs))
+		require.Nil(t, cache.fetchProof(id1, key1))
+		assertIndexMatchesCache()
+
+		// Replacing an existing key in place does not fire
+		// onDelete; the index should remain identical.
+		cache.insertProofs(id2, key3, cloneProofSlice(baseProofs))
+		assertIndexMatchesCache()
+
+		// RemoveUniverseProofs(id1) drops the remaining id1
+		// entry and its id-level set; id2 stays untouched.
+		cache.RemoveUniverseProofs(id1)
+		require.Nil(t, cache.fetchProof(id1, key2))
+		require.NotNil(t, cache.fetchProof(id2, key3))
+		_, present := cache.byID[id1.Key()]
+		require.False(
+			t, present, "byID set for id1 must be pruned "+
+				"after RemoveUniverseProofs",
+		)
+		assertIndexMatchesCache()
+
+		// Final RemoveLeafKeyProofs empties the cache.
+		cache.RemoveLeafKeyProofs(id2, key3)
+		require.Equal(t, 0, cache.cache.Len())
+		require.Empty(t, cache.byID)
+	})
 }
 
 func queryRoots(t *testing.T, multiverse *MultiverseStore,

--- a/tapdb/universe_test.go
+++ b/tapdb/universe_test.go
@@ -1810,3 +1810,86 @@ func TestDeleteProofLeafBothProofTypes(t *testing.T) {
 	_, err = db.FetchMultiverseRoot(ctx, transferNS)
 	require.ErrorIs(t, err, sql.ErrNoRows)
 }
+
+// TestProofCacheInvalidatesOnSiblingInsert verifies that inserting a
+// new leaf into a universe invalidates the cached UniverseRoot of any
+// previously cached sibling leaves under the same universe id. The
+// proof cache stores each leaf alongside the UniverseRoot snapshot it
+// was fetched at; if sibling inserts only evict their own cache entry,
+// callers reading a previously cached leaf get a stale UniverseRoot
+// that no longer matches the current tree. That stale root causes the
+// universe syncer's VerifyRoot check to fail, silently dropping the
+// leaf and surfacing as group-key-unknown errors downstream.
+func TestProofCacheInvalidatesOnSiblingInsert(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	db := NewTestDB(t)
+	id := randUniverseID(
+		t, true, withProofType(universe.ProofTypeIssuance),
+	)
+	baseUniverse, _ := newTestUniverseWithDb(db.BaseDB, id)
+	multiverse, _ := newTestMultiverseWithDb(t, db.BaseDB)
+
+	assetGen := asset.RandGenesis(t, asset.Normal)
+
+	// Insert the first leaf and prime the proof cache by reading it
+	// back through the multiverse store.
+	keyA := randLeafKey(t)
+	leafA := randMintingLeaf(t, assetGen, id.GroupKey)
+	_, err := multiverse.UpsertProofLeaf(ctx, id, keyA, &leafA, nil)
+	require.NoError(t, err)
+
+	primed, err := multiverse.FetchProofLeaf(ctx, id, keyA)
+	require.NoError(t, err)
+	require.Len(t, primed, 1)
+
+	// Snapshot the tree root after the first insert so we can verify
+	// the cached root really did capture this state.
+	rootAfterA, _, err := baseUniverse.RootNode(ctx)
+	require.NoError(t, err)
+	require.True(
+		t, mssmt.IsEqualNode(rootAfterA, primed[0].UniverseRoot),
+		"primed proof should embed the post-insert root",
+	)
+
+	// Insert a second leaf into the same universe. The tree's root
+	// must change, since every leaf contributes its sum to the root.
+	keyB := randLeafKey(t)
+	leafB := randMintingLeaf(t, assetGen, id.GroupKey)
+	_, err = multiverse.UpsertProofLeaf(ctx, id, keyB, &leafB, nil)
+	require.NoError(t, err)
+
+	rootAfterB, _, err := baseUniverse.RootNode(ctx)
+	require.NoError(t, err)
+	require.False(
+		t, mssmt.IsEqualNode(rootAfterA, rootAfterB),
+		"sanity: inserting leafB must change the tree root",
+	)
+
+	// Now re-fetch leafA through the multiverse store. With a correct
+	// cache invariant, the returned UniverseRoot must match the
+	// CURRENT tree root (rootAfterB), not the stale snapshot taken
+	// when leafA was first cached.
+	refetched, err := multiverse.FetchProofLeaf(ctx, id, keyA)
+	require.NoError(t, err)
+	require.Len(t, refetched, 1)
+
+	require.True(
+		t, mssmt.IsEqualNode(rootAfterB, refetched[0].UniverseRoot),
+		"refetched proof for leafA must embed the current "+
+			"universe root, not the snapshot from before "+
+			"leafB was inserted",
+	)
+
+	// The inclusion proof inside the refetched leaf must also
+	// reconstruct to the current root. This is the exact check the
+	// universe syncer's VerifyRoot performs against the root it
+	// fetched at the start of the sync; a stale UniverseRoot fails
+	// this and the leaf is silently dropped.
+	require.True(
+		t, refetched[0].VerifyRoot(rootAfterB),
+		"refetched proof for leafA must verify against the "+
+			"current universe root",
+	)
+}


### PR DESCRIPTION
Fixes an issue observed in the proof cache. Opus's summary:

> The proof cache stores each fetched leaf alongside the UniverseRoot that was current when the leaf was first read. Previously, upsert and delete paths in MultiverseStore only evicted the cache entry for the leaf being written, leaving every sibling under the same universe id holding a stale UniverseRoot that no longer matched the tree.
> 
> Universe sync then failed: the syncer would fetch the current root, then fetch each leaf and run VerifyRoot against that root. Cached siblings carrying old roots would fail VerifyRoot and get silently dropped, including the group anchor; the surviving leaves would later trip verifyGenesisGroupKey with "asset group is unknown" because the anchor was never inserted client-side.
> 
> The fix is to replace RemoveLeafKeyProofs with RemoveUniverseProofs in the upsert, batch upsert, and delete paths so every leaf's UniverseRoot snapshot under the affected universe is evicted, since any write changes the root that every cached proof embeds.

Also: the previous RemoveUniverseProofs was worst-case linear in the size of the entire cache. This PR also adds a secondary index such that RemoveUniverseProofs becomes O(k) in the size of the universe (i.e., the asset).