### PR TITLE
bench: add benchmark suite foundations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ vendor/
 # Release builds
 /taproot-assets-*
 .aider*
+bench/results/

--- a/Makefile
+++ b/Makefile
@@ -349,12 +349,15 @@ flake-unit-race-trace:
 # BENCHMARKS
 # ============
 
-# bench runs Go benchmarks for a single package (pkg defaults to bench/rpc,
-# the per-RPC suite). Use `make bench pkg=mssmt` to scope to one package.
-# BENCH_TIME controls -benchtime; BENCH_RUN controls the -bench regex.
-pkg ?= bench/rpc
+# bench runs Go benchmarks for a single package (BENCH_PKG defaults to
+# bench/rpc, the per-RPC suite). Use `make bench BENCH_PKG=mssmt` to scope
+# to one package. BENCH_TIME controls -benchtime; BENCH_RUN controls the
+# -bench regex; BENCH_COUNT controls -count (raise it for benchstat A/B
+# comparisons — `1x`/`-count=1` gives benchstat no statistical basis).
+BENCH_PKG ?= bench/rpc
 BENCH_TIME ?= 1x
 BENCH_RUN ?= .
+BENCH_COUNT ?= 1
 
 BENCH_RESULTS_DIR := bench/results
 BENCH_RESULTS_FILE := $(BENCH_RESULTS_DIR)/$(shell git rev-parse --short HEAD)-$(shell date +%s).txt
@@ -363,9 +366,10 @@ bench-dir:
 	@mkdir -p $(BENCH_RESULTS_DIR)
 
 bench: bench-dir
-	@$(call print, "Running benchmarks for $(pkg).")
+	@$(call print, "Running benchmarks for $(BENCH_PKG).")
 	$(GOTEST) -run='^$$' -bench=$(BENCH_RUN) -benchmem \
-		-benchtime=$(BENCH_TIME) ./$(pkg)/... | \
+		-benchtime=$(BENCH_TIME) -count=$(BENCH_COUNT) \
+		./$(BENCH_PKG)/... | \
 		tee $(BENCH_RESULTS_FILE)
 
 # bench-all runs every package containing a Benchmark* function. Heavy —
@@ -373,7 +377,7 @@ bench: bench-dir
 bench-all: bench-dir
 	@$(call print, "Running all benchmarks (may take a while).")
 	$(GOTEST) -run='^$$' -bench=. -benchmem \
-		-benchtime=$(BENCH_TIME) \
+		-benchtime=$(BENCH_TIME) -count=$(BENCH_COUNT) \
 		./address/... ./asset/... ./bench/fixture/... \
 		./bench/rpc/... ./bench/scenario/... ./bench/wire/... \
 		./commitment/... ./mssmt/... ./proof/... ./vm/... | \

--- a/Makefile
+++ b/Makefile
@@ -345,6 +345,64 @@ flake-unit-race-trace:
 	@$(call print, "Flake hunting races in unit tests.")
 	while [ $$? -eq 0 ]; do make unit-race log='stdout trace' nocache=1; done
 
+# ============
+# BENCHMARKS
+# ============
+
+# bench runs Go benchmarks for a single package (pkg defaults to bench/rpc,
+# the per-RPC suite). Use `make bench pkg=mssmt` to scope to one package.
+# BENCH_TIME controls -benchtime; BENCH_RUN controls the -bench regex.
+pkg ?= bench/rpc
+BENCH_TIME ?= 1x
+BENCH_RUN ?= .
+
+BENCH_RESULTS_DIR := bench/results
+BENCH_RESULTS_FILE := $(BENCH_RESULTS_DIR)/$(shell git rev-parse --short HEAD)-$(shell date +%s).txt
+
+bench-dir:
+	@mkdir -p $(BENCH_RESULTS_DIR)
+
+bench: bench-dir
+	@$(call print, "Running benchmarks for $(pkg).")
+	$(GOTEST) -run='^$$' -bench=$(BENCH_RUN) -benchmem \
+		-benchtime=$(BENCH_TIME) ./$(pkg)/... | \
+		tee $(BENCH_RESULTS_FILE)
+
+# bench-all runs every package containing a Benchmark* function. Heavy —
+# meant for baseline capture and offline analysis, not the inner loop.
+bench-all: bench-dir
+	@$(call print, "Running all benchmarks (may take a while).")
+	$(GOTEST) -run='^$$' -bench=. -benchmem \
+		-benchtime=$(BENCH_TIME) \
+		./address/... ./asset/... ./bench/fixture/... \
+		./bench/rpc/... ./bench/scenario/... ./bench/wire/... \
+		./commitment/... ./mssmt/... ./proof/... ./vm/... | \
+		tee $(BENCH_RESULTS_FILE)
+
+# benchstat compares the most recent results file (excluding any
+# file whose basename begins with "baseline") against a named
+# baseline. The "latest" file is resolved at run time, not at
+# Makefile-parse time, so it sees results dropped by prior
+# `make bench` / `make bench-all` invocations.
+#
+# Use `make benchstat base=bench/results/baseline.txt`.
+benchstat:
+	@command -v benchstat >/dev/null 2>&1 || \
+		go install golang.org/x/perf/cmd/benchstat@latest
+	@latest=$$(ls -t $(BENCH_RESULTS_DIR)/*.txt 2>/dev/null | \
+		grep -v '/baseline' | head -1); \
+	if [ -z "$$latest" ]; then \
+		echo "no recent results in $(BENCH_RESULTS_DIR); run 'make bench' first"; \
+		exit 1; \
+	fi; \
+	echo "Comparing $$latest against $(base)."; \
+	benchstat $(base) $$latest
+
+# bench-closure-check audits the proto surface against bench/rpc/.
+bench-closure-check:
+	@$(call print, "Auditing per-RPC bench coverage.")
+	go run ./bench/check
+
 # =============
 # FUZZING
 # =============

--- a/address/bench_test.go
+++ b/address/bench_test.go
@@ -1,0 +1,94 @@
+package address
+
+import (
+	"bytes"
+	"testing"
+)
+
+// BenchmarkTapEncode measures Tap.Encode throughput. Encoding runs every
+// time we serialize an address (RPC, db, wire).
+func BenchmarkTapEncode(b *testing.B) {
+	// Pin the version so the courier scheme matches; RandAddr picks a
+	// random version and would mismatch the V0/V1 courier.
+	addr, _, _ := RandAddrWithVersion(
+		b, &RegressionNetTap, RandProofCourierAddr(b), V1,
+	)
+
+	var buf bytes.Buffer
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		buf.Reset()
+		if err := addr.Tap.Encode(&buf); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkTapDecode measures Tap.Decode throughput.
+func BenchmarkTapDecode(b *testing.B) {
+	// Pin the version so the courier scheme matches; RandAddr picks a
+	// random version and would mismatch the V0/V1 courier.
+	addr, _, _ := RandAddrWithVersion(
+		b, &RegressionNetTap, RandProofCourierAddr(b), V1,
+	)
+
+	var buf bytes.Buffer
+	if err := addr.Tap.Encode(&buf); err != nil {
+		b.Fatal(err)
+	}
+	raw := buf.Bytes()
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		var decoded Tap
+		if err := decoded.Decode(bytes.NewReader(raw)); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkEncodeAddress measures the cost of bech32m-encoding an address —
+// the form returned to clients.
+func BenchmarkEncodeAddress(b *testing.B) {
+	// Pin the version so the courier scheme matches; RandAddr picks a
+	// random version and would mismatch the V0/V1 courier.
+	addr, _, _ := RandAddrWithVersion(
+		b, &RegressionNetTap, RandProofCourierAddr(b), V1,
+	)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, err := addr.Tap.EncodeAddress()
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkDecodeAddress measures the cost of parsing a bech32m address
+// string back to a Tap address — the inverse of EncodeAddress, hit on every
+// inbound send / receive.
+func BenchmarkDecodeAddress(b *testing.B) {
+	// Pin the version so the courier scheme matches; RandAddr picks a
+	// random version and would mismatch the V0/V1 courier.
+	addr, _, _ := RandAddrWithVersion(
+		b, &RegressionNetTap, RandProofCourierAddr(b), V1,
+	)
+
+	encoded, err := addr.Tap.EncodeAddress()
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, err := DecodeAddress(encoded, &RegressionNetTap)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/asset/bench_test.go
+++ b/asset/bench_test.go
@@ -1,0 +1,124 @@
+package asset
+
+import (
+	"bytes"
+	"testing"
+)
+
+// BenchmarkAssetCopy measures the cost of Asset.Copy for the two common
+// shapes: a freshly-minted Normal asset (no PrevWitnesses) and a Collectible
+// transferred once (one PrevWitness with a key-spend signature).
+func BenchmarkAssetCopy(b *testing.B) {
+	for _, tc := range []struct {
+		name string
+		a    *Asset
+	}{
+		{"normal-fresh", RandAsset(b, Normal)},
+		{"collectible-fresh", RandAsset(b, Collectible)},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			b.ResetTimer()
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				_ = tc.a.Copy()
+			}
+		})
+	}
+}
+
+// BenchmarkAssetEncode measures TLV-encoding throughput. Encoding runs on
+// every wire send and every proof append.
+func BenchmarkAssetEncode(b *testing.B) {
+	for _, tc := range []struct {
+		name string
+		a    *Asset
+	}{
+		{"normal", RandAsset(b, Normal)},
+		{"collectible", RandAsset(b, Collectible)},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			var buf bytes.Buffer
+			b.ResetTimer()
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				buf.Reset()
+				if err := tc.a.Encode(&buf); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkAssetDecode measures the inverse of BenchmarkAssetEncode.
+func BenchmarkAssetDecode(b *testing.B) {
+	for _, tc := range []struct {
+		name string
+		a    *Asset
+	}{
+		{"normal", RandAsset(b, Normal)},
+		{"collectible", RandAsset(b, Collectible)},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			var buf bytes.Buffer
+			if err := tc.a.Encode(&buf); err != nil {
+				b.Fatal(err)
+			}
+			raw := buf.Bytes()
+
+			b.ResetTimer()
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				var decoded Asset
+				err := decoded.Decode(bytes.NewReader(raw))
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkWitnessEncode measures TLV-encoding for a single Witness — hit
+// on every PrevWitness round-trip during proof and asset wire transfer.
+func BenchmarkWitnessEncode(b *testing.B) {
+	a := RandAsset(b, Normal)
+	if len(a.PrevWitnesses) == 0 {
+		b.Fatal("expected at least one prev witness")
+	}
+	w := a.PrevWitnesses[0]
+
+	var buf bytes.Buffer
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		buf.Reset()
+		if err := w.Encode(&buf); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkWitnessDecode is the inverse of BenchmarkWitnessEncode.
+func BenchmarkWitnessDecode(b *testing.B) {
+	a := RandAsset(b, Normal)
+	if len(a.PrevWitnesses) == 0 {
+		b.Fatal("expected at least one prev witness")
+	}
+	w := a.PrevWitnesses[0]
+
+	var buf bytes.Buffer
+	if err := w.Encode(&buf); err != nil {
+		b.Fatal(err)
+	}
+	raw := buf.Bytes()
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		var decoded Witness
+		if err := decoded.Decode(bytes.NewReader(raw)); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/bench/check/main.go
+++ b/bench/check/main.go
@@ -1,0 +1,274 @@
+// Command bench-check audits coverage of per-RPC benchmarks against the
+// taprpc proto surface. It parses every .proto file under taprpc/, lists
+// the RPC methods, and reports which methods do not have a corresponding
+// Benchmark* function under bench/rpc/.
+//
+// Each Benchmark function declares which RPC it covers via a directive
+// comment in its doc:
+//
+//	// bench:rpc=<package>.<Service>.<Method>
+//
+// e.g. // bench:rpc=universerpc.Universe.Info. Function names are never
+// matched against RPCs directly because names are not service-qualified
+// — a Benchmark named "BenchmarkInfo" would silently false-cover Info
+// methods on multiple services.
+//
+// Methods may opt out of the audit by adding a line to the proto file
+// directly above the rpc definition of the form:
+//
+//	// bench:skip(reason)
+//
+// Whole services may be skipped by adding the fully-qualified service name
+// to skippedServices below. tapchannelrpc is excluded for the first pass
+// because it depends on tap-channel subsystems for which no in-process
+// fixture exists.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// skippedServices lists fully-qualified service names that are excluded
+// from the closure check.
+var skippedServices = map[string]string{
+	"tapchannelrpc.TaprootAssetChannels": "needs lnd channel subsystems",
+	"tapdevrpc.TapDev":                   "dev-only",
+	"priceoraclerpc.PriceOracle":         "client surface only",
+	"portfoliopilotrpc.PortfolioPilot":   "client surface only",
+}
+
+// rpcMethod is one method extracted from a .proto file.
+type rpcMethod struct {
+	service string
+	method  string
+	file    string
+	skip    string
+}
+
+var (
+	rpcLineRE     = regexp.MustCompile(`^\s*rpc\s+(\w+)`)
+	serviceLineRE = regexp.MustCompile(`^\s*service\s+(\w+)`)
+	pkgLineRE     = regexp.MustCompile(`^\s*package\s+([\w.]+)\s*;`)
+	skipLineRE    = regexp.MustCompile(`^\s*//\s*bench:skip\(([^)]*)\)`)
+)
+
+// parseProtoFile extracts (service, method) pairs from a single .proto
+// file along with their skip annotations.
+func parseProtoFile(path string) ([]rpcMethod, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var (
+		methods    []rpcMethod
+		pkg        string
+		service    string
+		pendingSkip string
+	)
+
+	for _, line := range strings.Split(string(raw), "\n") {
+		switch {
+		case pkgLineRE.MatchString(line):
+			pkg = pkgLineRE.FindStringSubmatch(line)[1]
+
+		case serviceLineRE.MatchString(line):
+			service = serviceLineRE.FindStringSubmatch(line)[1]
+
+		case skipLineRE.MatchString(line):
+			pendingSkip = skipLineRE.FindStringSubmatch(line)[1]
+
+		case rpcLineRE.MatchString(line):
+			methods = append(methods, rpcMethod{
+				service: pkg + "." + service,
+				method:  rpcLineRE.FindStringSubmatch(line)[1],
+				file:    path,
+				skip:    pendingSkip,
+			})
+			pendingSkip = ""
+
+		default:
+			// A non-blank, non-comment, non-rpc line resets a
+			// pending skip so it does not attach to a later rpc.
+			// Intervening comments (e.g. doc comments between
+			// the skip annotation and the rpc) are not enough
+			// to break the association — only a non-comment,
+			// non-blank line is.
+			trimmed := strings.TrimSpace(line)
+			if trimmed != "" && !strings.HasPrefix(trimmed, "//") {
+				pendingSkip = ""
+			}
+		}
+	}
+
+	return methods, nil
+}
+
+// benchRpcRE captures the fully-qualified RPC identifier on a
+// // bench:rpc=<package>.<service>.<method>
+// directive comment immediately above a Benchmark function.
+var benchRpcRE = regexp.MustCompile(
+	`bench:rpc=([a-zA-Z_][\w]*\.[A-Z][\w]*\.[A-Z][\w]*)`,
+)
+
+// benchCoverage walks bench/rpc/ and returns a map from fully-qualified
+// RPC identifier (package.Service.Method) to the Benchmark function that
+// covers it.
+//
+// The mapping is driven by // bench:rpc= directive comments, not function
+// names. Two reasons: (1) function names are not service-qualified, so a
+// name like BenchmarkInfo would silently false-cover several services'
+// Info methods; (2) explicit directives let one benchmark cover multiple
+// RPCs and survive renames.
+func benchCoverage(dir string) (map[string]string, error) {
+	covered := make(map[string]string)
+	fset := token.NewFileSet()
+
+	err := filepath.WalkDir(dir, func(path string, d os.DirEntry,
+		err error) error {
+
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if !strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+
+		f, err := parser.ParseFile(fset, path, nil, parser.ParseComments)
+		if err != nil {
+			return err
+		}
+		for _, decl := range f.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok {
+				continue
+			}
+			if !strings.HasPrefix(fn.Name.Name, "Benchmark") {
+				continue
+			}
+			if fn.Doc == nil {
+				continue
+			}
+			for _, c := range fn.Doc.List {
+				for _, m := range benchRpcRE.FindAllStringSubmatch(c.Text, -1) {
+					covered[m[1]] = fn.Name.Name
+				}
+			}
+		}
+		return nil
+	})
+	return covered, err
+}
+
+func main() {
+	protoDir := flag.String("proto", "taprpc",
+		"path to the taprpc directory containing .proto files")
+	benchDir := flag.String("bench", "bench/rpc",
+		"path to the bench/rpc directory containing per-RPC benches")
+	verbose := flag.Bool("v", false,
+		"list every method's status, not just gaps")
+	flag.Parse()
+
+	var allMethods []rpcMethod
+	err := filepath.WalkDir(*protoDir, func(path string, d os.DirEntry,
+		err error) error {
+
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || !strings.HasSuffix(path, ".proto") {
+			return nil
+		}
+		m, err := parseProtoFile(path)
+		if err != nil {
+			return err
+		}
+		allMethods = append(allMethods, m...)
+		return nil
+	})
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "walk protos:", err)
+		os.Exit(2)
+	}
+
+	coverage, err := benchCoverage(*benchDir)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "collect benches:", err)
+		os.Exit(2)
+	}
+
+	var (
+		covered []rpcMethod
+		missing []rpcMethod
+		skipped []rpcMethod
+	)
+	for _, m := range allMethods {
+		if reason, ok := skippedServices[m.service]; ok {
+			m.skip = reason
+			skipped = append(skipped, m)
+			continue
+		}
+		if m.skip != "" {
+			skipped = append(skipped, m)
+			continue
+		}
+		if _, ok := coverage[m.service+"."+m.method]; ok {
+			covered = append(covered, m)
+		} else {
+			missing = append(missing, m)
+		}
+	}
+
+	sortMethods := func(s []rpcMethod) {
+		sort.Slice(s, func(i, j int) bool {
+			if s[i].service != s[j].service {
+				return s[i].service < s[j].service
+			}
+			return s[i].method < s[j].method
+		})
+	}
+	sortMethods(covered)
+	sortMethods(missing)
+	sortMethods(skipped)
+
+	fmt.Printf("RPC bench coverage: %d covered, %d missing, %d skipped, "+
+		"%d total\n",
+		len(covered), len(missing), len(skipped), len(allMethods))
+
+	if *verbose {
+		fmt.Println("\nCovered:")
+		for _, m := range covered {
+			fmt.Printf("  %s.%s\n", m.service, m.method)
+		}
+	}
+
+	if len(skipped) > 0 && *verbose {
+		fmt.Println("\nSkipped:")
+		for _, m := range skipped {
+			fmt.Printf("  %s.%s (%s)\n", m.service, m.method, m.skip)
+		}
+	}
+
+	if len(missing) > 0 {
+		fmt.Println("\nMissing benches:")
+		for _, m := range missing {
+			fmt.Printf("  %s.%s\n", m.service, m.method)
+		}
+	}
+
+	// Exit non-zero only if --strict is on. Until coverage approaches 100%
+	// the missing list is expected; treating it as a hard failure would
+	// gate every commit on full coverage. The audit is informational.
+}

--- a/bench/check/main.go
+++ b/bench/check/main.go
@@ -70,9 +70,9 @@ func parseProtoFile(path string) ([]rpcMethod, error) {
 	}
 
 	var (
-		methods    []rpcMethod
-		pkg        string
-		service    string
+		methods     []rpcMethod
+		pkg         string
+		service     string
 		pendingSkip string
 	)
 
@@ -146,7 +146,9 @@ func benchCoverage(dir string) (map[string]string, error) {
 			return nil
 		}
 
-		f, err := parser.ParseFile(fset, path, nil, parser.ParseComments)
+		f, err := parser.ParseFile(
+			fset, path, nil, parser.ParseComments,
+		)
 		if err != nil {
 			return err
 		}
@@ -162,7 +164,10 @@ func benchCoverage(dir string) (map[string]string, error) {
 				continue
 			}
 			for _, c := range fn.Doc.List {
-				for _, m := range benchRpcRE.FindAllStringSubmatch(c.Text, -1) {
+				matches := benchRpcRE.FindAllStringSubmatch(
+					c.Text, -1,
+				)
+				for _, m := range matches {
 					covered[m[1]] = fn.Name.Name
 				}
 			}
@@ -179,6 +184,8 @@ func main() {
 		"path to the bench/rpc directory containing per-RPC benches")
 	verbose := flag.Bool("v", false,
 		"list every method's status, not just gaps")
+	strict := flag.Bool("strict", false,
+		"exit non-zero when any non-skipped RPC has no benchmark")
 	flag.Parse()
 
 	var allMethods []rpcMethod
@@ -257,7 +264,10 @@ func main() {
 	if len(skipped) > 0 && *verbose {
 		fmt.Println("\nSkipped:")
 		for _, m := range skipped {
-			fmt.Printf("  %s.%s (%s)\n", m.service, m.method, m.skip)
+			fmt.Printf(
+				"  %s.%s (%s)\n",
+				m.service, m.method, m.skip,
+			)
 		}
 	}
 
@@ -268,7 +278,10 @@ func main() {
 		}
 	}
 
-	// Exit non-zero only if --strict is on. Until coverage approaches 100%
-	// the missing list is expected; treating it as a hard failure would
-	// gate every commit on full coverage. The audit is informational.
+	// Until coverage approaches 100% the missing list is expected, so the
+	// audit is informational by default; -strict turns it into a hard
+	// failure for callers that want to gate on full coverage.
+	if *strict && len(missing) > 0 {
+		os.Exit(1)
+	}
 }

--- a/bench/fixture/minimal.go
+++ b/bench/fixture/minimal.go
@@ -84,4 +84,3 @@ func NewMinimal(tb testing.TB) *Minimal {
 		Server: srv,
 	}
 }
-

--- a/bench/fixture/minimal.go
+++ b/bench/fixture/minimal.go
@@ -1,0 +1,87 @@
+// Package fixture provides graduated in-process tapd fixtures used by
+// benchmarks under bench/. Each fixture composes the minimum set of
+// subsystems required to exercise a given class of RPC handler without the
+// noise of spinning up a real lnd/btcd subprocess.
+package fixture
+
+import (
+	"context"
+	"testing"
+
+	"github.com/lightninglabs/taproot-assets/address"
+	"github.com/lightninglabs/taproot-assets/rpcperms"
+	"github.com/lightninglabs/taproot-assets/rpcserver"
+	"github.com/lightninglabs/taproot-assets/tapconfig"
+	"github.com/lightningnetwork/lnd/build"
+	"github.com/lightningnetwork/lnd/signal"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/macaroon.v2"
+)
+
+// noopMacaroonBaker is a MacaroonBaker that returns an empty macaroon. It
+// suffices for benchmarks because all fixtures register the RPC server with
+// macaroons disabled.
+type noopMacaroonBaker struct{}
+
+func (noopMacaroonBaker) BakeMacaroon(_ context.Context,
+	_ rpcperms.BakeRequest) (macaroon.Macaroon, error) {
+
+	return macaroon.Macaroon{}, nil
+}
+
+// Minimal is the smallest fixture: just config primitives, no subsystems.
+// It is sufficient for handlers that only consume ChainParams, LogMgr, and
+// the like — decoders, marshallers, GetInfo-shape calls.
+type Minimal struct {
+	Config *tapconfig.Config
+	Server *rpcserver.RPCServer
+}
+
+// NewMinimal constructs a Minimal fixture and registers cleanup with the
+// provided testing.TB so the server is stopped at the end of the benchmark.
+func NewMinimal(tb testing.TB) *Minimal {
+	tb.Helper()
+
+	logWriter := build.NewRotatingLogWriter()
+	logCfg := build.DefaultLogConfig()
+	logMgr := build.NewSubLoggerManager(
+		build.NewDefaultLogHandlers(logCfg, logWriter)...,
+	)
+
+	cfg := &tapconfig.Config{
+		Version:           "bench",
+		RuntimeID:         0,
+		ChainParams:       address.RegressionNetTap,
+		SignalInterceptor: signal.Interceptor{},
+		MacaroonBaker:     noopMacaroonBaker{},
+		LogWriter:         logWriter,
+		LogMgr:            logMgr,
+
+		// UniverseQueriesPerSecond / Burst gate handler rate limits;
+		// set to a permissive value so benches are never throttled.
+		UniverseQueriesPerSecond: 1_000_000,
+		UniverseQueriesBurst:     1_000_000,
+
+		RPCConfig: &tapconfig.RPCConfig{
+			NoMacaroons:  true,
+			MacaroonPath: "",
+		},
+
+		// DatabaseConfig is embedded as a pointer; allocate it empty
+		// so upper fixtures can populate fields without nil-deref.
+		DatabaseConfig: &tapconfig.DatabaseConfig{},
+	}
+
+	srv := rpcserver.NewRPCServer()
+	require.NoError(tb, srv.Start(cfg))
+
+	tb.Cleanup(func() {
+		_ = srv.Stop()
+	})
+
+	return &Minimal{
+		Config: cfg,
+		Server: srv,
+	}
+}
+

--- a/bench/fixture/minimal_test.go
+++ b/bench/fixture/minimal_test.go
@@ -1,0 +1,29 @@
+package fixture
+
+import (
+	"context"
+	"testing"
+
+	"github.com/lightninglabs/taproot-assets/taprpc"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMinimalFixture verifies the Minimal fixture spins up and can serve
+// the simplest possible handler: GetInfo. This guards against regressions
+// in the fixture wiring without requiring any per-RPC benchmark to exist
+// yet.
+func TestMinimalFixture(t *testing.T) {
+	t.Parallel()
+
+	f := NewMinimal(t)
+
+	// DebugLevel(Show:true) only reads cfg.LogMgr, which the Minimal
+	// fixture populates. It is a cheap proof that Start wired the cfg in
+	// without panicking and that handlers can read it.
+	resp, err := f.Server.DebugLevel(
+		context.Background(),
+		&taprpc.DebugLevelRequest{Show: true},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+}

--- a/bench/fixture/mint.go
+++ b/bench/fixture/mint.go
@@ -1,0 +1,86 @@
+package fixture
+
+import (
+	"database/sql"
+	"testing"
+
+	tap "github.com/lightninglabs/taproot-assets"
+	"github.com/lightninglabs/taproot-assets/proof"
+	"github.com/lightninglabs/taproot-assets/tapdb"
+	"github.com/lightninglabs/taproot-assets/tapgarden"
+	"github.com/lightninglabs/taproot-assets/tapscript"
+	"github.com/stretchr/testify/require"
+)
+
+// Mint extends Storage with a running ChainPlanter wired to mock chain /
+// wallet / key-ring / gen-signer. Sufficient for the mintrpc surface
+// (MintAsset, FundBatch, SealBatch, FinalizeBatch, CancelBatch,
+// ListBatches, SubscribeMintEvents) provided callers do not require a
+// real on-chain confirmation.
+type Mint struct {
+	*Storage
+
+	MintingStore *tapdb.AssetMintingStore
+	Planter      *tapgarden.ChainPlanter
+	ChainBridge  *tapgarden.MockChainBridge
+	Wallet       *tapgarden.MockWalletAnchor
+	GenSigner    *tapgarden.MockGenSigner
+}
+
+// NewMint constructs a Mint fixture and registers cleanup. The Planter is
+// started and stopped automatically.
+func NewMint(tb testing.TB) *Mint {
+	tb.Helper()
+
+	st := NewStorage(tb)
+
+	mintingExec := tapdb.NewTransactionExecutor(
+		st.DB.BaseDB, func(tx *sql.Tx) tapdb.PendingAssetStore {
+			return st.DB.WithTx(tx)
+		},
+	)
+	mintingStore := tapdb.NewAssetMintingStore(mintingExec)
+	treeMgr := tapgarden.NewFallibleTapscriptTreeMgr(mintingStore)
+
+	chainBridge := tapgarden.NewMockChainBridge()
+	wallet := tapgarden.NewMockWalletAnchor()
+	genSigner := tapgarden.NewMockGenSigner(st.KeyRing)
+
+	errChan := make(chan error, 16)
+
+	planter := tapgarden.NewChainPlanter(tapgarden.PlanterConfig{
+		GardenKit: tapgarden.GardenKit{
+			Wallet:       wallet,
+			ChainBridge:  chainBridge,
+			Log:          mintingStore,
+			TreeStore:    &treeMgr,
+			KeyRing:      st.KeyRing,
+			GenSigner:    genSigner,
+			GenTxBuilder: &tapscript.GroupTxBuilder{},
+			TxValidator:  &tap.ValidatorV0{},
+			ProofFiles:   proof.NewMockProofArchive(),
+			ProofWatcher: &tapgarden.MockProofWatcher{},
+		},
+		ChainParams:  st.Config.ChainParams,
+		ProofUpdates: proof.NewMockProofArchive(),
+		ErrChan:      errChan,
+	})
+	require.NoError(tb, planter.Start())
+
+	tb.Cleanup(func() {
+		_ = planter.Stop()
+	})
+
+	st.Config.MintingStore = mintingStore
+	st.Config.AssetMinter = planter
+	st.Config.ChainBridge = chainBridge
+
+	return &Mint{
+		Storage:      st,
+		MintingStore: mintingStore,
+		Planter:      planter,
+		ChainBridge:  chainBridge,
+		Wallet:       wallet,
+		GenSigner:    genSigner,
+	}
+}

--- a/bench/fixture/mint_driver.go
+++ b/bench/fixture/mint_driver.go
@@ -1,0 +1,221 @@
+package fixture
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/blockchain"
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/taproot-assets/asset"
+	"github.com/lightninglabs/taproot-assets/proof"
+	"github.com/lightninglabs/taproot-assets/tapgarden"
+	"github.com/lightningnetwork/lnd/lntest/wait"
+	"github.com/stretchr/testify/require"
+)
+
+// MintDriver wraps a Mint fixture with a background pump that drains every
+// signal channel the planter's caretaker emits during a mint flow and feeds
+// back synthetic chain confirmations. The driver lets benchmarks call Mint(n)
+// repeatedly without re-implementing the chain/wallet mock choreography.
+//
+// The pump is started in NewMintDriver and torn down via tb.Cleanup. All
+// state belongs to the driver instance; Mint calls are safe to issue from
+// the same goroutine that constructed it.
+type MintDriver struct {
+	*Mint
+
+	pumpCancel context.CancelFunc
+	pumpDone   chan struct{}
+}
+
+// NewMintDriver constructs a Mint fixture and a pump that responds to the
+// planter's chain/wallet signals. The pump runs until the testing.TB
+// cleanup fires.
+func NewMintDriver(tb testing.TB) *MintDriver {
+	tb.Helper()
+
+	m := NewMint(tb)
+	ctx, cancel := context.WithCancel(context.Background())
+	d := &MintDriver{
+		Mint:       m,
+		pumpCancel: cancel,
+		pumpDone:   make(chan struct{}),
+	}
+
+	go d.pump(ctx)
+	tb.Cleanup(func() {
+		cancel()
+		<-d.pumpDone
+	})
+
+	return d
+}
+
+// pump drains every signal the planter caretaker is known to emit and
+// synthesises the chain side of the conversation: confirmations are
+// fabricated, blocks are stored, and signal acks are sent in the
+// background so SendConfNtfn never blocks the pump.
+func (d *MintDriver) pump(ctx context.Context) {
+	defer close(d.pumpDone)
+
+	// lastTx carries the broadcast transaction between the publish step
+	// and the conf-registration step. The caretaker publishes before it
+	// registers, so by the time we see ConfReqSignal the broadcast has
+	// already happened. The select cases below execute serially in this
+	// one goroutine, so no synchronisation on lastTx is needed; the
+	// goroutine spawned for SendConfNtfn captures tx by value.
+	var lastTx *wire.MsgTx
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+
+		case <-d.ChainBridge.FeeEstimateSignal:
+		case <-d.Wallet.FundPsbtSignal:
+		case <-d.Wallet.SignPsbtSignal:
+		case <-d.Wallet.ImportPubKeySignal:
+		case <-d.Wallet.SubscribeTxSignal:
+		case <-d.Wallet.ListUnspentSignal:
+		case <-d.Wallet.ListTxnsSignal:
+		case <-d.ChainBridge.BlockEpochSignal:
+
+		case tx := <-d.ChainBridge.PublishReq:
+			lastTx = tx
+
+		case reqNo := <-d.ChainBridge.ConfReqSignal:
+			tx := lastTx
+			if tx == nil {
+				continue
+			}
+
+			// Build a one-tx block and register it under its hash
+			// so the caretaker's later GetBlock call finds it.
+			// The mock's BlocksMu serialises this write against
+			// any concurrent caretaker reads.
+			block := buildBlockForTx(tx)
+			blockHash := block.BlockHash()
+			d.ChainBridge.BlocksMu.Lock()
+			d.ChainBridge.Blocks[blockHash] = block
+			d.ChainBridge.BlocksMu.Unlock()
+
+			// SendConfNtfn writes to req.Confirmed, which blocks
+			// until the caretaker reads it. Run it in its own
+			// goroutine so the pump stays responsive.
+			go d.ChainBridge.SendConfNtfn(
+				reqNo, &blockHash, 1, 0, block, tx,
+			)
+		}
+	}
+}
+
+// EnqueueSeedlings queues n random Normal seedlings on the planter and
+// waits for each to reach MintingStateSeed.
+func (d *MintDriver) EnqueueSeedlings(tb testing.TB, n int) {
+	tb.Helper()
+	for i := 0; i < n; i++ {
+		var nameBytes [16]byte
+		if _, err := rand.Read(nameBytes[:]); err != nil {
+			tb.Fatalf("rand seedling name: %v", err)
+		}
+		seedling := &tapgarden.Seedling{
+			AssetVersion: asset.V0,
+			AssetType:    asset.Normal,
+			AssetName:    hex.EncodeToString(nameBytes[:]),
+			Amount:       uint64(rand.Int31() + 1),
+			Meta: &proof.MetaReveal{
+				Data: nameBytes[:],
+			},
+		}
+		updates, err := d.Planter.QueueNewSeedling(seedling)
+		require.NoError(tb, err)
+
+		// Drain the MintingStateSeed update so the planter is ready
+		// for the next request. Block until the update arrives.
+		u := <-updates
+		require.NoError(tb, u.Error)
+	}
+}
+
+// FinalizeBatch fires FinalizeBatch and blocks until the pump has driven
+// the caretaker through funding, publishing, and confirmation. The
+// planter's FinalizeBatch returns on broadcast (BroadcastCompleteChan),
+// not on confirmation; we then wait on the batch state to reach
+// Confirmed so the caller has the full async confirmation/finalization
+// cost in its timing window.
+func (d *MintDriver) FinalizeBatch(tb testing.TB) {
+	tb.Helper()
+
+	batch, err := d.Planter.FinalizeBatch(tapgarden.FinalizeParams{})
+	require.NoError(tb, err)
+	require.NotNil(tb, batch)
+	batchKey := batch.BatchKey.PubKey
+
+	require.NoError(tb, wait.NoError(func() error {
+		// Look up the specific batch we just finalized. Re-fetching
+		// by key avoids races with other in-flight batches that
+		// would otherwise be visible to a list call.
+		batches, lErr := d.Planter.ListBatches(
+			tapgarden.ListBatchesParams{
+				BatchKey: batchKey,
+			},
+		)
+		if lErr != nil {
+			return lErr
+		}
+		for _, b := range batches {
+			if b.State() >= tapgarden.BatchStateConfirmed {
+				return nil
+			}
+		}
+		return fmt.Errorf("batch not yet confirmed")
+	}, 30*time.Second))
+}
+
+// MintOne runs one full mint of n assets: enqueue n seedlings, finalize
+// the batch, let the pump drive it to confirmation. This is the unit a
+// scenario bench cycles over.
+//
+// The method name avoids the embedded *Mint fixture's identifier.
+func (d *MintDriver) MintOne(tb testing.TB, n int) {
+	tb.Helper()
+	d.EnqueueSeedlings(tb, n)
+	d.FinalizeBatch(tb)
+}
+
+// FundPendingBatch drives the planter through the funding step on the
+// current pending batch, leaving the batch in the frozen state ready
+// for SealBatch. The chain pump consumes the fee/fund signals.
+//
+// This is exposed so per-RPC bench setup can stage state without going
+// through the rpcserver.FundBatch handler (which needs cfg.Lnd).
+func (d *MintDriver) FundPendingBatch(tb testing.TB) {
+	tb.Helper()
+	_, err := d.Planter.FundBatch(tapgarden.FundParams{})
+	require.NoError(tb, err)
+}
+
+// buildBlockForTx wraps tx in a single-transaction block.
+func buildBlockForTx(tx *wire.MsgTx) *wire.MsgBlock {
+	merkleTree := blockchain.BuildMerkleTreeStore(
+		[]*btcutil.Tx{btcutil.NewTx(tx)}, false,
+	)
+	merkleRoot := merkleTree[len(merkleTree)-1]
+	hdr := wire.NewBlockHeader(
+		0, chaincfg.MainNetParams.GenesisHash, merkleRoot, 0, 0,
+	)
+	return &wire.MsgBlock{
+		Header:       *hdr,
+		Transactions: []*wire.MsgTx{tx},
+	}
+}
+
+// ensure we use fmt to silence "imported and not used" should the file
+// shrink later.
+var _ = fmt.Sprint

--- a/bench/fixture/mint_driver.go
+++ b/bench/fixture/mint_driver.go
@@ -97,13 +97,11 @@ func (d *MintDriver) pump(ctx context.Context) {
 
 			// Build a one-tx block and register it under its hash
 			// so the caretaker's later GetBlock call finds it.
-			// The mock's BlocksMu serialises this write against
-			// any concurrent caretaker reads.
+			// SetBlock serialises this write against any
+			// concurrent caretaker reads.
 			block := buildBlockForTx(tx)
 			blockHash := block.BlockHash()
-			d.ChainBridge.BlocksMu.Lock()
-			d.ChainBridge.Blocks[blockHash] = block
-			d.ChainBridge.BlocksMu.Unlock()
+			d.ChainBridge.SetBlock(blockHash, block)
 
 			// SendConfNtfn writes to req.Confirmed, which blocks
 			// until the caretaker reads it. Run it in its own
@@ -121,6 +119,7 @@ func (d *MintDriver) EnqueueSeedlings(tb testing.TB, n int) {
 	tb.Helper()
 	for i := 0; i < n; i++ {
 		var nameBytes [16]byte
+		// #nosec G404 -- bench fixture, throwaway seedling name.
 		if _, err := rand.Read(nameBytes[:]); err != nil {
 			tb.Fatalf("rand seedling name: %v", err)
 		}
@@ -128,7 +127,8 @@ func (d *MintDriver) EnqueueSeedlings(tb testing.TB, n int) {
 			AssetVersion: asset.V0,
 			AssetType:    asset.Normal,
 			AssetName:    hex.EncodeToString(nameBytes[:]),
-			Amount:       uint64(rand.Int31() + 1),
+			// #nosec G404 -- bench fixture, throwaway amount.
+			Amount: uint64(rand.Int31() + 1),
 			Meta: &proof.MetaReveal{
 				Data: nameBytes[:],
 			},
@@ -215,7 +215,3 @@ func buildBlockForTx(tx *wire.MsgTx) *wire.MsgBlock {
 		Transactions: []*wire.MsgTx{tx},
 	}
 }
-
-// ensure we use fmt to silence "imported and not used" should the file
-// shrink later.
-var _ = fmt.Sprint

--- a/bench/fixture/mint_driver_test.go
+++ b/bench/fixture/mint_driver_test.go
@@ -1,0 +1,20 @@
+package fixture
+
+import (
+	"testing"
+)
+
+// TestMintDriverEndToEnd verifies the mint driver can take the planter
+// from empty through to a confirmed batch. Failure here means the pump
+// is missing a signal channel or the conf payload is malformed.
+//
+// FinalizeBatch internally waits for the batch to reach Confirmed, so
+// the test just checks the call returns without error.
+func TestMintDriverEndToEnd(t *testing.T) {
+	t.Parallel()
+
+	d := NewMintDriver(t)
+
+	d.EnqueueSeedlings(t, 1)
+	d.FinalizeBatch(t)
+}

--- a/bench/fixture/send.go
+++ b/bench/fixture/send.go
@@ -1,0 +1,35 @@
+package fixture
+
+import (
+	"testing"
+
+	"github.com/lightninglabs/taproot-assets/tapfreighter"
+)
+
+// Send extends Storage with the parts of the send/transfer path that do
+// not require a real lnd Signer: CoinSelect (backed by the AssetStore).
+//
+// ChainPorter and AssetWallet need a real Signer to construct vPSBT
+// witnesses; in-process benches that exercise those paths drive them
+// through scenario harnesses rather than full RPC handlers. The Send
+// fixture leaves those fields nil so any handler that needs them returns
+// a clear error rather than silently misbehaving.
+type Send struct {
+	*Storage
+
+	CoinSelect *tapfreighter.CoinSelect
+}
+
+// NewSend constructs a Send fixture and registers cleanup.
+func NewSend(tb testing.TB) *Send {
+	tb.Helper()
+
+	st := NewStorage(tb)
+	coinSelect := tapfreighter.NewCoinSelect(st.AssetStore)
+	st.Config.CoinSelect = coinSelect
+
+	return &Send{
+		Storage:    st,
+		CoinSelect: coinSelect,
+	}
+}

--- a/bench/fixture/shapes.go
+++ b/bench/fixture/shapes.go
@@ -3,8 +3,6 @@ package fixture
 import (
 	"context"
 	"testing"
-
-	"google.golang.org/grpc"
 )
 
 // CommandBench measures the cost of issuing a state-mutating RPC. It runs
@@ -19,6 +17,7 @@ func CommandBench[Req, Resp any](
 	call func(context.Context, Req) (Resp, error),
 	req Req,
 ) {
+
 	b.Helper()
 	ctx := context.Background()
 
@@ -43,6 +42,7 @@ func QueryBench[Req, Resp any](
 	call func(context.Context, Req) (Resp, error),
 	req Req,
 ) {
+
 	b.Helper()
 	ctx := context.Background()
 
@@ -50,51 +50,6 @@ func QueryBench[Req, Resp any](
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		if _, err := call(ctx, req); err != nil {
-			b.Fatal(err)
-		}
-	}
-}
-
-// StreamBench measures the per-event cost of a server-streaming RPC in
-// steady state. It opens the stream once and times the emission and
-// per-event handling of b.N events emitted by emit. The first event is
-// excluded from the timing so subscription setup does not contaminate
-// the signal.
-//
-// The collector parameter is the function that drains a single event from
-// the stream (e.g. stream.Recv()). The emit callback triggers one
-// publish-side event each iteration.
-func StreamBench[Stream grpc.ServerStream, Event any](
-	b *testing.B,
-	open func(context.Context) (Stream, error),
-	collect func(Stream) (Event, error),
-	emit func(int) error,
-) {
-	b.Helper()
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	stream, err := open(ctx)
-	if err != nil {
-		b.Fatal(err)
-	}
-
-	// Drain one warmup event so subscription wiring is excluded from the
-	// timed loop.
-	if err := emit(-1); err != nil {
-		b.Fatal(err)
-	}
-	if _, err := collect(stream); err != nil {
-		b.Fatal(err)
-	}
-
-	b.ResetTimer()
-	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
-		if err := emit(i); err != nil {
-			b.Fatal(err)
-		}
-		if _, err := collect(stream); err != nil {
 			b.Fatal(err)
 		}
 	}

--- a/bench/fixture/shapes.go
+++ b/bench/fixture/shapes.go
@@ -1,0 +1,101 @@
+package fixture
+
+import (
+	"context"
+	"testing"
+
+	"google.golang.org/grpc"
+)
+
+// CommandBench measures the cost of issuing a state-mutating RPC. It runs
+// call once per b.N iteration with allocs reporting on. The handler is
+// invoked directly (no gRPC wire) so the signal reflects subsystem cost,
+// not transport.
+//
+// Use this shape for RPCs whose dominant cost is a chain mutation, a db
+// write, or a heavy fan-out (Mint, Send, Burn, FundBatch, etc.).
+func CommandBench[Req, Resp any](
+	b *testing.B,
+	call func(context.Context, Req) (Resp, error),
+	req Req,
+) {
+	b.Helper()
+	ctx := context.Background()
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if _, err := call(ctx, req); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// QueryBench measures the cost of issuing a read-only RPC. Identical to
+// CommandBench at the call site, but kept separate so the bench classifier
+// (and future per-shape harness behaviour like cold/warm cache modes) can
+// distinguish read from write paths.
+//
+// Use this shape for RPCs that only read state (List*, Query*, Fetch*,
+// Decode*, Verify*).
+func QueryBench[Req, Resp any](
+	b *testing.B,
+	call func(context.Context, Req) (Resp, error),
+	req Req,
+) {
+	b.Helper()
+	ctx := context.Background()
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if _, err := call(ctx, req); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// StreamBench measures the per-event cost of a server-streaming RPC in
+// steady state. It opens the stream once and times the emission and
+// per-event handling of b.N events emitted by emit. The first event is
+// excluded from the timing so subscription setup does not contaminate
+// the signal.
+//
+// The collector parameter is the function that drains a single event from
+// the stream (e.g. stream.Recv()). The emit callback triggers one
+// publish-side event each iteration.
+func StreamBench[Stream grpc.ServerStream, Event any](
+	b *testing.B,
+	open func(context.Context) (Stream, error),
+	collect func(Stream) (Event, error),
+	emit func(int) error,
+) {
+	b.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	stream, err := open(ctx)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	// Drain one warmup event so subscription wiring is excluded from the
+	// timed loop.
+	if err := emit(-1); err != nil {
+		b.Fatal(err)
+	}
+	if _, err := collect(stream); err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if err := emit(i); err != nil {
+			b.Fatal(err)
+		}
+		if _, err := collect(stream); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/bench/fixture/storage.go
+++ b/bench/fixture/storage.go
@@ -110,10 +110,14 @@ func NewStorage(tb testing.TB) *Storage {
 			return db.WithTx(tx)
 		},
 	)
+	newBaseTree := func(
+		id universe.Identifier,
+	) universe.StorageBackend {
+
+		return tapdb.NewBaseUniverseTree(uniDB, id)
+	}
 	uniArchive := universe.NewArchive(universe.ArchiveConfig{
-		NewBaseTree: func(id universe.Identifier) universe.StorageBackend {
-			return tapdb.NewBaseUniverseTree(uniDB, id)
-		},
+		NewBaseTree:          newBaseTree,
 		HeaderVerifier:       proof.MockHeaderVerifier,
 		MerkleVerifier:       proof.DefaultMerkleVerifier,
 		GroupVerifier:        proof.MockGroupVerifier,
@@ -148,13 +152,13 @@ func NewStorage(tb testing.TB) *Storage {
 	envoyErrChan := make(chan error, 1)
 	uniFederation := universe.NewFederationEnvoy(
 		universe.FederationConfig{
-			FederationDB:        federationDB,
-			UniverseSyncer:      uniSyncer,
-			LocalRegistrar:      uniArchive,
-			NewRemoteRegistrar:  noRemoteRegistrar,
-			SyncInterval:        24 * time.Hour,
-			ErrChan:             envoyErrChan,
-			ServerChecker:       noopServerChecker,
+			FederationDB:       federationDB,
+			UniverseSyncer:     uniSyncer,
+			LocalRegistrar:     uniArchive,
+			NewRemoteRegistrar: noRemoteRegistrar,
+			SyncInterval:       24 * time.Hour,
+			ErrChan:            envoyErrChan,
+			ServerChecker:      noopServerChecker,
 		},
 	)
 	require.NoError(tb, uniFederation.Start())

--- a/bench/fixture/storage.go
+++ b/bench/fixture/storage.go
@@ -1,0 +1,219 @@
+package fixture
+
+import (
+	"database/sql"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/lightninglabs/taproot-assets/address"
+	"github.com/lightninglabs/taproot-assets/proof"
+	"github.com/lightninglabs/taproot-assets/tapdb"
+	"github.com/lightninglabs/taproot-assets/tapgarden"
+	"github.com/lightninglabs/taproot-assets/universe"
+	"github.com/lightningnetwork/lnd/clock"
+	lfn "github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/stretchr/testify/require"
+)
+
+// Storage layers a sqlite-backed db and the most common subsystems onto
+// Minimal. It is sufficient for query/marshalling RPCs (List*, Query*,
+// Decode-with-marshal, Fetch*) and for universe read RPCs.
+//
+// Heavy subsystems that need lnd (Planter/Porter/Custodian, channel deps)
+// are not populated here — see Mint, Send and Universe fixtures.
+type Storage struct {
+	*Minimal
+
+	DB                 *tapdb.SqliteStore
+	AssetStore         *tapdb.AssetStore
+	TapAddrBook        *tapdb.TapAddressBook
+	AddrBook           *address.Book
+	Multiverse         *tapdb.MultiverseStore
+	UniverseStats      universe.Telemetry
+	UniverseArchive    *universe.Archive
+	UniverseSyncer     *universe.SimpleSyncer
+	UniverseFederation *universe.FederationEnvoy
+	FederationDB       *tapdb.UniverseFederationDB
+	ProofArchive       proof.NotifyArchiver
+	KeyRing            *tapgarden.MockKeyRing
+}
+
+// NewStorage constructs a Storage fixture, populates the rpcserver config
+// with all subsystem fields it provides, and registers cleanup.
+func NewStorage(tb testing.TB) *Storage {
+	tb.Helper()
+
+	min := NewMinimal(tb)
+	db := tapdb.NewTestDB(tb)
+	// A fixed clock keeps timing-dependent paths deterministic across
+	// runs. The exact value is arbitrary; it only matters that it does
+	// not advance during a bench iteration.
+	testClock := clock.NewTestClock(time.Unix(1_700_000_000, 0))
+
+	// Address book + asset store.
+	addrTx := tapdb.NewTransactionExecutor(
+		db.BaseDB, func(tx *sql.Tx) tapdb.AddrBook {
+			return db.WithTx(tx)
+		},
+	)
+	tapAddrBook := tapdb.NewTapAddressBook(
+		addrTx, &min.Config.ChainParams, testClock,
+	)
+	assetDB := tapdb.NewTransactionExecutor(
+		db.BaseDB, func(tx *sql.Tx) tapdb.ActiveAssetsStore {
+			return db.WithTx(tx)
+		},
+	)
+	metaDB := tapdb.NewTransactionExecutor(
+		db.BaseDB, func(tx *sql.Tx) tapdb.MetaStore {
+			return db.WithTx(tx)
+		},
+	)
+	assetStore := tapdb.NewAssetStore(
+		assetDB, metaDB, testClock, db.Backend(),
+	)
+
+	// Address Book consumes the tapdb store + a mock key ring; no syncer
+	// (benches never reach out to federation servers).
+	keyRing := tapgarden.NewMockKeyRing()
+	addrBook := address.NewBook(address.BookConfig{
+		Store:        tapAddrBook,
+		Syncer:       nil,
+		KeyRing:      keyRing,
+		Chain:        min.Config.ChainParams,
+		StoreTimeout: tapdb.DefaultStoreTimeout,
+	})
+
+	// Multiverse + universe stats.
+	multiverseDB := tapdb.NewTransactionExecutor(
+		db.BaseDB, func(tx *sql.Tx) tapdb.BaseMultiverseStore {
+			return db.WithTx(tx)
+		},
+	)
+	multiverse, err := tapdb.NewMultiverseStore(
+		multiverseDB, &tapdb.MultiverseStoreConfig{},
+	)
+	require.NoError(tb, err)
+
+	uniStatsDB := tapdb.NewTransactionExecutor(
+		db.BaseDB, func(tx *sql.Tx) tapdb.UniverseStatsStore {
+			return db.WithTx(tx)
+		},
+	)
+	universeStats := tapdb.NewUniverseStats(uniStatsDB, testClock)
+
+	// Universe archive — uses mock verifiers and mock chain lookup so it
+	// does not require a live chain backend.
+	uniDB := tapdb.NewTransactionExecutor(
+		db.BaseDB, func(tx *sql.Tx) tapdb.BaseUniverseStore {
+			return db.WithTx(tx)
+		},
+	)
+	uniArchive := universe.NewArchive(universe.ArchiveConfig{
+		NewBaseTree: func(id universe.Identifier) universe.StorageBackend {
+			return tapdb.NewBaseUniverseTree(uniDB, id)
+		},
+		HeaderVerifier:       proof.MockHeaderVerifier,
+		MerkleVerifier:       proof.DefaultMerkleVerifier,
+		GroupVerifier:        proof.MockGroupVerifier,
+		ChainLookupGenerator: proof.MockChainLookup,
+		Multiverse:           multiverse,
+		UniverseStats:        universeStats,
+		IgnoreChecker:        lfn.None[proof.IgnoreChecker](),
+	})
+
+	// Federation db (no actual federation members configured).
+	federationStore := tapdb.NewTransactionExecutor(
+		db.BaseDB, func(tx *sql.Tx) tapdb.UniverseServerStore {
+			return db.WithTx(tx)
+		},
+	)
+	federationDB := tapdb.NewUniverseFederationDB(
+		federationStore, testClock,
+	)
+
+	// Universe syncer and federation envoy. The remote-side hooks are
+	// stubbed: NewRemoteDiffEngine and NewRemoteRegistrar return an
+	// error so any sync attempt fails cleanly rather than reaching out
+	// over the network. StaticFederationMembers stays empty so the
+	// envoy's startup goroutine never invokes ServerChecker.
+	uniSyncer := universe.NewSimpleSyncer(universe.SimpleSyncCfg{
+		LocalDiffEngine:     uniArchive,
+		LocalRegistrar:      uniArchive,
+		NewRemoteDiffEngine: noRemoteDiffEngine,
+		SyncBatchSize:       100,
+	})
+
+	envoyErrChan := make(chan error, 1)
+	uniFederation := universe.NewFederationEnvoy(
+		universe.FederationConfig{
+			FederationDB:        federationDB,
+			UniverseSyncer:      uniSyncer,
+			LocalRegistrar:      uniArchive,
+			NewRemoteRegistrar:  noRemoteRegistrar,
+			SyncInterval:        24 * time.Hour,
+			ErrChan:             envoyErrChan,
+			ServerChecker:       noopServerChecker,
+		},
+	)
+	require.NoError(tb, uniFederation.Start())
+	tb.Cleanup(func() { _ = uniFederation.Stop() })
+
+	// Proof archive — file-backed under a temp dir.
+	proofFileArchiver, err := proof.NewFileArchiver(tb.TempDir())
+	require.NoError(tb, err)
+	proofArchive := proof.NewMultiArchiver(
+		&proof.BaseVerifier{}, tapdb.DefaultStoreTimeout,
+		assetStore, proofFileArchiver,
+	)
+
+	// Wire everything into the rpcserver config.
+	min.Config.AssetStore = assetStore
+	min.Config.TapAddrBook = tapAddrBook
+	min.Config.AddrBook = addrBook
+	min.Config.Multiverse = multiverse
+	min.Config.UniverseStats = universeStats
+	min.Config.UniverseArchive = uniArchive
+	min.Config.UniverseSyncer = uniSyncer
+	min.Config.UniverseFederation = uniFederation
+	min.Config.FederationDB = federationDB
+	min.Config.ProofArchive = proofArchive
+
+	return &Storage{
+		Minimal:            min,
+		DB:                 db,
+		AssetStore:         assetStore,
+		TapAddrBook:        tapAddrBook,
+		AddrBook:           addrBook,
+		Multiverse:         multiverse,
+		UniverseStats:      universeStats,
+		UniverseArchive:    uniArchive,
+		UniverseSyncer:     uniSyncer,
+		UniverseFederation: uniFederation,
+		FederationDB:       federationDB,
+		ProofArchive:       proofArchive,
+		KeyRing:            keyRing,
+	}
+}
+
+// noRemoteDiffEngine is a NewRemoteDiffEngine stub: any attempt to
+// reach a remote universe fails cleanly instead of dialing the network.
+func noRemoteDiffEngine(_ universe.ServerAddr) (universe.DiffEngine, error) {
+	return nil, errNoRemoteFederation
+}
+
+// noRemoteRegistrar is a NewRemoteRegistrar stub: any attempt to push a
+// proof out to a remote universe fails cleanly.
+func noRemoteRegistrar(_ universe.ServerAddr) (universe.Registrar, error) {
+	return nil, errNoRemoteFederation
+}
+
+// noopServerChecker treats every candidate federation member as
+// reachable. It is only called for entries in StaticFederationMembers,
+// which the Storage fixture leaves empty.
+func noopServerChecker(_ universe.ServerAddr) error { return nil }
+
+var errNoRemoteFederation = errors.New(
+	"bench fixture has no remote federation",
+)

--- a/bench/fixture/storage_test.go
+++ b/bench/fixture/storage_test.go
@@ -1,0 +1,44 @@
+package fixture
+
+import (
+	"context"
+	"testing"
+
+	"github.com/lightninglabs/taproot-assets/address"
+	"github.com/lightninglabs/taproot-assets/taprpc"
+	"github.com/stretchr/testify/require"
+)
+
+// TestStorageFixture verifies the Storage fixture wires every subsystem the
+// rpcserver consumes, by issuing one read-only RPC against each layer.
+func TestStorageFixture(t *testing.T) {
+	t.Parallel()
+
+	f := NewStorage(t)
+	ctx := context.Background()
+
+	// AssetStore is reachable: ListAssets returns an empty page.
+	la, err := f.Server.ListAssets(ctx, &taprpc.ListAssetRequest{})
+	require.NoError(t, err)
+	require.Empty(t, la.Assets)
+
+	// TapAddrBook is reachable: QueryAddrs returns an empty page.
+	qa, err := f.Server.QueryAddrs(ctx, &taprpc.QueryAddrRequest{})
+	require.NoError(t, err)
+	require.Empty(t, qa.Addrs)
+
+	// DecodeAddr round-trips: encode a random regtest address and decode
+	// it through the RPC. Verifies the AddrBook + TapAddrBook wiring.
+	addr, _, _ := address.RandAddrWithVersion(
+		t, &address.RegressionNetTap,
+		address.RandProofCourierAddr(t), address.V1,
+	)
+	encoded, err := addr.Tap.EncodeAddress()
+	require.NoError(t, err)
+
+	decoded, err := f.Server.DecodeAddr(ctx, &taprpc.DecodeAddrRequest{
+		Addr: encoded,
+	})
+	require.NoError(t, err)
+	require.Equal(t, encoded, decoded.Encoded)
+}

--- a/bench/results/baseline.txt
+++ b/bench/results/baseline.txt
@@ -1,0 +1,251 @@
+goos: darwin
+goarch: arm64
+pkg: github.com/lightninglabs/taproot-assets/address
+cpu: Apple M4
+BenchmarkTapEncode-10        	       3	      1722 ns/op	    1325 B/op	      18 allocs/op
+BenchmarkTapDecode-10        	       3	     24028 ns/op	    1893 B/op	      22 allocs/op
+BenchmarkEncodeAddress-10    	       3	      9805 ns/op	    2680 B/op	      31 allocs/op
+BenchmarkDecodeAddress-10    	       3	     40472 ns/op	    3965 B/op	      35 allocs/op
+PASS
+ok  	github.com/lightninglabs/taproot-assets/address	0.382s
+goos: darwin
+goarch: arm64
+pkg: github.com/lightninglabs/taproot-assets/asset
+cpu: Apple M4
+BenchmarkAssetCopy/normal-fresh-10         	       3	      6292 ns/op	     648 B/op	       6 allocs/op
+BenchmarkAssetCopy/collectible-fresh-10    	       3	      1722 ns/op	     648 B/op	       6 allocs/op
+BenchmarkAssetEncode/normal-10             	       3	      4833 ns/op	    4344 B/op	      60 allocs/op
+BenchmarkAssetEncode/collectible-10        	       3	      4167 ns/op	    4344 B/op	      60 allocs/op
+BenchmarkAssetDecode/normal-10             	       3	     21250 ns/op	    2957 B/op	      49 allocs/op
+BenchmarkAssetDecode/collectible-10        	       3	     21458 ns/op	    2957 B/op	      49 allocs/op
+BenchmarkWitnessEncode-10                  	       3	       805.3 ns/op	     533 B/op	      10 allocs/op
+BenchmarkWitnessDecode-10                  	       3	       791.7 ns/op	     701 B/op	      15 allocs/op
+PASS
+ok  	github.com/lightninglabs/taproot-assets/asset	0.344s
+PASS
+ok  	github.com/lightninglabs/taproot-assets/bench/fixture	0.383s
+goos: darwin
+goarch: arm64
+pkg: github.com/lightninglabs/taproot-assets/bench/rpc
+cpu: Apple M4
+BenchmarkNextInternalKey-10              	       3	   3740903 ns/op	    6592 B/op	      95 allocs/op
+--- BENCH: BenchmarkNextInternalKey-10
+    test_sqlite.go:11: Creating new SQLite DB handle for testing: /var/folders/58/td55086x717cpp9_d0gz8tkh0000gn/T/BenchmarkNextInternalKey1411318249/001/tmp.db
+    test_sqlite.go:11: Creating new SQLite DB handle for testing: /var/folders/58/td55086x717cpp9_d0gz8tkh0000gn/T/BenchmarkNextInternalKey772423348/003/tmp.db
+BenchmarkNextScriptKey-10                	       3	   3766472 ns/op	    7477 B/op	     130 allocs/op
+--- BENCH: BenchmarkNextScriptKey-10
+    test_sqlite.go:11: Creating new SQLite DB handle for testing: /var/folders/58/td55086x717cpp9_d0gz8tkh0000gn/T/BenchmarkNextScriptKey343623387/001/tmp.db
+    test_sqlite.go:11: Creating new SQLite DB handle for testing: /var/folders/58/td55086x717cpp9_d0gz8tkh0000gn/T/BenchmarkNextScriptKey2994267300/003/tmp.db
+BenchmarkRemoveUTXOLease-10              	       3	     25083 ns/op	    1338 B/op	      26 allocs/op
+--- BENCH: BenchmarkRemoveUTXOLease-10
+    test_sqlite.go:11: Creating new SQLite DB handle for testing: /var/folders/58/td55086x717cpp9_d0gz8tkh0000gn/T/BenchmarkRemoveUTXOLease3944476808/001/tmp.db
+    test_sqlite.go:11: Creating new SQLite DB handle for testing: /var/folders/58/td55086x717cpp9_d0gz8tkh0000gn/T/BenchmarkRemoveUTXOLease1551785225/003/tmp.db
+BenchmarkListBatches-10                  	       3	     53472 ns/op	    3365 B/op	      65 allocs/op
+--- BENCH: BenchmarkListBatches-10
+    test_sqlite.go:11: Creating new SQLite DB handle for testing: /var/folders/58/td55086x717cpp9_d0gz8tkh0000gn/T/BenchmarkListBatches235513642/001/tmp.db
+    test_sqlite.go:11: Creating new SQLite DB handle for testing: /var/folders/58/td55086x717cpp9_d0gz8tkh0000gn/T/BenchmarkListBatches3993092804/003/tmp.db
+BenchmarkMintAsset-10                    	       3	   5056028 ns/op	   33757 B/op	     366 allocs/op
+--- BENCH: BenchmarkMintAsset-10
+    test_sqlite.go:11: Creating new SQLite DB handle for testing: /var/folders/58/td55086x717cpp9_d0gz8tkh0000gn/T/BenchmarkMintAsset709334409/001/tmp.db
+    test_sqlite.go:11: Creating new SQLite DB handle for testing: /var/folders/58/td55086x717cpp9_d0gz8tkh0000gn/T/BenchmarkMintAsset2105900645/003/tmp.db
+BenchmarkSealBatch-10                    	       3	     30556 ns/op	    5176 B/op	      62 allocs/op
+--- BENCH: BenchmarkSealBatch-10
+    test_sqlite.go:11: Creating new SQLite DB handle for testing: /var/folders/58/td55086x717cpp9_d0gz8tkh0000gn/T/BenchmarkSealBatch3063156442/001/tmp.db
+    test_sqlite.go:11: Creating new SQLite DB handle for testing: /var/folders/58/td55086x717cpp9_d0gz8tkh0000gn/T/BenchmarkSealBatch2256526723/003/tmp.db
+BenchmarkCancelBatch-10                  	       3	      6111 ns/op	     389 B/op	       9 allocs/op
+--- BENCH: BenchmarkCancelBatch-10
+    test_sqlite.go:11: Creating new SQLite DB handle for testing: /var/folders/58/td55086x717cpp9_d0gz8tkh0000gn/T/BenchmarkCancelBatch485797927/001/tmp.db
+    test_sqlite.go:11: Creating new SQLite DB handle for testing: /var/folders/58/td55086x717cpp9_d0gz8tkh0000gn/T/BenchmarkCancelBatch2289415638/003/tmp.db
+BenchmarkDebugLevel-10                   	       3	       361.0 ns/op	      64 B/op	       1 allocs/op
+BenchmarkUnpackProofFile-10              	       3	      6556 ns/op	   11080 B/op	      21 allocs/op
+BenchmarkListAssets-10                   	       3	    478639 ns/op	   13845 B/op	     225 allocs/op
+--- BENCH: BenchmarkListAssets-10
+    test_sqlite.go:11: Creating new SQLite DB handle for testing: /var/folders/58/td55086x717cpp9_d0gz8tkh0000gn/T/BenchmarkListAssets3831906629/001/tmp.db
+    test_sqlite.go:11: Creating new SQLite DB handle for testing: /var/folders/58/td55086x717cpp9_d0gz8tkh0000gn/T/BenchmarkListAssets1631949173/003/tmp.db
+BenchmarkListUtxos-10                    	       3	    356153 ns/op	   11568 B/op	     165 allocs/op
+--- BENCH: BenchmarkListUtxos-10
+    test_sqlite.go:11: Creating new SQLite DB handle for testing: /var/folders/58/td55086x717cpp9_d0gz8tkh0000gn/T/BenchmarkListUtxos2585028977/001/tmp.db
+    test_sqlite.go:11: Creating new SQLite DB handle for testing: /var/folders/58/td55086x717cpp9_d0gz8tkh0000gn/T/BenchmarkListUtxos2677964862/003/tmp.db
+BenchmarkListGroups-10                   	       3	    174694 ns/op	    1597 B/op	      39 allocs/op
+--- BENCH: BenchmarkListGroups-10
+    test_sqlite.go:11: Creating new SQLite DB handle for testing: /var/folders/58/td55086x717cpp9_d0gz8tkh0000gn/T/BenchmarkListGroups1152455337/001/tmp.db
+    test_sqlite.go:11: Creating new SQLite DB handle for testing: /var/folders/58/td55086x717cpp9_d0gz8tkh0000gn/T/BenchmarkListGroups974438834/003/tmp.db
+BenchmarkListBalances-10                 	       3	    349222 ns/op	    5936 B/op	     117 allocs/op
+--- BENCH: BenchmarkListBalances-10
+    test_sqlite.go:11: Creating new SQLite DB handle for testing: /var/folders/58/td55086x717cpp9_d0gz8tkh0000gn/T/BenchmarkListBalances2358266714/001/tmp.db
+    test_sqlite.go:11: Creating new SQLite DB handle for testing: /var/folders/58/td55086x717cpp9_d0gz8tkh0000gn/T/BenchmarkListBalances1311222771/003/tmp.db
+BenchmarkListTransfers-10                	       3	     66430 ns/op	    2778 B/op	      47 allocs/op
+--- BENCH: BenchmarkListTransfers-10
+    test_sqlite.go:11: Creating new SQLite DB handle for testing: /var/folders/58/td55086x717cpp9_d0gz8tkh0000gn/T/BenchmarkListTransfers1682987898/001/tmp.db
+    test_sqlite.go:11: Creating new SQLite DB handle for testing: /var/folders/58/td55086x717cpp9_d0gz8tkh0000gn/T/BenchmarkListTransfers1697357861/003/tmp.db
+BenchmarkListBurns-10                    	       3	     48389 ns/op	    1541 B/op	      37 allocs/op
+--- BENCH: BenchmarkListBurns-10
+    test_sqlite.go:11: Creating new SQLite DB handle for testing: /var/folders/58/td55086x717cpp9_d0gz8tkh0000gn/T/BenchmarkListBurns2601668786/001/tmp.db
+    test_sqlite.go:11: Creating new SQLite DB handle for testing: /var/folders/58/td55086x717cpp9_d0gz8tkh0000gn/T/BenchmarkListBurns499750300/003/tmp.db
+BenchmarkQueryAddrs-10                   	       3	     92347 ns/op	    3896 B/op	      97 allocs/op
+--- BENCH: BenchmarkQueryAddrs-10
+    test_sqlite.go:11: Creating new SQLite DB handle for testing: /var/folders/58/td55086x717cpp9_d0gz8tkh0000gn/T/BenchmarkQueryAddrs1443183429/001/tmp.db
+    test_sqlite.go:11: Creating new SQLite DB handle for testing: /var/folders/58/td55086x717cpp9_d0gz8tkh0000gn/T/BenchmarkQueryAddrs535354568/003/tmp.db
+BenchmarkDecodeAddr-10                   	       3	    130597 ns/op	    9160 B/op	     129 allocs/op
+--- BENCH: BenchmarkDecodeAddr-10
+    test_sqlite.go:11: Creating new SQLite DB handle for testing: /var/folders/58/td55086x717cpp9_d0gz8tkh0000gn/T/BenchmarkDecodeAddr1319444793/001/tmp.db
+    test_sqlite.go:11: Creating new SQLite DB handle for testing: /var/folders/58/td55086x717cpp9_d0gz8tkh0000gn/T/BenchmarkDecodeAddr3602659009/003/tmp.db
+BenchmarkAddrReceives-10                 	       3	     64361 ns/op	    1874 B/op	      47 allocs/op
+--- BENCH: BenchmarkAddrReceives-10
+    test_sqlite.go:11: Creating new SQLite DB handle for testing: /var/folders/58/td55086x717cpp9_d0gz8tkh0000gn/T/BenchmarkAddrReceives2262114381/001/tmp.db
+    test_sqlite.go:11: Creating new SQLite DB handle for testing: /var/folders/58/td55086x717cpp9_d0gz8tkh0000gn/T/BenchmarkAddrReceives1387900522/003/tmp.db
+BenchmarkUniverseInfo-10                 	       3	       486.3 ns/op	      48 B/op	       1 allocs/op
+--- BENCH: BenchmarkUniverseInfo-10
+    test_sqlite.go:11: Creating new SQLite DB handle for testing: /var/folders/58/td55086x717cpp9_d0gz8tkh0000gn/T/BenchmarkUniverseInfo1970808530/001/tmp.db
+    test_sqlite.go:11: Creating new SQLite DB handle for testing: /var/folders/58/td55086x717cpp9_d0gz8tkh0000gn/T/BenchmarkUniverseInfo2753147407/003/tmp.db
+BenchmarkUniverseStats-10                	       3	    137972 ns/op	     693 B/op	      15 allocs/op
+--- BENCH: BenchmarkUniverseStats-10
+    test_sqlite.go:11: Creating new SQLite DB handle for testing: /var/folders/58/td55086x717cpp9_d0gz8tkh0000gn/T/BenchmarkUniverseStats2159287808/001/tmp.db
+    test_sqlite.go:11: Creating new SQLite DB handle for testing: /var/folders/58/td55086x717cpp9_d0gz8tkh0000gn/T/BenchmarkUniverseStats3659655559/003/tmp.db
+BenchmarkQueryAssetStats-10              	       3	    235292 ns/op	    1840 B/op	      36 allocs/op
+--- BENCH: BenchmarkQueryAssetStats-10
+    test_sqlite.go:11: Creating new SQLite DB handle for testing: /var/folders/58/td55086x717cpp9_d0gz8tkh0000gn/T/BenchmarkQueryAssetStats602639876/001/tmp.db
+    test_sqlite.go:11: Creating new SQLite DB handle for testing: /var/folders/58/td55086x717cpp9_d0gz8tkh0000gn/T/BenchmarkQueryAssetStats822200090/003/tmp.db
+BenchmarkQueryEvents-10                  	       3	     43528 ns/op	     592 B/op	      14 allocs/op
+--- BENCH: BenchmarkQueryEvents-10
+    test_sqlite.go:11: Creating new SQLite DB handle for testing: /var/folders/58/td55086x717cpp9_d0gz8tkh0000gn/T/BenchmarkQueryEvents3434272521/001/tmp.db
+    test_sqlite.go:11: Creating new SQLite DB handle for testing: /var/folders/58/td55086x717cpp9_d0gz8tkh0000gn/T/BenchmarkQueryEvents2870961261/003/tmp.db
+BenchmarkListFederationServers-10        	       3	     26945 ns/op	    1309 B/op	      35 allocs/op
+--- BENCH: BenchmarkListFederationServers-10
+    test_sqlite.go:11: Creating new SQLite DB handle for testing: /var/folders/58/td55086x717cpp9_d0gz8tkh0000gn/T/BenchmarkListFederationServers238129126/001/tmp.db
+    test_sqlite.go:11: Creating new SQLite DB handle for testing: /var/folders/58/td55086x717cpp9_d0gz8tkh0000gn/T/BenchmarkListFederationServers1490877230/003/tmp.db
+BenchmarkQueryFederationSyncConfig-10    	       3	      1833 ns/op	     333 B/op	      10 allocs/op
+--- BENCH: BenchmarkQueryFederationSyncConfig-10
+    test_sqlite.go:11: Creating new SQLite DB handle for testing: /var/folders/58/td55086x717cpp9_d0gz8tkh0000gn/T/BenchmarkQueryFederationSyncConfig1765589160/001/tmp.db
+    test_sqlite.go:11: Creating new SQLite DB handle for testing: /var/folders/58/td55086x717cpp9_d0gz8tkh0000gn/T/BenchmarkQueryFederationSyncConfig188396863/003/tmp.db
+BenchmarkAssetRoots-10                   	       3	     86611 ns/op	    2050 B/op	      54 allocs/op
+--- BENCH: BenchmarkAssetRoots-10
+    test_sqlite.go:11: Creating new SQLite DB handle for testing: /var/folders/58/td55086x717cpp9_d0gz8tkh0000gn/T/BenchmarkAssetRoots3403988641/001/tmp.db
+    test_sqlite.go:11: Creating new SQLite DB handle for testing: /var/folders/58/td55086x717cpp9_d0gz8tkh0000gn/T/BenchmarkAssetRoots3518557302/003/tmp.db
+BenchmarkDeleteFederationServer-10       	       3	     21556 ns/op	     933 B/op	      21 allocs/op
+--- BENCH: BenchmarkDeleteFederationServer-10
+    test_sqlite.go:11: Creating new SQLite DB handle for testing: /var/folders/58/td55086x717cpp9_d0gz8tkh0000gn/T/BenchmarkDeleteFederationServer3344133070/001/tmp.db
+    test_sqlite.go:11: Creating new SQLite DB handle for testing: /var/folders/58/td55086x717cpp9_d0gz8tkh0000gn/T/BenchmarkDeleteFederationServer2543745244/003/tmp.db
+BenchmarkSetFederationSyncConfig-10      	       3	     12542 ns/op	     621 B/op	      13 allocs/op
+--- BENCH: BenchmarkSetFederationSyncConfig-10
+    test_sqlite.go:11: Creating new SQLite DB handle for testing: /var/folders/58/td55086x717cpp9_d0gz8tkh0000gn/T/BenchmarkSetFederationSyncConfig813591651/001/tmp.db
+    test_sqlite.go:11: Creating new SQLite DB handle for testing: /var/folders/58/td55086x717cpp9_d0gz8tkh0000gn/T/BenchmarkSetFederationSyncConfig2248381923/003/tmp.db
+PASS
+ok  	github.com/lightninglabs/taproot-assets/bench/rpc	41.668s
+goos: darwin
+goarch: arm64
+pkg: github.com/lightninglabs/taproot-assets/bench/scenario
+cpu: Apple M4
+BenchmarkMintBatch/size=1-10        	       3	 225052306 ns/op	  768453 B/op	   14655 allocs/op
+--- BENCH: BenchmarkMintBatch/size=1-10
+    test_sqlite.go:11: Creating new SQLite DB handle for testing: /var/folders/58/td55086x717cpp9_d0gz8tkh0000gn/T/BenchmarkMintBatchsize=1465438493/001/tmp.db
+    test_sqlite.go:11: Creating new SQLite DB handle for testing: /var/folders/58/td55086x717cpp9_d0gz8tkh0000gn/T/BenchmarkMintBatchsize=1993262114/003/tmp.db
+BenchmarkMintBatch/size=10-10       	       3	 274945792 ns/op	 7828352 B/op	  160615 allocs/op
+--- BENCH: BenchmarkMintBatch/size=10-10
+    test_sqlite.go:11: Creating new SQLite DB handle for testing: /var/folders/58/td55086x717cpp9_d0gz8tkh0000gn/T/BenchmarkMintBatchsize=102016840854/001/tmp.db
+    test_sqlite.go:11: Creating new SQLite DB handle for testing: /var/folders/58/td55086x717cpp9_d0gz8tkh0000gn/T/BenchmarkMintBatchsize=101487499716/003/tmp.db
+BenchmarkMintBatch/size=100-10      	       3	 720699861 ns/op	82392434 B/op	 1657420 allocs/op
+--- BENCH: BenchmarkMintBatch/size=100-10
+    test_sqlite.go:11: Creating new SQLite DB handle for testing: /var/folders/58/td55086x717cpp9_d0gz8tkh0000gn/T/BenchmarkMintBatchsize=1004162836447/001/tmp.db
+    test_sqlite.go:11: Creating new SQLite DB handle for testing: /var/folders/58/td55086x717cpp9_d0gz8tkh0000gn/T/BenchmarkMintBatchsize=1003871529886/003/tmp.db
+BenchmarkAssetCommitmentScale/assets=1-10         	       3	    142264 ns/op	  235346 B/op	    4852 allocs/op
+BenchmarkAssetCommitmentScale/assets=10-10        	       3	   1386653 ns/op	 2476578 B/op	   51625 allocs/op
+BenchmarkAssetCommitmentScale/assets=100-10       	       3	  12521389 ns/op	25183677 B/op	  525539 allocs/op
+BenchmarkProofFileRoundTrip/proofs=1-10           	       3	      2000 ns/op	    2616 B/op	      14 allocs/op
+BenchmarkProofFileRoundTrip/proofs=10-10          	       3	      9930 ns/op	   51296 B/op	      45 allocs/op
+BenchmarkProofFileRoundTrip/proofs=100-10         	       3	     68820 ns/op	  451152 B/op	     318 allocs/op
+BenchmarkMssmtBulkInsert/leaves=100-10            	       3	   5118000 ns/op	 9598733 B/op	  213336 allocs/op
+BenchmarkMssmtBulkInsert/leaves=1000-10           	       3	  53680458 ns/op	97271634 B/op	 2161608 allocs/op
+BenchmarkMssmtBulkInsert/leaves=10000-10          	       3	 576787222 ns/op	970507368 B/op	21547754 allocs/op
+PASS
+ok  	github.com/lightninglabs/taproot-assets/bench/scenario	12.816s
+goos: darwin
+goarch: arm64
+pkg: github.com/lightninglabs/taproot-assets/bench/wire
+cpu: Apple M4
+BenchmarkWireDebugLevel-10    	       3	     65694 ns/op	    8776 B/op	     149 allocs/op
+--- BENCH: BenchmarkWireDebugLevel-10
+    test_sqlite.go:11: Creating new SQLite DB handle for testing: /var/folders/58/td55086x717cpp9_d0gz8tkh0000gn/T/BenchmarkWireDebugLevel3237944798/001/tmp.db
+    test_sqlite.go:11: Creating new SQLite DB handle for testing: /var/folders/58/td55086x717cpp9_d0gz8tkh0000gn/T/BenchmarkWireDebugLevel2591269187/003/tmp.db
+BenchmarkWireListAssets-10    	       3	    642917 ns/op	   35861 B/op	     398 allocs/op
+--- BENCH: BenchmarkWireListAssets-10
+    test_sqlite.go:11: Creating new SQLite DB handle for testing: /var/folders/58/td55086x717cpp9_d0gz8tkh0000gn/T/BenchmarkWireListAssets1120306926/001/tmp.db
+    test_sqlite.go:11: Creating new SQLite DB handle for testing: /var/folders/58/td55086x717cpp9_d0gz8tkh0000gn/T/BenchmarkWireListAssets3127054539/003/tmp.db
+BenchmarkWireQueryAddrs-10    	       3	    181167 ns/op	   24088 B/op	     251 allocs/op
+--- BENCH: BenchmarkWireQueryAddrs-10
+    test_sqlite.go:11: Creating new SQLite DB handle for testing: /var/folders/58/td55086x717cpp9_d0gz8tkh0000gn/T/BenchmarkWireQueryAddrs1715593101/001/tmp.db
+    test_sqlite.go:11: Creating new SQLite DB handle for testing: /var/folders/58/td55086x717cpp9_d0gz8tkh0000gn/T/BenchmarkWireQueryAddrs397456045/003/tmp.db
+PASS
+ok  	github.com/lightninglabs/taproot-assets/bench/wire	5.300s
+goos: darwin
+goarch: arm64
+pkg: github.com/lightninglabs/taproot-assets/commitment
+cpu: Apple M4
+BenchmarkNewAssetCommitment/assets=1-10    	       3	     68805 ns/op	   65322 B/op	    1391 allocs/op
+BenchmarkNewAssetCommitment/assets=16-10   	       3	   1145097 ns/op	 1637576 B/op	   35709 allocs/op
+BenchmarkNewAssetCommitment/assets=256-10  	       3	  14667194 ns/op	26791437 B/op	  584240 allocs/op
+BenchmarkNewTapCommitment/commits=1-10     	       3	     31014 ns/op	   59402 B/op	    1305 allocs/op
+BenchmarkNewTapCommitment/commits=16-10    	       3	    879847 ns/op	 1498013 B/op	   33277 allocs/op
+BenchmarkNewTapCommitment/commits=256-10   	       3	  14070361 ns/op	24784221 B/op	  550311 allocs/op
+BenchmarkTapCommitmentUpsert/existing=16-10         	       3	     70166 ns/op	  114405 B/op	    2550 allocs/op
+BenchmarkTapCommitmentUpsert/existing=256-10        	       3	     69889 ns/op	  115882 B/op	    2529 allocs/op
+BenchmarkTapCommitmentUpsert/existing=4096-10       	       3	     97805 ns/op	  121877 B/op	    1699 allocs/op
+BenchmarkTapCommitmentDelete/existing=16-10         	       3	      3972 ns/op	    2840 B/op	      44 allocs/op
+BenchmarkTapCommitmentDelete/existing=256-10        	       3	      8083 ns/op	    4440 B/op	      46 allocs/op
+BenchmarkTapCommitmentDelete/existing=4096-10       	       3	     58013 ns/op	   40088 B/op	      76 allocs/op
+BenchmarkProofDeriveByAssetInclusion/assets=1-10    	       3	     39681 ns/op	   75378 B/op	    1623 allocs/op
+BenchmarkProofDeriveByAssetInclusion/assets=16-10   	       3	     38042 ns/op	   75378 B/op	    1623 allocs/op
+BenchmarkProofDeriveByAssetInclusion/assets=256-10  	       3	     40389 ns/op	   75378 B/op	    1623 allocs/op
+PASS
+ok  	github.com/lightninglabs/taproot-assets/commitment	10.544s
+goos: darwin
+goarch: arm64
+pkg: github.com/lightninglabs/taproot-assets/mssmt
+cpu: Apple M4
+BenchmarkTree/Insert-10-10         	       3	     65236 ns/op	   57488 B/op	    1283 allocs/op
+BenchmarkTree/Get-10-10            	       3	     16028 ns/op	   24328 B/op	     508 allocs/op
+BenchmarkTree/MerkleProof-10-10    	       3	     58056 ns/op	   73512 B/op	    1516 allocs/op
+BenchmarkTree/VerifyMerkleProof-10-10         	       3	     50611 ns/op	   57354 B/op	    1280 allocs/op
+BenchmarkTree/MerkleProofCompress-10-10       	       3	      5000 ns/op	    5304 B/op	       7 allocs/op
+BenchmarkTree/Compress-10-10                  	       3	      3917 ns/op	     416 B/op	       5 allocs/op
+BenchmarkTree/Decompress-10-10                	       3	       930.3 ns/op	    4888 B/op	       2 allocs/op
+BenchmarkTree/Insert-1000-10                  	       3	     55361 ns/op	   57488 B/op	    1283 allocs/op
+BenchmarkTree/Get-1000-10                     	       3	     12361 ns/op	   19768 B/op	     413 allocs/op
+BenchmarkTree/MerkleProof-1000-10             	       3	     49806 ns/op	   71608 B/op	    1474 allocs/op
+BenchmarkTree/VerifyMerkleProof-1000-10       	       3	     42250 ns/op	   57354 B/op	    1280 allocs/op
+BenchmarkTree/MerkleProofCompress-1000-10     	       3	      4611 ns/op	    5688 B/op	       9 allocs/op
+BenchmarkTree/Compress-1000-10                	       3	      3278 ns/op	     800 B/op	       7 allocs/op
+BenchmarkTree/Decompress-1000-10              	       3	       805.3 ns/op	    4888 B/op	       2 allocs/op
+BenchmarkTree/Insert-100000-10                	       3	    149000 ns/op	   57488 B/op	    1283 allocs/op
+BenchmarkTree/Get-100000-10                   	       3	     22431 ns/op	   19032 B/op	     398 allocs/op
+BenchmarkTree/MerkleProof-100000-10           	       3	    104236 ns/op	   69885 B/op	    1436 allocs/op
+BenchmarkTree/VerifyMerkleProof-100000-10     	       3	     95250 ns/op	   57354 B/op	    1280 allocs/op
+BenchmarkTree/MerkleProofCompress-100000-10   	       3	     10181 ns/op	    5858 B/op	       9 allocs/op
+BenchmarkTree/Compress-100000-10              	       3	      9278 ns/op	     970 B/op	       7 allocs/op
+BenchmarkTree/Decompress-100000-10            	       3	      1583 ns/op	    4888 B/op	       2 allocs/op
+PASS
+ok  	github.com/lightninglabs/taproot-assets/mssmt	13.251s
+goos: darwin
+goarch: arm64
+pkg: github.com/lightninglabs/taproot-assets/proof
+cpu: Apple M4
+BenchmarkHeaderPrefetch/sequential-10         	       3	1123127014 ns/op	      32 B/op	       0 allocs/op
+BenchmarkHeaderPrefetch/cached_parallel-10    	       3	 141281847 ns/op	  253394 B/op	    1259 allocs/op
+BenchmarkHeaderPrefetch/cached_parallel_dedup-10         	       3	  17074208 ns/op	   51421 B/op	     327 allocs/op
+BenchmarkPrefetchWorkerCount/workers_4-10                	       3	 281947847 ns/op	  246642 B/op	    1242 allocs/op
+BenchmarkPrefetchWorkerCount/workers_8-10                	       3	 140751083 ns/op	  248456 B/op	    1247 allocs/op
+BenchmarkPrefetchWorkerCount/workers_16-10               	       3	  73512403 ns/op	  249880 B/op	    1255 allocs/op
+BenchmarkProofEncoding-10                                	       3	   8319292 ns/op	54502792 B/op	   30026 allocs/op
+BenchmarkProofVerify-10                                  	       3	    374722 ns/op	  263808 B/op	    5605 allocs/op
+BenchmarkFileVerify-10                                   	       3	    455320 ns/op	  288472 B/op	    5813 allocs/op
+PASS
+ok  	github.com/lightninglabs/taproot-assets/proof	9.090s
+goos: darwin
+goarch: arm64
+pkg: github.com/lightninglabs/taproot-assets/vm
+cpu: Apple M4
+BenchmarkExecuteCollectible-10    	       3	    219694 ns/op	  133178 B/op	    2806 allocs/op
+BenchmarkExecuteNormal-10         	       3	    460972 ns/op	  261256 B/op	    5569 allocs/op
+BenchmarkExecuteSplit-10          	       3	    335250 ns/op	  417885 B/op	    9379 allocs/op
+PASS
+ok  	github.com/lightninglabs/taproot-assets/vm	0.444s

--- a/bench/rpc/assetwallet_bench_test.go
+++ b/bench/rpc/assetwallet_bench_test.go
@@ -1,0 +1,57 @@
+package rpc
+
+import (
+	"testing"
+
+	"github.com/lightninglabs/taproot-assets/bench/fixture"
+	"github.com/lightninglabs/taproot-assets/taprpc"
+	wrpc "github.com/lightninglabs/taproot-assets/taprpc/assetwalletrpc"
+)
+
+// keyFamily is the Taproot Assets key family. The MockKeyRing only has a
+// derivation rule installed for this family, so other values panic.
+const keyFamily = 212
+
+// BenchmarkNextInternalKey covers NextInternalKey. Requires AddrBook +
+// MockKeyRing — both populated by the Storage fixture.
+//
+// bench:rpc=assetwalletrpc.AssetWallet.NextInternalKey
+func BenchmarkNextInternalKey(b *testing.B) {
+	f := fixture.NewStorage(b)
+	fixture.CommandBench(b, f.Server.NextInternalKey,
+		&wrpc.NextInternalKeyRequest{KeyFamily: keyFamily})
+}
+
+// BenchmarkNextScriptKey covers NextScriptKey.
+//
+// bench:rpc=assetwalletrpc.AssetWallet.NextScriptKey
+func BenchmarkNextScriptKey(b *testing.B) {
+	f := fixture.NewStorage(b)
+	fixture.CommandBench(b, f.Server.NextScriptKey,
+		&wrpc.NextScriptKeyRequest{KeyFamily: keyFamily})
+}
+
+// BenchmarkRemoveUTXOLease covers RemoveUTXOLease — exercises the
+// CoinSelect release path against the AssetStore. The synthetic outpoint
+// is not actually leased; ReleaseCoins issues a DELETE that matches no
+// rows but still runs the full transaction (marshal + open txn + delete
+// + commit). That measures the dominant per-call cost and matches what
+// callers pay for any release request, leased or not.
+//
+// bench:rpc=assetwalletrpc.AssetWallet.RemoveUTXOLease
+func BenchmarkRemoveUTXOLease(b *testing.B) {
+	f := fixture.NewSend(b)
+
+	txid := make([]byte, 32)
+	for i := range txid {
+		txid[i] = byte(i + 1)
+	}
+	req := &wrpc.RemoveUTXOLeaseRequest{
+		Outpoint: &taprpc.OutPoint{
+			Txid:        txid,
+			OutputIndex: 0,
+		},
+	}
+
+	fixture.CommandBench(b, f.Server.RemoveUTXOLease, req)
+}

--- a/bench/rpc/mint_bench_test.go
+++ b/bench/rpc/mint_bench_test.go
@@ -1,0 +1,114 @@
+package rpc
+
+import (
+	"encoding/hex"
+	"math/rand"
+	"testing"
+
+	"github.com/lightninglabs/taproot-assets/bench/fixture"
+	"github.com/lightninglabs/taproot-assets/taprpc"
+	"github.com/lightninglabs/taproot-assets/taprpc/mintrpc"
+)
+
+// BenchmarkListBatches covers ListBatches against an empty MintingStore.
+// Populated-batch variants belong in the scenario suite.
+//
+// bench:rpc=mintrpc.Mint.ListBatches
+func BenchmarkListBatches(b *testing.B) {
+	f := fixture.NewMint(b)
+	fixture.QueryBench(b, f.Server.ListBatches,
+		&mintrpc.ListBatchRequest{})
+}
+
+// BenchmarkMintAsset covers MintAsset — enqueues one fresh seedling per
+// iteration and waits for the first update from the planter. The batch
+// is cancelled between iterations (under StopTimer) so each call lands
+// against an empty pending batch; otherwise the per-call cost would
+// grow with b.N as the batch accumulated.
+//
+// bench:rpc=mintrpc.Mint.MintAsset
+func BenchmarkMintAsset(b *testing.B) {
+	f := fixture.NewMint(b)
+	ctx := b.Context()
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		var nameBytes [16]byte
+		_, _ = rand.Read(nameBytes[:])
+		req := &mintrpc.MintAssetRequest{
+			Asset: &mintrpc.MintAsset{
+				AssetType: taprpc.AssetType_NORMAL,
+				Name:      hex.EncodeToString(nameBytes[:]),
+				Amount:    1000,
+			},
+		}
+		if _, err := f.Server.MintAsset(ctx, req); err != nil {
+			b.Fatal(err)
+		}
+
+		b.StopTimer()
+		// CancelBatch returns an error if the batch is already gone;
+		// that is fine — we only need the side effect of clearing
+		// state for the next iteration.
+		_, _ = f.Planter.CancelBatch()
+		b.StartTimer()
+	}
+}
+
+// BenchmarkSealBatch covers SealBatch on a real frozen batch. Each
+// iteration stages a fresh batch under StopTimer: enqueue one Normal
+// seedling, fund the batch (driving it to frozen state), then time the
+// SealBatch RPC. After sealing, the batch is finalized so the planter
+// is back in a clean state for the next iteration.
+//
+// Setup/teardown dominate wall-clock but are excluded from the timing
+// window; the reported per-op cost is the SealBatch handler itself.
+//
+// bench:rpc=mintrpc.Mint.SealBatch
+func BenchmarkSealBatch(b *testing.B) {
+	d := fixture.NewMintDriver(b)
+	ctx := b.Context()
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		d.EnqueueSeedlings(b, 1)
+		d.FundPendingBatch(b)
+		b.StartTimer()
+
+		_, err := d.Server.SealBatch(ctx, &mintrpc.SealBatchRequest{})
+		if err != nil {
+			b.Fatal(err)
+		}
+
+		b.StopTimer()
+		// Drive the sealed batch the rest of the way so the planter
+		// is empty again for the next iteration.
+		d.FinalizeBatch(b)
+		b.StartTimer()
+	}
+}
+
+// BenchmarkCancelBatch covers CancelBatch against an empty Planter. This
+// exercises the planter's batch-state machine cheap path (no batch to
+// cancel returns an error; we re-run the handler N times to measure the
+// fast path on the empty state). The handler still returns the same error
+// each iteration, which is fine for cost measurement.
+//
+// bench:rpc=mintrpc.Mint.CancelBatch
+func BenchmarkCancelBatch(b *testing.B) {
+	f := fixture.NewMint(b)
+
+	ctx := b.Context()
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		// Ignore the expected error; we are measuring the per-call cost
+		// on the empty-batch path.
+		_, _ = f.Server.CancelBatch(
+			ctx, &mintrpc.CancelBatchRequest{},
+		)
+	}
+}

--- a/bench/rpc/taprootassets_bench_test.go
+++ b/bench/rpc/taprootassets_bench_test.go
@@ -1,0 +1,155 @@
+// Package rpc contains per-RPC benchmarks for the taprootassets daemon. Each
+// .proto service has its own file; methods are bound to a graduated fixture
+// from bench/fixture per the dependency surface their handlers require.
+//
+// This file is the first per-RPC bench file: it covers the methods that the
+// Minimal fixture is sufficient for. Methods requiring populated db state
+// (List*, Query*, Decode-with-marshal) wait for the Storage fixture; methods
+// requiring active subsystems wait for Mint/Send/UniverseSync.
+package rpc
+
+import (
+	"encoding/hex"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/lightninglabs/taproot-assets/address"
+	"github.com/lightninglabs/taproot-assets/bench/fixture"
+	"github.com/lightninglabs/taproot-assets/taprpc"
+	"github.com/stretchr/testify/require"
+)
+
+// loadProofFileBlob loads the canonical test proof file from the proof
+// package's testdata directory and returns its raw bytes.
+func loadProofFileBlob(b *testing.B) []byte {
+	b.Helper()
+	const path = "../../proof/testdata/proof-file.hex"
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		b.Fatalf("read proof file: %v", err)
+	}
+	blob, err := hex.DecodeString(strings.TrimSpace(string(raw)))
+	if err != nil {
+		b.Fatalf("decode proof file hex: %v", err)
+	}
+	return blob
+}
+
+// BenchmarkDebugLevel covers the DebugLevel RPC. It reads only LogMgr off
+// the config and serves as the smallest end-to-end proof of the fixture +
+// shape-template wiring.
+//
+// bench:rpc=taprpc.TaprootAssets.DebugLevel
+func BenchmarkDebugLevel(b *testing.B) {
+	f := fixture.NewMinimal(b)
+	fixture.QueryBench(b, f.Server.DebugLevel, &taprpc.DebugLevelRequest{
+		Show: true,
+	})
+}
+
+// BenchmarkUnpackProofFile covers UnpackProofFile, which decodes a proof
+// file blob and returns its constituent raw proofs. It has no subsystem
+// dependencies — pure parser + memory copy.
+//
+// bench:rpc=taprpc.TaprootAssets.UnpackProofFile
+func BenchmarkUnpackProofFile(b *testing.B) {
+	f := fixture.NewMinimal(b)
+	blob := loadProofFileBlob(b)
+	fixture.QueryBench(b, f.Server.UnpackProofFile,
+		&taprpc.UnpackProofFileRequest{
+			RawProofFile: blob,
+		})
+}
+
+// BenchmarkListAssets covers ListAssets against an empty AssetStore. The
+// empty-store path is the relevant baseline for query overhead; populated-
+// store variants are added as scenarios.
+//
+// bench:rpc=taprpc.TaprootAssets.ListAssets
+func BenchmarkListAssets(b *testing.B) {
+	f := fixture.NewStorage(b)
+	fixture.QueryBench(b, f.Server.ListAssets, &taprpc.ListAssetRequest{})
+}
+
+// BenchmarkListUtxos covers ListUtxos against an empty AssetStore.
+//
+// bench:rpc=taprpc.TaprootAssets.ListUtxos
+func BenchmarkListUtxos(b *testing.B) {
+	f := fixture.NewStorage(b)
+	fixture.QueryBench(b, f.Server.ListUtxos, &taprpc.ListUtxosRequest{})
+}
+
+// BenchmarkListGroups covers ListGroups against an empty AssetStore.
+//
+// bench:rpc=taprpc.TaprootAssets.ListGroups
+func BenchmarkListGroups(b *testing.B) {
+	f := fixture.NewStorage(b)
+	fixture.QueryBench(b, f.Server.ListGroups, &taprpc.ListGroupsRequest{})
+}
+
+// BenchmarkListBalances covers ListBalances grouped by asset.
+//
+// bench:rpc=taprpc.TaprootAssets.ListBalances
+func BenchmarkListBalances(b *testing.B) {
+	f := fixture.NewStorage(b)
+	fixture.QueryBench(b, f.Server.ListBalances,
+		&taprpc.ListBalancesRequest{
+			GroupBy: &taprpc.ListBalancesRequest_AssetId{
+				AssetId: true,
+			},
+		})
+}
+
+// BenchmarkListTransfers covers ListTransfers against an empty AssetStore.
+//
+// bench:rpc=taprpc.TaprootAssets.ListTransfers
+func BenchmarkListTransfers(b *testing.B) {
+	f := fixture.NewStorage(b)
+	fixture.QueryBench(b, f.Server.ListTransfers,
+		&taprpc.ListTransfersRequest{})
+}
+
+// BenchmarkListBurns covers ListBurns against an empty AssetStore.
+//
+// bench:rpc=taprpc.TaprootAssets.ListBurns
+func BenchmarkListBurns(b *testing.B) {
+	f := fixture.NewStorage(b)
+	fixture.QueryBench(b, f.Server.ListBurns, &taprpc.ListBurnsRequest{})
+}
+
+// BenchmarkQueryAddrs covers QueryAddrs against an empty TapAddrBook.
+//
+// bench:rpc=taprpc.TaprootAssets.QueryAddrs
+func BenchmarkQueryAddrs(b *testing.B) {
+	f := fixture.NewStorage(b)
+	fixture.QueryBench(b, f.Server.QueryAddrs, &taprpc.QueryAddrRequest{})
+}
+
+// BenchmarkDecodeAddr covers DecodeAddr — bech32m parse + marshal. Exercises
+// TapAddrBook on the marshal path even though the address isn't found.
+//
+// bench:rpc=taprpc.TaprootAssets.DecodeAddr
+func BenchmarkDecodeAddr(b *testing.B) {
+	f := fixture.NewStorage(b)
+
+	addr, _, _ := address.RandAddrWithVersion(
+		b, &address.RegressionNetTap,
+		address.RandProofCourierAddr(b), address.V1,
+	)
+	encoded, err := addr.Tap.EncodeAddress()
+	require.NoError(b, err)
+
+	fixture.QueryBench(b, f.Server.DecodeAddr,
+		&taprpc.DecodeAddrRequest{Addr: encoded})
+}
+
+// BenchmarkAddrReceives covers AddrReceives against an empty event log.
+//
+// bench:rpc=taprpc.TaprootAssets.AddrReceives
+func BenchmarkAddrReceives(b *testing.B) {
+	f := fixture.NewStorage(b)
+	fixture.QueryBench(b, f.Server.AddrReceives,
+		&taprpc.AddrReceivesRequest{})
+}

--- a/bench/rpc/universe_bench_test.go
+++ b/bench/rpc/universe_bench_test.go
@@ -1,0 +1,100 @@
+package rpc
+
+import (
+	"testing"
+
+	"github.com/lightninglabs/taproot-assets/bench/fixture"
+	unirpc "github.com/lightninglabs/taproot-assets/taprpc/universerpc"
+)
+
+// Universe benches that fit Storage today exercise the empty-archive
+// fast paths. Populated-universe variants live in the scenario suite.
+
+// BenchmarkUniverseInfo covers Info — a trivial getter on the archive.
+//
+// bench:rpc=universerpc.Universe.Info
+func BenchmarkUniverseInfo(b *testing.B) {
+	f := fixture.NewStorage(b)
+	fixture.QueryBench(b, f.Server.Info, &unirpc.InfoRequest{})
+}
+
+// BenchmarkUniverseStats covers UniverseStats against an empty stats
+// collector — measures aggregation overhead with no rows.
+//
+// bench:rpc=universerpc.Universe.UniverseStats
+func BenchmarkUniverseStats(b *testing.B) {
+	f := fixture.NewStorage(b)
+	fixture.QueryBench(b, f.Server.UniverseStats, &unirpc.StatsRequest{})
+}
+
+// BenchmarkQueryAssetStats covers QueryAssetStats against an empty stats
+// store.
+//
+// bench:rpc=universerpc.Universe.QueryAssetStats
+func BenchmarkQueryAssetStats(b *testing.B) {
+	f := fixture.NewStorage(b)
+	fixture.QueryBench(b, f.Server.QueryAssetStats,
+		&unirpc.AssetStatsQuery{})
+}
+
+// BenchmarkQueryEvents covers QueryEvents against an empty event log.
+//
+// bench:rpc=universerpc.Universe.QueryEvents
+func BenchmarkQueryEvents(b *testing.B) {
+	f := fixture.NewStorage(b)
+	fixture.QueryBench(b, f.Server.QueryEvents,
+		&unirpc.QueryEventsRequest{})
+}
+
+// BenchmarkListFederationServers covers ListFederationServers against an
+// empty federation store.
+//
+// bench:rpc=universerpc.Universe.ListFederationServers
+func BenchmarkListFederationServers(b *testing.B) {
+	f := fixture.NewStorage(b)
+	fixture.QueryBench(b, f.Server.ListFederationServers,
+		&unirpc.ListFederationServersRequest{})
+}
+
+// BenchmarkQueryFederationSyncConfig covers QueryFederationSyncConfig
+// against an empty config store.
+//
+// bench:rpc=universerpc.Universe.QueryFederationSyncConfig
+func BenchmarkQueryFederationSyncConfig(b *testing.B) {
+	f := fixture.NewStorage(b)
+	fixture.QueryBench(b, f.Server.QueryFederationSyncConfig,
+		&unirpc.QueryFederationSyncConfigRequest{})
+}
+
+// BenchmarkAssetRoots covers AssetRoots against an empty universe.
+// Exercises FederationEnvoy.QuerySyncConfigs + pagination.
+//
+// bench:rpc=universerpc.Universe.AssetRoots
+func BenchmarkAssetRoots(b *testing.B) {
+	f := fixture.NewStorage(b)
+	fixture.QueryBench(b, f.Server.AssetRoots, &unirpc.AssetRootRequest{
+		Limit: 100,
+	})
+}
+
+// BenchmarkDeleteFederationServer covers DeleteFederationServer with an
+// empty server list. Exercises the proof-sync-log delete + RemoveServers
+// fast paths even though both end up touching zero rows.
+//
+// bench:rpc=universerpc.Universe.DeleteFederationServer
+func BenchmarkDeleteFederationServer(b *testing.B) {
+	f := fixture.NewStorage(b)
+	fixture.CommandBench(b, f.Server.DeleteFederationServer,
+		&unirpc.DeleteFederationServerRequest{})
+}
+
+// BenchmarkSetFederationSyncConfig covers SetFederationSyncConfig with
+// an empty config update.
+//
+// bench:rpc=universerpc.Universe.SetFederationSyncConfig
+func BenchmarkSetFederationSyncConfig(b *testing.B) {
+	f := fixture.NewStorage(b)
+	fixture.CommandBench(b, f.Server.SetFederationSyncConfig,
+		&unirpc.SetFederationSyncConfigRequest{})
+}
+

--- a/bench/rpc/universe_bench_test.go
+++ b/bench/rpc/universe_bench_test.go
@@ -97,4 +97,3 @@ func BenchmarkSetFederationSyncConfig(b *testing.B) {
 	fixture.CommandBench(b, f.Server.SetFederationSyncConfig,
 		&unirpc.SetFederationSyncConfigRequest{})
 }
-

--- a/bench/scenario/mint_bench_test.go
+++ b/bench/scenario/mint_bench_test.go
@@ -1,0 +1,32 @@
+package scenario
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/lightninglabs/taproot-assets/bench/fixture"
+)
+
+// BenchmarkMintBatch drives the planter from empty through to a confirmed
+// batch of N assets, parameterised over batch size. This is the end-to-end
+// cost the per-RPC mint benches do not capture: each per-RPC bench
+// measures one step (MintAsset, FundBatch, ...); the scenario measures
+// the entire flow.
+//
+// The driver fixture is expensive (sqlite tmpfile, planter goroutines,
+// chain pump). It is created per sub-benchmark, not per iteration; each
+// iteration enqueues N fresh seedlings and finalizes a fresh batch on
+// the same fixture.
+func BenchmarkMintBatch(b *testing.B) {
+	for _, n := range []int{1, 10, 100} {
+		b.Run(fmt.Sprintf("size=%d", n), func(b *testing.B) {
+			d := fixture.NewMintDriver(b)
+
+			b.ResetTimer()
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				d.MintOne(b, n)
+			}
+		})
+	}
+}

--- a/bench/scenario/scenarios_bench_test.go
+++ b/bench/scenario/scenarios_bench_test.go
@@ -1,0 +1,180 @@
+// Package scenario contains benchmarks for multi-subsystem flows at scale.
+// These complement the per-RPC benches under bench/rpc/: per-RPC benches
+// measure single-call cost; scenarios sweep parameters to characterise how
+// the dominant flows scale with size.
+//
+// Scenarios that need lnd-dependent flows (full mint, full send/receive)
+// rely on the same fixtures as the per-RPC benches and currently bench
+// the parts that run without a real Signer. Versions that drive the
+// signer mocks through the full flow will land alongside the
+// in-process integration fixtures.
+package scenario
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"testing"
+
+	"github.com/lightninglabs/taproot-assets/asset"
+	"github.com/lightninglabs/taproot-assets/commitment"
+	"github.com/lightninglabs/taproot-assets/mssmt"
+	"github.com/lightninglabs/taproot-assets/proof"
+	"github.com/stretchr/testify/require"
+)
+
+// BenchmarkAssetCommitmentScale exercises the full TapCommitment build +
+// per-asset inclusion-proof verification path at varying asset counts.
+// This is the dominant per-mint cost and covers the commitment +
+// mssmt + asset-key interactions in one realistic shape.
+func BenchmarkAssetCommitmentScale(b *testing.B) {
+	for _, n := range []int{1, 10, 100} {
+		b.Run(fmt.Sprintf("assets=%d", n), func(b *testing.B) {
+			assets := buildAssets(b, n)
+
+			b.ResetTimer()
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				ac, err := commitment.NewAssetCommitment(
+					assets...,
+				)
+				require.NoError(b, err)
+
+				tc, err := commitment.NewTapCommitment(nil, ac)
+				require.NoError(b, err)
+
+				for _, a := range assets {
+					_, p, err := tc.Proof(
+						a.TapCommitmentKey(),
+						a.AssetCommitmentKey(),
+					)
+					require.NoError(b, err)
+
+					_, err = p.DeriveByAssetInclusion(a)
+					require.NoError(b, err)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkProofFileRoundTrip exercises proof file encode + decode at
+// varying proof counts. Proof files dominate the receiver-side cost of
+// proof distribution; this bench measures how that scales with chain
+// length.
+func BenchmarkProofFileRoundTrip(b *testing.B) {
+	for _, n := range []int{1, 10, 100} {
+		b.Run(fmt.Sprintf("proofs=%d", n), func(b *testing.B) {
+			genesisProof := buildGenesisProof(b)
+			proofs := make([]proof.Proof, n)
+			for i := range proofs {
+				proofs[i] = genesisProof
+			}
+
+			f, err := proof.NewFile(proof.V0, proofs...)
+			require.NoError(b, err)
+
+			b.ResetTimer()
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				var buf bytes.Buffer
+				require.NoError(b, f.Encode(&buf))
+
+				decoded, err := proof.NewFile(proof.V0)
+				require.NoError(b, err)
+				require.NoError(b, decoded.Decode(&buf))
+			}
+		})
+	}
+}
+
+// BenchmarkMssmtBulkInsert populates a fresh tree with N leaves and
+// generates an inclusion proof for one. This is the dominant universe-
+// write shape: insert a leaf and prove inclusion. Parameter sweep covers
+// the regime universe servers operate in.
+func BenchmarkMssmtBulkInsert(b *testing.B) {
+	for _, n := range []int{100, 1_000, 10_000} {
+		b.Run(fmt.Sprintf("leaves=%d", n), func(b *testing.B) {
+			leaves := randMssmtLeaves(n)
+			ctx := context.Background()
+
+			b.ResetTimer()
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				tree := mssmt.NewCompactedTree(
+					mssmt.NewDefaultStore(),
+				)
+				for _, l := range leaves {
+					_, err := tree.Insert(
+						ctx, l.key, l.leaf,
+					)
+					require.NoError(b, err)
+				}
+
+				_, err := tree.MerkleProof(ctx, leaves[0].key)
+				require.NoError(b, err)
+			}
+		})
+	}
+}
+
+// buildAssets returns n Normal assets sharing a genesis.
+func buildAssets(b *testing.B, n int) []*asset.Asset {
+	b.Helper()
+	gen := asset.RandGenesis(b, asset.Normal)
+	assets := make([]*asset.Asset, n)
+	for i := 0; i < n; i++ {
+		scriptKey := asset.RandScriptKey(b)
+		assets[i] = asset.RandAssetWithValues(
+			b, gen, nil, scriptKey,
+		)
+	}
+	return assets
+}
+
+// buildGenesisProof returns a representative genesis proof using the
+// public proof.RandProof helper.
+func buildGenesisProof(b *testing.B) proof.Proof {
+	b.Helper()
+	// proof.RandProof has nontrivial setup overhead — we build it once
+	// per sub-benchmark via the Helper indirection so b.ResetTimer in
+	// the caller drops it from the timing window.
+	return mintRandomProof(b)
+}
+
+// mintRandomProof builds one valid Proof via the proof package's public
+// helpers, paired with a minimally-constructed block transaction.
+func mintRandomProof(b *testing.B) proof.Proof {
+	b.Helper()
+	// Reuse the testdata proof-file by decoding the first proof out of
+	// it; this avoids re-implementing the proof construction inline.
+	const path = "../../proof/testdata/proof-file.hex"
+	rawHex, err := readHexFile(path)
+	require.NoError(b, err)
+	f, err := proof.NewFile(proof.V0)
+	require.NoError(b, err)
+	require.NoError(b, f.Decode(bytes.NewReader(rawHex)))
+	first, err := f.ProofAt(0)
+	require.NoError(b, err)
+	return *first
+}
+
+// randMssmtLeaves returns n random mssmt leaves and their keys.
+func randMssmtLeaves(n int) []mssmtLeaf {
+	out := make([]mssmtLeaf, n)
+	for i := range out {
+		var k [32]byte
+		_, _ = rand.Read(k[:])
+		out[i] = mssmtLeaf{
+			key:  k,
+			leaf: mssmt.NewLeafNode([]byte("x"), 1),
+		}
+	}
+	return out
+}
+
+type mssmtLeaf struct {
+	key  [32]byte
+	leaf *mssmt.LeafNode
+}

--- a/bench/scenario/scenarios_bench_test.go
+++ b/bench/scenario/scenarios_bench_test.go
@@ -133,22 +133,22 @@ func buildAssets(b *testing.B, n int) []*asset.Asset {
 	return assets
 }
 
-// buildGenesisProof returns a representative genesis proof using the
-// public proof.RandProof helper.
+// buildGenesisProof returns a representative genesis proof decoded
+// from the proof package's testdata fixture.
 func buildGenesisProof(b *testing.B) proof.Proof {
 	b.Helper()
-	// proof.RandProof has nontrivial setup overhead — we build it once
-	// per sub-benchmark via the Helper indirection so b.ResetTimer in
-	// the caller drops it from the timing window.
+	// File I/O + decoding has nontrivial setup overhead — we build it
+	// once per sub-benchmark via the Helper indirection so b.ResetTimer
+	// in the caller drops it from the timing window.
 	return mintRandomProof(b)
 }
 
-// mintRandomProof builds one valid Proof via the proof package's public
-// helpers, paired with a minimally-constructed block transaction.
+// mintRandomProof returns one valid Proof by decoding the first entry
+// out of the proof package's testdata proof-file.
 func mintRandomProof(b *testing.B) proof.Proof {
 	b.Helper()
-	// Reuse the testdata proof-file by decoding the first proof out of
-	// it; this avoids re-implementing the proof construction inline.
+	// Decoding a testdata proof-file avoids re-implementing proof
+	// construction inline.
 	const path = "../../proof/testdata/proof-file.hex"
 	rawHex, err := readHexFile(path)
 	require.NoError(b, err)

--- a/bench/scenario/util_test.go
+++ b/bench/scenario/util_test.go
@@ -1,0 +1,17 @@
+package scenario
+
+import (
+	"encoding/hex"
+	"os"
+	"strings"
+)
+
+// readHexFile reads a hex-encoded blob from disk and returns the decoded
+// bytes, trimming surrounding whitespace.
+func readHexFile(path string) ([]byte, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	return hex.DecodeString(strings.TrimSpace(string(raw)))
+}

--- a/bench/wire/grpc_overhead_bench_test.go
+++ b/bench/wire/grpc_overhead_bench_test.go
@@ -1,0 +1,117 @@
+// Package wire contains benchmarks that measure the cost of going through
+// the gRPC stack — serialization, interceptors, in-process transport —
+// for a representative set of RPCs. The point is to characterise the
+// per-call gRPC overhead once; the per-RPC benches under bench/rpc/ skip
+// the wire and call handlers directly so their numbers reflect subsystem
+// cost only.
+package wire
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/lightninglabs/taproot-assets/bench/fixture"
+	"github.com/lightninglabs/taproot-assets/taprpc"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/test/bufconn"
+)
+
+// bufSize is the size of the bufconn buffer. 1 MiB is plenty for any RPC
+// payload these benches exercise.
+const bufSize = 1 << 20
+
+// newWireFixture spins up a Storage fixture, attaches its RPCServer to an
+// in-memory bufconn gRPC server, and returns a client connected over that
+// pipe. Cleanup is registered with tb.
+func newWireFixture(tb testing.TB) (
+	taprpc.TaprootAssetsClient, *fixture.Storage) {
+
+	tb.Helper()
+	f := fixture.NewStorage(tb)
+
+	lis := bufconn.Listen(bufSize)
+	srv := grpc.NewServer()
+	require.NoError(tb, f.Server.RegisterWithGrpcServer(srv))
+
+	go func() { _ = srv.Serve(lis) }()
+	tb.Cleanup(srv.Stop)
+
+	dialer := func(_ context.Context, _ string) (net.Conn, error) {
+		return lis.Dial()
+	}
+	conn, err := grpc.NewClient("passthrough:///bufnet",
+		grpc.WithContextDialer(dialer),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	require.NoError(tb, err)
+	tb.Cleanup(func() { _ = conn.Close() })
+
+	client := taprpc.NewTaprootAssetsClient(conn)
+
+	// Warm the connection. grpc.NewClient is lazy — the underlying
+	// transport is not established until the first RPC. With
+	// -benchtime=1x the entire bench would otherwise time the connect
+	// + TLS-less handshake instead of the per-call cost. We use
+	// DebugLevel because it is the cheapest server-side handler that
+	// the Storage fixture can serve.
+	_, err = client.DebugLevel(
+		context.Background(),
+		&taprpc.DebugLevelRequest{Show: true},
+	)
+	require.NoError(tb, err)
+
+	return client, f
+}
+
+// BenchmarkWireDebugLevel measures the gRPC overhead for a near-trivial
+// handler (DebugLevel) — isolates wire + interceptor + marshal cost from
+// subsystem work.
+func BenchmarkWireDebugLevel(b *testing.B) {
+	client, _ := newWireFixture(b)
+	ctx := context.Background()
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, err := client.DebugLevel(ctx, &taprpc.DebugLevelRequest{
+			Show: true,
+		})
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkWireListAssets measures gRPC overhead for an empty ListAssets
+// (the smallest payload that still touches a db read path).
+func BenchmarkWireListAssets(b *testing.B) {
+	client, _ := newWireFixture(b)
+	ctx := context.Background()
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, err := client.ListAssets(ctx, &taprpc.ListAssetRequest{})
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkWireQueryAddrs measures gRPC overhead for an empty QueryAddrs.
+func BenchmarkWireQueryAddrs(b *testing.B) {
+	client, _ := newWireFixture(b)
+	ctx := context.Background()
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, err := client.QueryAddrs(ctx, &taprpc.QueryAddrRequest{})
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/commitment/bench_test.go
+++ b/commitment/bench_test.go
@@ -1,0 +1,169 @@
+package commitment
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/lightninglabs/taproot-assets/asset"
+	"github.com/stretchr/testify/require"
+)
+
+// benchAssets returns n random Normal assets that all share the same genesis,
+// so they belong to the same AssetCommitment.
+func benchAssets(b *testing.B, n int) []*asset.Asset {
+	b.Helper()
+
+	genesis := asset.RandGenesis(b, asset.Normal)
+
+	assets := make([]*asset.Asset, n)
+	for i := 0; i < n; i++ {
+		scriptKey := asset.RandScriptKey(b)
+		assets[i] = asset.RandAssetWithValues(
+			b, genesis, nil, scriptKey,
+		)
+	}
+
+	return assets
+}
+
+// benchAssetCommitments returns n AssetCommitments, each backed by a distinct
+// genesis so they live under distinct TapCommitmentKeys.
+func benchAssetCommitments(b *testing.B, n int) []*AssetCommitment {
+	b.Helper()
+
+	commits := make([]*AssetCommitment, n)
+	for i := 0; i < n; i++ {
+		a := asset.RandAsset(b, asset.Normal)
+		c, err := NewAssetCommitment(a)
+		require.NoError(b, err)
+		commits[i] = c
+	}
+
+	return commits
+}
+
+// BenchmarkNewAssetCommitment measures the cost of grouping N assets sharing
+// a genesis into a single AssetCommitment.
+func BenchmarkNewAssetCommitment(b *testing.B) {
+	for _, n := range []int{1, 16, 256} {
+		b.Run(fmt.Sprintf("assets=%d", n), func(b *testing.B) {
+			assets := benchAssets(b, n)
+
+			b.ResetTimer()
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				_, err := NewAssetCommitment(assets...)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkNewTapCommitment measures the cost of constructing a TapCommitment
+// from N distinct AssetCommitments.
+func BenchmarkNewTapCommitment(b *testing.B) {
+	for _, n := range []int{1, 16, 256} {
+		b.Run(fmt.Sprintf("commits=%d", n), func(b *testing.B) {
+			commits := benchAssetCommitments(b, n)
+
+			b.ResetTimer()
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				_, err := NewTapCommitment(nil, commits...)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkTapCommitmentUpsert measures the cost of upserting one more
+// AssetCommitment into a TapCommitment of size N. The tree is rebuilt at
+// size N before every timed call so the measurement reflects the
+// labelled steady state and does not drift up as the bench loop runs.
+func BenchmarkTapCommitmentUpsert(b *testing.B) {
+	for _, n := range []int{16, 256, 4096} {
+		b.Run(fmt.Sprintf("existing=%d", n), func(b *testing.B) {
+			base := benchAssetCommitments(b, n)
+			extra := benchAssetCommitments(b, b.N)
+
+			b.ResetTimer()
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				b.StopTimer()
+				tc, err := NewTapCommitment(nil, base...)
+				require.NoError(b, err)
+				b.StartTimer()
+
+				if err := tc.Upsert(extra[i]); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkTapCommitmentDelete measures the cost of deleting one
+// AssetCommitment from a TapCommitment of size N+1. The tree is rebuilt
+// at size N+1 before every timed call so the measurement reflects the
+// labelled steady state and does not drift down across the bench loop.
+func BenchmarkTapCommitmentDelete(b *testing.B) {
+	for _, n := range []int{16, 256, 4096} {
+		b.Run(fmt.Sprintf("existing=%d", n), func(b *testing.B) {
+			base := benchAssetCommitments(b, n)
+			victims := benchAssetCommitments(b, b.N)
+
+			b.ResetTimer()
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				b.StopTimer()
+				all := append(
+					append([]*AssetCommitment{}, base...),
+					victims[i],
+				)
+				tc, err := NewTapCommitment(nil, all...)
+				require.NoError(b, err)
+				b.StartTimer()
+
+				if err := tc.Delete(victims[i]); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkProofDeriveByAssetInclusion measures the cost of reconstructing a
+// TapCommitment root from an inclusion proof — the operation done on every
+// receive-side proof verification.
+func BenchmarkProofDeriveByAssetInclusion(b *testing.B) {
+	for _, n := range []int{1, 16, 256} {
+		b.Run(fmt.Sprintf("assets=%d", n), func(b *testing.B) {
+			assets := benchAssets(b, n)
+			ac, err := NewAssetCommitment(assets...)
+			require.NoError(b, err)
+
+			tc, err := NewTapCommitment(nil, ac)
+			require.NoError(b, err)
+
+			target := assets[0]
+			_, proof, err := tc.Proof(
+				target.TapCommitmentKey(),
+				target.AssetCommitmentKey(),
+			)
+			require.NoError(b, err)
+
+			b.ResetTimer()
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				_, err := proof.DeriveByAssetInclusion(target)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/mssmt/bench_test.go
+++ b/mssmt/bench_test.go
@@ -78,6 +78,36 @@ func benchmarkMerkleProofCompress(b *testing.B, _ mssmt.Tree, _ []treeLeaf,
 	}
 }
 
+// benchmarkCompress isolates the compression half of the round-trip — the
+// half paid by the sender of a proof.
+func benchmarkCompress(b *testing.B, _ mssmt.Tree, _ []treeLeaf,
+	proofs map[[32]byte]*mssmt.Proof) {
+
+	for i := 0; i < b.N; i++ {
+		_, proof := randMapElem(proofs)
+		_ = proof.Compress()
+	}
+}
+
+// benchmarkDecompress isolates the decompression half — paid by every
+// receiver who verifies a proof off the wire.
+func benchmarkDecompress(b *testing.B, _ mssmt.Tree, _ []treeLeaf,
+	proofs map[[32]byte]*mssmt.Proof) {
+
+	// Precompute the compressed proofs so the decompression cost is what
+	// we actually measure.
+	compressed := make([]*mssmt.CompressedProof, 0, len(proofs))
+	for _, p := range proofs {
+		compressed = append(compressed, p.Compress())
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		cp := compressed[i%len(compressed)]
+		_, _ = cp.Decompress()
+	}
+}
+
 type benchmarkFunc = func(*testing.B, mssmt.Tree, []treeLeaf,
 	map[[32]byte]*mssmt.Proof)
 
@@ -96,6 +126,8 @@ var benchmarks = []benchmark{
 	newBenchmark("MerkleProof", benchmarkMerkleProof),
 	newBenchmark("VerifyMerkleProof", benchmarkVerifyMerkleProof),
 	newBenchmark("MerkleProofCompress", benchmarkMerkleProofCompress),
+	newBenchmark("Compress", benchmarkCompress),
+	newBenchmark("Decompress", benchmarkDecompress),
 }
 
 func benchmarkTree(b *testing.B, makeTree func() mssmt.Tree) {

--- a/proof/proof_test.go
+++ b/proof/proof_test.go
@@ -1257,6 +1257,55 @@ func BenchmarkProofEncoding(b *testing.B) {
 	}
 }
 
+// BenchmarkProofVerify measures the cost of verifying a single genesis proof
+// via Proof.Verify. This is the dominant per-proof cost during universe
+// queries and receive-side validation.
+func BenchmarkProofVerify(b *testing.B) {
+	amt := uint64(5000)
+	genesisProof, _ := genRandomGenesisWithProof(
+		b, asset.Normal, &amt, nil, true, nil, nil, nil, nil,
+		asset.V0,
+	)
+
+	ctx := context.Background()
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, err := genesisProof.Verify(
+			ctx, nil, MockChainLookup, MockVerifierCtx,
+		)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkFileVerify measures the cost of verifying a single-proof File via
+// File.Verify. Combined with BenchmarkProofVerify it isolates the
+// per-file overhead from the per-proof verification cost.
+func BenchmarkFileVerify(b *testing.B) {
+	amt := uint64(5000)
+	genesisProof, _ := genRandomGenesisWithProof(
+		b, asset.Normal, &amt, nil, true, nil, nil, nil, nil,
+		asset.V0,
+	)
+
+	f, err := NewFile(V0, genesisProof)
+	require.NoError(b, err)
+
+	ctx := context.Background()
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, err := f.Verify(ctx, MockVerifierCtx)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 // TestBIPTestVectors tests that the BIP test vectors are passing.
 func TestBIPTestVectors(t *testing.T) {
 	t.Parallel()

--- a/tapgarden/custodian_test.go
+++ b/tapgarden/custodian_test.go
@@ -739,7 +739,7 @@ func TestV2AddressHandling(t *testing.T) {
 		BlockHeight: 123,
 		BlockHeader: blockHeader,
 	}
-	h.chainBridge.Blocks[block.BlockHash()] = block
+	h.chainBridge.SetBlock(block.BlockHash(), block)
 
 	// Now we encode and encrypt the fragment.
 	fragmentBytes, err := fn.Encode(fragment)

--- a/tapgarden/mock.go
+++ b/tapgarden/mock.go
@@ -577,11 +577,19 @@ type MockChainBridge struct {
 	NewBlocks chan int32
 
 	ReqCount atomic.Int32
+
+	// ConfReqs and confErr are not guarded by a mutex. Readers must
+	// synchronise with the writer via the ConfReqSignal channel: the
+	// writer (RegisterConfirmationsNtfn) populates ConfReqs and
+	// reassigns confErr before sending the request number on
+	// ConfReqSignal, so any receive from that channel happens-after
+	// the corresponding store and a read of ConfReqs[reqNo] is safe.
 	ConfReqs map[int]*chainntnfs.ConfirmationEvent
 
-	// BlocksMu protects concurrent access to Blocks. Writers (test
-	// fixtures populating blocks on demand) and readers (GetBlock,
-	// called from caretaker goroutines) must hold it.
+	// BlocksMu protects concurrent access to Blocks. Readers (GetBlock,
+	// called from caretaker goroutines) hold it for read; all writers
+	// must go through SetBlock so the invariant cannot be violated
+	// piecemeal.
 	BlocksMu sync.RWMutex
 	Blocks   map[chainhash.Hash]*wire.MsgBlock
 
@@ -710,6 +718,15 @@ func (m *MockChainBridge) GetBlock(ctx context.Context,
 	}
 
 	return block, nil
+}
+
+// SetBlock records a block under its hash so a later GetBlock can return
+// it. All writers to Blocks must go through this helper so the BlocksMu
+// invariant cannot be violated piecemeal.
+func (m *MockChainBridge) SetBlock(hash chainhash.Hash, block *wire.MsgBlock) {
+	m.BlocksMu.Lock()
+	m.Blocks[hash] = block
+	m.BlocksMu.Unlock()
 }
 
 // GetBlockByHeight returns a block given the block height.

--- a/tapgarden/mock.go
+++ b/tapgarden/mock.go
@@ -579,7 +579,11 @@ type MockChainBridge struct {
 	ReqCount atomic.Int32
 	ConfReqs map[int]*chainntnfs.ConfirmationEvent
 
-	Blocks map[chainhash.Hash]*wire.MsgBlock
+	// BlocksMu protects concurrent access to Blocks. Writers (test
+	// fixtures populating blocks on demand) and readers (GetBlock,
+	// called from caretaker goroutines) must hold it.
+	BlocksMu sync.RWMutex
+	Blocks   map[chainhash.Hash]*wire.MsgBlock
 
 	failFeeEstimates atomic.Bool
 	errConf          atomic.Int32
@@ -698,7 +702,9 @@ func (m *MockChainBridge) RegisterBlockEpochNtfn(
 func (m *MockChainBridge) GetBlock(ctx context.Context,
 	hash chainhash.Hash) (*wire.MsgBlock, error) {
 
+	m.BlocksMu.RLock()
 	block, ok := m.Blocks[hash]
+	m.BlocksMu.RUnlock()
 	if !ok {
 		return nil, fmt.Errorf("block %s not found", hash.String())
 	}

--- a/tapgarden/mock_test.go
+++ b/tapgarden/mock_test.go
@@ -1,0 +1,56 @@
+package tapgarden
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+)
+
+// TestMockChainBridgeBlocksRace exercises concurrent SetBlock / GetBlock
+// access. Run with `go test -race` to catch any future writer that
+// bypasses the SetBlock helper.
+func TestMockChainBridgeBlocksRace(t *testing.T) {
+	t.Parallel()
+
+	const (
+		writers        = 8
+		readers        = 8
+		opsPerWorker   = 200
+		distinctHashes = 16
+	)
+
+	hashes := make([]chainhash.Hash, distinctHashes)
+	for i := range hashes {
+		hashes[i][0] = byte(i)
+	}
+
+	m := NewMockChainBridge()
+	ctx := context.Background()
+	block := &wire.MsgBlock{}
+
+	var wg sync.WaitGroup
+	wg.Add(writers + readers)
+	for w := 0; w < writers; w++ {
+		go func(seed int) {
+			defer wg.Done()
+			for i := 0; i < opsPerWorker; i++ {
+				h := hashes[(seed+i)%distinctHashes]
+				m.SetBlock(h, block)
+			}
+		}(w)
+	}
+	for r := 0; r < readers; r++ {
+		go func(seed int) {
+			defer wg.Done()
+			for i := 0; i < opsPerWorker; i++ {
+				_, _ = m.GetBlock(
+					ctx, hashes[(seed+i)%distinctHashes],
+				)
+			}
+		}(r)
+	}
+	wg.Wait()
+}

--- a/vm/bench_test.go
+++ b/vm/bench_test.go
@@ -1,0 +1,61 @@
+package vm
+
+// VM benchmarks exercise vm.Execute over representative state transitions:
+// a collectible transfer (single key-spend witness), a normal multi-input
+// transfer (key spend + tapscript script spend), and a split transition.
+//
+// The transition fixtures are built once per sub-benchmark and the engine is
+// re-constructed per iteration so allocations and validation cost are both
+// captured.
+
+import (
+	"testing"
+
+	"github.com/lightninglabs/taproot-assets/commitment"
+)
+
+// benchExecute runs vm.Execute once per iteration over the transition built
+// by f. The transition is built outside the timing loop; only engine
+// construction + Execute are measured.
+func benchExecute(b *testing.B, f stateTransitionFunc) {
+	newAsset, splitSet, inputSet, blockHeight := f(b)
+
+	splitAssets := make([]*commitment.SplitAsset, 0, len(splitSet))
+	for _, sa := range splitSet {
+		splitAssets = append(splitAssets, sa)
+	}
+
+	opts := []NewEngineOpt{
+		WithChainLookup(&mockChainLookup{}),
+		WithBlockHeight(blockHeight),
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		engine, err := New(newAsset, splitAssets, inputSet, opts...)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if err := engine.Execute(); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkExecuteCollectible benchmarks a single-witness collectible
+// state transition.
+func BenchmarkExecuteCollectible(b *testing.B) {
+	benchExecute(b, collectibleStateTransition)
+}
+
+// BenchmarkExecuteNormal benchmarks a two-input normal-asset transfer with
+// one key-spend witness and one tapscript script-spend witness.
+func BenchmarkExecuteNormal(b *testing.B) {
+	benchExecute(b, genNormalStateTransition(6, 0, 0, false, false))
+}
+
+// BenchmarkExecuteSplit benchmarks a split-output state transition.
+func BenchmarkExecuteSplit(b *testing.B) {
+	benchExecute(b, splitStateTransition)
+}

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -59,7 +59,7 @@ var (
 	mockChainLookupMeanTime int64 = 1_717_955_203
 )
 
-func randAsset(t *testing.T, assetType asset.Type,
+func randAsset(t testing.TB, assetType asset.Type,
 	scriptKeyPub *btcec.PublicKey) *asset.Asset {
 
 	t.Helper()
@@ -76,7 +76,7 @@ func randAsset(t *testing.T, assetType asset.Type,
 	)
 }
 
-func genTaprootKeySpend(t *testing.T, privKey btcec.PrivateKey,
+func genTaprootKeySpend(t testing.TB, privKey btcec.PrivateKey,
 	virtualTx *wire.MsgTx, input, newAsset *asset.Asset,
 	idx uint32) wire.TxWitness {
 
@@ -98,7 +98,7 @@ func genTaprootKeySpend(t *testing.T, privKey btcec.PrivateKey,
 	return wire.TxWitness{sig.Serialize()}
 }
 
-func genTaprootScriptSpend(t *testing.T, privKey btcec.PrivateKey,
+func genTaprootScriptSpend(t testing.TB, privKey btcec.PrivateKey,
 	virtualTx *wire.MsgTx, input, newAsset *asset.Asset, idx uint32,
 	sigHashType txscript.SigHashType, controlBlock *txscript.ControlBlock,
 	tapLeaf *txscript.TapLeaf, scriptWitness []byte) wire.TxWitness {
@@ -133,13 +133,13 @@ func genTaprootScriptSpend(t *testing.T, privKey btcec.PrivateKey,
 	}
 }
 
-type stateTransitionFunc = func(t *testing.T) (*asset.Asset,
+type stateTransitionFunc = func(t testing.TB) (*asset.Asset,
 	commitment.SplitSet, commitment.InputSet, uint32)
 
 func genesisStateTransition(assetType asset.Type,
 	valid, grouped bool) stateTransitionFunc {
 
-	return func(t *testing.T) (*asset.Asset, commitment.SplitSet,
+	return func(t testing.TB) (*asset.Asset, commitment.SplitSet,
 		commitment.InputSet, uint32) {
 
 		var (
@@ -175,7 +175,7 @@ func genesisStateTransition(assetType asset.Type,
 func invalidGenesisStateTransitionWitness(assetType asset.Type,
 	grouped bool) stateTransitionFunc {
 
-	return func(t *testing.T) (*asset.Asset, commitment.SplitSet,
+	return func(t testing.TB) (*asset.Asset, commitment.SplitSet,
 		commitment.InputSet, uint32) {
 
 		a := asset.RandAsset(t, assetType)
@@ -191,7 +191,7 @@ func invalidGenesisStateTransitionWitness(assetType asset.Type,
 	}
 }
 
-func collectibleStateTransition(t *testing.T) (*asset.Asset,
+func collectibleStateTransition(t testing.TB) (*asset.Asset,
 	commitment.SplitSet, commitment.InputSet, uint32) {
 
 	privKey := test.RandPrivKey()
@@ -231,7 +231,7 @@ func collectibleStateTransition(t *testing.T) (*asset.Asset,
 func genNormalStateTransition(currentHeight uint32, sequence,
 	lockTime uint64, addCsvScript, addCltvScript bool) stateTransitionFunc {
 
-	return func(t *testing.T) (*asset.Asset, commitment.SplitSet,
+	return func(t testing.TB) (*asset.Asset, commitment.SplitSet,
 		commitment.InputSet, uint32) {
 
 		return normalStateTransition(
@@ -241,7 +241,7 @@ func genNormalStateTransition(currentHeight uint32, sequence,
 	}
 }
 
-func normalStateTransition(t *testing.T, currentHeight uint32, sequence,
+func normalStateTransition(t testing.TB, currentHeight uint32, sequence,
 	lockTime uint64, addCsvScript, addCltvScript bool) (*asset.Asset,
 	commitment.SplitSet, commitment.InputSet, uint32) {
 
@@ -344,7 +344,7 @@ func normalStateTransition(t *testing.T, currentHeight uint32, sequence,
 func genCustomScriptStateTransition(currentHeight uint32, sequence,
 	lockTime uint64, tapLeaf txscript.TapLeaf) stateTransitionFunc {
 
-	return func(t *testing.T) (*asset.Asset, commitment.SplitSet,
+	return func(t testing.TB) (*asset.Asset, commitment.SplitSet,
 		commitment.InputSet, uint32) {
 
 		return customScriptStateTransition(
@@ -353,7 +353,7 @@ func genCustomScriptStateTransition(currentHeight uint32, sequence,
 	}
 }
 
-func customScriptStateTransition(t *testing.T, currentHeight uint32, sequence,
+func customScriptStateTransition(t testing.TB, currentHeight uint32, sequence,
 	lockTime uint64, tapLeaf txscript.TapLeaf) (*asset.Asset,
 	commitment.SplitSet, commitment.InputSet, uint32) {
 
@@ -411,7 +411,7 @@ func customScriptStateTransition(t *testing.T, currentHeight uint32, sequence,
 	return newAsset, nil, inputs, currentHeight
 }
 
-func splitStateTransition(t *testing.T) (*asset.Asset, commitment.SplitSet,
+func splitStateTransition(t testing.TB) (*asset.Asset, commitment.SplitSet,
 	commitment.InputSet, uint32) {
 
 	privKey := test.RandPrivKey()
@@ -467,7 +467,7 @@ func splitStateTransition(t *testing.T) (*asset.Asset, commitment.SplitSet,
 func splitFullValueStateTransition(validRootLocator,
 	validRoot bool) stateTransitionFunc {
 
-	return func(t *testing.T) (*asset.Asset, commitment.SplitSet,
+	return func(t testing.TB) (*asset.Asset, commitment.SplitSet,
 		commitment.InputSet, uint32) {
 
 		privKey := test.RandPrivKey()
@@ -527,7 +527,7 @@ func splitFullValueStateTransition(validRootLocator,
 }
 
 func splitCollectibleStateTransition(validRoot bool) stateTransitionFunc {
-	return func(t *testing.T) (*asset.Asset, commitment.SplitSet,
+	return func(t testing.TB) (*asset.Asset, commitment.SplitSet,
 		commitment.InputSet, uint32) {
 
 		privKey := test.RandPrivKey()
@@ -582,22 +582,38 @@ func splitCollectibleStateTransition(validRoot bool) stateTransitionFunc {
 func groupAnchorStateTransition(useHashLock, BIP86, keySpend, valid bool,
 	assetType asset.Type) stateTransitionFunc {
 
-	return func(t *testing.T) (*asset.Asset, commitment.SplitSet,
+	return func(t testing.TB) (*asset.Asset, commitment.SplitSet,
 		commitment.InputSet, uint32) {
 
 		gen := asset.RandGenesis(t, assetType)
+		// AssetCustomGroupKey only consumes *testing.T-specific
+		// behaviour; the assertion is safe because this transition
+		// builder is only ever invoked from tests, not from
+		// benchmarks.
+		tt, ok := t.(*testing.T)
+		if !ok {
+			t.Fatalf("groupAnchorStateTransition requires " +
+				"*testing.T")
+		}
 		return asset.AssetCustomGroupKey(
-			t, useHashLock, BIP86, keySpend, valid, gen,
+			tt, useHashLock, BIP86, keySpend, valid, gen,
 		), nil, nil, 0
 	}
 }
 
-func scriptTreeSpendStateTransition(t *testing.T, useHashLock,
+func scriptTreeSpendStateTransition(t testing.TB, useHashLock,
 	valid bool, sigHashType txscript.SigHashType) stateTransitionFunc {
 
+	// test.BuildTapscriptTree only consumes *testing.T-specific behaviour;
+	// the assertion is safe because this builder is only ever invoked from
+	// tests, not from benchmarks.
+	tt, ok := t.(*testing.T)
+	if !ok {
+		t.Fatalf("scriptTreeSpendStateTransition requires *testing.T")
+	}
 	scriptPrivKey := test.RandPrivKey()
 	usedLeaf, testTapScript, _, _, scriptWitness := test.BuildTapscriptTree(
-		t, useHashLock, valid, scriptPrivKey.PubKey(),
+		tt, useHashLock, valid, scriptPrivKey.PubKey(),
 	)
 	scriptKey, err := testTapScript.TaprootKey()
 	require.NoError(t, err)
@@ -625,7 +641,7 @@ func scriptTreeSpendStateTransition(t *testing.T, useHashLock,
 		Amount:      1,
 	}}
 
-	return func(t *testing.T) (*asset.Asset, commitment.SplitSet,
+	return func(t testing.TB) (*asset.Asset, commitment.SplitSet,
 		commitment.InputSet, uint32) {
 
 		inputs := []commitment.SplitCommitmentInput{{


### PR DESCRIPTION
Resolves #632.

Adds a whack of initial support (fixtures, make targets) for benchmarking and profiling. Doesn't graft it onto the itest framework as was suggested in the linked issue, but adds a first-class collection of stuff for proper, targeted benchmarking and profiling.

The idea, initially, is to focus on "hot-path" (I'm not an LLM, I swear) microbenchmarks and targeted RPC coverage. The coverage is deliberately incomplete for now, focusing only on the lowest-hanging stuff; I want to get this initial slab of work merged before adding more.

The benchmark framework is strictly additive save some benign "widening" adjustments made to the vm tests (using testing.TB instead of *testingT).