### PR TITLE
flake: fix a couple of backup itest flakes

### DIFF
--- a/itest/backup_test.go
+++ b/itest/backup_test.go
@@ -20,7 +20,7 @@ import (
 //  3. Bob imports the same backup again — 0 imported (idempotent)
 func testBackupRestoreGenesis(t *harnessTest) {
 	ctxb := context.Background()
-	ctxt, cancel := context.WithTimeout(ctxb, defaultWaitTimeout)
+	ctxt, cancel := context.WithTimeout(ctxb, defaultWaitTimeout*2)
 	defer cancel()
 
 	// Mint a single asset on Alice.

--- a/itest/backup_test.go
+++ b/itest/backup_test.go
@@ -121,7 +121,7 @@ func testBackupRestoreGenesis(t *harnessTest) {
 //     imported (both anchor outpoints spent in step 7)
 func testBackupRestoreTransferred(t *harnessTest) {
 	ctxb := context.Background()
-	ctxt, cancel := context.WithTimeout(ctxb, defaultWaitTimeout*4)
+	ctxt, cancel := context.WithTimeout(ctxb, defaultWaitTimeout*6)
 	defer cancel()
 
 	// === Stage 1: Mint 2 assets on Alice in separate batches ===


### PR DESCRIPTION
I had these things sitting around locally from like a month ago. They're simple itest timeout widenings; 98ced886c5d28710a66e6f2bd237fd2a03439837 in particular should resolve the flake I just spotted in [this CI job](https://github.com/lightninglabs/taproot-assets/actions/runs/28592527077/job/84780931145), and the other commit, I guess, should resolve something else that popped up at some point.