### PR TITLE
tapgarden: use current instead of initial request

### DIFF
--- a/tapgarden/planter.go
+++ b/tapgarden/planter.go
@@ -2297,7 +2297,7 @@ func matchPsbtToGroupReq(psbt psbt.Packet,
 
 		// Formulate the group virtual TX for the group key request so
 		// we can extract the previous output.
-		tx, err := groupReqs[0].BuildGroupVirtualTx(
+		tx, err := req.BuildGroupVirtualTx(
 			&tapscript.GroupTxBuilder{},
 		)
 		if err != nil {


### PR DESCRIPTION
(N.b., just happened to notice this while doing something else; seemed worth a fix.)

matchPsbtToGroupReq rebuilt the group virtual tx from groupReqs[0] on every iteration while returning the current loop request on match. For batches with multiple group requests, this could mis-associate signed group PSBTs or fail to match them at all, causing SealBatch to reject valid externally signed PSBTs or attach witnesses to the wrong asset request.

The issue appears most material for externally signed group virtual PSBTs in multi-request batches, while normal internally signed multi-asset-group minting can still work.

The fix is to use the current loop request when building the virtual tx so each candidate is compared against its own prevout.