### PR TITLE
universe: improve sync reliability and performance

### DIFF
--- a/bench/fixture/storage.go
+++ b/bench/fixture/storage.go
@@ -146,7 +146,7 @@ func NewStorage(tb testing.TB) *Storage {
 		LocalDiffEngine:     uniArchive,
 		LocalRegistrar:      uniArchive,
 		NewRemoteDiffEngine: noRemoteDiffEngine,
-		SyncBatchSize:       100,
+		SyncBatchSize:       50,
 	})
 
 	envoyErrChan := make(chan error, 1)

--- a/bench/fixture/sync.go
+++ b/bench/fixture/sync.go
@@ -1,0 +1,456 @@
+package fixture
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"math/rand"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	crand "crypto/rand"
+
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/lightninglabs/taproot-assets/asset"
+	"github.com/lightninglabs/taproot-assets/fn"
+	"github.com/lightninglabs/taproot-assets/internal/test"
+	"github.com/lightninglabs/taproot-assets/proof"
+	"github.com/lightninglabs/taproot-assets/tapdb"
+	"github.com/lightninglabs/taproot-assets/universe"
+	"github.com/lightningnetwork/lnd/clock"
+	lfn "github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/stretchr/testify/require"
+)
+
+// SyncMetrics accumulates registrar-observable events across a run of
+// SyncFixture. Every counter is written atomically because the syncer's
+// fan-out invokes the registrar from multiple goroutines.
+type SyncMetrics struct {
+	// UpsertBatches counts calls into UpsertProofLeafBatch.
+	UpsertBatches atomic.Int64
+
+	// LeavesInserted counts the total number of leaves passed through
+	// the registrar (single + batch, summed).
+	LeavesInserted atomic.Int64
+
+	// DBRetryErrors counts insertions that failed because the DB
+	// transaction retry budget was exhausted — the "db tx retries
+	// exceeded" symptom from issue #2026.
+	DBRetryErrors atomic.Int64
+
+	// DependencyMissing counts insertions that failed because a
+	// referenced prior proof was not present locally. Only surfaces when
+	// the registrar routes through the Archive verifier; the direct-
+	// write registrar in this fixture will keep it at zero.
+	DependencyMissing atomic.Int64
+}
+
+// Report emits the current counters to a bench via b.ReportMetric so
+// each shows up as its own column in benchstat output.
+func (m *SyncMetrics) Report(b *testing.B) {
+	b.Helper()
+
+	b.ReportMetric(
+		float64(m.UpsertBatches.Load()), "upsert_batches",
+	)
+	b.ReportMetric(
+		float64(m.LeavesInserted.Load()), "leaves_inserted",
+	)
+	b.ReportMetric(
+		float64(m.DBRetryErrors.Load()), "db_retry_errs",
+	)
+	b.ReportMetric(
+		float64(m.DependencyMissing.Load()), "dep_missing",
+	)
+}
+
+// Fraction is a bounded float in [0, 1]. Construct via NewFraction to
+// enforce the invariant. The zero value is 0 (valid).
+type Fraction float64
+
+// NewFraction returns f as a Fraction, panicking if f is outside
+// [0, 1]. Bench setup failing loudly is preferable to a silently
+// clamped value drifting the workload away from what the caller
+// intended.
+func NewFraction(f float64) Fraction {
+	if f < 0 || f > 1 {
+		panic(fmt.Sprintf("fixture: fraction %v out of [0, 1]", f))
+	}
+	return Fraction(f)
+}
+
+// RootSweep is a compact description of "N universes, each with M
+// leaves." Used by SeedSpec to describe issuance- and transfer-typed
+// roots separately.
+type RootSweep struct {
+	Roots  int
+	Leaves int
+}
+
+// SeedSpec describes the shape of a seeded corpus. Issuance and
+// Transfer are separate fields (rather than a flat list tagged by
+// proof type) so a caller cannot accidentally interleave the two.
+type SeedSpec struct {
+	// Issuance describes the issuance-typed universes to create.
+	Issuance RootSweep
+
+	// Transfer describes the transfer-typed universes to create.
+	Transfer RootSweep
+
+	// LocalOverlap is the fraction of each remote root's leaves that
+	// also get inserted into the local universe before sync. Zero means
+	// the local side starts empty; one means the two sides are already
+	// identical (and sync should be a no-op).
+	LocalOverlap Fraction
+}
+
+// universePair is one side of the sync fixture. Each side has its own
+// SQLite DB, multiverse store, and archive. The archive is what the
+// syncer talks to as a DiffEngine.
+type universePair struct {
+	DB         *tapdb.SqliteStore
+	Multiverse *tapdb.MultiverseStore
+	Archive    *universe.Archive
+}
+
+// newUniversePair spins up a fresh SQLite-backed universe suitable for
+// use as the local or remote side of a sync benchmark. Verifiers are
+// mock (permissive) because the seed corpus is random and would not
+// survive real chain-backed verification.
+func newUniversePair(tb testing.TB, clk clock.Clock) *universePair {
+	tb.Helper()
+
+	db := tapdb.NewTestDB(tb)
+
+	multiverseDB := tapdb.NewTransactionExecutor(
+		db.BaseDB, func(tx *sql.Tx) tapdb.BaseMultiverseStore {
+			return db.WithTx(tx)
+		},
+	)
+	mv, err := tapdb.NewMultiverseStore(
+		multiverseDB, tapdb.DefaultMultiverseStoreConfig(),
+	)
+	require.NoError(tb, err)
+
+	uniDB := tapdb.NewTransactionExecutor(
+		db.BaseDB, func(tx *sql.Tx) tapdb.BaseUniverseStore {
+			return db.WithTx(tx)
+		},
+	)
+	newBaseTree := func(id universe.Identifier) universe.StorageBackend {
+		return tapdb.NewBaseUniverseTree(uniDB, id)
+	}
+
+	uniStatsDB := tapdb.NewTransactionExecutor(
+		db.BaseDB, func(tx *sql.Tx) tapdb.UniverseStatsStore {
+			return db.WithTx(tx)
+		},
+	)
+	stats := tapdb.NewUniverseStats(uniStatsDB, clk)
+
+	archive := universe.NewArchive(universe.ArchiveConfig{
+		NewBaseTree:          newBaseTree,
+		HeaderVerifier:       proof.MockHeaderVerifier,
+		MerkleVerifier:       proof.DefaultMerkleVerifier,
+		GroupVerifier:        proof.MockGroupVerifier,
+		ChainLookupGenerator: proof.MockChainLookup,
+		Multiverse:           mv,
+		UniverseStats:        stats,
+		IgnoreChecker:        lfn.None[proof.IgnoreChecker](),
+	})
+
+	return &universePair{
+		DB:         db,
+		Multiverse: mv,
+		Archive:    archive,
+	}
+}
+
+// directRegistrar is a BatchRegistrar that writes directly into the
+// multiverse store, bypassing the Archive's per-proof verification
+// pipeline. Two reasons:
+//
+//  1. Seed corpora are random proofs that would not survive real
+//     proof.Verify; keeping verification off the write path lets us
+//     bench the sync-side and DB-side work in isolation.
+//  2. The DB transaction contention we care about happens inside
+//     MultiverseStore.UpsertProofLeafBatch. Routing writes through the
+//     archive would layer verifier work on top without changing the
+//     contention pattern under measurement.
+type directRegistrar struct {
+	multiverse *tapdb.MultiverseStore
+	metrics    *SyncMetrics
+}
+
+var _ universe.BatchRegistrar = (*directRegistrar)(nil)
+
+func (r *directRegistrar) UpsertProofLeaf(ctx context.Context,
+	id universe.Identifier, key universe.LeafKey,
+	leaf *universe.Leaf) (*universe.Proof, error) {
+
+	r.metrics.LeavesInserted.Add(1)
+	p, err := r.multiverse.UpsertProofLeaf(ctx, id, key, leaf, nil)
+	r.classify(err)
+	return p, err
+}
+
+func (r *directRegistrar) UpsertProofLeafBatch(ctx context.Context,
+	items []*universe.Item) error {
+
+	r.metrics.UpsertBatches.Add(1)
+	r.metrics.LeavesInserted.Add(int64(len(items)))
+	err := r.multiverse.UpsertProofLeafBatch(ctx, items)
+	r.classify(err)
+	return err
+}
+
+func (r *directRegistrar) Close() error { return nil }
+
+// classify categorises an insertion error into the per-symptom
+// counters the bench reports. The upstream errors are string-wrapped
+// via fmt.Errorf with no sentinel, so substring matching is what we
+// have to work with.
+func (r *directRegistrar) classify(err error) {
+	if err == nil {
+		return
+	}
+	msg := err.Error()
+	switch {
+	case strings.Contains(msg, "db tx retries exceeded"):
+		r.metrics.DBRetryErrors.Add(1)
+	case strings.Contains(msg, "no universe proof found"):
+		r.metrics.DependencyMissing.Add(1)
+	}
+}
+
+// SyncFixtureOpts configures a SyncFixture. The zero value picks the
+// production default for SyncBatchSize (200 as of writing).
+type SyncFixtureOpts struct {
+	// SyncBatchSize is the leaf batch size passed to SimpleSyncer.
+	SyncBatchSize int
+}
+
+func (o SyncFixtureOpts) withDefaults() SyncFixtureOpts {
+	if o.SyncBatchSize == 0 {
+		o.SyncBatchSize = 200
+	}
+	return o
+}
+
+// SyncFixture pairs two in-process universes (local, remote) with a
+// SimpleSyncer wired to treat one side as remote. Use it from a bench
+// to drive SyncUniverse end-to-end without any network I/O.
+type SyncFixture struct {
+	Local   *universePair
+	Remote  *universePair
+	Syncer  *universe.SimpleSyncer
+	Metrics *SyncMetrics
+}
+
+// NewSyncFixture constructs an unseeded SyncFixture. Call Seed to
+// populate the two sides before running SyncUniverse.
+func NewSyncFixture(tb testing.TB, opts SyncFixtureOpts) *SyncFixture {
+	tb.Helper()
+
+	opts = opts.withDefaults()
+
+	// A fixed clock keeps timing-dependent paths deterministic across
+	// bench runs.
+	clk := clock.NewTestClock(time.Unix(1_700_000_000, 0))
+
+	local := newUniversePair(tb, clk)
+	remote := newUniversePair(tb, clk)
+
+	metrics := &SyncMetrics{}
+
+	syncer := universe.NewSimpleSyncer(universe.SimpleSyncCfg{
+		LocalDiffEngine: local.Archive,
+		LocalRegistrar: &directRegistrar{
+			multiverse: local.Multiverse,
+			metrics:    metrics,
+		},
+		NewRemoteDiffEngine: func(
+			_ universe.ServerAddr) (universe.DiffEngine, error) {
+
+			return remote.Archive, nil
+		},
+		SyncBatchSize: opts.SyncBatchSize,
+	})
+
+	return &SyncFixture{
+		Local:   local,
+		Remote:  remote,
+		Syncer:  syncer,
+		Metrics: metrics,
+	}
+}
+
+// GlobalSyncConfig returns a SyncConfigs value that enables global
+// insert for both proof types, matching the mainnet default a fresh
+// tapd would use.
+func GlobalSyncConfig() universe.SyncConfigs {
+	return universe.SyncConfigs{
+		GlobalSyncConfigs: []*universe.FedGlobalSyncConfig{
+			{
+				ProofType:       universe.ProofTypeIssuance,
+				AllowSyncInsert: true,
+				AllowSyncExport: true,
+			},
+			{
+				ProofType:       universe.ProofTypeTransfer,
+				AllowSyncInsert: true,
+				AllowSyncExport: true,
+			},
+		},
+	}
+}
+
+// Seed populates the fixture according to spec. Every remote root and
+// leaf is inserted into the Remote side; a leading LocalOverlap
+// fraction of each root's leaves is additionally inserted into the
+// Local side, so the syncer sees a partial-overlap workload.
+func (f *SyncFixture) Seed(tb testing.TB, spec SeedSpec) {
+	tb.Helper()
+
+	ctx := context.Background()
+
+	seedType(tb, ctx, f, universe.ProofTypeIssuance, spec.Issuance,
+		spec.LocalOverlap)
+	seedType(tb, ctx, f, universe.ProofTypeTransfer, spec.Transfer,
+		spec.LocalOverlap)
+}
+
+// seedType is the per-proof-type worker used by Seed.
+func seedType(tb testing.TB, ctx context.Context, f *SyncFixture,
+	pt universe.ProofType, sweep RootSweep, overlap Fraction) {
+
+	tb.Helper()
+
+	if sweep.Roots == 0 || sweep.Leaves == 0 {
+		return
+	}
+
+	localCount := int(float64(sweep.Leaves) * float64(overlap))
+
+	for r := 0; r < sweep.Roots; r++ {
+		// All leaves under one root share a single asset genesis; the
+		// universe identifier is derived from that same genesis so
+		// insert-time and query-time namespaces agree. Deriving id
+		// from the genesis (rather than choosing a random AssetID
+		// independently) is what makes id.String() at read-time match
+		// the namespace under which leaves were actually stored.
+		assetGen := asset.RandGenesis(tb, asset.Normal)
+		id := universe.Identifier{
+			AssetID:   assetGen.ID(),
+			ProofType: pt,
+		}
+
+		remoteItems := make([]*universe.Item, sweep.Leaves)
+		for i := 0; i < sweep.Leaves; i++ {
+			key := randLeafKey(tb)
+			leaf := randMintingLeafFor(tb, assetGen)
+			remoteItems[i] = &universe.Item{
+				ID:   id,
+				Key:  key,
+				Leaf: leaf,
+			}
+		}
+
+		err := f.Remote.Multiverse.UpsertProofLeafBatch(
+			ctx, remoteItems,
+		)
+		require.NoError(tb, err)
+
+		if localCount == 0 {
+			continue
+		}
+
+		err = f.Local.Multiverse.UpsertProofLeafBatch(
+			ctx, remoteItems[:localCount],
+		)
+		require.NoError(tb, err)
+	}
+}
+
+// randLeafKey returns a random universe leaf key. Each call allocates
+// a fresh *asset.ScriptKey, which is exactly the shape that reveals
+// the pointer-identity diff bug when the returned keys are diffed via
+// fn.SetDiff.
+func randLeafKey(tb testing.TB) universe.LeafKey {
+	tb.Helper()
+
+	return universe.BaseLeafKey{
+		OutPoint:  test.RandOp(tb),
+		ScriptKey: fn.Ptr(asset.NewScriptKey(test.RandPubKey(tb))),
+	}
+}
+
+// randMintingLeafFor returns a random universe leaf carrying a
+// serialized proof. Every leaf under one universe root must share the
+// same asset genesis, otherwise the multiverse's per-namespace bookkeeping
+// would treat each leaf as belonging to a distinct universe.
+func randMintingLeafFor(tb testing.TB,
+	assetGen asset.Genesis) *universe.Leaf {
+
+	tb.Helper()
+
+	p := randProof(tb)
+	p.Asset.Genesis = assetGen
+	p.GenesisReveal = &assetGen
+
+	leaf := &universe.Leaf{
+		GenesisWithGroup: universe.GenesisWithGroup{
+			Genesis: assetGen,
+		},
+		Asset: &p.Asset,
+		Amt:   uint64(rand.Int31()), //nolint:gosec
+	}
+
+	proofBytes, err := p.Bytes()
+	require.NoError(tb, err)
+	leaf.RawProof = proofBytes
+
+	return leaf
+}
+
+// randProof builds a minimal but structurally valid proof.Proof
+// suitable for round-tripping through Bytes/Decode. The fields are
+// random; the fixture uses mock verifiers so semantic validity is not
+// required.
+func randProof(tb testing.TB) *proof.Proof {
+	tb.Helper()
+
+	proofAsset := *asset.RandAsset(tb, asset.Normal)
+
+	var witnessData [32]byte
+	_, err := crand.Read(witnessData[:])
+	require.NoError(tb, err)
+
+	var pkScript [32]byte
+	_, err = crand.Read(pkScript[:])
+	require.NoError(tb, err)
+
+	return &proof.Proof{
+		PrevOut: wire.OutPoint{},
+		BlockHeader: wire.BlockHeader{
+			Timestamp: time.Unix(rand.Int63(), 0), //nolint:gosec
+		},
+		AnchorTx: wire.MsgTx{
+			Version: 2,
+			TxIn: []*wire.TxIn{{
+				Witness: [][]byte{witnessData[:]},
+			}},
+			TxOut: []*wire.TxOut{{
+				PkScript: pkScript[:],
+				Value:    1000,
+			}},
+		},
+		Asset: proofAsset,
+		InclusionProof: proof.TaprootProof{
+			InternalKey: test.RandPubKey(tb),
+		},
+		AltLeaves: asset.ToAltLeaves(asset.RandAltLeaves(tb, true)),
+	}
+}

--- a/bench/fixture/sync.go
+++ b/bench/fixture/sync.go
@@ -225,16 +225,22 @@ func (r *directRegistrar) classify(err error) {
 	}
 }
 
-// SyncFixtureOpts configures a SyncFixture. The zero value picks the
-// production default for SyncBatchSize (200 as of writing).
+// SyncFixtureOpts configures a SyncFixture. Zero fields fall back to
+// the production defaults (batch=50, root-concurrency=2).
 type SyncFixtureOpts struct {
 	// SyncBatchSize is the leaf batch size passed to SimpleSyncer.
 	SyncBatchSize int
+
+	// SyncRootConcurrency caps the syncer's per-root fan-out.
+	SyncRootConcurrency int
 }
 
 func (o SyncFixtureOpts) withDefaults() SyncFixtureOpts {
 	if o.SyncBatchSize == 0 {
-		o.SyncBatchSize = 200
+		o.SyncBatchSize = 50
+	}
+	if o.SyncRootConcurrency == 0 {
+		o.SyncRootConcurrency = 2
 	}
 	return o
 }
@@ -276,7 +282,8 @@ func NewSyncFixture(tb testing.TB, opts SyncFixtureOpts) *SyncFixture {
 
 			return remote.Archive, nil
 		},
-		SyncBatchSize: opts.SyncBatchSize,
+		SyncBatchSize:       opts.SyncBatchSize,
+		SyncRootConcurrency: opts.SyncRootConcurrency,
 	})
 
 	return &SyncFixture{

--- a/bench/fixture/sync_test.go
+++ b/bench/fixture/sync_test.go
@@ -2,8 +2,10 @@ package fixture
 
 import (
 	"context"
+	"math/rand"
 	"testing"
 
+	"github.com/lightninglabs/taproot-assets/asset"
 	"github.com/lightninglabs/taproot-assets/universe"
 	"github.com/stretchr/testify/require"
 )
@@ -34,11 +36,9 @@ func TestSyncFixture_EndToEnd(t *testing.T) {
 	// One batch call per root (5 roots, all diverge).
 	require.EqualValues(t, 5, f.Metrics.UpsertBatches.Load())
 
-	// The syncer over-fetches under the pointer-identity SetDiff bug
-	// this PR is fixing (issue #2026): 5 leaves per root fetched even
-	// though local already had 2 per root, so 25 leaves cross the
-	// wire instead of the correct 15. Phase 1 tightens this to 15.
-	require.EqualValues(t, 25, f.Metrics.LeavesInserted.Load())
+	// With the content-based diff in place, only the new leaves cross
+	// over: 5 roots x (5 remote - 2 local overlap) = 15.
+	require.EqualValues(t, 15, f.Metrics.LeavesInserted.Load())
 
 	// No DB retries or dep-missing errors should surface at this scale.
 	require.Zero(t, f.Metrics.DBRetryErrors.Load())
@@ -69,6 +69,146 @@ func TestSyncFixture_FullOverlap(t *testing.T) {
 	// exit at syncer.go:302 fires per root — no writes should occur.
 	require.Zero(t, f.Metrics.UpsertBatches.Load())
 	require.Zero(t, f.Metrics.LeavesInserted.Load())
+}
+
+// TestSyncFixture_StaleContentAtSharedKeys covers the re-org shape:
+// remote and local hold leaves at the same (outpoint, script_key) but
+// with different content. The syncer's LeafEntry diff carries each
+// leaf's canonical H(value || sum) node hash, so a shared key with
+// disagreeing content surfaces as a normal diff entry and its
+// remote-side leaf gets fetched. Regression for the
+// TestTaprootAssetsDaemon/tranche07/re-org_mint itest.
+func TestSyncFixture_StaleContentAtSharedKeys(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	f := NewSyncFixture(t, SyncFixtureOpts{})
+
+	// Both sides share a single universe with two shared leaf keys but
+	// distinct leaf contents. randMintingLeafFor allocates a fresh
+	// proof each time, so remote.Amt and local.Amt differ with
+	// overwhelming probability — sufficient to force different SMT
+	// leaf hashes at the same key.
+	assetGen := asset.RandGenesis(t, asset.Normal)
+	id := universe.Identifier{
+		AssetID:   assetGen.ID(),
+		ProofType: universe.ProofTypeIssuance,
+	}
+
+	const numLeaves = 2
+	keys := make([]universe.LeafKey, numLeaves)
+	remoteItems := make([]*universe.Item, numLeaves)
+	localItems := make([]*universe.Item, numLeaves)
+	for i := 0; i < numLeaves; i++ {
+		keys[i] = randLeafKey(t)
+		remoteItems[i] = &universe.Item{
+			ID:   id,
+			Key:  keys[i],
+			Leaf: randMintingLeafFor(t, assetGen),
+		}
+
+		// Local leaf shares the key but carries a different Amt (and
+		// therefore a different SMT leaf hash) than the remote leaf.
+		staleLeaf := randMintingLeafFor(t, assetGen)
+		for staleLeaf.Amt == remoteItems[i].Leaf.Amt {
+			staleLeaf.Amt = uint64(rand.Int31()) //nolint:gosec
+		}
+		localItems[i] = &universe.Item{
+			ID:   id,
+			Key:  keys[i],
+			Leaf: staleLeaf,
+		}
+	}
+
+	require.NoError(t, f.Remote.Multiverse.UpsertProofLeafBatch(
+		ctx, remoteItems,
+	))
+	require.NoError(t, f.Local.Multiverse.UpsertProofLeafBatch(
+		ctx, localItems,
+	))
+
+	_, err := f.Syncer.SyncUniverse(
+		ctx, universe.ServerAddr{}, universe.SyncFull,
+		GlobalSyncConfig(),
+	)
+	require.NoError(t, err)
+
+	// Every shared key showed up in the diff (differing content
+	// hashes) and its remote-side leaf was fetched and reinserted.
+	require.EqualValues(t, numLeaves, f.Metrics.LeavesInserted.Load())
+
+	// And the underlying content actually got overwritten — post-sync,
+	// local's leaf Amt values match remote's.
+	for i, key := range keys {
+		proofs, err := f.Local.Multiverse.FetchProofLeaf(
+			ctx, id, key,
+		)
+		require.NoError(t, err)
+		require.Len(t, proofs, 1)
+		require.Equal(t, remoteItems[i].Leaf.Amt, proofs[0].Leaf.Amt)
+	}
+}
+
+// TestSyncFixture_RemoteBehindPeer covers the peer-is-behind shape:
+// remote's leaf-key set is a strict subset of local's, so the two
+// roots diverge but the LeafEntry diff finds no remote-only or
+// content-differing entries. No leaves must be fetched or upserted;
+// the syncer must not busy-loop refetching every remote leaf on
+// each pass. Regression against the empty-diff-refetch pathology
+// this branch's LeafEntry work replaces.
+func TestSyncFixture_RemoteBehindPeer(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	f := NewSyncFixture(t, SyncFixtureOpts{})
+
+	assetGen := asset.RandGenesis(t, asset.Normal)
+	id := universe.Identifier{
+		AssetID:   assetGen.ID(),
+		ProofType: universe.ProofTypeIssuance,
+	}
+
+	// Build 5 shared leaves — same key and same leaf on both sides.
+	const numShared = 5
+	shared := make([]*universe.Item, numShared)
+	for i := 0; i < numShared; i++ {
+		shared[i] = &universe.Item{
+			ID:   id,
+			Key:  randLeafKey(t),
+			Leaf: randMintingLeafFor(t, assetGen),
+		}
+	}
+
+	// Local additionally holds 3 leaves the remote does not — this
+	// is what makes the roots diverge while keeping remote's keyset
+	// a strict subset of local's.
+	const numExtra = 3
+	extras := make([]*universe.Item, numExtra)
+	for i := 0; i < numExtra; i++ {
+		extras[i] = &universe.Item{
+			ID:   id,
+			Key:  randLeafKey(t),
+			Leaf: randMintingLeafFor(t, assetGen),
+		}
+	}
+
+	require.NoError(t, f.Remote.Multiverse.UpsertProofLeafBatch(
+		ctx, shared,
+	))
+	require.NoError(t, f.Local.Multiverse.UpsertProofLeafBatch(
+		ctx, append(shared, extras...),
+	))
+
+	_, err := f.Syncer.SyncUniverse(
+		ctx, universe.ServerAddr{}, universe.SyncFull,
+		GlobalSyncConfig(),
+	)
+	require.NoError(t, err)
+
+	// No leaves crossed over: shared entries match by content and
+	// local-only entries have no remote counterpart to fetch.
+	require.Zero(t, f.Metrics.LeavesInserted.Load())
+	require.Zero(t, f.Metrics.UpsertBatches.Load())
 }
 
 // TestNewFraction_PanicOutOfRange guards the Fraction invariant.

--- a/bench/fixture/sync_test.go
+++ b/bench/fixture/sync_test.go
@@ -1,0 +1,84 @@
+package fixture
+
+import (
+	"context"
+	"testing"
+
+	"github.com/lightninglabs/taproot-assets/universe"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSyncFixture_EndToEnd exercises the sync fixture end to end: it
+// seeds the remote with a mix of issuance and transfer roots, seeds
+// half the leaves into the local side, then drives one SyncUniverse
+// call. Passing means the local + remote wiring, the seeded random
+// proofs, and the direct-write registrar all agree.
+func TestSyncFixture_EndToEnd(t *testing.T) {
+	t.Parallel()
+
+	f := NewSyncFixture(t, SyncFixtureOpts{})
+	f.Seed(t, SeedSpec{
+		Issuance:     RootSweep{Roots: 3, Leaves: 5},
+		Transfer:     RootSweep{Roots: 2, Leaves: 5},
+		LocalOverlap: NewFraction(0.4),
+	})
+
+	ctx := context.Background()
+
+	_, err := f.Syncer.SyncUniverse(
+		ctx, universe.ServerAddr{}, universe.SyncFull,
+		GlobalSyncConfig(),
+	)
+	require.NoError(t, err)
+
+	// One batch call per root (5 roots, all diverge).
+	require.EqualValues(t, 5, f.Metrics.UpsertBatches.Load())
+
+	// The syncer over-fetches under the pointer-identity SetDiff bug
+	// this PR is fixing (issue #2026): 5 leaves per root fetched even
+	// though local already had 2 per root, so 25 leaves cross the
+	// wire instead of the correct 15. Phase 1 tightens this to 15.
+	require.EqualValues(t, 25, f.Metrics.LeavesInserted.Load())
+
+	// No DB retries or dep-missing errors should surface at this scale.
+	require.Zero(t, f.Metrics.DBRetryErrors.Load())
+	require.Zero(t, f.Metrics.DependencyMissing.Load())
+}
+
+// TestSyncFixture_FullOverlap covers the degenerate case where local
+// already has every leaf remote has. The syncer should observe no
+// leaves to insert — a direct check that seeding is symmetric across
+// the two sides for the overlapping prefix.
+func TestSyncFixture_FullOverlap(t *testing.T) {
+	t.Parallel()
+
+	f := NewSyncFixture(t, SyncFixtureOpts{})
+	f.Seed(t, SeedSpec{
+		Issuance:     RootSweep{Roots: 2, Leaves: 3},
+		LocalOverlap: NewFraction(1),
+	})
+
+	ctx := context.Background()
+	_, err := f.Syncer.SyncUniverse(
+		ctx, universe.ServerAddr{}, universe.SyncFull,
+		GlobalSyncConfig(),
+	)
+	require.NoError(t, err)
+
+	// With full overlap, roots are identical and the syncer's early
+	// exit at syncer.go:302 fires per root — no writes should occur.
+	require.Zero(t, f.Metrics.UpsertBatches.Load())
+	require.Zero(t, f.Metrics.LeavesInserted.Load())
+}
+
+// TestNewFraction_PanicOutOfRange guards the Fraction invariant.
+func TestNewFraction_PanicOutOfRange(t *testing.T) {
+	t.Parallel()
+
+	require.Panics(t, func() { NewFraction(-0.01) })
+	require.Panics(t, func() { NewFraction(1.01) })
+
+	// Boundary values are valid.
+	require.NotPanics(t, func() { NewFraction(0) })
+	require.NotPanics(t, func() { NewFraction(1) })
+}

--- a/bench/scenario/universe_sync_bench_test.go
+++ b/bench/scenario/universe_sync_bench_test.go
@@ -1,0 +1,112 @@
+package scenario
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/lightninglabs/taproot-assets/bench/fixture"
+	"github.com/lightninglabs/taproot-assets/universe"
+)
+
+// BenchmarkUniverseSync_FreshLocal drives a full sync into an empty
+// local universe. This is the dominant cost the first time an operator
+// joins a federation: every remote leaf crosses the wire and hits the
+// registrar. Parameter sweeps expose how throughput and DB tx
+// contention scale with the shape of the workload.
+func BenchmarkUniverseSync_FreshLocal(b *testing.B) {
+	for _, roots := range []int{10, 50} {
+		for _, leaves := range []int{50, 200} {
+			name := fmt.Sprintf("roots=%d/leaves=%d",
+				roots, leaves)
+			b.Run(name, func(b *testing.B) {
+				runSyncBench(b, fixture.SeedSpec{
+					Issuance: fixture.RootSweep{
+						Roots:  roots,
+						Leaves: leaves,
+					},
+					LocalOverlap: fixture.NewFraction(0),
+				})
+			})
+		}
+	}
+}
+
+// BenchmarkUniverseSync_MostlySynced is the key test for issue #2026's
+// SetDiff fix. Local already has 90% of remote's leaves; correct
+// behavior is to fetch only the missing 10%. Today's pointer-identity
+// diff re-fetches everything — the leaves_inserted metric quantifies
+// the over-fetch.
+func BenchmarkUniverseSync_MostlySynced(b *testing.B) {
+	for _, roots := range []int{10, 50} {
+		for _, leaves := range []int{50, 200} {
+			name := fmt.Sprintf("roots=%d/leaves=%d",
+				roots, leaves)
+			b.Run(name, func(b *testing.B) {
+				runSyncBench(b, fixture.SeedSpec{
+					Issuance: fixture.RootSweep{
+						Roots:  roots,
+						Leaves: leaves,
+					},
+					LocalOverlap: fixture.NewFraction(0.9),
+				})
+			})
+		}
+	}
+}
+
+// BenchmarkUniverseSync_Mixed interleaves issuance and transfer roots
+// at roughly the same rate. It is the target for the Phase 2 ordering
+// fix: today the syncer processes roots in the order the remote
+// returned them, so a transfer root can race ahead of its issuance and
+// surface a dep_missing metric. Post-Phase 2 that column should be
+// zero.
+func BenchmarkUniverseSync_Mixed(b *testing.B) {
+	for _, leaves := range []int{50, 200} {
+		name := fmt.Sprintf("leaves=%d", leaves)
+		b.Run(name, func(b *testing.B) {
+			runSyncBench(b, fixture.SeedSpec{
+				Issuance: fixture.RootSweep{
+					Roots:  20,
+					Leaves: leaves,
+				},
+				Transfer: fixture.RootSweep{
+					Roots:  20,
+					Leaves: leaves,
+				},
+				LocalOverlap: fixture.NewFraction(0),
+			})
+		})
+	}
+}
+
+// runSyncBench is the shared shape: build a fixture, seed it, then run
+// b.N sync passes. Each iteration reseeds so the syncer sees the same
+// diff each time — otherwise the second iteration would find nothing
+// to sync and skew the numbers.
+func runSyncBench(b *testing.B, spec fixture.SeedSpec) {
+	b.Helper()
+
+	ctx := context.Background()
+	cfg := fixture.GlobalSyncConfig()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		f := fixture.NewSyncFixture(b, fixture.SyncFixtureOpts{})
+		f.Seed(b, spec)
+		b.StartTimer()
+
+		_, err := f.Syncer.SyncUniverse(
+			ctx, universe.ServerAddr{}, universe.SyncFull, cfg,
+		)
+		if err != nil {
+			b.Fatalf("sync: %v", err)
+		}
+
+		b.StopTimer()
+		f.Metrics.Report(b)
+		b.StartTimer()
+	}
+}

--- a/docs/release-notes/release-notes-0.8.1.md
+++ b/docs/release-notes/release-notes-0.8.1.md
@@ -50,6 +50,10 @@
 
 ## Functional Updates
 
+- [PR#2187](https://github.com/lightninglabs/taproot-assets/pull/2187)
+  substantially improves the reliability and performance of universe
+  sync.
+
 ## RPC Updates
 
 ## tapcli Updates

--- a/rpcserver/rpcserver.go
+++ b/rpcserver/rpcserver.go
@@ -7242,7 +7242,7 @@ func (r *RPCServer) AssetLeafKeys(ctx context.Context,
 		limit = universe.RequestPageSize
 	}
 
-	leafKeys, err := r.cfg.UniverseArchive.UniverseLeafKeys(
+	leafEntries, err := r.cfg.UniverseArchive.UniverseLeafKeys(
 		ctx, universe.UniverseLeafKeysQuery{
 			Id:            universeID,
 			SortDirection: unmarshalUniSortDirection(req.Direction),
@@ -7256,18 +7256,30 @@ func (r *RPCServer) AssetLeafKeys(ctx context.Context,
 			universeID.StringForLog(), req.Offset, limit, err)
 	}
 
-	hasMore := int32(len(leafKeys)) > limit
+	hasMore := int32(len(leafEntries)) > limit
 	if hasMore {
-		leafKeys = leafKeys[:limit]
+		leafEntries = leafEntries[:limit]
 	}
 
+	// Populate both the legacy `asset_keys` field and the new
+	// `entries` field. Old clients read `asset_keys`; new clients
+	// prefer `entries` and use its leaf_node_hash to diff on
+	// content.
 	resp := &unirpc.AssetLeafKeyResponse{
-		AssetKeys: make([]*unirpc.AssetKey, len(leafKeys)),
+		AssetKeys: make([]*unirpc.AssetKey, len(leafEntries)),
+		Entries:   make([]*unirpc.AssetLeafEntry, len(leafEntries)),
 		HasMore:   hasMore,
 	}
 
-	for i, leafKey := range leafKeys {
-		resp.AssetKeys[i] = marshalLeafKey(leafKey)
+	for i, entry := range leafEntries {
+		assetKey := marshalLeafKey(entry.Key)
+		resp.AssetKeys[i] = assetKey
+
+		rpcEntry := &unirpc.AssetLeafEntry{AssetKey: assetKey}
+		entry.NodeHash.WhenSome(func(h mssmt.NodeHash) {
+			rpcEntry.LeafNodeHash = h[:]
+		})
+		resp.Entries[i] = rpcEntry
 	}
 
 	return resp, nil

--- a/rpcserver/universe_rpc_diff.go
+++ b/rpcserver/universe_rpc_diff.go
@@ -137,9 +137,11 @@ func (r *RpcUniverseDiff) RootNode(ctx context.Context,
 }
 
 // UniverseLeafKeys returns all the leaf entries in the universe.
-// The RPC schema exposes only universe keys, so NodeHash is left
-// unset on every returned entry — callers must fall back to a
-// key-only diff for RPC-sourced entries.
+// When the responding peer populates `entries`, each returned
+// LeafEntry carries the peer's MS-SMT leaf node hash so the syncer
+// can diff on content. When only the legacy `asset_keys` field is
+// populated, NodeHash is left as None and callers must fall back to
+// a key-only diff for that peer.
 func (r *RpcUniverseDiff) UniverseLeafKeys(ctx context.Context,
 	q universe.UniverseLeafKeysQuery) ([]universe.LeafEntry, error) {
 
@@ -158,6 +160,38 @@ func (r *RpcUniverseDiff) UniverseLeafKeys(ctx context.Context,
 	)
 	if err != nil {
 		return nil, err
+	}
+
+	// Prefer the entries field (carries per-leaf node hashes) when
+	// the peer populated it; otherwise fall back to the legacy
+	// asset_keys field with NodeHash unset.
+	if len(resp.Entries) > 0 {
+		entries := make([]universe.LeafEntry, len(resp.Entries))
+		for i, entry := range resp.Entries {
+			leafKey, err := unmarshalLeafKey(entry.AssetKey)
+			if err != nil {
+				return nil, err
+			}
+
+			nodeHash := fn.None[mssmt.NodeHash]()
+			if len(entry.LeafNodeHash) > 0 {
+				h, err := mssmt.NewNodeHashFromBytes(
+					entry.LeafNodeHash,
+				)
+				if err != nil {
+					return nil, fmt.Errorf("invalid "+
+						"leaf node hash: %w", err)
+				}
+				nodeHash = fn.Some(h)
+			}
+
+			entries[i] = universe.LeafEntry{
+				Key:      leafKey,
+				NodeHash: nodeHash,
+			}
+		}
+
+		return entries, nil
 	}
 
 	entries := make([]universe.LeafEntry, len(resp.AssetKeys))

--- a/rpcserver/universe_rpc_diff.go
+++ b/rpcserver/universe_rpc_diff.go
@@ -136,16 +136,19 @@ func (r *RpcUniverseDiff) RootNode(ctx context.Context,
 	return unmarshalUniverseRoot(universeRoot.TransferRoot)
 }
 
-// UniverseLeafKeys returns all the keys inserted in the universe.
+// UniverseLeafKeys returns all the leaf entries in the universe.
+// The RPC schema exposes only universe keys, so NodeHash is left
+// unset on every returned entry — callers must fall back to a
+// key-only diff for RPC-sourced entries.
 func (r *RpcUniverseDiff) UniverseLeafKeys(ctx context.Context,
-	q universe.UniverseLeafKeysQuery) ([]universe.LeafKey, error) {
+	q universe.UniverseLeafKeysQuery) ([]universe.LeafEntry, error) {
 
 	uniID, err := MarshalUniID(q.Id)
 	if err != nil {
 		return nil, err
 	}
 
-	assetKeys, err := r.conn.AssetLeafKeys(
+	resp, err := r.conn.AssetLeafKeys(
 		ctx, &unirpc.AssetLeafKeysRequest{
 			Id:        uniID,
 			Direction: taprpc.SortDirection(q.SortDirection),
@@ -157,17 +160,20 @@ func (r *RpcUniverseDiff) UniverseLeafKeys(ctx context.Context,
 		return nil, err
 	}
 
-	keys := make([]universe.LeafKey, len(assetKeys.AssetKeys))
-	for i, key := range assetKeys.AssetKeys {
+	entries := make([]universe.LeafEntry, len(resp.AssetKeys))
+	for i, key := range resp.AssetKeys {
 		leafKey, err := unmarshalLeafKey(key)
 		if err != nil {
 			return nil, err
 		}
 
-		keys[i] = leafKey
+		entries[i] = universe.LeafEntry{
+			Key:      leafKey,
+			NodeHash: fn.None[mssmt.NodeHash](),
+		}
 	}
 
-	return keys, nil
+	return entries, nil
 }
 
 // FetchProofLeaf attempts to fetch a proof leaf for the target leaf key

--- a/tapcfg/config.go
+++ b/tapcfg/config.go
@@ -111,8 +111,17 @@ const (
 	defaultUniverseSyncInterval = time.Minute * 10
 
 	// defaultUniverseSyncBatchSize is the default number of proofs we'll
-	// sync in a single batch.
-	defaultUniverseSyncBatchSize = 200
+	// sync in a single batch. Kept small to shorten the write-side DB
+	// transaction and reduce contention when several roots are being
+	// synced concurrently — see issue #2026 for the "db tx retries
+	// exceeded" symptom the old value of 200 was surfacing.
+	defaultUniverseSyncBatchSize = 50
+
+	// defaultUniverseSyncRootConcurrency caps the number of universe
+	// roots the syncer processes at once. A small cap in combination
+	// with the smaller batch size above keeps the write-side DB
+	// transaction pool from thrashing.
+	defaultUniverseSyncRootConcurrency = 2
 
 	// defaultReOrgSafeDepth is the default number of confirmations we'll
 	// wait for before considering a transaction safely buried in the chain.

--- a/tapcfg/server.go
+++ b/tapcfg/server.go
@@ -448,6 +448,7 @@ func genServerConfig(cfg *Config, cfgLogger btclog.Logger,
 		NewRemoteDiffEngine: rpcserver.NewRpcUniverseDiff,
 		LocalRegistrar:      uniArchive,
 		SyncBatchSize:       defaultUniverseSyncBatchSize,
+		SyncRootConcurrency: defaultUniverseSyncRootConcurrency,
 	})
 
 	var runtimeIDBytes [8]byte

--- a/tapdb/multiverse.go
+++ b/tapdb/multiverse.go
@@ -341,11 +341,13 @@ func (b *MultiverseStore) UniverseRootNode(ctx context.Context,
 	return dbRoot, nil
 }
 
-// UniverseLeafKeys returns the set of leaf keys for the given universe.
+// UniverseLeafKeys returns the set of leaf entries for the given
+// universe. Each entry pairs the leaf's universe key with the
+// MS-SMT node hash committing to its content.
 func (b *MultiverseStore) UniverseLeafKeys(ctx context.Context,
-	q universe.UniverseLeafKeysQuery) ([]universe.LeafKey, error) {
+	q universe.UniverseLeafKeysQuery) ([]universe.LeafEntry, error) {
 
-	// First, check to see if we have the leaf keys cached.
+	// First, check to see if we have the leaf entries cached.
 	leafKeys := b.leafKeysCache.fetchLeafKeys(q)
 	if len(leafKeys) > 0 {
 		return leafKeys, nil

--- a/tapdb/multiverse_cache.go
+++ b/tapdb/multiverse_cache.go
@@ -738,8 +738,9 @@ func (r *rootNodeCache) wipeCache() {
 	r.rootIndex.wipe()
 }
 
-// cachedLeafKeys is used to cache the set of leaf keys for a given universe.
-type cachedLeafKeys []universe.LeafKey
+// cachedLeafKeys is used to cache the set of leaf entries for a
+// given universe.
+type cachedLeafKeys []universe.LeafEntry
 
 // Size just returns 1, as we cache based on the total number of assets, but
 // not the sum of their leaves.
@@ -800,9 +801,9 @@ func newUniverseLeafPageCache(numCachedUniverses,
 	}
 }
 
-// fetchLeafKeys reads the cached leaf keys for the given ID.
+// fetchLeafKeys reads the cached leaf entries for the given ID.
 func (u *universeLeafPageCache) fetchLeafKeys(
-	q universe.UniverseLeafKeysQuery) []universe.LeafKey {
+	q universe.UniverseLeafKeysQuery) []universe.LeafEntry {
 
 	leafPageCache, err := u.leafCache.Get(q.Id.String())
 	if err == nil {
@@ -820,9 +821,9 @@ func (u *universeLeafPageCache) fetchLeafKeys(
 	return nil
 }
 
-// cacheLeafKeys stores the given leaf keys in the cache.
+// cacheLeafKeys stores the given leaf entries in the cache.
 func (u *universeLeafPageCache) cacheLeafKeys(q universe.UniverseLeafKeysQuery,
-	keys []universe.LeafKey) {
+	keys []universe.LeafEntry) {
 
 	cachedKeys := cachedLeafKeys(keys)
 

--- a/tapdb/sqlc/querier.go
+++ b/tapdb/sqlc/querier.go
@@ -120,6 +120,13 @@ type Querier interface {
 	FetchTapscriptTree(ctx context.Context, rootHash []byte) ([]FetchTapscriptTreeRow, error)
 	FetchTransferInputs(ctx context.Context, transferID int64) ([]FetchTransferInputsRow, error)
 	FetchTransferOutputs(ctx context.Context, transferID int64) ([]FetchTransferOutputsRow, error)
+	// Note on hash construction: mssmt_nodes.hash_key on a compacted leaf
+	// commits to the subtree root at that leaf's tree height, which
+	// varies with the tree's shape and is therefore NOT canonical across
+	// universes with the same leaves. What we want for a cross-universe
+	// diff is the leaf's own canonical content hash H(value || sum),
+	// computed from mssmt_nodes.value (the leaf's RawProof bytes) and
+	// mssmt_nodes.sum. Callers compute the hash from these two columns.
 	FetchUniverseKeys(ctx context.Context, arg FetchUniverseKeysParams) ([]FetchUniverseKeysRow, error)
 	FetchUniverseRoot(ctx context.Context, namespace string) (FetchUniverseRootRow, error)
 	FetchUniverseSupplyRoot(ctx context.Context, namespaceRoot string) (FetchUniverseSupplyRootRow, error)

--- a/tapdb/sqlc/queries/universe.sql
+++ b/tapdb/sqlc/queries/universe.sql
@@ -81,10 +81,21 @@ ORDER BY
 LIMIT @num_limit OFFSET @num_offset;
 
 -- name: FetchUniverseKeys :many
-SELECT leaves.minting_point, leaves.script_key_bytes
+-- Note on hash construction: mssmt_nodes.hash_key on a compacted leaf
+-- commits to the subtree root at that leaf's tree height, which
+-- varies with the tree's shape and is therefore NOT canonical across
+-- universes with the same leaves. What we want for a cross-universe
+-- diff is the leaf's own canonical content hash H(value || sum),
+-- computed from mssmt_nodes.value (the leaf's RawProof bytes) and
+-- mssmt_nodes.sum. Callers compute the hash from these two columns.
+SELECT leaves.minting_point, leaves.script_key_bytes,
+       nodes.value AS leaf_value, nodes.sum AS leaf_sum
 FROM universe_leaves AS leaves
+JOIN mssmt_nodes AS nodes
+    ON leaves.leaf_node_key = nodes.key
+       AND leaves.leaf_node_namespace = nodes.namespace
 WHERE leaves.leaf_node_namespace = @namespace
-ORDER BY 
+ORDER BY
     CASE WHEN sqlc.narg('sort_direction') = 0 THEN leaves.id END ASC,
     CASE WHEN sqlc.narg('sort_direction') = 1 THEN leaves.id END DESC
 LIMIT @num_limit OFFSET @num_offset;

--- a/tapdb/sqlc/universe.sql.go
+++ b/tapdb/sqlc/universe.sql.go
@@ -171,10 +171,14 @@ func (q *Queries) FetchMultiverseRoot(ctx context.Context, namespaceRoot string)
 }
 
 const FetchUniverseKeys = `-- name: FetchUniverseKeys :many
-SELECT leaves.minting_point, leaves.script_key_bytes
+SELECT leaves.minting_point, leaves.script_key_bytes,
+       nodes.value AS leaf_value, nodes.sum AS leaf_sum
 FROM universe_leaves AS leaves
+JOIN mssmt_nodes AS nodes
+    ON leaves.leaf_node_key = nodes.key
+       AND leaves.leaf_node_namespace = nodes.namespace
 WHERE leaves.leaf_node_namespace = $1
-ORDER BY 
+ORDER BY
     CASE WHEN $2 = 0 THEN leaves.id END ASC,
     CASE WHEN $2 = 1 THEN leaves.id END DESC
 LIMIT $4 OFFSET $3
@@ -190,8 +194,17 @@ type FetchUniverseKeysParams struct {
 type FetchUniverseKeysRow struct {
 	MintingPoint   []byte
 	ScriptKeyBytes []byte
+	LeafValue      []byte
+	LeafSum        int64
 }
 
+// Note on hash construction: mssmt_nodes.hash_key on a compacted leaf
+// commits to the subtree root at that leaf's tree height, which
+// varies with the tree's shape and is therefore NOT canonical across
+// universes with the same leaves. What we want for a cross-universe
+// diff is the leaf's own canonical content hash H(value || sum),
+// computed from mssmt_nodes.value (the leaf's RawProof bytes) and
+// mssmt_nodes.sum. Callers compute the hash from these two columns.
 func (q *Queries) FetchUniverseKeys(ctx context.Context, arg FetchUniverseKeysParams) ([]FetchUniverseKeysRow, error) {
 	rows, err := q.db.QueryContext(ctx, FetchUniverseKeys,
 		arg.Namespace,
@@ -206,7 +219,12 @@ func (q *Queries) FetchUniverseKeys(ctx context.Context, arg FetchUniverseKeysPa
 	var items []FetchUniverseKeysRow
 	for rows.Next() {
 		var i FetchUniverseKeysRow
-		if err := rows.Scan(&i.MintingPoint, &i.ScriptKeyBytes); err != nil {
+		if err := rows.Scan(
+			&i.MintingPoint,
+			&i.ScriptKeyBytes,
+			&i.LeafValue,
+			&i.LeafSum,
+		); err != nil {
 			return nil, err
 		}
 		items = append(items, i)

--- a/tapdb/universe.go
+++ b/tapdb/universe.go
@@ -1204,10 +1204,12 @@ func universeFetchProofLeaf(ctx context.Context,
 	return proofs, nil
 }
 
-// mintingKeys returns all the leaf keys in the target universe.
+// mintingKeys returns all the leaf entries in the target universe,
+// each pairing a universe key with the MS-SMT node hash that
+// commits to the leaf's content.
 func mintingKeys(ctx context.Context, dbTx BaseUniverseStore,
 	q universe.UniverseLeafKeysQuery,
-	namespace string) ([]universe.LeafKey, error) {
+	namespace string) ([]universe.LeafEntry, error) {
 
 	universeKeys, err := dbTx.FetchUniverseKeys(
 		ctx, UniverseLeafKeysQuery{
@@ -1227,7 +1229,7 @@ func mintingKeys(ctx context.Context, dbTx BaseUniverseStore,
 		return nil, err
 	}
 
-	var leafKeys []universe.LeafKey
+	var entries []universe.LeafEntry
 	err = fn.ForEachErr(universeKeys, func(key UniverseKeys) error {
 		scriptKeyPub, err := schnorr.ParsePubKey(
 			key.ScriptKeyBytes,
@@ -1246,9 +1248,22 @@ func mintingKeys(ctx context.Context, dbTx BaseUniverseStore,
 			return err
 		}
 
-		leafKeys = append(leafKeys, universe.BaseLeafKey{
-			OutPoint:  genPoint,
-			ScriptKey: &scriptKey,
+		// The canonical leaf hash H(value || sum) commits to the
+		// leaf's content independently of tree shape, unlike the
+		// compacted-leaf hash_key stored in mssmt_nodes (which
+		// commits to the subtree root at the leaf's height and so
+		// varies with the enclosing tree). Reconstruct it from
+		// the leaf's stored value + sum.
+		nodeHash := mssmt.NewLeafNode(
+			key.LeafValue, uint64(key.LeafSum),
+		).NodeHash()
+
+		entries = append(entries, universe.LeafEntry{
+			Key: universe.BaseLeafKey{
+				OutPoint:  genPoint,
+				ScriptKey: &scriptKey,
+			},
+			NodeHash: fn.Some(nodeHash),
 		})
 
 		return nil
@@ -1257,14 +1272,14 @@ func mintingKeys(ctx context.Context, dbTx BaseUniverseStore,
 		return nil, err
 	}
 
-	return leafKeys, nil
+	return entries, nil
 }
 
-// FetchKeys retrieves all keys from the universe tree.
+// FetchKeys retrieves all leaf entries from the universe tree.
 func (b *BaseUniverseTree) FetchKeys(ctx context.Context,
-	q universe.UniverseLeafKeysQuery) ([]universe.LeafKey, error) {
+	q universe.UniverseLeafKeysQuery) ([]universe.LeafEntry, error) {
 
-	var leafKeys []universe.LeafKey
+	var leafKeys []universe.LeafEntry
 
 	readTx := NewBaseUniverseReadTx()
 	dbErr := b.db.ExecTx(ctx, &readTx, func(db BaseUniverseStore) error {

--- a/tapdb/universe_test.go
+++ b/tapdb/universe_test.go
@@ -384,9 +384,9 @@ func TestUniverseIssuanceProofs(t *testing.T) {
 	require.Equal(t, numLeaves, len(mintingKeys))
 
 	// The set of leaves we created above should match what was returned.
-	require.True(t, fn.All(mintingKeys, func(key universe.LeafKey) bool {
+	require.True(t, fn.All(mintingKeys, func(e universe.LeafEntry) bool {
 		return fn.Any(testLeaves, func(testLeaf leafWithKey) bool {
-			return reflect.DeepEqual(key, testLeaf.LeafKey)
+			return reflect.DeepEqual(e.Key, testLeaf.LeafKey)
 		})
 	}))
 

--- a/taprpc/universerpc/universe.pb.go
+++ b/taprpc/universerpc/universe.pb.go
@@ -1318,20 +1318,85 @@ func (x *AssetLeavesRequest) GetDirection() taprpc.SortDirection {
 	return taprpc.SortDirection(0)
 }
 
+type AssetLeafEntry struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The asset key identifying the leaf within the universe.
+	AssetKey *AssetKey `protobuf:"bytes,1,opt,name=asset_key,json=assetKey,proto3" json:"asset_key,omitempty"`
+	// The 32-byte MS-SMT leaf node hash committing to the leaf's
+	// content. Peers that predate this field leave it empty; readers
+	// must fall back to a key-only diff in that case.
+	LeafNodeHash  []byte `protobuf:"bytes,2,opt,name=leaf_node_hash,json=leafNodeHash,proto3" json:"leaf_node_hash,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AssetLeafEntry) Reset() {
+	*x = AssetLeafEntry{}
+	mi := &file_universerpc_universe_proto_msgTypes[17]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AssetLeafEntry) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AssetLeafEntry) ProtoMessage() {}
+
+func (x *AssetLeafEntry) ProtoReflect() protoreflect.Message {
+	mi := &file_universerpc_universe_proto_msgTypes[17]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AssetLeafEntry.ProtoReflect.Descriptor instead.
+func (*AssetLeafEntry) Descriptor() ([]byte, []int) {
+	return file_universerpc_universe_proto_rawDescGZIP(), []int{17}
+}
+
+func (x *AssetLeafEntry) GetAssetKey() *AssetKey {
+	if x != nil {
+		return x.AssetKey
+	}
+	return nil
+}
+
+func (x *AssetLeafEntry) GetLeafNodeHash() []byte {
+	if x != nil {
+		return x.LeafNodeHash
+	}
+	return nil
+}
+
 type AssetLeafKeyResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// The set of asset leaf keys for the given asset ID or group key.
+	// Deprecated. Superseded by `entries`, which additionally carries
+	// each leaf's MS-SMT node hash so a diff can detect shared-key
+	// content divergence directly. Populated for peers whose readers
+	// predate `entries`.
+	//
+	// Deprecated: Marked as deprecated in universerpc/universe.proto.
 	AssetKeys []*AssetKey `protobuf:"bytes,1,rep,name=asset_keys,json=assetKeys,proto3" json:"asset_keys,omitempty"`
 	// Indicates whether there are more results beyond the current
 	// page.
-	HasMore       bool `protobuf:"varint,2,opt,name=has_more,json=hasMore,proto3" json:"has_more,omitempty"`
+	HasMore bool `protobuf:"varint,2,opt,name=has_more,json=hasMore,proto3" json:"has_more,omitempty"`
+	// The set of asset leaf entries for the given asset ID or group
+	// key. Each entry pairs an asset key with the MS-SMT node hash
+	// committing to the leaf's content.
+	Entries       []*AssetLeafEntry `protobuf:"bytes,3,rep,name=entries,proto3" json:"entries,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *AssetLeafKeyResponse) Reset() {
 	*x = AssetLeafKeyResponse{}
-	mi := &file_universerpc_universe_proto_msgTypes[17]
+	mi := &file_universerpc_universe_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1343,7 +1408,7 @@ func (x *AssetLeafKeyResponse) String() string {
 func (*AssetLeafKeyResponse) ProtoMessage() {}
 
 func (x *AssetLeafKeyResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_universerpc_universe_proto_msgTypes[17]
+	mi := &file_universerpc_universe_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1356,9 +1421,10 @@ func (x *AssetLeafKeyResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AssetLeafKeyResponse.ProtoReflect.Descriptor instead.
 func (*AssetLeafKeyResponse) Descriptor() ([]byte, []int) {
-	return file_universerpc_universe_proto_rawDescGZIP(), []int{17}
+	return file_universerpc_universe_proto_rawDescGZIP(), []int{18}
 }
 
+// Deprecated: Marked as deprecated in universerpc/universe.proto.
 func (x *AssetLeafKeyResponse) GetAssetKeys() []*AssetKey {
 	if x != nil {
 		return x.AssetKeys
@@ -1371,6 +1437,13 @@ func (x *AssetLeafKeyResponse) GetHasMore() bool {
 		return x.HasMore
 	}
 	return false
+}
+
+func (x *AssetLeafKeyResponse) GetEntries() []*AssetLeafEntry {
+	if x != nil {
+		return x.Entries
+	}
+	return nil
 }
 
 type AssetLeaf struct {
@@ -1387,7 +1460,7 @@ type AssetLeaf struct {
 
 func (x *AssetLeaf) Reset() {
 	*x = AssetLeaf{}
-	mi := &file_universerpc_universe_proto_msgTypes[18]
+	mi := &file_universerpc_universe_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1399,7 +1472,7 @@ func (x *AssetLeaf) String() string {
 func (*AssetLeaf) ProtoMessage() {}
 
 func (x *AssetLeaf) ProtoReflect() protoreflect.Message {
-	mi := &file_universerpc_universe_proto_msgTypes[18]
+	mi := &file_universerpc_universe_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1412,7 +1485,7 @@ func (x *AssetLeaf) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AssetLeaf.ProtoReflect.Descriptor instead.
 func (*AssetLeaf) Descriptor() ([]byte, []int) {
-	return file_universerpc_universe_proto_rawDescGZIP(), []int{18}
+	return file_universerpc_universe_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *AssetLeaf) GetAsset() *taprpc.Asset {
@@ -1442,7 +1515,7 @@ type AssetLeafResponse struct {
 
 func (x *AssetLeafResponse) Reset() {
 	*x = AssetLeafResponse{}
-	mi := &file_universerpc_universe_proto_msgTypes[19]
+	mi := &file_universerpc_universe_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1454,7 +1527,7 @@ func (x *AssetLeafResponse) String() string {
 func (*AssetLeafResponse) ProtoMessage() {}
 
 func (x *AssetLeafResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_universerpc_universe_proto_msgTypes[19]
+	mi := &file_universerpc_universe_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1467,7 +1540,7 @@ func (x *AssetLeafResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AssetLeafResponse.ProtoReflect.Descriptor instead.
 func (*AssetLeafResponse) Descriptor() ([]byte, []int) {
-	return file_universerpc_universe_proto_rawDescGZIP(), []int{19}
+	return file_universerpc_universe_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *AssetLeafResponse) GetLeaves() []*AssetLeaf {
@@ -1496,7 +1569,7 @@ type UniverseKey struct {
 
 func (x *UniverseKey) Reset() {
 	*x = UniverseKey{}
-	mi := &file_universerpc_universe_proto_msgTypes[20]
+	mi := &file_universerpc_universe_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1508,7 +1581,7 @@ func (x *UniverseKey) String() string {
 func (*UniverseKey) ProtoMessage() {}
 
 func (x *UniverseKey) ProtoReflect() protoreflect.Message {
-	mi := &file_universerpc_universe_proto_msgTypes[20]
+	mi := &file_universerpc_universe_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1521,7 +1594,7 @@ func (x *UniverseKey) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UniverseKey.ProtoReflect.Descriptor instead.
 func (*UniverseKey) Descriptor() ([]byte, []int) {
-	return file_universerpc_universe_proto_rawDescGZIP(), []int{20}
+	return file_universerpc_universe_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *UniverseKey) GetId() *ID {
@@ -1564,7 +1637,7 @@ type AssetProofResponse struct {
 
 func (x *AssetProofResponse) Reset() {
 	*x = AssetProofResponse{}
-	mi := &file_universerpc_universe_proto_msgTypes[21]
+	mi := &file_universerpc_universe_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1576,7 +1649,7 @@ func (x *AssetProofResponse) String() string {
 func (*AssetProofResponse) ProtoMessage() {}
 
 func (x *AssetProofResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_universerpc_universe_proto_msgTypes[21]
+	mi := &file_universerpc_universe_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1589,7 +1662,7 @@ func (x *AssetProofResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AssetProofResponse.ProtoReflect.Descriptor instead.
 func (*AssetProofResponse) Descriptor() ([]byte, []int) {
-	return file_universerpc_universe_proto_rawDescGZIP(), []int{21}
+	return file_universerpc_universe_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *AssetProofResponse) GetReq() *UniverseKey {
@@ -1657,7 +1730,7 @@ type IssuanceData struct {
 
 func (x *IssuanceData) Reset() {
 	*x = IssuanceData{}
-	mi := &file_universerpc_universe_proto_msgTypes[22]
+	mi := &file_universerpc_universe_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1669,7 +1742,7 @@ func (x *IssuanceData) String() string {
 func (*IssuanceData) ProtoMessage() {}
 
 func (x *IssuanceData) ProtoReflect() protoreflect.Message {
-	mi := &file_universerpc_universe_proto_msgTypes[22]
+	mi := &file_universerpc_universe_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1682,7 +1755,7 @@ func (x *IssuanceData) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IssuanceData.ProtoReflect.Descriptor instead.
 func (*IssuanceData) Descriptor() ([]byte, []int) {
-	return file_universerpc_universe_proto_rawDescGZIP(), []int{22}
+	return file_universerpc_universe_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *IssuanceData) GetMetaReveal() *taprpc.AssetMeta {
@@ -1718,7 +1791,7 @@ type AssetProof struct {
 
 func (x *AssetProof) Reset() {
 	*x = AssetProof{}
-	mi := &file_universerpc_universe_proto_msgTypes[23]
+	mi := &file_universerpc_universe_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1730,7 +1803,7 @@ func (x *AssetProof) String() string {
 func (*AssetProof) ProtoMessage() {}
 
 func (x *AssetProof) ProtoReflect() protoreflect.Message {
-	mi := &file_universerpc_universe_proto_msgTypes[23]
+	mi := &file_universerpc_universe_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1743,7 +1816,7 @@ func (x *AssetProof) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AssetProof.ProtoReflect.Descriptor instead.
 func (*AssetProof) Descriptor() ([]byte, []int) {
-	return file_universerpc_universe_proto_rawDescGZIP(), []int{23}
+	return file_universerpc_universe_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *AssetProof) GetKey() *UniverseKey {
@@ -1772,7 +1845,7 @@ type PushProofRequest struct {
 
 func (x *PushProofRequest) Reset() {
 	*x = PushProofRequest{}
-	mi := &file_universerpc_universe_proto_msgTypes[24]
+	mi := &file_universerpc_universe_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1784,7 +1857,7 @@ func (x *PushProofRequest) String() string {
 func (*PushProofRequest) ProtoMessage() {}
 
 func (x *PushProofRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_universerpc_universe_proto_msgTypes[24]
+	mi := &file_universerpc_universe_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1797,7 +1870,7 @@ func (x *PushProofRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PushProofRequest.ProtoReflect.Descriptor instead.
 func (*PushProofRequest) Descriptor() ([]byte, []int) {
-	return file_universerpc_universe_proto_rawDescGZIP(), []int{24}
+	return file_universerpc_universe_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *PushProofRequest) GetKey() *UniverseKey {
@@ -1824,7 +1897,7 @@ type PushProofResponse struct {
 
 func (x *PushProofResponse) Reset() {
 	*x = PushProofResponse{}
-	mi := &file_universerpc_universe_proto_msgTypes[25]
+	mi := &file_universerpc_universe_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1836,7 +1909,7 @@ func (x *PushProofResponse) String() string {
 func (*PushProofResponse) ProtoMessage() {}
 
 func (x *PushProofResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_universerpc_universe_proto_msgTypes[25]
+	mi := &file_universerpc_universe_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1849,7 +1922,7 @@ func (x *PushProofResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PushProofResponse.ProtoReflect.Descriptor instead.
 func (*PushProofResponse) Descriptor() ([]byte, []int) {
-	return file_universerpc_universe_proto_rawDescGZIP(), []int{25}
+	return file_universerpc_universe_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *PushProofResponse) GetKey() *UniverseKey {
@@ -1867,7 +1940,7 @@ type InfoRequest struct {
 
 func (x *InfoRequest) Reset() {
 	*x = InfoRequest{}
-	mi := &file_universerpc_universe_proto_msgTypes[26]
+	mi := &file_universerpc_universe_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1879,7 +1952,7 @@ func (x *InfoRequest) String() string {
 func (*InfoRequest) ProtoMessage() {}
 
 func (x *InfoRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_universerpc_universe_proto_msgTypes[26]
+	mi := &file_universerpc_universe_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1892,7 +1965,7 @@ func (x *InfoRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InfoRequest.ProtoReflect.Descriptor instead.
 func (*InfoRequest) Descriptor() ([]byte, []int) {
-	return file_universerpc_universe_proto_rawDescGZIP(), []int{26}
+	return file_universerpc_universe_proto_rawDescGZIP(), []int{27}
 }
 
 type InfoResponse struct {
@@ -1907,7 +1980,7 @@ type InfoResponse struct {
 
 func (x *InfoResponse) Reset() {
 	*x = InfoResponse{}
-	mi := &file_universerpc_universe_proto_msgTypes[27]
+	mi := &file_universerpc_universe_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1919,7 +1992,7 @@ func (x *InfoResponse) String() string {
 func (*InfoResponse) ProtoMessage() {}
 
 func (x *InfoResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_universerpc_universe_proto_msgTypes[27]
+	mi := &file_universerpc_universe_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1932,7 +2005,7 @@ func (x *InfoResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InfoResponse.ProtoReflect.Descriptor instead.
 func (*InfoResponse) Descriptor() ([]byte, []int) {
-	return file_universerpc_universe_proto_rawDescGZIP(), []int{27}
+	return file_universerpc_universe_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *InfoResponse) GetRuntimeId() int64 {
@@ -1952,7 +2025,7 @@ type SyncTarget struct {
 
 func (x *SyncTarget) Reset() {
 	*x = SyncTarget{}
-	mi := &file_universerpc_universe_proto_msgTypes[28]
+	mi := &file_universerpc_universe_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1964,7 +2037,7 @@ func (x *SyncTarget) String() string {
 func (*SyncTarget) ProtoMessage() {}
 
 func (x *SyncTarget) ProtoReflect() protoreflect.Message {
-	mi := &file_universerpc_universe_proto_msgTypes[28]
+	mi := &file_universerpc_universe_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1977,7 +2050,7 @@ func (x *SyncTarget) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SyncTarget.ProtoReflect.Descriptor instead.
 func (*SyncTarget) Descriptor() ([]byte, []int) {
-	return file_universerpc_universe_proto_rawDescGZIP(), []int{28}
+	return file_universerpc_universe_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *SyncTarget) GetId() *ID {
@@ -2003,7 +2076,7 @@ type SyncRequest struct {
 
 func (x *SyncRequest) Reset() {
 	*x = SyncRequest{}
-	mi := &file_universerpc_universe_proto_msgTypes[29]
+	mi := &file_universerpc_universe_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2015,7 +2088,7 @@ func (x *SyncRequest) String() string {
 func (*SyncRequest) ProtoMessage() {}
 
 func (x *SyncRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_universerpc_universe_proto_msgTypes[29]
+	mi := &file_universerpc_universe_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2028,7 +2101,7 @@ func (x *SyncRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SyncRequest.ProtoReflect.Descriptor instead.
 func (*SyncRequest) Descriptor() ([]byte, []int) {
-	return file_universerpc_universe_proto_rawDescGZIP(), []int{29}
+	return file_universerpc_universe_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *SyncRequest) GetUniverseHost() string {
@@ -2066,7 +2139,7 @@ type SyncedUniverse struct {
 
 func (x *SyncedUniverse) Reset() {
 	*x = SyncedUniverse{}
-	mi := &file_universerpc_universe_proto_msgTypes[30]
+	mi := &file_universerpc_universe_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2078,7 +2151,7 @@ func (x *SyncedUniverse) String() string {
 func (*SyncedUniverse) ProtoMessage() {}
 
 func (x *SyncedUniverse) ProtoReflect() protoreflect.Message {
-	mi := &file_universerpc_universe_proto_msgTypes[30]
+	mi := &file_universerpc_universe_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2091,7 +2164,7 @@ func (x *SyncedUniverse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SyncedUniverse.ProtoReflect.Descriptor instead.
 func (*SyncedUniverse) Descriptor() ([]byte, []int) {
-	return file_universerpc_universe_proto_rawDescGZIP(), []int{30}
+	return file_universerpc_universe_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *SyncedUniverse) GetOldAssetRoot() *UniverseRoot {
@@ -2123,7 +2196,7 @@ type StatsRequest struct {
 
 func (x *StatsRequest) Reset() {
 	*x = StatsRequest{}
-	mi := &file_universerpc_universe_proto_msgTypes[31]
+	mi := &file_universerpc_universe_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2135,7 +2208,7 @@ func (x *StatsRequest) String() string {
 func (*StatsRequest) ProtoMessage() {}
 
 func (x *StatsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_universerpc_universe_proto_msgTypes[31]
+	mi := &file_universerpc_universe_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2148,7 +2221,7 @@ func (x *StatsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StatsRequest.ProtoReflect.Descriptor instead.
 func (*StatsRequest) Descriptor() ([]byte, []int) {
-	return file_universerpc_universe_proto_rawDescGZIP(), []int{31}
+	return file_universerpc_universe_proto_rawDescGZIP(), []int{32}
 }
 
 type SyncResponse struct {
@@ -2161,7 +2234,7 @@ type SyncResponse struct {
 
 func (x *SyncResponse) Reset() {
 	*x = SyncResponse{}
-	mi := &file_universerpc_universe_proto_msgTypes[32]
+	mi := &file_universerpc_universe_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2173,7 +2246,7 @@ func (x *SyncResponse) String() string {
 func (*SyncResponse) ProtoMessage() {}
 
 func (x *SyncResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_universerpc_universe_proto_msgTypes[32]
+	mi := &file_universerpc_universe_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2186,7 +2259,7 @@ func (x *SyncResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SyncResponse.ProtoReflect.Descriptor instead.
 func (*SyncResponse) Descriptor() ([]byte, []int) {
-	return file_universerpc_universe_proto_rawDescGZIP(), []int{32}
+	return file_universerpc_universe_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *SyncResponse) GetSyncedUniverses() []*SyncedUniverse {
@@ -2210,7 +2283,7 @@ type UniverseFederationServer struct {
 
 func (x *UniverseFederationServer) Reset() {
 	*x = UniverseFederationServer{}
-	mi := &file_universerpc_universe_proto_msgTypes[33]
+	mi := &file_universerpc_universe_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2222,7 +2295,7 @@ func (x *UniverseFederationServer) String() string {
 func (*UniverseFederationServer) ProtoMessage() {}
 
 func (x *UniverseFederationServer) ProtoReflect() protoreflect.Message {
-	mi := &file_universerpc_universe_proto_msgTypes[33]
+	mi := &file_universerpc_universe_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2235,7 +2308,7 @@ func (x *UniverseFederationServer) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UniverseFederationServer.ProtoReflect.Descriptor instead.
 func (*UniverseFederationServer) Descriptor() ([]byte, []int) {
-	return file_universerpc_universe_proto_rawDescGZIP(), []int{33}
+	return file_universerpc_universe_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *UniverseFederationServer) GetHost() string {
@@ -2260,7 +2333,7 @@ type ListFederationServersRequest struct {
 
 func (x *ListFederationServersRequest) Reset() {
 	*x = ListFederationServersRequest{}
-	mi := &file_universerpc_universe_proto_msgTypes[34]
+	mi := &file_universerpc_universe_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2272,7 +2345,7 @@ func (x *ListFederationServersRequest) String() string {
 func (*ListFederationServersRequest) ProtoMessage() {}
 
 func (x *ListFederationServersRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_universerpc_universe_proto_msgTypes[34]
+	mi := &file_universerpc_universe_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2285,7 +2358,7 @@ func (x *ListFederationServersRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListFederationServersRequest.ProtoReflect.Descriptor instead.
 func (*ListFederationServersRequest) Descriptor() ([]byte, []int) {
-	return file_universerpc_universe_proto_rawDescGZIP(), []int{34}
+	return file_universerpc_universe_proto_rawDescGZIP(), []int{35}
 }
 
 type ListFederationServersResponse struct {
@@ -2299,7 +2372,7 @@ type ListFederationServersResponse struct {
 
 func (x *ListFederationServersResponse) Reset() {
 	*x = ListFederationServersResponse{}
-	mi := &file_universerpc_universe_proto_msgTypes[35]
+	mi := &file_universerpc_universe_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2311,7 +2384,7 @@ func (x *ListFederationServersResponse) String() string {
 func (*ListFederationServersResponse) ProtoMessage() {}
 
 func (x *ListFederationServersResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_universerpc_universe_proto_msgTypes[35]
+	mi := &file_universerpc_universe_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2324,7 +2397,7 @@ func (x *ListFederationServersResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListFederationServersResponse.ProtoReflect.Descriptor instead.
 func (*ListFederationServersResponse) Descriptor() ([]byte, []int) {
-	return file_universerpc_universe_proto_rawDescGZIP(), []int{35}
+	return file_universerpc_universe_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *ListFederationServersResponse) GetServers() []*UniverseFederationServer {
@@ -2344,7 +2417,7 @@ type AddFederationServerRequest struct {
 
 func (x *AddFederationServerRequest) Reset() {
 	*x = AddFederationServerRequest{}
-	mi := &file_universerpc_universe_proto_msgTypes[36]
+	mi := &file_universerpc_universe_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2356,7 +2429,7 @@ func (x *AddFederationServerRequest) String() string {
 func (*AddFederationServerRequest) ProtoMessage() {}
 
 func (x *AddFederationServerRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_universerpc_universe_proto_msgTypes[36]
+	mi := &file_universerpc_universe_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2369,7 +2442,7 @@ func (x *AddFederationServerRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddFederationServerRequest.ProtoReflect.Descriptor instead.
 func (*AddFederationServerRequest) Descriptor() ([]byte, []int) {
-	return file_universerpc_universe_proto_rawDescGZIP(), []int{36}
+	return file_universerpc_universe_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *AddFederationServerRequest) GetServers() []*UniverseFederationServer {
@@ -2387,7 +2460,7 @@ type AddFederationServerResponse struct {
 
 func (x *AddFederationServerResponse) Reset() {
 	*x = AddFederationServerResponse{}
-	mi := &file_universerpc_universe_proto_msgTypes[37]
+	mi := &file_universerpc_universe_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2399,7 +2472,7 @@ func (x *AddFederationServerResponse) String() string {
 func (*AddFederationServerResponse) ProtoMessage() {}
 
 func (x *AddFederationServerResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_universerpc_universe_proto_msgTypes[37]
+	mi := &file_universerpc_universe_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2412,7 +2485,7 @@ func (x *AddFederationServerResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddFederationServerResponse.ProtoReflect.Descriptor instead.
 func (*AddFederationServerResponse) Descriptor() ([]byte, []int) {
-	return file_universerpc_universe_proto_rawDescGZIP(), []int{37}
+	return file_universerpc_universe_proto_rawDescGZIP(), []int{38}
 }
 
 type DeleteFederationServerRequest struct {
@@ -2425,7 +2498,7 @@ type DeleteFederationServerRequest struct {
 
 func (x *DeleteFederationServerRequest) Reset() {
 	*x = DeleteFederationServerRequest{}
-	mi := &file_universerpc_universe_proto_msgTypes[38]
+	mi := &file_universerpc_universe_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2437,7 +2510,7 @@ func (x *DeleteFederationServerRequest) String() string {
 func (*DeleteFederationServerRequest) ProtoMessage() {}
 
 func (x *DeleteFederationServerRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_universerpc_universe_proto_msgTypes[38]
+	mi := &file_universerpc_universe_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2450,7 +2523,7 @@ func (x *DeleteFederationServerRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteFederationServerRequest.ProtoReflect.Descriptor instead.
 func (*DeleteFederationServerRequest) Descriptor() ([]byte, []int) {
-	return file_universerpc_universe_proto_rawDescGZIP(), []int{38}
+	return file_universerpc_universe_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *DeleteFederationServerRequest) GetServers() []*UniverseFederationServer {
@@ -2468,7 +2541,7 @@ type DeleteFederationServerResponse struct {
 
 func (x *DeleteFederationServerResponse) Reset() {
 	*x = DeleteFederationServerResponse{}
-	mi := &file_universerpc_universe_proto_msgTypes[39]
+	mi := &file_universerpc_universe_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2480,7 +2553,7 @@ func (x *DeleteFederationServerResponse) String() string {
 func (*DeleteFederationServerResponse) ProtoMessage() {}
 
 func (x *DeleteFederationServerResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_universerpc_universe_proto_msgTypes[39]
+	mi := &file_universerpc_universe_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2493,7 +2566,7 @@ func (x *DeleteFederationServerResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteFederationServerResponse.ProtoReflect.Descriptor instead.
 func (*DeleteFederationServerResponse) Descriptor() ([]byte, []int) {
-	return file_universerpc_universe_proto_rawDescGZIP(), []int{39}
+	return file_universerpc_universe_proto_rawDescGZIP(), []int{40}
 }
 
 type StatsResponse struct {
@@ -2508,7 +2581,7 @@ type StatsResponse struct {
 
 func (x *StatsResponse) Reset() {
 	*x = StatsResponse{}
-	mi := &file_universerpc_universe_proto_msgTypes[40]
+	mi := &file_universerpc_universe_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2520,7 +2593,7 @@ func (x *StatsResponse) String() string {
 func (*StatsResponse) ProtoMessage() {}
 
 func (x *StatsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_universerpc_universe_proto_msgTypes[40]
+	mi := &file_universerpc_universe_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2533,7 +2606,7 @@ func (x *StatsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StatsResponse.ProtoReflect.Descriptor instead.
 func (*StatsResponse) Descriptor() ([]byte, []int) {
-	return file_universerpc_universe_proto_rawDescGZIP(), []int{40}
+	return file_universerpc_universe_proto_rawDescGZIP(), []int{41}
 }
 
 func (x *StatsResponse) GetNumTotalAssets() int64 {
@@ -2592,7 +2665,7 @@ type AssetStatsQuery struct {
 
 func (x *AssetStatsQuery) Reset() {
 	*x = AssetStatsQuery{}
-	mi := &file_universerpc_universe_proto_msgTypes[41]
+	mi := &file_universerpc_universe_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2604,7 +2677,7 @@ func (x *AssetStatsQuery) String() string {
 func (*AssetStatsQuery) ProtoMessage() {}
 
 func (x *AssetStatsQuery) ProtoReflect() protoreflect.Message {
-	mi := &file_universerpc_universe_proto_msgTypes[41]
+	mi := &file_universerpc_universe_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2617,7 +2690,7 @@ func (x *AssetStatsQuery) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AssetStatsQuery.ProtoReflect.Descriptor instead.
 func (*AssetStatsQuery) Descriptor() ([]byte, []int) {
-	return file_universerpc_universe_proto_rawDescGZIP(), []int{41}
+	return file_universerpc_universe_proto_rawDescGZIP(), []int{42}
 }
 
 func (x *AssetStatsQuery) GetAssetNameFilter() string {
@@ -2695,7 +2768,7 @@ type AssetStatsSnapshot struct {
 
 func (x *AssetStatsSnapshot) Reset() {
 	*x = AssetStatsSnapshot{}
-	mi := &file_universerpc_universe_proto_msgTypes[42]
+	mi := &file_universerpc_universe_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2707,7 +2780,7 @@ func (x *AssetStatsSnapshot) String() string {
 func (*AssetStatsSnapshot) ProtoMessage() {}
 
 func (x *AssetStatsSnapshot) ProtoReflect() protoreflect.Message {
-	mi := &file_universerpc_universe_proto_msgTypes[42]
+	mi := &file_universerpc_universe_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2720,7 +2793,7 @@ func (x *AssetStatsSnapshot) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AssetStatsSnapshot.ProtoReflect.Descriptor instead.
 func (*AssetStatsSnapshot) Descriptor() ([]byte, []int) {
-	return file_universerpc_universe_proto_rawDescGZIP(), []int{42}
+	return file_universerpc_universe_proto_rawDescGZIP(), []int{43}
 }
 
 func (x *AssetStatsSnapshot) GetGroupKey() []byte {
@@ -2797,7 +2870,7 @@ type AssetStatsAsset struct {
 
 func (x *AssetStatsAsset) Reset() {
 	*x = AssetStatsAsset{}
-	mi := &file_universerpc_universe_proto_msgTypes[43]
+	mi := &file_universerpc_universe_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2809,7 +2882,7 @@ func (x *AssetStatsAsset) String() string {
 func (*AssetStatsAsset) ProtoMessage() {}
 
 func (x *AssetStatsAsset) ProtoReflect() protoreflect.Message {
-	mi := &file_universerpc_universe_proto_msgTypes[43]
+	mi := &file_universerpc_universe_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2822,7 +2895,7 @@ func (x *AssetStatsAsset) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AssetStatsAsset.ProtoReflect.Descriptor instead.
 func (*AssetStatsAsset) Descriptor() ([]byte, []int) {
-	return file_universerpc_universe_proto_rawDescGZIP(), []int{43}
+	return file_universerpc_universe_proto_rawDescGZIP(), []int{44}
 }
 
 func (x *AssetStatsAsset) GetAssetId() []byte {
@@ -2901,7 +2974,7 @@ type UniverseAssetStats struct {
 
 func (x *UniverseAssetStats) Reset() {
 	*x = UniverseAssetStats{}
-	mi := &file_universerpc_universe_proto_msgTypes[44]
+	mi := &file_universerpc_universe_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2913,7 +2986,7 @@ func (x *UniverseAssetStats) String() string {
 func (*UniverseAssetStats) ProtoMessage() {}
 
 func (x *UniverseAssetStats) ProtoReflect() protoreflect.Message {
-	mi := &file_universerpc_universe_proto_msgTypes[44]
+	mi := &file_universerpc_universe_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2926,7 +2999,7 @@ func (x *UniverseAssetStats) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UniverseAssetStats.ProtoReflect.Descriptor instead.
 func (*UniverseAssetStats) Descriptor() ([]byte, []int) {
-	return file_universerpc_universe_proto_rawDescGZIP(), []int{44}
+	return file_universerpc_universe_proto_rawDescGZIP(), []int{45}
 }
 
 func (x *UniverseAssetStats) GetAssetStats() []*AssetStatsSnapshot {
@@ -2955,7 +3028,7 @@ type QueryEventsRequest struct {
 
 func (x *QueryEventsRequest) Reset() {
 	*x = QueryEventsRequest{}
-	mi := &file_universerpc_universe_proto_msgTypes[45]
+	mi := &file_universerpc_universe_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2967,7 +3040,7 @@ func (x *QueryEventsRequest) String() string {
 func (*QueryEventsRequest) ProtoMessage() {}
 
 func (x *QueryEventsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_universerpc_universe_proto_msgTypes[45]
+	mi := &file_universerpc_universe_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2980,7 +3053,7 @@ func (x *QueryEventsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use QueryEventsRequest.ProtoReflect.Descriptor instead.
 func (*QueryEventsRequest) Descriptor() ([]byte, []int) {
-	return file_universerpc_universe_proto_rawDescGZIP(), []int{45}
+	return file_universerpc_universe_proto_rawDescGZIP(), []int{46}
 }
 
 func (x *QueryEventsRequest) GetStartTimestamp() int64 {
@@ -3009,7 +3082,7 @@ type QueryEventsResponse struct {
 
 func (x *QueryEventsResponse) Reset() {
 	*x = QueryEventsResponse{}
-	mi := &file_universerpc_universe_proto_msgTypes[46]
+	mi := &file_universerpc_universe_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3021,7 +3094,7 @@ func (x *QueryEventsResponse) String() string {
 func (*QueryEventsResponse) ProtoMessage() {}
 
 func (x *QueryEventsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_universerpc_universe_proto_msgTypes[46]
+	mi := &file_universerpc_universe_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3034,7 +3107,7 @@ func (x *QueryEventsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use QueryEventsResponse.ProtoReflect.Descriptor instead.
 func (*QueryEventsResponse) Descriptor() ([]byte, []int) {
-	return file_universerpc_universe_proto_rawDescGZIP(), []int{46}
+	return file_universerpc_universe_proto_rawDescGZIP(), []int{47}
 }
 
 func (x *QueryEventsResponse) GetEvents() []*GroupedUniverseEvents {
@@ -3058,7 +3131,7 @@ type GroupedUniverseEvents struct {
 
 func (x *GroupedUniverseEvents) Reset() {
 	*x = GroupedUniverseEvents{}
-	mi := &file_universerpc_universe_proto_msgTypes[47]
+	mi := &file_universerpc_universe_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3070,7 +3143,7 @@ func (x *GroupedUniverseEvents) String() string {
 func (*GroupedUniverseEvents) ProtoMessage() {}
 
 func (x *GroupedUniverseEvents) ProtoReflect() protoreflect.Message {
-	mi := &file_universerpc_universe_proto_msgTypes[47]
+	mi := &file_universerpc_universe_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3083,7 +3156,7 @@ func (x *GroupedUniverseEvents) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GroupedUniverseEvents.ProtoReflect.Descriptor instead.
 func (*GroupedUniverseEvents) Descriptor() ([]byte, []int) {
-	return file_universerpc_universe_proto_rawDescGZIP(), []int{47}
+	return file_universerpc_universe_proto_rawDescGZIP(), []int{48}
 }
 
 func (x *GroupedUniverseEvents) GetDate() string {
@@ -3119,7 +3192,7 @@ type SetFederationSyncConfigRequest struct {
 
 func (x *SetFederationSyncConfigRequest) Reset() {
 	*x = SetFederationSyncConfigRequest{}
-	mi := &file_universerpc_universe_proto_msgTypes[48]
+	mi := &file_universerpc_universe_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3131,7 +3204,7 @@ func (x *SetFederationSyncConfigRequest) String() string {
 func (*SetFederationSyncConfigRequest) ProtoMessage() {}
 
 func (x *SetFederationSyncConfigRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_universerpc_universe_proto_msgTypes[48]
+	mi := &file_universerpc_universe_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3144,7 +3217,7 @@ func (x *SetFederationSyncConfigRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetFederationSyncConfigRequest.ProtoReflect.Descriptor instead.
 func (*SetFederationSyncConfigRequest) Descriptor() ([]byte, []int) {
-	return file_universerpc_universe_proto_rawDescGZIP(), []int{48}
+	return file_universerpc_universe_proto_rawDescGZIP(), []int{49}
 }
 
 func (x *SetFederationSyncConfigRequest) GetGlobalSyncConfigs() []*GlobalFederationSyncConfig {
@@ -3169,7 +3242,7 @@ type SetFederationSyncConfigResponse struct {
 
 func (x *SetFederationSyncConfigResponse) Reset() {
 	*x = SetFederationSyncConfigResponse{}
-	mi := &file_universerpc_universe_proto_msgTypes[49]
+	mi := &file_universerpc_universe_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3181,7 +3254,7 @@ func (x *SetFederationSyncConfigResponse) String() string {
 func (*SetFederationSyncConfigResponse) ProtoMessage() {}
 
 func (x *SetFederationSyncConfigResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_universerpc_universe_proto_msgTypes[49]
+	mi := &file_universerpc_universe_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3194,7 +3267,7 @@ func (x *SetFederationSyncConfigResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetFederationSyncConfigResponse.ProtoReflect.Descriptor instead.
 func (*SetFederationSyncConfigResponse) Descriptor() ([]byte, []int) {
-	return file_universerpc_universe_proto_rawDescGZIP(), []int{49}
+	return file_universerpc_universe_proto_rawDescGZIP(), []int{50}
 }
 
 // GlobalFederationSyncConfig is a global proof type specific configuration
@@ -3217,7 +3290,7 @@ type GlobalFederationSyncConfig struct {
 
 func (x *GlobalFederationSyncConfig) Reset() {
 	*x = GlobalFederationSyncConfig{}
-	mi := &file_universerpc_universe_proto_msgTypes[50]
+	mi := &file_universerpc_universe_proto_msgTypes[51]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3229,7 +3302,7 @@ func (x *GlobalFederationSyncConfig) String() string {
 func (*GlobalFederationSyncConfig) ProtoMessage() {}
 
 func (x *GlobalFederationSyncConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_universerpc_universe_proto_msgTypes[50]
+	mi := &file_universerpc_universe_proto_msgTypes[51]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3242,7 +3315,7 @@ func (x *GlobalFederationSyncConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GlobalFederationSyncConfig.ProtoReflect.Descriptor instead.
 func (*GlobalFederationSyncConfig) Descriptor() ([]byte, []int) {
-	return file_universerpc_universe_proto_rawDescGZIP(), []int{50}
+	return file_universerpc_universe_proto_rawDescGZIP(), []int{51}
 }
 
 func (x *GlobalFederationSyncConfig) GetProofType() ProofType {
@@ -3286,7 +3359,7 @@ type AssetFederationSyncConfig struct {
 
 func (x *AssetFederationSyncConfig) Reset() {
 	*x = AssetFederationSyncConfig{}
-	mi := &file_universerpc_universe_proto_msgTypes[51]
+	mi := &file_universerpc_universe_proto_msgTypes[52]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3298,7 +3371,7 @@ func (x *AssetFederationSyncConfig) String() string {
 func (*AssetFederationSyncConfig) ProtoMessage() {}
 
 func (x *AssetFederationSyncConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_universerpc_universe_proto_msgTypes[51]
+	mi := &file_universerpc_universe_proto_msgTypes[52]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3311,7 +3384,7 @@ func (x *AssetFederationSyncConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AssetFederationSyncConfig.ProtoReflect.Descriptor instead.
 func (*AssetFederationSyncConfig) Descriptor() ([]byte, []int) {
-	return file_universerpc_universe_proto_rawDescGZIP(), []int{51}
+	return file_universerpc_universe_proto_rawDescGZIP(), []int{52}
 }
 
 func (x *AssetFederationSyncConfig) GetId() *ID {
@@ -3345,7 +3418,7 @@ type QueryFederationSyncConfigRequest struct {
 
 func (x *QueryFederationSyncConfigRequest) Reset() {
 	*x = QueryFederationSyncConfigRequest{}
-	mi := &file_universerpc_universe_proto_msgTypes[52]
+	mi := &file_universerpc_universe_proto_msgTypes[53]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3357,7 +3430,7 @@ func (x *QueryFederationSyncConfigRequest) String() string {
 func (*QueryFederationSyncConfigRequest) ProtoMessage() {}
 
 func (x *QueryFederationSyncConfigRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_universerpc_universe_proto_msgTypes[52]
+	mi := &file_universerpc_universe_proto_msgTypes[53]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3370,7 +3443,7 @@ func (x *QueryFederationSyncConfigRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use QueryFederationSyncConfigRequest.ProtoReflect.Descriptor instead.
 func (*QueryFederationSyncConfigRequest) Descriptor() ([]byte, []int) {
-	return file_universerpc_universe_proto_rawDescGZIP(), []int{52}
+	return file_universerpc_universe_proto_rawDescGZIP(), []int{53}
 }
 
 func (x *QueryFederationSyncConfigRequest) GetId() []*ID {
@@ -3392,7 +3465,7 @@ type QueryFederationSyncConfigResponse struct {
 
 func (x *QueryFederationSyncConfigResponse) Reset() {
 	*x = QueryFederationSyncConfigResponse{}
-	mi := &file_universerpc_universe_proto_msgTypes[53]
+	mi := &file_universerpc_universe_proto_msgTypes[54]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3404,7 +3477,7 @@ func (x *QueryFederationSyncConfigResponse) String() string {
 func (*QueryFederationSyncConfigResponse) ProtoMessage() {}
 
 func (x *QueryFederationSyncConfigResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_universerpc_universe_proto_msgTypes[53]
+	mi := &file_universerpc_universe_proto_msgTypes[54]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3417,7 +3490,7 @@ func (x *QueryFederationSyncConfigResponse) ProtoReflect() protoreflect.Message 
 
 // Deprecated: Use QueryFederationSyncConfigResponse.ProtoReflect.Descriptor instead.
 func (*QueryFederationSyncConfigResponse) Descriptor() ([]byte, []int) {
-	return file_universerpc_universe_proto_rawDescGZIP(), []int{53}
+	return file_universerpc_universe_proto_rawDescGZIP(), []int{54}
 }
 
 func (x *QueryFederationSyncConfigResponse) GetGlobalSyncConfigs() []*GlobalFederationSyncConfig {
@@ -3446,7 +3519,7 @@ type IgnoreAssetOutPointRequest struct {
 
 func (x *IgnoreAssetOutPointRequest) Reset() {
 	*x = IgnoreAssetOutPointRequest{}
-	mi := &file_universerpc_universe_proto_msgTypes[54]
+	mi := &file_universerpc_universe_proto_msgTypes[55]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3458,7 +3531,7 @@ func (x *IgnoreAssetOutPointRequest) String() string {
 func (*IgnoreAssetOutPointRequest) ProtoMessage() {}
 
 func (x *IgnoreAssetOutPointRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_universerpc_universe_proto_msgTypes[54]
+	mi := &file_universerpc_universe_proto_msgTypes[55]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3471,7 +3544,7 @@ func (x *IgnoreAssetOutPointRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IgnoreAssetOutPointRequest.ProtoReflect.Descriptor instead.
 func (*IgnoreAssetOutPointRequest) Descriptor() ([]byte, []int) {
-	return file_universerpc_universe_proto_rawDescGZIP(), []int{54}
+	return file_universerpc_universe_proto_rawDescGZIP(), []int{55}
 }
 
 func (x *IgnoreAssetOutPointRequest) GetAssetOutPoint() *taprpc.AssetOutPoint {
@@ -3501,7 +3574,7 @@ type IgnoreAssetOutPointResponse struct {
 
 func (x *IgnoreAssetOutPointResponse) Reset() {
 	*x = IgnoreAssetOutPointResponse{}
-	mi := &file_universerpc_universe_proto_msgTypes[55]
+	mi := &file_universerpc_universe_proto_msgTypes[56]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3513,7 +3586,7 @@ func (x *IgnoreAssetOutPointResponse) String() string {
 func (*IgnoreAssetOutPointResponse) ProtoMessage() {}
 
 func (x *IgnoreAssetOutPointResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_universerpc_universe_proto_msgTypes[55]
+	mi := &file_universerpc_universe_proto_msgTypes[56]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3526,7 +3599,7 @@ func (x *IgnoreAssetOutPointResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IgnoreAssetOutPointResponse.ProtoReflect.Descriptor instead.
 func (*IgnoreAssetOutPointResponse) Descriptor() ([]byte, []int) {
-	return file_universerpc_universe_proto_rawDescGZIP(), []int{55}
+	return file_universerpc_universe_proto_rawDescGZIP(), []int{56}
 }
 
 func (x *IgnoreAssetOutPointResponse) GetLeafKey() []byte {
@@ -3559,7 +3632,7 @@ type UpdateSupplyCommitRequest struct {
 
 func (x *UpdateSupplyCommitRequest) Reset() {
 	*x = UpdateSupplyCommitRequest{}
-	mi := &file_universerpc_universe_proto_msgTypes[56]
+	mi := &file_universerpc_universe_proto_msgTypes[57]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3571,7 +3644,7 @@ func (x *UpdateSupplyCommitRequest) String() string {
 func (*UpdateSupplyCommitRequest) ProtoMessage() {}
 
 func (x *UpdateSupplyCommitRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_universerpc_universe_proto_msgTypes[56]
+	mi := &file_universerpc_universe_proto_msgTypes[57]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3584,7 +3657,7 @@ func (x *UpdateSupplyCommitRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateSupplyCommitRequest.ProtoReflect.Descriptor instead.
 func (*UpdateSupplyCommitRequest) Descriptor() ([]byte, []int) {
-	return file_universerpc_universe_proto_rawDescGZIP(), []int{56}
+	return file_universerpc_universe_proto_rawDescGZIP(), []int{57}
 }
 
 func (x *UpdateSupplyCommitRequest) GetGroupKey() isUpdateSupplyCommitRequest_GroupKey {
@@ -3639,7 +3712,7 @@ type UpdateSupplyCommitResponse struct {
 
 func (x *UpdateSupplyCommitResponse) Reset() {
 	*x = UpdateSupplyCommitResponse{}
-	mi := &file_universerpc_universe_proto_msgTypes[57]
+	mi := &file_universerpc_universe_proto_msgTypes[58]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3651,7 +3724,7 @@ func (x *UpdateSupplyCommitResponse) String() string {
 func (*UpdateSupplyCommitResponse) ProtoMessage() {}
 
 func (x *UpdateSupplyCommitResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_universerpc_universe_proto_msgTypes[57]
+	mi := &file_universerpc_universe_proto_msgTypes[58]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3664,7 +3737,7 @@ func (x *UpdateSupplyCommitResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateSupplyCommitResponse.ProtoReflect.Descriptor instead.
 func (*UpdateSupplyCommitResponse) Descriptor() ([]byte, []int) {
-	return file_universerpc_universe_proto_rawDescGZIP(), []int{57}
+	return file_universerpc_universe_proto_rawDescGZIP(), []int{58}
 }
 
 type FetchSupplyCommitRequest struct {
@@ -3692,7 +3765,7 @@ type FetchSupplyCommitRequest struct {
 
 func (x *FetchSupplyCommitRequest) Reset() {
 	*x = FetchSupplyCommitRequest{}
-	mi := &file_universerpc_universe_proto_msgTypes[58]
+	mi := &file_universerpc_universe_proto_msgTypes[59]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3704,7 +3777,7 @@ func (x *FetchSupplyCommitRequest) String() string {
 func (*FetchSupplyCommitRequest) ProtoMessage() {}
 
 func (x *FetchSupplyCommitRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_universerpc_universe_proto_msgTypes[58]
+	mi := &file_universerpc_universe_proto_msgTypes[59]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3717,7 +3790,7 @@ func (x *FetchSupplyCommitRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FetchSupplyCommitRequest.ProtoReflect.Descriptor instead.
 func (*FetchSupplyCommitRequest) Descriptor() ([]byte, []int) {
-	return file_universerpc_universe_proto_rawDescGZIP(), []int{58}
+	return file_universerpc_universe_proto_rawDescGZIP(), []int{59}
 }
 
 func (x *FetchSupplyCommitRequest) GetGroupKey() isFetchSupplyCommitRequest_GroupKey {
@@ -3867,7 +3940,7 @@ type SupplyCommitSubtreeRoot struct {
 
 func (x *SupplyCommitSubtreeRoot) Reset() {
 	*x = SupplyCommitSubtreeRoot{}
-	mi := &file_universerpc_universe_proto_msgTypes[59]
+	mi := &file_universerpc_universe_proto_msgTypes[60]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3879,7 +3952,7 @@ func (x *SupplyCommitSubtreeRoot) String() string {
 func (*SupplyCommitSubtreeRoot) ProtoMessage() {}
 
 func (x *SupplyCommitSubtreeRoot) ProtoReflect() protoreflect.Message {
-	mi := &file_universerpc_universe_proto_msgTypes[59]
+	mi := &file_universerpc_universe_proto_msgTypes[60]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3892,7 +3965,7 @@ func (x *SupplyCommitSubtreeRoot) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SupplyCommitSubtreeRoot.ProtoReflect.Descriptor instead.
 func (*SupplyCommitSubtreeRoot) Descriptor() ([]byte, []int) {
-	return file_universerpc_universe_proto_rawDescGZIP(), []int{59}
+	return file_universerpc_universe_proto_rawDescGZIP(), []int{60}
 }
 
 func (x *SupplyCommitSubtreeRoot) GetType() string {
@@ -3965,7 +4038,7 @@ type FetchSupplyCommitResponse struct {
 
 func (x *FetchSupplyCommitResponse) Reset() {
 	*x = FetchSupplyCommitResponse{}
-	mi := &file_universerpc_universe_proto_msgTypes[60]
+	mi := &file_universerpc_universe_proto_msgTypes[61]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3977,7 +4050,7 @@ func (x *FetchSupplyCommitResponse) String() string {
 func (*FetchSupplyCommitResponse) ProtoMessage() {}
 
 func (x *FetchSupplyCommitResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_universerpc_universe_proto_msgTypes[60]
+	mi := &file_universerpc_universe_proto_msgTypes[61]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3990,7 +4063,7 @@ func (x *FetchSupplyCommitResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FetchSupplyCommitResponse.ProtoReflect.Descriptor instead.
 func (*FetchSupplyCommitResponse) Descriptor() ([]byte, []int) {
-	return file_universerpc_universe_proto_rawDescGZIP(), []int{60}
+	return file_universerpc_universe_proto_rawDescGZIP(), []int{61}
 }
 
 func (x *FetchSupplyCommitResponse) GetChainData() *SupplyCommitChainData {
@@ -4099,7 +4172,7 @@ type FetchSupplyLeavesRequest struct {
 
 func (x *FetchSupplyLeavesRequest) Reset() {
 	*x = FetchSupplyLeavesRequest{}
-	mi := &file_universerpc_universe_proto_msgTypes[61]
+	mi := &file_universerpc_universe_proto_msgTypes[62]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4111,7 +4184,7 @@ func (x *FetchSupplyLeavesRequest) String() string {
 func (*FetchSupplyLeavesRequest) ProtoMessage() {}
 
 func (x *FetchSupplyLeavesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_universerpc_universe_proto_msgTypes[61]
+	mi := &file_universerpc_universe_proto_msgTypes[62]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4124,7 +4197,7 @@ func (x *FetchSupplyLeavesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FetchSupplyLeavesRequest.ProtoReflect.Descriptor instead.
 func (*FetchSupplyLeavesRequest) Descriptor() ([]byte, []int) {
-	return file_universerpc_universe_proto_rawDescGZIP(), []int{61}
+	return file_universerpc_universe_proto_rawDescGZIP(), []int{62}
 }
 
 func (x *FetchSupplyLeavesRequest) GetGroupKey() isFetchSupplyLeavesRequest_GroupKey {
@@ -4224,7 +4297,7 @@ type SupplyLeafKey struct {
 
 func (x *SupplyLeafKey) Reset() {
 	*x = SupplyLeafKey{}
-	mi := &file_universerpc_universe_proto_msgTypes[62]
+	mi := &file_universerpc_universe_proto_msgTypes[63]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4236,7 +4309,7 @@ func (x *SupplyLeafKey) String() string {
 func (*SupplyLeafKey) ProtoMessage() {}
 
 func (x *SupplyLeafKey) ProtoReflect() protoreflect.Message {
-	mi := &file_universerpc_universe_proto_msgTypes[62]
+	mi := &file_universerpc_universe_proto_msgTypes[63]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4249,7 +4322,7 @@ func (x *SupplyLeafKey) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SupplyLeafKey.ProtoReflect.Descriptor instead.
 func (*SupplyLeafKey) Descriptor() ([]byte, []int) {
-	return file_universerpc_universe_proto_rawDescGZIP(), []int{62}
+	return file_universerpc_universe_proto_rawDescGZIP(), []int{63}
 }
 
 func (x *SupplyLeafKey) GetOutpoint() *Outpoint {
@@ -4290,7 +4363,7 @@ type SupplyLeafEntry struct {
 
 func (x *SupplyLeafEntry) Reset() {
 	*x = SupplyLeafEntry{}
-	mi := &file_universerpc_universe_proto_msgTypes[63]
+	mi := &file_universerpc_universe_proto_msgTypes[64]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4302,7 +4375,7 @@ func (x *SupplyLeafEntry) String() string {
 func (*SupplyLeafEntry) ProtoMessage() {}
 
 func (x *SupplyLeafEntry) ProtoReflect() protoreflect.Message {
-	mi := &file_universerpc_universe_proto_msgTypes[63]
+	mi := &file_universerpc_universe_proto_msgTypes[64]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4315,7 +4388,7 @@ func (x *SupplyLeafEntry) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SupplyLeafEntry.ProtoReflect.Descriptor instead.
 func (*SupplyLeafEntry) Descriptor() ([]byte, []int) {
-	return file_universerpc_universe_proto_rawDescGZIP(), []int{63}
+	return file_universerpc_universe_proto_rawDescGZIP(), []int{64}
 }
 
 func (x *SupplyLeafEntry) GetLeafKey() *SupplyLeafKey {
@@ -4358,7 +4431,7 @@ type SupplyLeafBlockHeader struct {
 
 func (x *SupplyLeafBlockHeader) Reset() {
 	*x = SupplyLeafBlockHeader{}
-	mi := &file_universerpc_universe_proto_msgTypes[64]
+	mi := &file_universerpc_universe_proto_msgTypes[65]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4370,7 +4443,7 @@ func (x *SupplyLeafBlockHeader) String() string {
 func (*SupplyLeafBlockHeader) ProtoMessage() {}
 
 func (x *SupplyLeafBlockHeader) ProtoReflect() protoreflect.Message {
-	mi := &file_universerpc_universe_proto_msgTypes[64]
+	mi := &file_universerpc_universe_proto_msgTypes[65]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4383,7 +4456,7 @@ func (x *SupplyLeafBlockHeader) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SupplyLeafBlockHeader.ProtoReflect.Descriptor instead.
 func (*SupplyLeafBlockHeader) Descriptor() ([]byte, []int) {
-	return file_universerpc_universe_proto_rawDescGZIP(), []int{64}
+	return file_universerpc_universe_proto_rawDescGZIP(), []int{65}
 }
 
 func (x *SupplyLeafBlockHeader) GetTimestamp() int64 {
@@ -4425,7 +4498,7 @@ type FetchSupplyLeavesResponse struct {
 
 func (x *FetchSupplyLeavesResponse) Reset() {
 	*x = FetchSupplyLeavesResponse{}
-	mi := &file_universerpc_universe_proto_msgTypes[65]
+	mi := &file_universerpc_universe_proto_msgTypes[66]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4437,7 +4510,7 @@ func (x *FetchSupplyLeavesResponse) String() string {
 func (*FetchSupplyLeavesResponse) ProtoMessage() {}
 
 func (x *FetchSupplyLeavesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_universerpc_universe_proto_msgTypes[65]
+	mi := &file_universerpc_universe_proto_msgTypes[66]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4450,7 +4523,7 @@ func (x *FetchSupplyLeavesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FetchSupplyLeavesResponse.ProtoReflect.Descriptor instead.
 func (*FetchSupplyLeavesResponse) Descriptor() ([]byte, []int) {
-	return file_universerpc_universe_proto_rawDescGZIP(), []int{65}
+	return file_universerpc_universe_proto_rawDescGZIP(), []int{66}
 }
 
 func (x *FetchSupplyLeavesResponse) GetIssuanceLeaves() []*SupplyLeafEntry {
@@ -4542,7 +4615,7 @@ type SupplyCommitChainData struct {
 
 func (x *SupplyCommitChainData) Reset() {
 	*x = SupplyCommitChainData{}
-	mi := &file_universerpc_universe_proto_msgTypes[66]
+	mi := &file_universerpc_universe_proto_msgTypes[67]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4554,7 +4627,7 @@ func (x *SupplyCommitChainData) String() string {
 func (*SupplyCommitChainData) ProtoMessage() {}
 
 func (x *SupplyCommitChainData) ProtoReflect() protoreflect.Message {
-	mi := &file_universerpc_universe_proto_msgTypes[66]
+	mi := &file_universerpc_universe_proto_msgTypes[67]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4567,7 +4640,7 @@ func (x *SupplyCommitChainData) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SupplyCommitChainData.ProtoReflect.Descriptor instead.
 func (*SupplyCommitChainData) Descriptor() ([]byte, []int) {
-	return file_universerpc_universe_proto_rawDescGZIP(), []int{66}
+	return file_universerpc_universe_proto_rawDescGZIP(), []int{67}
 }
 
 func (x *SupplyCommitChainData) GetTxn() []byte {
@@ -4681,7 +4754,7 @@ type InsertSupplyCommitRequest struct {
 
 func (x *InsertSupplyCommitRequest) Reset() {
 	*x = InsertSupplyCommitRequest{}
-	mi := &file_universerpc_universe_proto_msgTypes[67]
+	mi := &file_universerpc_universe_proto_msgTypes[68]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4693,7 +4766,7 @@ func (x *InsertSupplyCommitRequest) String() string {
 func (*InsertSupplyCommitRequest) ProtoMessage() {}
 
 func (x *InsertSupplyCommitRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_universerpc_universe_proto_msgTypes[67]
+	mi := &file_universerpc_universe_proto_msgTypes[68]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4706,7 +4779,7 @@ func (x *InsertSupplyCommitRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InsertSupplyCommitRequest.ProtoReflect.Descriptor instead.
 func (*InsertSupplyCommitRequest) Descriptor() ([]byte, []int) {
-	return file_universerpc_universe_proto_rawDescGZIP(), []int{67}
+	return file_universerpc_universe_proto_rawDescGZIP(), []int{68}
 }
 
 func (x *InsertSupplyCommitRequest) GetGroupKey() isInsertSupplyCommitRequest_GroupKey {
@@ -4796,7 +4869,7 @@ type InsertSupplyCommitResponse struct {
 
 func (x *InsertSupplyCommitResponse) Reset() {
 	*x = InsertSupplyCommitResponse{}
-	mi := &file_universerpc_universe_proto_msgTypes[68]
+	mi := &file_universerpc_universe_proto_msgTypes[69]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4808,7 +4881,7 @@ func (x *InsertSupplyCommitResponse) String() string {
 func (*InsertSupplyCommitResponse) ProtoMessage() {}
 
 func (x *InsertSupplyCommitResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_universerpc_universe_proto_msgTypes[68]
+	mi := &file_universerpc_universe_proto_msgTypes[69]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4821,7 +4894,7 @@ func (x *InsertSupplyCommitResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InsertSupplyCommitResponse.ProtoReflect.Descriptor instead.
 func (*InsertSupplyCommitResponse) Descriptor() ([]byte, []int) {
-	return file_universerpc_universe_proto_rawDescGZIP(), []int{68}
+	return file_universerpc_universe_proto_rawDescGZIP(), []int{69}
 }
 
 var File_universerpc_universe_proto protoreflect.FileDescriptor
@@ -4900,11 +4973,15 @@ const file_universerpc_universe_proto_rawDesc = "" +
 	"\x02id\x18\x01 \x01(\v2\x0f.universerpc.IDR\x02id\x12\x16\n" +
 	"\x06offset\x18\x02 \x01(\x05R\x06offset\x12\x14\n" +
 	"\x05limit\x18\x03 \x01(\x05R\x05limit\x123\n" +
-	"\tdirection\x18\x04 \x01(\x0e2\x15.taprpc.SortDirectionR\tdirection\"g\n" +
-	"\x14AssetLeafKeyResponse\x124\n" +
+	"\tdirection\x18\x04 \x01(\x0e2\x15.taprpc.SortDirectionR\tdirection\"j\n" +
+	"\x0eAssetLeafEntry\x122\n" +
+	"\tasset_key\x18\x01 \x01(\v2\x15.universerpc.AssetKeyR\bassetKey\x12$\n" +
+	"\x0eleaf_node_hash\x18\x02 \x01(\fR\fleafNodeHash\"\xa2\x01\n" +
+	"\x14AssetLeafKeyResponse\x128\n" +
 	"\n" +
-	"asset_keys\x18\x01 \x03(\v2\x15.universerpc.AssetKeyR\tassetKeys\x12\x19\n" +
-	"\bhas_more\x18\x02 \x01(\bR\ahasMore\"F\n" +
+	"asset_keys\x18\x01 \x03(\v2\x15.universerpc.AssetKeyB\x02\x18\x01R\tassetKeys\x12\x19\n" +
+	"\bhas_more\x18\x02 \x01(\bR\ahasMore\x125\n" +
+	"\aentries\x18\x03 \x03(\v2\x1b.universerpc.AssetLeafEntryR\aentries\"F\n" +
 	"\tAssetLeaf\x12#\n" +
 	"\x05asset\x18\x01 \x01(\v2\r.taprpc.AssetR\x05asset\x12\x14\n" +
 	"\x05proof\x18\x02 \x01(\fR\x05proof\"^\n" +
@@ -5202,7 +5279,7 @@ func file_universerpc_universe_proto_rawDescGZIP() []byte {
 }
 
 var file_universerpc_universe_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
-var file_universerpc_universe_proto_msgTypes = make([]protoimpl.MessageInfo, 73)
+var file_universerpc_universe_proto_msgTypes = make([]protoimpl.MessageInfo, 74)
 var file_universerpc_universe_proto_goTypes = []any{
 	(ProofType)(0),                            // 0: universerpc.ProofType
 	(UniverseSyncMode)(0),                     // 1: universerpc.UniverseSyncMode
@@ -5225,218 +5302,221 @@ var file_universerpc_universe_proto_goTypes = []any{
 	(*AssetKey)(nil),                          // 18: universerpc.AssetKey
 	(*AssetLeafKeysRequest)(nil),              // 19: universerpc.AssetLeafKeysRequest
 	(*AssetLeavesRequest)(nil),                // 20: universerpc.AssetLeavesRequest
-	(*AssetLeafKeyResponse)(nil),              // 21: universerpc.AssetLeafKeyResponse
-	(*AssetLeaf)(nil),                         // 22: universerpc.AssetLeaf
-	(*AssetLeafResponse)(nil),                 // 23: universerpc.AssetLeafResponse
-	(*UniverseKey)(nil),                       // 24: universerpc.UniverseKey
-	(*AssetProofResponse)(nil),                // 25: universerpc.AssetProofResponse
-	(*IssuanceData)(nil),                      // 26: universerpc.IssuanceData
-	(*AssetProof)(nil),                        // 27: universerpc.AssetProof
-	(*PushProofRequest)(nil),                  // 28: universerpc.PushProofRequest
-	(*PushProofResponse)(nil),                 // 29: universerpc.PushProofResponse
-	(*InfoRequest)(nil),                       // 30: universerpc.InfoRequest
-	(*InfoResponse)(nil),                      // 31: universerpc.InfoResponse
-	(*SyncTarget)(nil),                        // 32: universerpc.SyncTarget
-	(*SyncRequest)(nil),                       // 33: universerpc.SyncRequest
-	(*SyncedUniverse)(nil),                    // 34: universerpc.SyncedUniverse
-	(*StatsRequest)(nil),                      // 35: universerpc.StatsRequest
-	(*SyncResponse)(nil),                      // 36: universerpc.SyncResponse
-	(*UniverseFederationServer)(nil),          // 37: universerpc.UniverseFederationServer
-	(*ListFederationServersRequest)(nil),      // 38: universerpc.ListFederationServersRequest
-	(*ListFederationServersResponse)(nil),     // 39: universerpc.ListFederationServersResponse
-	(*AddFederationServerRequest)(nil),        // 40: universerpc.AddFederationServerRequest
-	(*AddFederationServerResponse)(nil),       // 41: universerpc.AddFederationServerResponse
-	(*DeleteFederationServerRequest)(nil),     // 42: universerpc.DeleteFederationServerRequest
-	(*DeleteFederationServerResponse)(nil),    // 43: universerpc.DeleteFederationServerResponse
-	(*StatsResponse)(nil),                     // 44: universerpc.StatsResponse
-	(*AssetStatsQuery)(nil),                   // 45: universerpc.AssetStatsQuery
-	(*AssetStatsSnapshot)(nil),                // 46: universerpc.AssetStatsSnapshot
-	(*AssetStatsAsset)(nil),                   // 47: universerpc.AssetStatsAsset
-	(*UniverseAssetStats)(nil),                // 48: universerpc.UniverseAssetStats
-	(*QueryEventsRequest)(nil),                // 49: universerpc.QueryEventsRequest
-	(*QueryEventsResponse)(nil),               // 50: universerpc.QueryEventsResponse
-	(*GroupedUniverseEvents)(nil),             // 51: universerpc.GroupedUniverseEvents
-	(*SetFederationSyncConfigRequest)(nil),    // 52: universerpc.SetFederationSyncConfigRequest
-	(*SetFederationSyncConfigResponse)(nil),   // 53: universerpc.SetFederationSyncConfigResponse
-	(*GlobalFederationSyncConfig)(nil),        // 54: universerpc.GlobalFederationSyncConfig
-	(*AssetFederationSyncConfig)(nil),         // 55: universerpc.AssetFederationSyncConfig
-	(*QueryFederationSyncConfigRequest)(nil),  // 56: universerpc.QueryFederationSyncConfigRequest
-	(*QueryFederationSyncConfigResponse)(nil), // 57: universerpc.QueryFederationSyncConfigResponse
-	(*IgnoreAssetOutPointRequest)(nil),        // 58: universerpc.IgnoreAssetOutPointRequest
-	(*IgnoreAssetOutPointResponse)(nil),       // 59: universerpc.IgnoreAssetOutPointResponse
-	(*UpdateSupplyCommitRequest)(nil),         // 60: universerpc.UpdateSupplyCommitRequest
-	(*UpdateSupplyCommitResponse)(nil),        // 61: universerpc.UpdateSupplyCommitResponse
-	(*FetchSupplyCommitRequest)(nil),          // 62: universerpc.FetchSupplyCommitRequest
-	(*SupplyCommitSubtreeRoot)(nil),           // 63: universerpc.SupplyCommitSubtreeRoot
-	(*FetchSupplyCommitResponse)(nil),         // 64: universerpc.FetchSupplyCommitResponse
-	(*FetchSupplyLeavesRequest)(nil),          // 65: universerpc.FetchSupplyLeavesRequest
-	(*SupplyLeafKey)(nil),                     // 66: universerpc.SupplyLeafKey
-	(*SupplyLeafEntry)(nil),                   // 67: universerpc.SupplyLeafEntry
-	(*SupplyLeafBlockHeader)(nil),             // 68: universerpc.SupplyLeafBlockHeader
-	(*FetchSupplyLeavesResponse)(nil),         // 69: universerpc.FetchSupplyLeavesResponse
-	(*SupplyCommitChainData)(nil),             // 70: universerpc.SupplyCommitChainData
-	(*InsertSupplyCommitRequest)(nil),         // 71: universerpc.InsertSupplyCommitRequest
-	(*InsertSupplyCommitResponse)(nil),        // 72: universerpc.InsertSupplyCommitResponse
-	nil,                                       // 73: universerpc.UniverseRoot.AmountsByAssetIdEntry
-	nil,                                       // 74: universerpc.AssetRootResponse.UniverseRootsEntry
-	nil,                                       // 75: universerpc.FetchSupplyCommitResponse.BlockHeadersEntry
-	nil,                                       // 76: universerpc.FetchSupplyLeavesResponse.BlockHeadersEntry
-	(taprpc.SortDirection)(0),                 // 77: taprpc.SortDirection
-	(*taprpc.Asset)(nil),                      // 78: taprpc.Asset
-	(*taprpc.AssetMeta)(nil),                  // 79: taprpc.AssetMeta
-	(*taprpc.GenesisReveal)(nil),              // 80: taprpc.GenesisReveal
-	(*taprpc.GroupKeyReveal)(nil),             // 81: taprpc.GroupKeyReveal
-	(taprpc.AssetType)(0),                     // 82: taprpc.AssetType
-	(*taprpc.AssetOutPoint)(nil),              // 83: taprpc.AssetOutPoint
-	(*taprpc.OutPoint)(nil),                   // 84: taprpc.OutPoint
+	(*AssetLeafEntry)(nil),                    // 21: universerpc.AssetLeafEntry
+	(*AssetLeafKeyResponse)(nil),              // 22: universerpc.AssetLeafKeyResponse
+	(*AssetLeaf)(nil),                         // 23: universerpc.AssetLeaf
+	(*AssetLeafResponse)(nil),                 // 24: universerpc.AssetLeafResponse
+	(*UniverseKey)(nil),                       // 25: universerpc.UniverseKey
+	(*AssetProofResponse)(nil),                // 26: universerpc.AssetProofResponse
+	(*IssuanceData)(nil),                      // 27: universerpc.IssuanceData
+	(*AssetProof)(nil),                        // 28: universerpc.AssetProof
+	(*PushProofRequest)(nil),                  // 29: universerpc.PushProofRequest
+	(*PushProofResponse)(nil),                 // 30: universerpc.PushProofResponse
+	(*InfoRequest)(nil),                       // 31: universerpc.InfoRequest
+	(*InfoResponse)(nil),                      // 32: universerpc.InfoResponse
+	(*SyncTarget)(nil),                        // 33: universerpc.SyncTarget
+	(*SyncRequest)(nil),                       // 34: universerpc.SyncRequest
+	(*SyncedUniverse)(nil),                    // 35: universerpc.SyncedUniverse
+	(*StatsRequest)(nil),                      // 36: universerpc.StatsRequest
+	(*SyncResponse)(nil),                      // 37: universerpc.SyncResponse
+	(*UniverseFederationServer)(nil),          // 38: universerpc.UniverseFederationServer
+	(*ListFederationServersRequest)(nil),      // 39: universerpc.ListFederationServersRequest
+	(*ListFederationServersResponse)(nil),     // 40: universerpc.ListFederationServersResponse
+	(*AddFederationServerRequest)(nil),        // 41: universerpc.AddFederationServerRequest
+	(*AddFederationServerResponse)(nil),       // 42: universerpc.AddFederationServerResponse
+	(*DeleteFederationServerRequest)(nil),     // 43: universerpc.DeleteFederationServerRequest
+	(*DeleteFederationServerResponse)(nil),    // 44: universerpc.DeleteFederationServerResponse
+	(*StatsResponse)(nil),                     // 45: universerpc.StatsResponse
+	(*AssetStatsQuery)(nil),                   // 46: universerpc.AssetStatsQuery
+	(*AssetStatsSnapshot)(nil),                // 47: universerpc.AssetStatsSnapshot
+	(*AssetStatsAsset)(nil),                   // 48: universerpc.AssetStatsAsset
+	(*UniverseAssetStats)(nil),                // 49: universerpc.UniverseAssetStats
+	(*QueryEventsRequest)(nil),                // 50: universerpc.QueryEventsRequest
+	(*QueryEventsResponse)(nil),               // 51: universerpc.QueryEventsResponse
+	(*GroupedUniverseEvents)(nil),             // 52: universerpc.GroupedUniverseEvents
+	(*SetFederationSyncConfigRequest)(nil),    // 53: universerpc.SetFederationSyncConfigRequest
+	(*SetFederationSyncConfigResponse)(nil),   // 54: universerpc.SetFederationSyncConfigResponse
+	(*GlobalFederationSyncConfig)(nil),        // 55: universerpc.GlobalFederationSyncConfig
+	(*AssetFederationSyncConfig)(nil),         // 56: universerpc.AssetFederationSyncConfig
+	(*QueryFederationSyncConfigRequest)(nil),  // 57: universerpc.QueryFederationSyncConfigRequest
+	(*QueryFederationSyncConfigResponse)(nil), // 58: universerpc.QueryFederationSyncConfigResponse
+	(*IgnoreAssetOutPointRequest)(nil),        // 59: universerpc.IgnoreAssetOutPointRequest
+	(*IgnoreAssetOutPointResponse)(nil),       // 60: universerpc.IgnoreAssetOutPointResponse
+	(*UpdateSupplyCommitRequest)(nil),         // 61: universerpc.UpdateSupplyCommitRequest
+	(*UpdateSupplyCommitResponse)(nil),        // 62: universerpc.UpdateSupplyCommitResponse
+	(*FetchSupplyCommitRequest)(nil),          // 63: universerpc.FetchSupplyCommitRequest
+	(*SupplyCommitSubtreeRoot)(nil),           // 64: universerpc.SupplyCommitSubtreeRoot
+	(*FetchSupplyCommitResponse)(nil),         // 65: universerpc.FetchSupplyCommitResponse
+	(*FetchSupplyLeavesRequest)(nil),          // 66: universerpc.FetchSupplyLeavesRequest
+	(*SupplyLeafKey)(nil),                     // 67: universerpc.SupplyLeafKey
+	(*SupplyLeafEntry)(nil),                   // 68: universerpc.SupplyLeafEntry
+	(*SupplyLeafBlockHeader)(nil),             // 69: universerpc.SupplyLeafBlockHeader
+	(*FetchSupplyLeavesResponse)(nil),         // 70: universerpc.FetchSupplyLeavesResponse
+	(*SupplyCommitChainData)(nil),             // 71: universerpc.SupplyCommitChainData
+	(*InsertSupplyCommitRequest)(nil),         // 72: universerpc.InsertSupplyCommitRequest
+	(*InsertSupplyCommitResponse)(nil),        // 73: universerpc.InsertSupplyCommitResponse
+	nil,                                       // 74: universerpc.UniverseRoot.AmountsByAssetIdEntry
+	nil,                                       // 75: universerpc.AssetRootResponse.UniverseRootsEntry
+	nil,                                       // 76: universerpc.FetchSupplyCommitResponse.BlockHeadersEntry
+	nil,                                       // 77: universerpc.FetchSupplyLeavesResponse.BlockHeadersEntry
+	(taprpc.SortDirection)(0),                 // 78: taprpc.SortDirection
+	(*taprpc.Asset)(nil),                      // 79: taprpc.Asset
+	(*taprpc.AssetMeta)(nil),                  // 80: taprpc.AssetMeta
+	(*taprpc.GenesisReveal)(nil),              // 81: taprpc.GenesisReveal
+	(*taprpc.GroupKeyReveal)(nil),             // 82: taprpc.GroupKeyReveal
+	(taprpc.AssetType)(0),                     // 83: taprpc.AssetType
+	(*taprpc.AssetOutPoint)(nil),              // 84: taprpc.AssetOutPoint
+	(*taprpc.OutPoint)(nil),                   // 85: taprpc.OutPoint
 }
 var file_universerpc_universe_proto_depIdxs = []int32{
 	0,   // 0: universerpc.MultiverseRootRequest.proof_type:type_name -> universerpc.ProofType
 	8,   // 1: universerpc.MultiverseRootRequest.specific_ids:type_name -> universerpc.ID
 	7,   // 2: universerpc.MultiverseRootResponse.multiverse_root:type_name -> universerpc.MerkleSumNode
-	77,  // 3: universerpc.AssetRootRequest.direction:type_name -> taprpc.SortDirection
+	78,  // 3: universerpc.AssetRootRequest.direction:type_name -> taprpc.SortDirection
 	0,   // 4: universerpc.ID.proof_type:type_name -> universerpc.ProofType
 	8,   // 5: universerpc.UniverseRoot.id:type_name -> universerpc.ID
 	7,   // 6: universerpc.UniverseRoot.mssmt_root:type_name -> universerpc.MerkleSumNode
-	73,  // 7: universerpc.UniverseRoot.amounts_by_asset_id:type_name -> universerpc.UniverseRoot.AmountsByAssetIdEntry
-	74,  // 8: universerpc.AssetRootResponse.universe_roots:type_name -> universerpc.AssetRootResponse.UniverseRootsEntry
+	74,  // 7: universerpc.UniverseRoot.amounts_by_asset_id:type_name -> universerpc.UniverseRoot.AmountsByAssetIdEntry
+	75,  // 8: universerpc.AssetRootResponse.universe_roots:type_name -> universerpc.AssetRootResponse.UniverseRootsEntry
 	8,   // 9: universerpc.AssetRootQuery.id:type_name -> universerpc.ID
 	9,   // 10: universerpc.QueryRootResponse.issuance_root:type_name -> universerpc.UniverseRoot
 	9,   // 11: universerpc.QueryRootResponse.transfer_root:type_name -> universerpc.UniverseRoot
 	8,   // 12: universerpc.DeleteRootQuery.id:type_name -> universerpc.ID
-	24,  // 13: universerpc.DeleteAssetLeafRequest.key:type_name -> universerpc.UniverseKey
+	25,  // 13: universerpc.DeleteAssetLeafRequest.key:type_name -> universerpc.UniverseKey
 	17,  // 14: universerpc.AssetKey.op:type_name -> universerpc.Outpoint
 	8,   // 15: universerpc.AssetLeafKeysRequest.id:type_name -> universerpc.ID
-	77,  // 16: universerpc.AssetLeafKeysRequest.direction:type_name -> taprpc.SortDirection
+	78,  // 16: universerpc.AssetLeafKeysRequest.direction:type_name -> taprpc.SortDirection
 	8,   // 17: universerpc.AssetLeavesRequest.id:type_name -> universerpc.ID
-	77,  // 18: universerpc.AssetLeavesRequest.direction:type_name -> taprpc.SortDirection
-	18,  // 19: universerpc.AssetLeafKeyResponse.asset_keys:type_name -> universerpc.AssetKey
-	78,  // 20: universerpc.AssetLeaf.asset:type_name -> taprpc.Asset
-	22,  // 21: universerpc.AssetLeafResponse.leaves:type_name -> universerpc.AssetLeaf
-	8,   // 22: universerpc.UniverseKey.id:type_name -> universerpc.ID
-	18,  // 23: universerpc.UniverseKey.leaf_key:type_name -> universerpc.AssetKey
-	24,  // 24: universerpc.AssetProofResponse.req:type_name -> universerpc.UniverseKey
-	9,   // 25: universerpc.AssetProofResponse.universe_root:type_name -> universerpc.UniverseRoot
-	22,  // 26: universerpc.AssetProofResponse.asset_leaf:type_name -> universerpc.AssetLeaf
-	7,   // 27: universerpc.AssetProofResponse.multiverse_root:type_name -> universerpc.MerkleSumNode
-	26,  // 28: universerpc.AssetProofResponse.issuance_data:type_name -> universerpc.IssuanceData
-	79,  // 29: universerpc.IssuanceData.meta_reveal:type_name -> taprpc.AssetMeta
-	80,  // 30: universerpc.IssuanceData.genesis_reveal:type_name -> taprpc.GenesisReveal
-	81,  // 31: universerpc.IssuanceData.group_key_reveal:type_name -> taprpc.GroupKeyReveal
-	24,  // 32: universerpc.AssetProof.key:type_name -> universerpc.UniverseKey
-	22,  // 33: universerpc.AssetProof.asset_leaf:type_name -> universerpc.AssetLeaf
-	24,  // 34: universerpc.PushProofRequest.key:type_name -> universerpc.UniverseKey
-	37,  // 35: universerpc.PushProofRequest.server:type_name -> universerpc.UniverseFederationServer
-	24,  // 36: universerpc.PushProofResponse.key:type_name -> universerpc.UniverseKey
-	8,   // 37: universerpc.SyncTarget.id:type_name -> universerpc.ID
-	1,   // 38: universerpc.SyncRequest.sync_mode:type_name -> universerpc.UniverseSyncMode
-	32,  // 39: universerpc.SyncRequest.sync_targets:type_name -> universerpc.SyncTarget
-	9,   // 40: universerpc.SyncedUniverse.old_asset_root:type_name -> universerpc.UniverseRoot
-	9,   // 41: universerpc.SyncedUniverse.new_asset_root:type_name -> universerpc.UniverseRoot
-	22,  // 42: universerpc.SyncedUniverse.new_asset_leaves:type_name -> universerpc.AssetLeaf
-	34,  // 43: universerpc.SyncResponse.synced_universes:type_name -> universerpc.SyncedUniverse
-	37,  // 44: universerpc.ListFederationServersResponse.servers:type_name -> universerpc.UniverseFederationServer
-	37,  // 45: universerpc.AddFederationServerRequest.servers:type_name -> universerpc.UniverseFederationServer
-	37,  // 46: universerpc.DeleteFederationServerRequest.servers:type_name -> universerpc.UniverseFederationServer
-	3,   // 47: universerpc.AssetStatsQuery.asset_type_filter:type_name -> universerpc.AssetTypeFilter
-	2,   // 48: universerpc.AssetStatsQuery.sort_by:type_name -> universerpc.AssetQuerySort
-	77,  // 49: universerpc.AssetStatsQuery.direction:type_name -> taprpc.SortDirection
-	47,  // 50: universerpc.AssetStatsSnapshot.group_anchor:type_name -> universerpc.AssetStatsAsset
-	47,  // 51: universerpc.AssetStatsSnapshot.asset:type_name -> universerpc.AssetStatsAsset
-	82,  // 52: universerpc.AssetStatsAsset.asset_type:type_name -> taprpc.AssetType
-	46,  // 53: universerpc.UniverseAssetStats.asset_stats:type_name -> universerpc.AssetStatsSnapshot
-	51,  // 54: universerpc.QueryEventsResponse.events:type_name -> universerpc.GroupedUniverseEvents
-	54,  // 55: universerpc.SetFederationSyncConfigRequest.global_sync_configs:type_name -> universerpc.GlobalFederationSyncConfig
-	55,  // 56: universerpc.SetFederationSyncConfigRequest.asset_sync_configs:type_name -> universerpc.AssetFederationSyncConfig
-	0,   // 57: universerpc.GlobalFederationSyncConfig.proof_type:type_name -> universerpc.ProofType
-	8,   // 58: universerpc.AssetFederationSyncConfig.id:type_name -> universerpc.ID
-	8,   // 59: universerpc.QueryFederationSyncConfigRequest.id:type_name -> universerpc.ID
-	54,  // 60: universerpc.QueryFederationSyncConfigResponse.global_sync_configs:type_name -> universerpc.GlobalFederationSyncConfig
-	55,  // 61: universerpc.QueryFederationSyncConfigResponse.asset_sync_configs:type_name -> universerpc.AssetFederationSyncConfig
-	83,  // 62: universerpc.IgnoreAssetOutPointRequest.asset_out_point:type_name -> taprpc.AssetOutPoint
-	7,   // 63: universerpc.IgnoreAssetOutPointResponse.leaf:type_name -> universerpc.MerkleSumNode
-	84,  // 64: universerpc.FetchSupplyCommitRequest.commit_outpoint:type_name -> taprpc.OutPoint
-	84,  // 65: universerpc.FetchSupplyCommitRequest.spent_commit_outpoint:type_name -> taprpc.OutPoint
-	7,   // 66: universerpc.SupplyCommitSubtreeRoot.root_node:type_name -> universerpc.MerkleSumNode
-	70,  // 67: universerpc.FetchSupplyCommitResponse.chain_data:type_name -> universerpc.SupplyCommitChainData
-	63,  // 68: universerpc.FetchSupplyCommitResponse.issuance_subtree_root:type_name -> universerpc.SupplyCommitSubtreeRoot
-	63,  // 69: universerpc.FetchSupplyCommitResponse.burn_subtree_root:type_name -> universerpc.SupplyCommitSubtreeRoot
-	63,  // 70: universerpc.FetchSupplyCommitResponse.ignore_subtree_root:type_name -> universerpc.SupplyCommitSubtreeRoot
-	67,  // 71: universerpc.FetchSupplyCommitResponse.issuance_leaves:type_name -> universerpc.SupplyLeafEntry
-	67,  // 72: universerpc.FetchSupplyCommitResponse.burn_leaves:type_name -> universerpc.SupplyLeafEntry
-	67,  // 73: universerpc.FetchSupplyCommitResponse.ignore_leaves:type_name -> universerpc.SupplyLeafEntry
-	84,  // 74: universerpc.FetchSupplyCommitResponse.spent_commitment_outpoint:type_name -> taprpc.OutPoint
-	75,  // 75: universerpc.FetchSupplyCommitResponse.block_headers:type_name -> universerpc.FetchSupplyCommitResponse.BlockHeadersEntry
-	17,  // 76: universerpc.SupplyLeafKey.outpoint:type_name -> universerpc.Outpoint
-	66,  // 77: universerpc.SupplyLeafEntry.leaf_key:type_name -> universerpc.SupplyLeafKey
-	7,   // 78: universerpc.SupplyLeafEntry.leaf_node:type_name -> universerpc.MerkleSumNode
-	67,  // 79: universerpc.FetchSupplyLeavesResponse.issuance_leaves:type_name -> universerpc.SupplyLeafEntry
-	67,  // 80: universerpc.FetchSupplyLeavesResponse.burn_leaves:type_name -> universerpc.SupplyLeafEntry
-	67,  // 81: universerpc.FetchSupplyLeavesResponse.ignore_leaves:type_name -> universerpc.SupplyLeafEntry
-	76,  // 82: universerpc.FetchSupplyLeavesResponse.block_headers:type_name -> universerpc.FetchSupplyLeavesResponse.BlockHeadersEntry
-	70,  // 83: universerpc.InsertSupplyCommitRequest.chain_data:type_name -> universerpc.SupplyCommitChainData
-	84,  // 84: universerpc.InsertSupplyCommitRequest.spent_commitment_outpoint:type_name -> taprpc.OutPoint
-	67,  // 85: universerpc.InsertSupplyCommitRequest.issuance_leaves:type_name -> universerpc.SupplyLeafEntry
-	67,  // 86: universerpc.InsertSupplyCommitRequest.burn_leaves:type_name -> universerpc.SupplyLeafEntry
-	67,  // 87: universerpc.InsertSupplyCommitRequest.ignore_leaves:type_name -> universerpc.SupplyLeafEntry
-	9,   // 88: universerpc.AssetRootResponse.UniverseRootsEntry.value:type_name -> universerpc.UniverseRoot
-	68,  // 89: universerpc.FetchSupplyCommitResponse.BlockHeadersEntry.value:type_name -> universerpc.SupplyLeafBlockHeader
-	68,  // 90: universerpc.FetchSupplyLeavesResponse.BlockHeadersEntry.value:type_name -> universerpc.SupplyLeafBlockHeader
-	4,   // 91: universerpc.Universe.MultiverseRoot:input_type -> universerpc.MultiverseRootRequest
-	6,   // 92: universerpc.Universe.AssetRoots:input_type -> universerpc.AssetRootRequest
-	11,  // 93: universerpc.Universe.QueryAssetRoots:input_type -> universerpc.AssetRootQuery
-	13,  // 94: universerpc.Universe.DeleteAssetRoot:input_type -> universerpc.DeleteRootQuery
-	15,  // 95: universerpc.Universe.DeleteAssetLeaf:input_type -> universerpc.DeleteAssetLeafRequest
-	19,  // 96: universerpc.Universe.AssetLeafKeys:input_type -> universerpc.AssetLeafKeysRequest
-	20,  // 97: universerpc.Universe.AssetLeaves:input_type -> universerpc.AssetLeavesRequest
-	24,  // 98: universerpc.Universe.QueryProof:input_type -> universerpc.UniverseKey
-	27,  // 99: universerpc.Universe.InsertProof:input_type -> universerpc.AssetProof
-	28,  // 100: universerpc.Universe.PushProof:input_type -> universerpc.PushProofRequest
-	30,  // 101: universerpc.Universe.Info:input_type -> universerpc.InfoRequest
-	33,  // 102: universerpc.Universe.SyncUniverse:input_type -> universerpc.SyncRequest
-	38,  // 103: universerpc.Universe.ListFederationServers:input_type -> universerpc.ListFederationServersRequest
-	40,  // 104: universerpc.Universe.AddFederationServer:input_type -> universerpc.AddFederationServerRequest
-	42,  // 105: universerpc.Universe.DeleteFederationServer:input_type -> universerpc.DeleteFederationServerRequest
-	35,  // 106: universerpc.Universe.UniverseStats:input_type -> universerpc.StatsRequest
-	45,  // 107: universerpc.Universe.QueryAssetStats:input_type -> universerpc.AssetStatsQuery
-	49,  // 108: universerpc.Universe.QueryEvents:input_type -> universerpc.QueryEventsRequest
-	52,  // 109: universerpc.Universe.SetFederationSyncConfig:input_type -> universerpc.SetFederationSyncConfigRequest
-	56,  // 110: universerpc.Universe.QueryFederationSyncConfig:input_type -> universerpc.QueryFederationSyncConfigRequest
-	58,  // 111: universerpc.Universe.IgnoreAssetOutPoint:input_type -> universerpc.IgnoreAssetOutPointRequest
-	60,  // 112: universerpc.Universe.UpdateSupplyCommit:input_type -> universerpc.UpdateSupplyCommitRequest
-	62,  // 113: universerpc.Universe.FetchSupplyCommit:input_type -> universerpc.FetchSupplyCommitRequest
-	65,  // 114: universerpc.Universe.FetchSupplyLeaves:input_type -> universerpc.FetchSupplyLeavesRequest
-	71,  // 115: universerpc.Universe.InsertSupplyCommit:input_type -> universerpc.InsertSupplyCommitRequest
-	5,   // 116: universerpc.Universe.MultiverseRoot:output_type -> universerpc.MultiverseRootResponse
-	10,  // 117: universerpc.Universe.AssetRoots:output_type -> universerpc.AssetRootResponse
-	12,  // 118: universerpc.Universe.QueryAssetRoots:output_type -> universerpc.QueryRootResponse
-	14,  // 119: universerpc.Universe.DeleteAssetRoot:output_type -> universerpc.DeleteRootResponse
-	16,  // 120: universerpc.Universe.DeleteAssetLeaf:output_type -> universerpc.DeleteAssetLeafResponse
-	21,  // 121: universerpc.Universe.AssetLeafKeys:output_type -> universerpc.AssetLeafKeyResponse
-	23,  // 122: universerpc.Universe.AssetLeaves:output_type -> universerpc.AssetLeafResponse
-	25,  // 123: universerpc.Universe.QueryProof:output_type -> universerpc.AssetProofResponse
-	25,  // 124: universerpc.Universe.InsertProof:output_type -> universerpc.AssetProofResponse
-	29,  // 125: universerpc.Universe.PushProof:output_type -> universerpc.PushProofResponse
-	31,  // 126: universerpc.Universe.Info:output_type -> universerpc.InfoResponse
-	36,  // 127: universerpc.Universe.SyncUniverse:output_type -> universerpc.SyncResponse
-	39,  // 128: universerpc.Universe.ListFederationServers:output_type -> universerpc.ListFederationServersResponse
-	41,  // 129: universerpc.Universe.AddFederationServer:output_type -> universerpc.AddFederationServerResponse
-	43,  // 130: universerpc.Universe.DeleteFederationServer:output_type -> universerpc.DeleteFederationServerResponse
-	44,  // 131: universerpc.Universe.UniverseStats:output_type -> universerpc.StatsResponse
-	48,  // 132: universerpc.Universe.QueryAssetStats:output_type -> universerpc.UniverseAssetStats
-	50,  // 133: universerpc.Universe.QueryEvents:output_type -> universerpc.QueryEventsResponse
-	53,  // 134: universerpc.Universe.SetFederationSyncConfig:output_type -> universerpc.SetFederationSyncConfigResponse
-	57,  // 135: universerpc.Universe.QueryFederationSyncConfig:output_type -> universerpc.QueryFederationSyncConfigResponse
-	59,  // 136: universerpc.Universe.IgnoreAssetOutPoint:output_type -> universerpc.IgnoreAssetOutPointResponse
-	61,  // 137: universerpc.Universe.UpdateSupplyCommit:output_type -> universerpc.UpdateSupplyCommitResponse
-	64,  // 138: universerpc.Universe.FetchSupplyCommit:output_type -> universerpc.FetchSupplyCommitResponse
-	69,  // 139: universerpc.Universe.FetchSupplyLeaves:output_type -> universerpc.FetchSupplyLeavesResponse
-	72,  // 140: universerpc.Universe.InsertSupplyCommit:output_type -> universerpc.InsertSupplyCommitResponse
-	116, // [116:141] is the sub-list for method output_type
-	91,  // [91:116] is the sub-list for method input_type
-	91,  // [91:91] is the sub-list for extension type_name
-	91,  // [91:91] is the sub-list for extension extendee
-	0,   // [0:91] is the sub-list for field type_name
+	78,  // 18: universerpc.AssetLeavesRequest.direction:type_name -> taprpc.SortDirection
+	18,  // 19: universerpc.AssetLeafEntry.asset_key:type_name -> universerpc.AssetKey
+	18,  // 20: universerpc.AssetLeafKeyResponse.asset_keys:type_name -> universerpc.AssetKey
+	21,  // 21: universerpc.AssetLeafKeyResponse.entries:type_name -> universerpc.AssetLeafEntry
+	79,  // 22: universerpc.AssetLeaf.asset:type_name -> taprpc.Asset
+	23,  // 23: universerpc.AssetLeafResponse.leaves:type_name -> universerpc.AssetLeaf
+	8,   // 24: universerpc.UniverseKey.id:type_name -> universerpc.ID
+	18,  // 25: universerpc.UniverseKey.leaf_key:type_name -> universerpc.AssetKey
+	25,  // 26: universerpc.AssetProofResponse.req:type_name -> universerpc.UniverseKey
+	9,   // 27: universerpc.AssetProofResponse.universe_root:type_name -> universerpc.UniverseRoot
+	23,  // 28: universerpc.AssetProofResponse.asset_leaf:type_name -> universerpc.AssetLeaf
+	7,   // 29: universerpc.AssetProofResponse.multiverse_root:type_name -> universerpc.MerkleSumNode
+	27,  // 30: universerpc.AssetProofResponse.issuance_data:type_name -> universerpc.IssuanceData
+	80,  // 31: universerpc.IssuanceData.meta_reveal:type_name -> taprpc.AssetMeta
+	81,  // 32: universerpc.IssuanceData.genesis_reveal:type_name -> taprpc.GenesisReveal
+	82,  // 33: universerpc.IssuanceData.group_key_reveal:type_name -> taprpc.GroupKeyReveal
+	25,  // 34: universerpc.AssetProof.key:type_name -> universerpc.UniverseKey
+	23,  // 35: universerpc.AssetProof.asset_leaf:type_name -> universerpc.AssetLeaf
+	25,  // 36: universerpc.PushProofRequest.key:type_name -> universerpc.UniverseKey
+	38,  // 37: universerpc.PushProofRequest.server:type_name -> universerpc.UniverseFederationServer
+	25,  // 38: universerpc.PushProofResponse.key:type_name -> universerpc.UniverseKey
+	8,   // 39: universerpc.SyncTarget.id:type_name -> universerpc.ID
+	1,   // 40: universerpc.SyncRequest.sync_mode:type_name -> universerpc.UniverseSyncMode
+	33,  // 41: universerpc.SyncRequest.sync_targets:type_name -> universerpc.SyncTarget
+	9,   // 42: universerpc.SyncedUniverse.old_asset_root:type_name -> universerpc.UniverseRoot
+	9,   // 43: universerpc.SyncedUniverse.new_asset_root:type_name -> universerpc.UniverseRoot
+	23,  // 44: universerpc.SyncedUniverse.new_asset_leaves:type_name -> universerpc.AssetLeaf
+	35,  // 45: universerpc.SyncResponse.synced_universes:type_name -> universerpc.SyncedUniverse
+	38,  // 46: universerpc.ListFederationServersResponse.servers:type_name -> universerpc.UniverseFederationServer
+	38,  // 47: universerpc.AddFederationServerRequest.servers:type_name -> universerpc.UniverseFederationServer
+	38,  // 48: universerpc.DeleteFederationServerRequest.servers:type_name -> universerpc.UniverseFederationServer
+	3,   // 49: universerpc.AssetStatsQuery.asset_type_filter:type_name -> universerpc.AssetTypeFilter
+	2,   // 50: universerpc.AssetStatsQuery.sort_by:type_name -> universerpc.AssetQuerySort
+	78,  // 51: universerpc.AssetStatsQuery.direction:type_name -> taprpc.SortDirection
+	48,  // 52: universerpc.AssetStatsSnapshot.group_anchor:type_name -> universerpc.AssetStatsAsset
+	48,  // 53: universerpc.AssetStatsSnapshot.asset:type_name -> universerpc.AssetStatsAsset
+	83,  // 54: universerpc.AssetStatsAsset.asset_type:type_name -> taprpc.AssetType
+	47,  // 55: universerpc.UniverseAssetStats.asset_stats:type_name -> universerpc.AssetStatsSnapshot
+	52,  // 56: universerpc.QueryEventsResponse.events:type_name -> universerpc.GroupedUniverseEvents
+	55,  // 57: universerpc.SetFederationSyncConfigRequest.global_sync_configs:type_name -> universerpc.GlobalFederationSyncConfig
+	56,  // 58: universerpc.SetFederationSyncConfigRequest.asset_sync_configs:type_name -> universerpc.AssetFederationSyncConfig
+	0,   // 59: universerpc.GlobalFederationSyncConfig.proof_type:type_name -> universerpc.ProofType
+	8,   // 60: universerpc.AssetFederationSyncConfig.id:type_name -> universerpc.ID
+	8,   // 61: universerpc.QueryFederationSyncConfigRequest.id:type_name -> universerpc.ID
+	55,  // 62: universerpc.QueryFederationSyncConfigResponse.global_sync_configs:type_name -> universerpc.GlobalFederationSyncConfig
+	56,  // 63: universerpc.QueryFederationSyncConfigResponse.asset_sync_configs:type_name -> universerpc.AssetFederationSyncConfig
+	84,  // 64: universerpc.IgnoreAssetOutPointRequest.asset_out_point:type_name -> taprpc.AssetOutPoint
+	7,   // 65: universerpc.IgnoreAssetOutPointResponse.leaf:type_name -> universerpc.MerkleSumNode
+	85,  // 66: universerpc.FetchSupplyCommitRequest.commit_outpoint:type_name -> taprpc.OutPoint
+	85,  // 67: universerpc.FetchSupplyCommitRequest.spent_commit_outpoint:type_name -> taprpc.OutPoint
+	7,   // 68: universerpc.SupplyCommitSubtreeRoot.root_node:type_name -> universerpc.MerkleSumNode
+	71,  // 69: universerpc.FetchSupplyCommitResponse.chain_data:type_name -> universerpc.SupplyCommitChainData
+	64,  // 70: universerpc.FetchSupplyCommitResponse.issuance_subtree_root:type_name -> universerpc.SupplyCommitSubtreeRoot
+	64,  // 71: universerpc.FetchSupplyCommitResponse.burn_subtree_root:type_name -> universerpc.SupplyCommitSubtreeRoot
+	64,  // 72: universerpc.FetchSupplyCommitResponse.ignore_subtree_root:type_name -> universerpc.SupplyCommitSubtreeRoot
+	68,  // 73: universerpc.FetchSupplyCommitResponse.issuance_leaves:type_name -> universerpc.SupplyLeafEntry
+	68,  // 74: universerpc.FetchSupplyCommitResponse.burn_leaves:type_name -> universerpc.SupplyLeafEntry
+	68,  // 75: universerpc.FetchSupplyCommitResponse.ignore_leaves:type_name -> universerpc.SupplyLeafEntry
+	85,  // 76: universerpc.FetchSupplyCommitResponse.spent_commitment_outpoint:type_name -> taprpc.OutPoint
+	76,  // 77: universerpc.FetchSupplyCommitResponse.block_headers:type_name -> universerpc.FetchSupplyCommitResponse.BlockHeadersEntry
+	17,  // 78: universerpc.SupplyLeafKey.outpoint:type_name -> universerpc.Outpoint
+	67,  // 79: universerpc.SupplyLeafEntry.leaf_key:type_name -> universerpc.SupplyLeafKey
+	7,   // 80: universerpc.SupplyLeafEntry.leaf_node:type_name -> universerpc.MerkleSumNode
+	68,  // 81: universerpc.FetchSupplyLeavesResponse.issuance_leaves:type_name -> universerpc.SupplyLeafEntry
+	68,  // 82: universerpc.FetchSupplyLeavesResponse.burn_leaves:type_name -> universerpc.SupplyLeafEntry
+	68,  // 83: universerpc.FetchSupplyLeavesResponse.ignore_leaves:type_name -> universerpc.SupplyLeafEntry
+	77,  // 84: universerpc.FetchSupplyLeavesResponse.block_headers:type_name -> universerpc.FetchSupplyLeavesResponse.BlockHeadersEntry
+	71,  // 85: universerpc.InsertSupplyCommitRequest.chain_data:type_name -> universerpc.SupplyCommitChainData
+	85,  // 86: universerpc.InsertSupplyCommitRequest.spent_commitment_outpoint:type_name -> taprpc.OutPoint
+	68,  // 87: universerpc.InsertSupplyCommitRequest.issuance_leaves:type_name -> universerpc.SupplyLeafEntry
+	68,  // 88: universerpc.InsertSupplyCommitRequest.burn_leaves:type_name -> universerpc.SupplyLeafEntry
+	68,  // 89: universerpc.InsertSupplyCommitRequest.ignore_leaves:type_name -> universerpc.SupplyLeafEntry
+	9,   // 90: universerpc.AssetRootResponse.UniverseRootsEntry.value:type_name -> universerpc.UniverseRoot
+	69,  // 91: universerpc.FetchSupplyCommitResponse.BlockHeadersEntry.value:type_name -> universerpc.SupplyLeafBlockHeader
+	69,  // 92: universerpc.FetchSupplyLeavesResponse.BlockHeadersEntry.value:type_name -> universerpc.SupplyLeafBlockHeader
+	4,   // 93: universerpc.Universe.MultiverseRoot:input_type -> universerpc.MultiverseRootRequest
+	6,   // 94: universerpc.Universe.AssetRoots:input_type -> universerpc.AssetRootRequest
+	11,  // 95: universerpc.Universe.QueryAssetRoots:input_type -> universerpc.AssetRootQuery
+	13,  // 96: universerpc.Universe.DeleteAssetRoot:input_type -> universerpc.DeleteRootQuery
+	15,  // 97: universerpc.Universe.DeleteAssetLeaf:input_type -> universerpc.DeleteAssetLeafRequest
+	19,  // 98: universerpc.Universe.AssetLeafKeys:input_type -> universerpc.AssetLeafKeysRequest
+	20,  // 99: universerpc.Universe.AssetLeaves:input_type -> universerpc.AssetLeavesRequest
+	25,  // 100: universerpc.Universe.QueryProof:input_type -> universerpc.UniverseKey
+	28,  // 101: universerpc.Universe.InsertProof:input_type -> universerpc.AssetProof
+	29,  // 102: universerpc.Universe.PushProof:input_type -> universerpc.PushProofRequest
+	31,  // 103: universerpc.Universe.Info:input_type -> universerpc.InfoRequest
+	34,  // 104: universerpc.Universe.SyncUniverse:input_type -> universerpc.SyncRequest
+	39,  // 105: universerpc.Universe.ListFederationServers:input_type -> universerpc.ListFederationServersRequest
+	41,  // 106: universerpc.Universe.AddFederationServer:input_type -> universerpc.AddFederationServerRequest
+	43,  // 107: universerpc.Universe.DeleteFederationServer:input_type -> universerpc.DeleteFederationServerRequest
+	36,  // 108: universerpc.Universe.UniverseStats:input_type -> universerpc.StatsRequest
+	46,  // 109: universerpc.Universe.QueryAssetStats:input_type -> universerpc.AssetStatsQuery
+	50,  // 110: universerpc.Universe.QueryEvents:input_type -> universerpc.QueryEventsRequest
+	53,  // 111: universerpc.Universe.SetFederationSyncConfig:input_type -> universerpc.SetFederationSyncConfigRequest
+	57,  // 112: universerpc.Universe.QueryFederationSyncConfig:input_type -> universerpc.QueryFederationSyncConfigRequest
+	59,  // 113: universerpc.Universe.IgnoreAssetOutPoint:input_type -> universerpc.IgnoreAssetOutPointRequest
+	61,  // 114: universerpc.Universe.UpdateSupplyCommit:input_type -> universerpc.UpdateSupplyCommitRequest
+	63,  // 115: universerpc.Universe.FetchSupplyCommit:input_type -> universerpc.FetchSupplyCommitRequest
+	66,  // 116: universerpc.Universe.FetchSupplyLeaves:input_type -> universerpc.FetchSupplyLeavesRequest
+	72,  // 117: universerpc.Universe.InsertSupplyCommit:input_type -> universerpc.InsertSupplyCommitRequest
+	5,   // 118: universerpc.Universe.MultiverseRoot:output_type -> universerpc.MultiverseRootResponse
+	10,  // 119: universerpc.Universe.AssetRoots:output_type -> universerpc.AssetRootResponse
+	12,  // 120: universerpc.Universe.QueryAssetRoots:output_type -> universerpc.QueryRootResponse
+	14,  // 121: universerpc.Universe.DeleteAssetRoot:output_type -> universerpc.DeleteRootResponse
+	16,  // 122: universerpc.Universe.DeleteAssetLeaf:output_type -> universerpc.DeleteAssetLeafResponse
+	22,  // 123: universerpc.Universe.AssetLeafKeys:output_type -> universerpc.AssetLeafKeyResponse
+	24,  // 124: universerpc.Universe.AssetLeaves:output_type -> universerpc.AssetLeafResponse
+	26,  // 125: universerpc.Universe.QueryProof:output_type -> universerpc.AssetProofResponse
+	26,  // 126: universerpc.Universe.InsertProof:output_type -> universerpc.AssetProofResponse
+	30,  // 127: universerpc.Universe.PushProof:output_type -> universerpc.PushProofResponse
+	32,  // 128: universerpc.Universe.Info:output_type -> universerpc.InfoResponse
+	37,  // 129: universerpc.Universe.SyncUniverse:output_type -> universerpc.SyncResponse
+	40,  // 130: universerpc.Universe.ListFederationServers:output_type -> universerpc.ListFederationServersResponse
+	42,  // 131: universerpc.Universe.AddFederationServer:output_type -> universerpc.AddFederationServerResponse
+	44,  // 132: universerpc.Universe.DeleteFederationServer:output_type -> universerpc.DeleteFederationServerResponse
+	45,  // 133: universerpc.Universe.UniverseStats:output_type -> universerpc.StatsResponse
+	49,  // 134: universerpc.Universe.QueryAssetStats:output_type -> universerpc.UniverseAssetStats
+	51,  // 135: universerpc.Universe.QueryEvents:output_type -> universerpc.QueryEventsResponse
+	54,  // 136: universerpc.Universe.SetFederationSyncConfig:output_type -> universerpc.SetFederationSyncConfigResponse
+	58,  // 137: universerpc.Universe.QueryFederationSyncConfig:output_type -> universerpc.QueryFederationSyncConfigResponse
+	60,  // 138: universerpc.Universe.IgnoreAssetOutPoint:output_type -> universerpc.IgnoreAssetOutPointResponse
+	62,  // 139: universerpc.Universe.UpdateSupplyCommit:output_type -> universerpc.UpdateSupplyCommitResponse
+	65,  // 140: universerpc.Universe.FetchSupplyCommit:output_type -> universerpc.FetchSupplyCommitResponse
+	70,  // 141: universerpc.Universe.FetchSupplyLeaves:output_type -> universerpc.FetchSupplyLeavesResponse
+	73,  // 142: universerpc.Universe.InsertSupplyCommit:output_type -> universerpc.InsertSupplyCommitResponse
+	118, // [118:143] is the sub-list for method output_type
+	93,  // [93:118] is the sub-list for method input_type
+	93,  // [93:93] is the sub-list for extension type_name
+	93,  // [93:93] is the sub-list for extension extendee
+	0,   // [0:93] is the sub-list for field type_name
 }
 
 func init() { file_universerpc_universe_proto_init() }
@@ -5456,11 +5536,11 @@ func file_universerpc_universe_proto_init() {
 		(*AssetKey_ScriptKeyBytes)(nil),
 		(*AssetKey_ScriptKeyStr)(nil),
 	}
-	file_universerpc_universe_proto_msgTypes[56].OneofWrappers = []any{
+	file_universerpc_universe_proto_msgTypes[57].OneofWrappers = []any{
 		(*UpdateSupplyCommitRequest_GroupKeyBytes)(nil),
 		(*UpdateSupplyCommitRequest_GroupKeyStr)(nil),
 	}
-	file_universerpc_universe_proto_msgTypes[58].OneofWrappers = []any{
+	file_universerpc_universe_proto_msgTypes[59].OneofWrappers = []any{
 		(*FetchSupplyCommitRequest_GroupKeyBytes)(nil),
 		(*FetchSupplyCommitRequest_GroupKeyStr)(nil),
 		(*FetchSupplyCommitRequest_CommitOutpoint)(nil),
@@ -5468,11 +5548,11 @@ func file_universerpc_universe_proto_init() {
 		(*FetchSupplyCommitRequest_VeryFirst)(nil),
 		(*FetchSupplyCommitRequest_Latest)(nil),
 	}
-	file_universerpc_universe_proto_msgTypes[61].OneofWrappers = []any{
+	file_universerpc_universe_proto_msgTypes[62].OneofWrappers = []any{
 		(*FetchSupplyLeavesRequest_GroupKeyBytes)(nil),
 		(*FetchSupplyLeavesRequest_GroupKeyStr)(nil),
 	}
-	file_universerpc_universe_proto_msgTypes[67].OneofWrappers = []any{
+	file_universerpc_universe_proto_msgTypes[68].OneofWrappers = []any{
 		(*InsertSupplyCommitRequest_GroupKeyBytes)(nil),
 		(*InsertSupplyCommitRequest_GroupKeyStr)(nil),
 	}
@@ -5482,7 +5562,7 @@ func file_universerpc_universe_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_universerpc_universe_proto_rawDesc), len(file_universerpc_universe_proto_rawDesc)),
 			NumEnums:      4,
-			NumMessages:   73,
+			NumMessages:   74,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/taprpc/universerpc/universe.proto
+++ b/taprpc/universerpc/universe.proto
@@ -387,13 +387,31 @@ message AssetLeavesRequest {
     taprpc.SortDirection direction = 4;
 }
 
+message AssetLeafEntry {
+    // The asset key identifying the leaf within the universe.
+    AssetKey asset_key = 1;
+
+    // The 32-byte MS-SMT leaf node hash committing to the leaf's
+    // content. Peers that predate this field leave it empty; readers
+    // must fall back to a key-only diff in that case.
+    bytes leaf_node_hash = 2;
+}
+
 message AssetLeafKeyResponse {
-    // The set of asset leaf keys for the given asset ID or group key.
-    repeated AssetKey asset_keys = 1;
+    // Deprecated. Superseded by `entries`, which additionally carries
+    // each leaf's MS-SMT node hash so a diff can detect shared-key
+    // content divergence directly. Populated for peers whose readers
+    // predate `entries`.
+    repeated AssetKey asset_keys = 1 [deprecated = true];
 
     // Indicates whether there are more results beyond the current
     // page.
     bool has_more = 2;
+
+    // The set of asset leaf entries for the given asset ID or group
+    // key. Each entry pairs an asset key with the MS-SMT node hash
+    // committing to the leaf's content.
+    repeated AssetLeafEntry entries = 3;
 }
 
 message AssetLeaf {

--- a/taprpc/universerpc/universe.swagger.json
+++ b/taprpc/universerpc/universe.swagger.json
@@ -2519,6 +2519,20 @@
         }
       }
     },
+    "universerpcAssetLeafEntry": {
+      "type": "object",
+      "properties": {
+        "asset_key": {
+          "$ref": "#/definitions/universerpcAssetKey",
+          "description": "The asset key identifying the leaf within the universe."
+        },
+        "leaf_node_hash": {
+          "type": "string",
+          "format": "byte",
+          "description": "The 32-byte MS-SMT leaf node hash committing to the leaf's\ncontent. Peers that predate this field leave it empty; readers\nmust fall back to a key-only diff in that case."
+        }
+      }
+    },
     "universerpcAssetLeafKeyResponse": {
       "type": "object",
       "properties": {
@@ -2528,11 +2542,19 @@
             "type": "object",
             "$ref": "#/definitions/universerpcAssetKey"
           },
-          "description": "The set of asset leaf keys for the given asset ID or group key."
+          "description": "Deprecated. Superseded by `entries`, which additionally carries\neach leaf's MS-SMT node hash so a diff can detect shared-key\ncontent divergence directly. Populated for peers whose readers\npredate `entries`."
         },
         "has_more": {
           "type": "boolean",
           "description": "Indicates whether there are more results beyond the current\npage."
+        },
+        "entries": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/universerpcAssetLeafEntry"
+          },
+          "description": "The set of asset leaf entries for the given asset ID or group\nkey. Each entry pairs an asset key with the MS-SMT node hash\ncommitting to the leaf's content."
         }
       }
     },

--- a/universe/archive.go
+++ b/universe/archive.go
@@ -728,10 +728,11 @@ type UniverseLeafKeysQuery struct {
 	Limit int32
 }
 
-// UniverseLeafKeys returns the set of leaf keys known for the specified
-// universe identifier.
+// UniverseLeafKeys returns the set of leaf entries known for the
+// specified universe identifier. Each entry pairs a leaf's universe
+// key with the MS-SMT node hash committing to its content.
 func (a *Archive) UniverseLeafKeys(ctx context.Context,
-	q UniverseLeafKeysQuery) ([]LeafKey, error) {
+	q UniverseLeafKeysQuery) ([]LeafEntry, error) {
 
 	log.Debugf("Retrieving all keys for Universe: id=%v", q.Id.StringForLog())
 

--- a/universe/archive_test.go
+++ b/universe/archive_test.go
@@ -67,7 +67,7 @@ func (m *mockMultiverse) DeleteProofLeaf(context.Context,
 }
 
 func (m *mockMultiverse) UniverseLeafKeys(context.Context,
-	UniverseLeafKeysQuery) ([]LeafKey, error) {
+	UniverseLeafKeysQuery) ([]LeafEntry, error) {
 
 	return nil, nil
 }
@@ -106,7 +106,7 @@ func (m *mockStorageBackend) FetchProof(context.Context,
 }
 
 func (m *mockStorageBackend) FetchKeys(context.Context,
-	UniverseLeafKeysQuery) ([]LeafKey, error) {
+	UniverseLeafKeysQuery) ([]LeafEntry, error) {
 
 	return nil, nil
 }

--- a/universe/interface.go
+++ b/universe/interface.go
@@ -279,6 +279,25 @@ type LeafKey interface {
 	LeafOutPoint() wire.OutPoint
 }
 
+// LeafEntry pairs a leaf's key with the MS-SMT node hash the tree
+// commits it to. The universe key names the leaf; the node hash
+// witnesses its content. A diff over LeafEntry values catches shared-
+// key content divergence (re-org rewrites) directly, without an
+// extra fetch and re-verify pass.
+//
+// NodeHash is optional to accommodate legacy peers whose leaf-key
+// listing predates this field on the wire: when None, the reader
+// must fall back to key-only diff behavior for that pair. Locally-
+// sourced entries (from the multiverse store) always populate it.
+type LeafEntry struct {
+	// Key identifies the leaf within the universe.
+	Key LeafKey
+
+	// NodeHash is the MS-SMT leaf node hash committing to the
+	// leaf's content, when the source populates it.
+	NodeHash fn.Option[mssmt.NodeHash]
+}
+
 // UniqueLeafKey is an interface that allows us to obtain the universe key for a
 // leaf within a universe. This is used to uniquely identify a leaf within a
 // universe. Compared to LeafKey, it includes the asset ID of a leaf within the
@@ -444,9 +463,11 @@ type StorageBackend interface {
 	// TODO(roasbeef): can eventually do multi-proofs for the SMT
 	FetchProof(ctx context.Context, key LeafKey) ([]*Proof, error)
 
-	// FetchKeys retrieves all keys from the universe tree.
+	// FetchKeys retrieves all leaf entries from the universe tree.
+	// Each entry pairs the leaf's universe key with the MS-SMT
+	// node hash committing to its content.
 	FetchKeys(ctx context.Context,
-		q UniverseLeafKeysQuery) ([]LeafKey, error)
+		q UniverseLeafKeysQuery) ([]LeafEntry, error)
 
 	// FetchLeaves retrieves leaves from the universe tree,
 	// paginated according to the given query.
@@ -543,10 +564,12 @@ type MultiverseArchive interface {
 	// ID.
 	UniverseRootNode(ctx context.Context, id Identifier) (Root, error)
 
-	// UniverseLeafKeys returns the set of leaf keys for the given
-	// universe.
+	// UniverseLeafKeys returns the set of leaf entries for the given
+	// universe. Each entry pairs the leaf's universe key with the
+	// MS-SMT node hash committing to its content, so a diff can
+	// detect shared-key content divergence directly.
 	UniverseLeafKeys(ctx context.Context,
-		q UniverseLeafKeysQuery) ([]LeafKey, error)
+		q UniverseLeafKeysQuery) ([]LeafEntry, error)
 
 	// FetchLeaves returns the set of multiverse leaves that satisfy the set
 	// of universe targets. If the set of targets is empty, all leaves for
@@ -782,9 +805,13 @@ type DiffEngine interface {
 	// RootNodes returns the set of root nodes for all known universes.
 	RootNodes(ctx context.Context, q RootNodesQuery) ([]Root, error)
 
-	// UniverseLeafKeys returns all the keys inserted in the universe.
+	// UniverseLeafKeys returns all the leaf entries in the universe.
+	// Each entry pairs a leaf's universe key with the MS-SMT node
+	// hash committing to its content; a remote diff engine may
+	// leave NodeHash unpopulated on entries sourced from a peer
+	// whose wire schema predates the field.
 	UniverseLeafKeys(ctx context.Context,
-		q UniverseLeafKeysQuery) ([]LeafKey, error)
+		q UniverseLeafKeysQuery) ([]LeafEntry, error)
 
 	// FetchProofLeaf attempts to fetch a proof leaf for the target leaf key
 	// and given a universe identifier (assetID/groupKey).

--- a/universe/syncer.go
+++ b/universe/syncer.go
@@ -217,20 +217,88 @@ func (s *SimpleSyncer) executeSync(ctx context.Context, diffEngine DiffEngine,
 	log.Infof("Obtained %v roots from remote Universe server",
 		len(targetRoots))
 
-	// Now that we know the set of Universes we need to sync, we'll execute
-	// the diff operation for each of them.
+	// Split the target roots by proof type. Issuance roots must land
+	// first so that any transfer root referencing an issuance can find
+	// its predecessor when the archive verifies the batch — otherwise
+	// the transfer would surface a "no universe proof found" error
+	// mid-batch and abort. See issue #2026 for the reported symptom.
+	sorted := partitionByProofType(targetRoots)
+
 	syncDiffs := make(chan AssetSyncDiff, len(targetRoots))
-	err = fn.ParSlice(
-		ctx, targetRoots, func(ctx context.Context, r Root) error {
-			return s.syncRoot(ctx, r, diffEngine, syncDiffs)
-		},
-	)
-	if err != nil {
+	if err := s.syncRoots(
+		ctx, sorted.Issuance, diffEngine, syncDiffs,
+	); err != nil {
+		return nil, err
+	}
+	if err := s.syncRoots(
+		ctx, sorted.Transfer, diffEngine, syncDiffs,
+	); err != nil {
+		return nil, err
+	}
+	for _, r := range sorted.Other {
+		log.Warnf("Syncing UniverseRoot(%v) with unusual proof "+
+			"type %v through SimpleSyncer; dedicated syncers "+
+			"exist for burn/ignore/mint-supply", r.ID.String(),
+			r.ID.ProofType)
+	}
+	if err := s.syncRoots(
+		ctx, sorted.Other, diffEngine, syncDiffs,
+	); err != nil {
 		return nil, err
 	}
 
-	// Finally, we'll collect all the diffs and return them to the caller.
 	return fn.Collect(syncDiffs), nil
+}
+
+// SortedRoots is a proof-type-partitioned view of a set of Root
+// values. The three fields are structurally distinct so a caller
+// cannot accidentally interleave issuance, transfer, and unknown-
+// type processing — each must be handled in its own phase.
+type SortedRoots struct {
+	Issuance []Root
+	Transfer []Root
+
+	// Other holds roots whose proof type is neither issuance nor
+	// transfer (burn, ignore, mint-supply, unspecified). SimpleSyncer's
+	// leaf-fetch path was designed for issuance and transfer, so these
+	// roots are rare here in practice — they normally flow through
+	// dedicated syncers. Retained rather than dropped so an explicit
+	// idsToSync call driving an unusual proof type still produces some
+	// visible effect (a warning) rather than a silent no-op.
+	Other []Root
+}
+
+// partitionByProofType splits roots into issuance, transfer, and
+// other buckets by their ID.ProofType. Relative order within each
+// bucket is preserved.
+func partitionByProofType(roots []Root) SortedRoots {
+	var out SortedRoots
+	for _, r := range roots {
+		switch r.ID.ProofType {
+		case ProofTypeIssuance:
+			out.Issuance = append(out.Issuance, r)
+		case ProofTypeTransfer:
+			out.Transfer = append(out.Transfer, r)
+		case ProofTypeUnspecified, ProofTypeIgnore, ProofTypeBurn,
+			ProofTypeMintSupply:
+			out.Other = append(out.Other, r)
+		}
+	}
+	return out
+}
+
+// syncRoots is the shared per-root fan-out used by executeSync. It
+// runs syncRoot over every input root, currently in fully-parallel
+// fashion via fn.ParSlice; Phase 3 replaces that with a bounded
+// worker pool.
+func (s *SimpleSyncer) syncRoots(ctx context.Context, roots []Root,
+	diffEngine DiffEngine, syncDiffs chan<- AssetSyncDiff) error {
+
+	return fn.ParSlice(
+		ctx, roots, func(ctx context.Context, r Root) error {
+			return s.syncRoot(ctx, r, diffEngine, syncDiffs)
+		},
+	)
 }
 
 // fetchRootsForIDs fetches the roots for a specific set of universe IDs.

--- a/universe/syncer.go
+++ b/universe/syncer.go
@@ -400,32 +400,52 @@ func (s *SimpleSyncer) syncRoot(ctx context.Context, remoteRoot Root,
 	log.Infof("UniverseRoot(%v) diverges, performing leaf diff...",
 		uniID.String())
 
-	// Otherwise, we'll need to perform a diff operation to find the set of
-	// keys we need to fetch. We'll start by fetching the set of keys from
-	// both the local and remote Universe.
+	// Fetch the leaf entries from both sides. Each entry pairs a
+	// universe key with the leaf's MS-SMT node hash, so a
+	// disagreement at either component surfaces in the diff.
 	var (
-		remoteUniKeys []LeafKey
-		localUniKeys  []LeafKey
+		remoteEntries []LeafEntry
+		localEntries  []LeafEntry
 	)
 
-	remoteUniKeys, err = s.fetchAllLeafKeys(ctx, diffEngine, uniID)
+	remoteEntries, err = s.fetchAllLeafEntries(ctx, diffEngine, uniID)
 	if err != nil {
 		return err
 	}
 
-	localUniKeys, err = s.fetchAllLeafKeys(ctx, s.cfg.LocalDiffEngine, uniID)
+	localEntries, err = s.fetchAllLeafEntries(
+		ctx, s.cfg.LocalDiffEngine, uniID,
+	)
 	if err != nil {
 		return err
 	}
 
-	// With the set of keys fetched, we can now find the set of keys that
-	// need to be synced.
-	keysToFetch := fn.SetDiff(remoteUniKeys, localUniKeys)
+	// The diff yields exactly the set of remote keys we must
+	// fetch to converge: new keys, plus shared keys whose leaf
+	// node hash disagrees with what we hold. Every other class of
+	// divergence (peer strictly behind us, or divergence localized
+	// to leaves the peer no longer advertises) is a no-op by
+	// construction.
+	keysToFetch := diffLeafEntries(remoteEntries, localEntries)
 
 	log.Infof("UniverseRoot(%v): diff_size=%v", uniID.String(),
 		len(keysToFetch))
 	log.Tracef("UniverseRoot(%v): diff_size=%v, diff=%v", uniID.String(),
 		len(keysToFetch), spew.Sdump(keysToFetch))
+
+	// Roots diverge but the LeafEntry diff is empty: every remote
+	// leaf is content-identical to what we already hold, so the
+	// divergence lives in local-only entries and sync has no work
+	// to do. Skip the fetch/batch scaffolding entirely to avoid the
+	// no-op registrar call that CollectBatch would issue on the
+	// closed empty channel.
+	if len(keysToFetch) == 0 {
+		result <- AssetSyncDiff{
+			OldUniverseRoot: localRoot,
+			NewUniverseRoot: remoteRoot,
+		}
+		return nil
+	}
 
 	// Before we start fetching leaves, we already start our batch stream
 	// for the new leaves. This allows us to stream the new leaves to the
@@ -763,19 +783,20 @@ func (s *SimpleSyncer) fetchAllRoots(ctx context.Context,
 	return roots, nil
 }
 
-// fetchAllLeafKeys fetches all the leaf keys from the remote Universe. This
-// function is used in order to isolate any logic related to the specifics of
-// how we fetch the data from the universe server.
-func (s *SimpleSyncer) fetchAllLeafKeys(ctx context.Context,
-	diffEngine DiffEngine, uniID Identifier) ([]LeafKey, error) {
+// fetchAllLeafEntries fetches every leaf entry the diff engine
+// exposes for the given universe, paginating until a page comes back
+// empty. Each entry pairs the leaf's universe key with the MS-SMT
+// node hash committing to its content (unpopulated for entries
+// sourced from a peer whose wire schema predates the field).
+func (s *SimpleSyncer) fetchAllLeafEntries(ctx context.Context,
+	diffEngine DiffEngine, uniID Identifier) ([]LeafEntry, error) {
 
-	// Initialize the offset to be used for the pages.
 	offset := int32(0)
 	pageSize := defaultPageSize
-	leafKeys := make([]LeafKey, 0)
+	entries := make([]LeafEntry, 0)
 
 	for {
-		tempRemoteKeys, err := diffEngine.UniverseLeafKeys(
+		page, err := diffEngine.UniverseLeafKeys(
 			ctx, UniverseLeafKeysQuery{
 				Id:            uniID,
 				Offset:        offset,
@@ -787,15 +808,74 @@ func (s *SimpleSyncer) fetchAllLeafKeys(ctx context.Context,
 			return nil, err
 		}
 
-		if len(tempRemoteKeys) == 0 {
+		if len(page) == 0 {
 			break
 		}
 
-		leafKeys = append(leafKeys, tempRemoteKeys...)
+		entries = append(entries, page...)
 		offset += pageSize
 	}
 
-	return leafKeys, nil
+	return entries, nil
+}
+
+// diffLeafEntries returns the leaf keys in remote whose content
+// differs from local's, exhaustively over the three shapes of
+// disagreement an MS-SMT can expose:
+//
+//   - universe key present remotely, absent locally → fetch (new
+//     leaf).
+//   - universe key present on both sides, node hashes disagree →
+//     fetch (shared-key content divergence, e.g. a re-org rewriting
+//     the leaf's proof).
+//   - universe key absent remotely, present locally → no-op by
+//     construction (sync pulls; it does not shrink).
+//
+// The result is a subsequence of remote in its original order, so
+// error attribution in the parallel fetch loop lines up index-for-
+// index. NodeHash comparison uses fn.Option semantics: when either
+// side's hash is None (a legacy peer that predates the wire field),
+// we fall back to key-only inclusion — the leaf is fetched only if
+// the universe key is missing locally. That reduces to the pre-hash
+// diff behavior and is strictly conservative: the mixed-cause case
+// (behind AND re-org rewrite) can go undetected under a legacy peer,
+// but that failure mode already existed and is bounded to peers
+// running the older schema.
+func diffLeafEntries(remote, local []LeafEntry) []LeafKey {
+	type localEntry struct {
+		hash fn.Option[mssmt.NodeHash]
+	}
+
+	localSet := make(map[[32]byte]localEntry, len(local))
+	for _, e := range local {
+		localSet[e.Key.UniverseKey()] = localEntry{hash: e.NodeHash}
+	}
+
+	diff := make([]LeafKey, 0, len(remote))
+	for _, e := range remote {
+		match, ok := localSet[e.Key.UniverseKey()]
+		if !ok {
+			// Remote-only key: fetch.
+			diff = append(diff, e.Key)
+			continue
+		}
+
+		// Shared key. If both sides carry a hash, compare on
+		// content; a mismatch is a shared-key divergence and
+		// must be refetched. When either hash is missing, the
+		// key-only view says "already have it" and we skip.
+		if !e.NodeHash.IsSome() || !match.hash.IsSome() {
+			continue
+		}
+		var zero mssmt.NodeHash
+		remoteHash := e.NodeHash.UnwrapOr(zero)
+		localHash := match.hash.UnwrapOr(zero)
+		if remoteHash != localHash {
+			diff = append(diff, e.Key)
+		}
+	}
+
+	return diff
 }
 
 // IsEmptyRoot return true if the given root does not have any values set.

--- a/universe/syncer.go
+++ b/universe/syncer.go
@@ -45,6 +45,15 @@ type SimpleSyncCfg struct {
 
 	// SyncBatchSize is the number of items to sync in a single batch.
 	SyncBatchSize int
+
+	// SyncRootConcurrency caps the number of universe roots syncRoots
+	// processes at once. Left unset (or non-positive), it defaults to
+	// 1 in NewSimpleSyncer. Kept internal for now — issue #2026's
+	// reporter observed DB tx retry exhaustion at unbounded fan-out
+	// and no retries at concurrency 2 in their environment; the
+	// production wiring picks 2, and only the tests exercise other
+	// values.
+	SyncRootConcurrency int
 }
 
 // SyncDiffEvent is sent to subscribers after a universe sync completes,
@@ -80,8 +89,13 @@ type SimpleSyncer struct {
 	eventDistributor *fn.EventDistributor[fn.Event]
 }
 
-// NewSimpleSyncer creates a new SimpleSyncer instance.
+// NewSimpleSyncer creates a new SimpleSyncer instance. Any
+// non-positive SyncRootConcurrency is clamped up to 1 so the internal
+// fan-out can trust the invariant "at least one worker."
 func NewSimpleSyncer(cfg SimpleSyncCfg) *SimpleSyncer {
+	if cfg.SyncRootConcurrency <= 0 {
+		cfg.SyncRootConcurrency = 1
+	}
 	return &SimpleSyncer{
 		cfg:              cfg,
 		eventDistributor: fn.NewEventDistributor[fn.Event](),
@@ -287,18 +301,23 @@ func partitionByProofType(roots []Root) SortedRoots {
 	return out
 }
 
-// syncRoots is the shared per-root fan-out used by executeSync. It
-// runs syncRoot over every input root, currently in fully-parallel
-// fashion via fn.ParSlice; Phase 3 replaces that with a bounded
-// worker pool.
+// syncRoots is the shared per-root fan-out used by executeSync. Roots
+// are processed by a worker pool bounded to cfg.SyncRootConcurrency.
+// Bounded concurrency (rather than the previous unbounded fn.ParSlice)
+// is what keeps DB transaction retries from exhausting themselves on
+// large sync sets, per issue #2026.
 func (s *SimpleSyncer) syncRoots(ctx context.Context, roots []Root,
 	diffEngine DiffEngine, syncDiffs chan<- AssetSyncDiff) error {
 
-	return fn.ParSlice(
-		ctx, roots, func(ctx context.Context, r Root) error {
+	eg, ctx := errgroup.WithContext(ctx)
+	eg.SetLimit(s.cfg.SyncRootConcurrency)
+	for _, r := range roots {
+		r := r
+		eg.Go(func() error {
 			return s.syncRoot(ctx, r, diffEngine, syncDiffs)
-		},
-	)
+		})
+	}
+	return eg.Wait()
 }
 
 // fetchRootsForIDs fetches the roots for a specific set of universe IDs.

--- a/universe/syncer_concurrency_test.go
+++ b/universe/syncer_concurrency_test.go
@@ -48,7 +48,7 @@ func (p *concurrencyProbe) RootNodes(_ context.Context,
 }
 
 func (p *concurrencyProbe) UniverseLeafKeys(_ context.Context,
-	_ UniverseLeafKeysQuery) ([]LeafKey, error) {
+	_ UniverseLeafKeysQuery) ([]LeafEntry, error) {
 
 	return nil, nil
 }

--- a/universe/syncer_concurrency_test.go
+++ b/universe/syncer_concurrency_test.go
@@ -1,0 +1,135 @@
+package universe
+
+import (
+	"context"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// concurrencyProbe is a DiffEngine that gates its RootNode call on a
+// live gauge, so a test can observe how many syncRoot invocations are
+// in flight at once. Each call blocks briefly to make racing
+// invocations overlap in time and expose any limit violation.
+type concurrencyProbe struct {
+	roots []Root
+
+	inFlight atomic.Int64
+	peak     atomic.Int64
+}
+
+func (p *concurrencyProbe) RootNode(_ context.Context,
+	_ Identifier) (Root, error) {
+
+	n := p.inFlight.Add(1)
+	for {
+		peak := p.peak.Load()
+		if n <= peak || p.peak.CompareAndSwap(peak, n) {
+			break
+		}
+	}
+
+	// A short sleep widens the window in which limit violations can
+	// be observed. Without it a serial-looking invocation pattern
+	// would only reflect the cost of the atomic ops.
+	time.Sleep(2 * time.Millisecond)
+	p.inFlight.Add(-1)
+
+	return Root{}, ErrNoUniverseRoot
+}
+
+func (p *concurrencyProbe) RootNodes(_ context.Context,
+	_ RootNodesQuery) ([]Root, error) {
+
+	return p.roots, nil
+}
+
+func (p *concurrencyProbe) UniverseLeafKeys(_ context.Context,
+	_ UniverseLeafKeysQuery) ([]LeafKey, error) {
+
+	return nil, nil
+}
+
+func (p *concurrencyProbe) FetchProofLeaf(_ context.Context,
+	_ Identifier, _ LeafKey) ([]*Proof, error) {
+
+	return nil, nil
+}
+
+func (p *concurrencyProbe) Close() error { return nil }
+
+// TestSyncRoots_HonoursConcurrencyCap runs syncRoots with a probe
+// that widens the observation window, asserts the peak observed
+// concurrency never exceeds the limit, and covers a few limit values
+// to catch off-by-ones.
+func TestSyncRoots_HonoursConcurrencyCap(t *testing.T) {
+	t.Parallel()
+
+	for _, limit := range []int{1, 2, 4, 8} {
+		limit := limit
+		t.Run("limit="+strconv.Itoa(limit), func(t *testing.T) {
+			t.Parallel()
+
+			var roots []Root
+			for i := 0; i < 16; i++ {
+				var id Identifier
+				id.ProofType = ProofTypeIssuance
+				id.AssetID[0] = byte(i)
+				roots = append(roots, Root{ID: id})
+			}
+
+			probe := &concurrencyProbe{roots: roots}
+			remote := &syncOrderRecorder{roots: roots}
+
+			syncer := NewSimpleSyncer(SimpleSyncCfg{
+				LocalDiffEngine: probe,
+				LocalRegistrar:  noopRegistrar{},
+				NewRemoteDiffEngine: func(
+					_ ServerAddr) (DiffEngine, error) {
+
+					return remote, nil
+				},
+				SyncBatchSize:       50,
+				SyncRootConcurrency: limit,
+			})
+
+			cfg := SyncConfigs{
+				GlobalSyncConfigs: []*FedGlobalSyncConfig{{
+					ProofType:       ProofTypeIssuance,
+					AllowSyncInsert: true,
+				}},
+			}
+			_, err := syncer.SyncUniverse(
+				context.Background(), ServerAddr{},
+				SyncFull, cfg,
+			)
+			require.NoError(t, err)
+
+			peak := int(probe.peak.Load())
+			require.LessOrEqual(t, peak, limit,
+				"peak concurrency %d exceeded limit %d",
+				peak, limit)
+		})
+	}
+}
+
+// TestNewSimpleSyncer_ClampsNonPositiveConcurrency pins that a config
+// with an invalid SyncRootConcurrency (zero or negative) resolves to
+// concurrency 1 rather than silently jamming with a zero-slot
+// errgroup.
+func TestNewSimpleSyncer_ClampsNonPositiveConcurrency(t *testing.T) {
+	t.Parallel()
+
+	for _, val := range []int{-1, 0} {
+		s := NewSimpleSyncer(SimpleSyncCfg{
+			LocalRegistrar:      noopRegistrar{},
+			SyncBatchSize:       50,
+			SyncRootConcurrency: val,
+		})
+		require.Equal(t, 1, s.cfg.SyncRootConcurrency,
+			"input %d should clamp to 1", val)
+	}
+}

--- a/universe/syncer_diff_property_test.go
+++ b/universe/syncer_diff_property_test.go
@@ -1,0 +1,174 @@
+package universe
+
+import (
+	"testing"
+
+	"github.com/lightninglabs/taproot-assets/asset"
+	"github.com/lightninglabs/taproot-assets/fn"
+	"pgregory.net/rapid"
+)
+
+// baseLeafKeyGen returns a rapid generator that produces a random
+// BaseLeafKey. Each draw allocates a fresh *asset.ScriptKey — the same
+// shape that surfaces the pointer-identity SetDiff bug in practice.
+var baseLeafKeyGen = rapid.Custom(func(t *rapid.T) BaseLeafKey {
+	return BaseLeafKey{
+		OutPoint: asset.OutPointGen.Draw(t, "outpoint"),
+		ScriptKey: fn.Ptr(asset.NewScriptKey(
+			asset.PubKeyGen.Draw(t, "script_key"),
+		)),
+	}
+})
+
+// leafKeySliceGen returns a random slice of LeafKey with up to 16
+// entries. The size cap keeps rapid's shrinker responsive without
+// meaningfully weakening the properties — the invariants are
+// structural, not size-dependent.
+var leafKeySliceGen = rapid.Custom(func(t *rapid.T) []LeafKey {
+	keys := rapid.SliceOfN(baseLeafKeyGen, 0, 16).Draw(t, "keys")
+	out := make([]LeafKey, len(keys))
+	for i, k := range keys {
+		out[i] = k
+	}
+	return out
+})
+
+// clone rebuilds a leaf-key slice with freshly-allocated ScriptKey
+// pointers but identical content. Used to construct the exact shape
+// that would trigger the fn.SetDiff pointer-identity bug.
+func clone(keys []LeafKey) []LeafKey {
+	out := make([]LeafKey, len(keys))
+	for i, k := range keys {
+		bk := k.(BaseLeafKey)
+		out[i] = BaseLeafKey{
+			OutPoint: bk.OutPoint,
+			ScriptKey: fn.Ptr(asset.NewScriptKey(
+				bk.ScriptKey.PubKey,
+			)),
+		}
+	}
+	return out
+}
+
+// keyByContent is the reference impl: compares BaseLeafKeys by
+// content (outpoint + script pubkey serialization) without going
+// through UniverseKey. Used as the trusted oracle in the extensional
+// property.
+func keyByContent(k LeafKey) [32 + 33]byte {
+	bk := k.(BaseLeafKey)
+	var out [32 + 33]byte
+	copy(out[:32], bk.OutPoint.Hash[:])
+	// The outpoint index folds into the script pubkey slot because
+	// this key is only used for equivalence checks in tests, not for
+	// on-disk lookup — collisions between different (outpoint index,
+	// script key) pairs are astronomically unlikely for random inputs.
+	copy(out[32:65], bk.ScriptKey.PubKey.SerializeCompressed())
+	out[32] ^= byte(bk.OutPoint.Index)
+	return out
+}
+
+// TestDiffLeafKeys_Subset asserts that every survivor of the diff
+// appears somewhere in remote, matched by content.
+func TestDiffLeafKeys_Subset(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		remote := leafKeySliceGen.Draw(t, "remote")
+		local := leafKeySliceGen.Draw(t, "local")
+
+		remoteContent := make(map[[65]byte]struct{}, len(remote))
+		for _, k := range remote {
+			remoteContent[keyByContent(k)] = struct{}{}
+		}
+
+		for _, k := range diffLeafEntries(
+			leafEntries(remote...), leafEntries(local...),
+		) {
+			if _, ok := remoteContent[keyByContent(k)]; !ok {
+				t.Fatalf("diff contains key not in remote: %v",
+					k)
+			}
+		}
+	})
+}
+
+// TestDiffLeafKeys_Subsequence asserts that survivors keep their
+// relative order from remote. The syncer's error attribution loop
+// depends on this at syncer.go:436.
+func TestDiffLeafKeys_Subsequence(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		remote := leafKeySliceGen.Draw(t, "remote")
+		local := leafKeySliceGen.Draw(t, "local")
+
+		diff := diffLeafEntries(
+			leafEntries(remote...), leafEntries(local...),
+		)
+		j := 0
+		for _, k := range remote {
+			if j < len(diff) &&
+				keyByContent(diff[j]) == keyByContent(k) {
+
+				j++
+			}
+		}
+
+		if j != len(diff) {
+			t.Fatalf("diff is not a subsequence of remote "+
+				"(matched %d of %d)", j, len(diff))
+		}
+	})
+}
+
+// TestDiffLeafKeys_ExtensionalReference asserts that the content
+// diff agrees with a naive reference impl comparing by (outpoint,
+// pubkey) directly. Extensional: same input → same output as a
+// slower, structurally simpler routine.
+func TestDiffLeafKeys_ExtensionalReference(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		remote := leafKeySliceGen.Draw(t, "remote")
+		local := leafKeySliceGen.Draw(t, "local")
+
+		localContent := make(map[[65]byte]struct{}, len(local))
+		for _, k := range local {
+			localContent[keyByContent(k)] = struct{}{}
+		}
+
+		var expected []LeafKey
+		for _, k := range remote {
+			if _, ok := localContent[keyByContent(k)]; !ok {
+				expected = append(expected, k)
+			}
+		}
+
+		got := diffLeafEntries(
+			leafEntries(remote...), leafEntries(local...),
+		)
+		if len(got) != len(expected) {
+			t.Fatalf("length mismatch: got=%d want=%d",
+				len(got), len(expected))
+		}
+		for i := range got {
+			if keyByContent(got[i]) != keyByContent(expected[i]) {
+				t.Fatalf("mismatch at %d: got=%v want=%v",
+					i, got[i], expected[i])
+			}
+		}
+	})
+}
+
+// TestDiffLeafKeys_PointerInvariant asserts the exact invariant that
+// motivates this PR: for any local slice, if remote is a
+// content-identical clone with fresh pointer addresses, the diff is
+// empty. Regression against issue #2026.
+func TestDiffLeafKeys_PointerInvariant(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		local := leafKeySliceGen.Draw(t, "local")
+		remote := clone(local)
+
+		got := diffLeafEntries(
+			leafEntries(remote...), leafEntries(local...),
+		)
+		if len(got) != 0 {
+			t.Fatalf("expected empty diff for pointer-reallocated "+
+				"clone, got %d entries", len(got))
+		}
+	})
+}

--- a/universe/syncer_partition_property_test.go
+++ b/universe/syncer_partition_property_test.go
@@ -1,0 +1,130 @@
+package universe
+
+import (
+	"testing"
+
+	"pgregory.net/rapid"
+)
+
+// proofTypeGen generates any ProofType, including Unspecified — the
+// partition must handle that class too (by dropping it, matching
+// pre-partition uniIdSyncFilter behaviour).
+var proofTypeGen = rapid.SampledFrom([]ProofType{
+	ProofTypeUnspecified,
+	ProofTypeIssuance,
+	ProofTypeTransfer,
+})
+
+// rootGen produces a Root with a random proof type. The other fields
+// stay zero because partitionByProofType only inspects ID.ProofType.
+var rootGen = rapid.Custom(func(t *rapid.T) Root {
+	return Root{
+		ID: Identifier{
+			ProofType: proofTypeGen.Draw(t, "proof_type"),
+		},
+	}
+})
+
+var rootSliceGen = rapid.SliceOfN(rootGen, 0, 32)
+
+// TestPartitionByProofType_Soundness pins that every root in a
+// bucket carries the matching proof type.
+func TestPartitionByProofType_Soundness(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		roots := rootSliceGen.Draw(t, "roots")
+		sorted := partitionByProofType(roots)
+
+		for _, r := range sorted.Issuance {
+			if r.ID.ProofType != ProofTypeIssuance {
+				t.Fatalf("issuance bucket contains %v",
+					r.ID.ProofType)
+			}
+		}
+		for _, r := range sorted.Transfer {
+			if r.ID.ProofType != ProofTypeTransfer {
+				t.Fatalf("transfer bucket contains %v",
+					r.ID.ProofType)
+			}
+		}
+		for _, r := range sorted.Other {
+			switch r.ID.ProofType {
+			case ProofTypeIssuance, ProofTypeTransfer:
+				t.Fatalf("other bucket contains %v",
+					r.ID.ProofType)
+			case ProofTypeUnspecified, ProofTypeIgnore,
+				ProofTypeBurn, ProofTypeMintSupply:
+				// Expected in Other.
+			}
+		}
+	})
+}
+
+// TestPartitionByProofType_Totality pins that every input root ends
+// up in exactly one bucket. Non-issuance/non-transfer types land in
+// Other rather than being silently dropped, so an explicit-lookup
+// caller driving an unusual proof type still gets processed.
+func TestPartitionByProofType_Totality(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		roots := rootSliceGen.Draw(t, "roots")
+		sorted := partitionByProofType(roots)
+
+		var wantIssuance, wantTransfer, wantOther int
+		for _, r := range roots {
+			switch r.ID.ProofType {
+			case ProofTypeIssuance:
+				wantIssuance++
+			case ProofTypeTransfer:
+				wantTransfer++
+			case ProofTypeUnspecified, ProofTypeIgnore,
+				ProofTypeBurn, ProofTypeMintSupply:
+				wantOther++
+			}
+		}
+
+		if len(sorted.Issuance) != wantIssuance {
+			t.Fatalf("issuance count: got=%d want=%d",
+				len(sorted.Issuance), wantIssuance)
+		}
+		if len(sorted.Transfer) != wantTransfer {
+			t.Fatalf("transfer count: got=%d want=%d",
+				len(sorted.Transfer), wantTransfer)
+		}
+		if len(sorted.Other) != wantOther {
+			t.Fatalf("other count: got=%d want=%d",
+				len(sorted.Other), wantOther)
+		}
+	})
+}
+
+// TestPartitionByProofType_OrderPreserving pins that within a bucket
+// the relative order of the input is preserved. This matters if a
+// caller depends on stable iteration (e.g. deterministic bench
+// results or replay-of-logs debugging).
+func TestPartitionByProofType_OrderPreserving(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		roots := rootSliceGen.Draw(t, "roots")
+
+		// Tag each root with its input index via AssetID's first
+		// byte, so we can check the survivors keep monotonic order
+		// within each bucket.
+		for i := range roots {
+			roots[i].ID.AssetID[0] = byte(i)
+		}
+
+		sorted := partitionByProofType(roots)
+
+		checkMonotonic := func(bucket []Root, name string) {
+			for i := 1; i < len(bucket); i++ {
+				if bucket[i-1].ID.AssetID[0] >=
+					bucket[i].ID.AssetID[0] {
+
+					t.Fatalf("%s bucket lost order at %d",
+						name, i)
+				}
+			}
+		}
+		checkMonotonic(sorted.Issuance, "issuance")
+		checkMonotonic(sorted.Transfer, "transfer")
+		checkMonotonic(sorted.Other, "other")
+	})
+}

--- a/universe/syncer_partition_test.go
+++ b/universe/syncer_partition_test.go
@@ -1,0 +1,165 @@
+package universe
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestPartitionByProofType_ExampleSplit is a compact example that
+// documents the shape of partitionByProofType alongside the property
+// tests in this file.
+func TestPartitionByProofType_ExampleSplit(t *testing.T) {
+	t.Parallel()
+
+	roots := []Root{
+		{ID: Identifier{ProofType: ProofTypeIssuance}},
+		{ID: Identifier{ProofType: ProofTypeTransfer}},
+		{ID: Identifier{ProofType: ProofTypeIssuance}},
+		{ID: Identifier{ProofType: ProofTypeIssuance}},
+		{ID: Identifier{ProofType: ProofTypeTransfer}},
+		{ID: Identifier{ProofType: ProofTypeBurn}},
+	}
+
+	sorted := partitionByProofType(roots)
+	require.Len(t, sorted.Issuance, 3)
+	require.Len(t, sorted.Transfer, 2)
+	require.Len(t, sorted.Other, 1)
+}
+
+// syncOrderRecorder is a minimal DiffEngine used to observe the order
+// in which the syncer processes roots by proof type. RootNode is the
+// first call syncRoot makes per root, so recording it there gives an
+// accurate ordering trace.
+//
+// UniverseLeafKeys is stubbed to return an empty slice on both sides,
+// which sends every root through the "no keys to fetch" fast path in
+// syncRoot without touching the archive or the registrar.
+type syncOrderRecorder struct {
+	roots []Root
+	mu    sync.Mutex
+	order []ProofType
+}
+
+func (r *syncOrderRecorder) RootNode(_ context.Context,
+	id Identifier) (Root, error) {
+
+	r.mu.Lock()
+	r.order = append(r.order, id.ProofType)
+	r.mu.Unlock()
+
+	return Root{}, ErrNoUniverseRoot
+}
+
+func (r *syncOrderRecorder) RootNodes(_ context.Context,
+	_ RootNodesQuery) ([]Root, error) {
+
+	return r.roots, nil
+}
+
+func (r *syncOrderRecorder) UniverseLeafKeys(_ context.Context,
+	_ UniverseLeafKeysQuery) ([]LeafKey, error) {
+
+	return nil, nil
+}
+
+func (r *syncOrderRecorder) FetchProofLeaf(_ context.Context,
+	_ Identifier, _ LeafKey) ([]*Proof, error) {
+
+	return nil, nil
+}
+
+func (r *syncOrderRecorder) Close() error { return nil }
+
+// noopRegistrar satisfies BatchRegistrar without doing anything. The
+// ordering test never reaches the registrar because the diff comes up
+// empty per root, but SimpleSyncCfg requires the field to be set.
+type noopRegistrar struct{}
+
+func (noopRegistrar) UpsertProofLeaf(_ context.Context, _ Identifier,
+	_ LeafKey, _ *Leaf) (*Proof, error) {
+
+	return nil, nil
+}
+
+func (noopRegistrar) UpsertProofLeafBatch(_ context.Context,
+	_ []*Item) error {
+
+	return nil
+}
+
+func (noopRegistrar) Close() error { return nil }
+
+// TestExecuteSync_IssuanceBeforeTransfer is the direct regression for
+// the ordering piece of issue #2026: with a mix of issuance and
+// transfer roots on the remote, every issuance-typed root must reach
+// syncRoot before any transfer-typed root does. The property is
+// observed via a call log threaded through the LocalDiffEngine.
+func TestExecuteSync_IssuanceBeforeTransfer(t *testing.T) {
+	t.Parallel()
+
+	// Interleave issuance and transfer to catch any accidental
+	// reliance on insertion order.
+	var roots []Root
+	for i := 0; i < 6; i++ {
+		var id Identifier
+		copy(id.AssetID[:], []byte{byte(i)})
+
+		if i%2 == 0 {
+			id.ProofType = ProofTypeIssuance
+		} else {
+			id.ProofType = ProofTypeTransfer
+		}
+		roots = append(roots, Root{ID: id})
+	}
+
+	local := &syncOrderRecorder{}
+	remote := &syncOrderRecorder{roots: roots}
+
+	syncer := NewSimpleSyncer(SimpleSyncCfg{
+		LocalDiffEngine: local,
+		LocalRegistrar:  noopRegistrar{},
+		NewRemoteDiffEngine: func(_ ServerAddr) (DiffEngine, error) {
+			return remote, nil
+		},
+		SyncBatchSize: 50,
+	})
+
+	_, err := syncer.SyncUniverse(
+		context.Background(), ServerAddr{}, SyncFull,
+		SyncConfigs{
+			GlobalSyncConfigs: []*FedGlobalSyncConfig{
+				{
+					ProofType:       ProofTypeIssuance,
+					AllowSyncInsert: true,
+				},
+				{
+					ProofType:       ProofTypeTransfer,
+					AllowSyncInsert: true,
+				},
+			},
+		},
+	)
+	require.NoError(t, err)
+
+	// Every issuance call must precede every transfer call. Since
+	// the ordering fix runs the two sync phases sequentially, the
+	// order slice partitions cleanly at the issuance/transfer
+	// boundary.
+	seenTransfer := false
+	for _, pt := range local.order {
+		if pt == ProofTypeTransfer {
+			seenTransfer = true
+			continue
+		}
+		if seenTransfer {
+			t.Fatalf("issuance root observed after transfer "+
+				"root; order=%v", local.order)
+		}
+	}
+
+	// Sanity: every root was actually visited.
+	require.Len(t, local.order, len(roots))
+}

--- a/universe/syncer_partition_test.go
+++ b/universe/syncer_partition_test.go
@@ -68,7 +68,7 @@ func (r *syncOrderRecorder) RootNodes(_ context.Context,
 }
 
 func (r *syncOrderRecorder) UniverseLeafKeys(_ context.Context,
-	_ UniverseLeafKeysQuery) ([]LeafKey, error) {
+	_ UniverseLeafKeysQuery) ([]LeafEntry, error) {
 
 	return nil, nil
 }

--- a/universe/syncer_partition_test.go
+++ b/universe/syncer_partition_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -49,6 +50,13 @@ func (r *syncOrderRecorder) RootNode(_ context.Context,
 	r.mu.Lock()
 	r.order = append(r.order, id.ProofType)
 	r.mu.Unlock()
+
+	// A short sleep after recording widens the window in which a
+	// collapsed single-pool refactor would interleave transfer with
+	// issuance. Without it the goroutine could return before any
+	// racing goroutine had a chance to start recording, letting a
+	// bad refactor pass by accident.
+	time.Sleep(time.Millisecond)
 
 	return Root{}, ErrNoUniverseRoot
 }
@@ -97,6 +105,13 @@ func (noopRegistrar) Close() error { return nil }
 // transfer roots on the remote, every issuance-typed root must reach
 // syncRoot before any transfer-typed root does. The property is
 // observed via a call log threaded through the LocalDiffEngine.
+//
+// SyncRootConcurrency is set well above the input size so that within
+// a phase all roots race in parallel — the only reason issuance can
+// still finish before transfer is the sequential invocation of the
+// two syncRoots calls in executeSync. A refactor that collapsed the
+// two calls into one bounded worker pool would fail this test even if
+// partitionByProofType still returned roots in the right buckets.
 func TestExecuteSync_IssuanceBeforeTransfer(t *testing.T) {
 	t.Parallel()
 
@@ -124,7 +139,8 @@ func TestExecuteSync_IssuanceBeforeTransfer(t *testing.T) {
 		NewRemoteDiffEngine: func(_ ServerAddr) (DiffEngine, error) {
 			return remote, nil
 		},
-		SyncBatchSize: 50,
+		SyncBatchSize:       50,
+		SyncRootConcurrency: 8,
 	})
 
 	_, err := syncer.SyncUniverse(

--- a/universe/syncer_test.go
+++ b/universe/syncer_test.go
@@ -1,0 +1,188 @@
+package universe
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/lightninglabs/taproot-assets/asset"
+	"github.com/lightninglabs/taproot-assets/fn"
+	"github.com/lightninglabs/taproot-assets/internal/test"
+	"github.com/lightninglabs/taproot-assets/mssmt"
+	"github.com/stretchr/testify/require"
+)
+
+// leafEntries wraps a slice of LeafKey into a slice of LeafEntry
+// with no node hash. This exercises diffLeafEntries in its key-only
+// fallback mode — the semantics the legacy keyset-only diff pinned.
+func leafEntries(keys ...LeafKey) []LeafEntry {
+	entries := make([]LeafEntry, len(keys))
+	for i, k := range keys {
+		entries[i] = LeafEntry{
+			Key:      k,
+			NodeHash: fn.None[mssmt.NodeHash](),
+		}
+	}
+	return entries
+}
+
+// leafEntriesWithHash wraps a slice of LeafKey into a slice of
+// LeafEntry, deriving each entry's node hash deterministically from
+// its universe key so that identical keys yield identical hashes.
+// Exercises diffLeafEntries in its content-aware mode.
+func leafEntriesWithHash(keys ...LeafKey) []LeafEntry {
+	entries := make([]LeafEntry, len(keys))
+	for i, k := range keys {
+		hash := mssmt.NodeHash(k.UniverseKey())
+		entries[i] = LeafEntry{
+			Key:      k,
+			NodeHash: fn.Some(hash),
+		}
+	}
+	return entries
+}
+
+// TestDiffLeafEntries_PointerInvariance is the direct regression for
+// issue #2026's diff bug: two BaseLeafKey values with identical
+// outpoint + script pubkey but freshly-allocated ScriptKey pointers
+// must be treated as equal by the diff, so that a mostly-synced node
+// stops re-fetching every remote leaf on each sync.
+func TestDiffLeafEntries_PointerInvariance(t *testing.T) {
+	t.Parallel()
+
+	outpoint := test.RandOp(t)
+	pubKey := test.RandPubKey(t)
+
+	// Same content, distinct pointer addresses.
+	a := BaseLeafKey{
+		OutPoint:  outpoint,
+		ScriptKey: fn.Ptr(asset.NewScriptKey(pubKey)),
+	}
+	b := BaseLeafKey{
+		OutPoint:  outpoint,
+		ScriptKey: fn.Ptr(asset.NewScriptKey(pubKey)),
+	}
+
+	require.NotSame(t, a.ScriptKey, b.ScriptKey,
+		"test presupposes distinct pointer addresses")
+
+	require.Empty(t, diffLeafEntries(
+		leafEntries(a), leafEntries(b),
+	))
+}
+
+// TestDiffLeafEntries_ReturnsMissing checks the positive case: a leaf
+// present only in remote is returned.
+func TestDiffLeafEntries_ReturnsMissing(t *testing.T) {
+	t.Parallel()
+
+	shared := BaseLeafKey{
+		OutPoint:  test.RandOp(t),
+		ScriptKey: fn.Ptr(asset.NewScriptKey(test.RandPubKey(t))),
+	}
+	only := BaseLeafKey{
+		OutPoint:  test.RandOp(t),
+		ScriptKey: fn.Ptr(asset.NewScriptKey(test.RandPubKey(t))),
+	}
+
+	diff := diffLeafEntries(
+		leafEntries(shared, only), leafEntries(shared),
+	)
+	require.Len(t, diff, 1)
+	require.Equal(t, only.UniverseKey(), diff[0].UniverseKey())
+}
+
+// TestDiffLeafEntries_PreservesRemoteOrder pins the subsequence
+// invariant: survivors appear in the same order as they did in
+// remote. Downstream error attribution indexes into the returned
+// slice.
+func TestDiffLeafEntries_PreservesRemoteOrder(t *testing.T) {
+	t.Parallel()
+
+	// Build a run of remote keys and remove the middle one from local.
+	remote := make([]LeafKey, 5)
+	for i := range remote {
+		remote[i] = BaseLeafKey{
+			OutPoint: wire.OutPoint{
+				Hash: [32]byte{byte(i)}, Index: uint32(i),
+			},
+			ScriptKey: fn.Ptr(asset.NewScriptKey(
+				test.RandPubKey(t),
+			)),
+		}
+	}
+
+	// Local has everything except remote[2].
+	local := append([]LeafKey{}, remote[:2]...)
+	local = append(local, remote[3:]...)
+
+	diff := diffLeafEntries(leafEntries(remote...), leafEntries(local...))
+	require.Len(t, diff, 1)
+	require.Equal(t, remote[2].UniverseKey(), diff[0].UniverseKey())
+}
+
+// TestDiffLeafEntries_SharedKeyContentMismatch pins the content-aware
+// case that motivated the wire change: same universe key on both
+// sides, disagreeing leaf node hashes, must be surfaced for refetch.
+// Under the legacy keyset-only diff this shared key would never
+// appear in the result.
+func TestDiffLeafEntries_SharedKeyContentMismatch(t *testing.T) {
+	t.Parallel()
+
+	shared := BaseLeafKey{
+		OutPoint:  test.RandOp(t),
+		ScriptKey: fn.Ptr(asset.NewScriptKey(test.RandPubKey(t))),
+	}
+
+	remote := []LeafEntry{{
+		Key:      shared,
+		NodeHash: fn.Some(mssmt.NodeHash{0x01}),
+	}}
+	local := []LeafEntry{{
+		Key:      shared,
+		NodeHash: fn.Some(mssmt.NodeHash{0x02}),
+	}}
+
+	diff := diffLeafEntries(remote, local)
+	require.Len(t, diff, 1)
+	require.Equal(t, shared.UniverseKey(), diff[0].UniverseKey())
+}
+
+// TestDiffLeafEntries_SharedKeyContentMatch pins the converse: same
+// key, same hash on both sides is a no-op.
+func TestDiffLeafEntries_SharedKeyContentMatch(t *testing.T) {
+	t.Parallel()
+
+	shared := BaseLeafKey{
+		OutPoint:  test.RandOp(t),
+		ScriptKey: fn.Ptr(asset.NewScriptKey(test.RandPubKey(t))),
+	}
+
+	diff := diffLeafEntries(
+		leafEntriesWithHash(shared), leafEntriesWithHash(shared),
+	)
+	require.Empty(t, diff)
+}
+
+// TestDiffLeafEntries_RemoteSubsetIsNoop pins the peer-is-behind
+// case: when every remote key is also in local, no leaf is fetched.
+// The legacy diff's empty-diff-with-diverging-roots fallback used
+// to spend a full refetch here; the entry-based diff makes it a
+// no-op by construction.
+func TestDiffLeafEntries_RemoteSubsetIsNoop(t *testing.T) {
+	t.Parallel()
+
+	shared := BaseLeafKey{
+		OutPoint:  test.RandOp(t),
+		ScriptKey: fn.Ptr(asset.NewScriptKey(test.RandPubKey(t))),
+	}
+	localExtra := BaseLeafKey{
+		OutPoint:  test.RandOp(t),
+		ScriptKey: fn.Ptr(asset.NewScriptKey(test.RandPubKey(t))),
+	}
+
+	diff := diffLeafEntries(
+		leafEntriesWithHash(shared),
+		leafEntriesWithHash(shared, localExtra),
+	)
+	require.Empty(t, diff)
+}


### PR DESCRIPTION
Resolves #2026.

This should substantially improve universe sync reliability and performance. In some cases the performance improvement/bandwidth reduction can be multiple orders of magnitude, and some DB contention/failure modes are eliminated entirely.

Codex's estimate of the reliability/performance wins:

> For production scale: on a fresh empty sync, total work is still roughly all 186,377 proofs, so this mostly improves reliability and peak pressure, not total bytes. Peak DB batch pressure falls from roughly GOMAXPROCS * 200 leaves to 2 * 50; on an 8-16 core process that is about 16x-32x less peak write-side batch pressure. Peak nested proof-fetch concurrency should also drop about GOMAXPROCS / 2, so usually 4x-8x lower.
> 
> For steady-state or mostly-synced nodes, the improvement is much larger. Old behavior re-fetched all leaves in each divergent root; new behavior fetches only the delta. If a large 8,622-leaf root gains 1 new proof, that root’s leaf fetch/ write work drops by about 8,600x.  At whole-server scale, if a sync is behind by 100, 1,000, or 10,000 proofs, the theoretical leaf-level work reduction versus worst-case refetching is about 1,864x, 186x, or 19x, respectively.
> 
> Net estimate: fresh syncs should stop retry-looping and have far smoother traffic; incremental syncs should see one to three orders of magnitude less redundant proof fetch/verify/write work depending on delta size.

The PR itself fixes three issues, each in a different layer of the universe sync pipeline (Opus's summary follows):

- ~Leaf-key diff previously compared by pointer identity, so a mostly-synced node re-fetched every remote leaf on each sync. Now compared by content hash.~
- Leaf-key diff previously compared by pointer identity, so a mostly-synced node re-fetched every remote leaf on each sync. Now leaves are diffed by canonical content, so remote-only keys, shared-key content mismatches, and peer-behind cases all converge in one pass with work proportional to the actual delta.
- Roots were synced in the order the remote returned them, letting a transfer race ahead of its issuance and abort on dependency lookup.  Now partitioned by proof type, issuance first.
- Sync fan-out was unbounded and the write batch large, exhausting the DB transaction retry budget at scale. Now bounded, with a smaller batch.
