### PR TITLE
tapdb: keep universe root page cache warm across proof inserts

### DIFF
--- a/docs/release-notes/release-notes-0.8.1.md
+++ b/docs/release-notes/release-notes-0.8.1.md
@@ -62,6 +62,11 @@
 
 ## Performance Improvements
 
+- [PR#2192](https://github.com/lightninglabs/taproot-assets/pull/2192)
+  keeps the universe root node page cache warm across proof inserts.
+  Previously, every inserted proof leaf wiped the whole page cache,
+  leaving `AssetRoots` pagination permanently cold on a busy server.
+
 ## Deprecations
 
 # Technical and Architectural Updates

--- a/tapdb/burn_tree.go
+++ b/tapdb/burn_tree.go
@@ -131,7 +131,7 @@ func insertBurnsInternal(ctx context.Context, db BaseUniverseStore,
 				"tree type to universe proof type: %w", err)
 		}
 
-		_, err = universeUpsertProofLeaf(
+		_, _, err = universeUpsertProofLeaf(
 			ctx, db, subNs, uniProofType, groupKey, leafKey, leaf,
 			nil, blockHeight,
 		)

--- a/tapdb/multiverse.go
+++ b/tapdb/multiverse.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/btcsuite/btcd/btcec/v2"
@@ -792,6 +793,7 @@ func (b *MultiverseStore) UpsertProofLeaf(ctx context.Context,
 	var (
 		writeTx         BaseMultiverseOptions
 		uniProof        *universe.Proof
+		rootStatus      universeRootStatus
 		multiverseRoot  mssmt.Node
 		multiverseProof *mssmt.Proof
 	)
@@ -805,7 +807,7 @@ func (b *MultiverseStore) UpsertProofLeaf(ctx context.Context,
 			return err
 		}
 
-		uniProof, _, err = universeUpsertProofLeaf(
+		uniProof, rootStatus, err = universeUpsertProofLeaf(
 			ctx, dbTx, id.String(), id.ProofType,
 			id.GroupKey, key, leaf, metaReveal, blockHeight,
 		)
@@ -836,19 +838,22 @@ func (b *MultiverseStore) UpsertProofLeaf(ctx context.Context,
 	uniProof.MultiverseRoot = multiverseRoot
 	uniProof.MultiverseInclusionProof = multiverseProof
 
-	// Invalidate the cache since we just updated the root. Every
-	// previously cached proof under this universe embeds the
-	// UniverseRoot at the time it was fetched; inserting a new leaf
-	// changes the root, so all sibling entries are now stale and
-	// must be evicted, not just the one we wrote.
-	b.rootNodeCache.wipeCache()
-	b.proofCache.RemoveUniverseProofs(id)
-	b.leafKeysCache.wipeCache(id.String())
-	b.syncerCache.addOrReplace(universe.Root{
+	// The transaction is committed, so invalidate the affected caches.
+	// The root node page cache is wiped if the upsert created the
+	// universe, and only has the pages containing the universe's root
+	// evicted otherwise. Every previously cached proof under this
+	// universe embeds the UniverseRoot at the time it was fetched;
+	// inserting a new leaf changes the root, so all of the universe's
+	// proofs and leaf keys are evicted, not just the one we wrote.
+	newRoot := universe.Root{
 		ID:        id,
 		AssetName: leaf.Asset.Tag,
 		Node:      uniProof.UniverseRoot,
-	})
+	}
+	b.rootNodeCache.handleRootUpdate(newRoot, rootStatus)
+	b.proofCache.RemoveUniverseProofs(id)
+	b.leafKeysCache.wipeCache(id.String())
+	b.syncerCache.addOrReplace(newRoot)
 
 	// Notify subscribers about the new proof leaf, now that we're sure we
 	// have written it to the database. But we only care about transfer
@@ -867,12 +872,16 @@ func (b *MultiverseStore) UpsertProofLeafBatch(ctx context.Context,
 	items []*universe.Item) error {
 
 	var (
-		writeTx   BaseMultiverseOptions
-		uniProofs []*universe.Proof
+		writeTx      BaseMultiverseOptions
+		uniProofs    []*universe.Proof
+		rootStatuses []universeRootStatus
 	)
 	dbErr := b.db.ExecTx(
 		ctx, &writeTx, func(store BaseMultiverseStore) error {
 			uniProofs = make([]*universe.Proof, len(items))
+			rootStatuses = make(
+				[]universeRootStatus, len(items),
+			)
 			for idx := range items {
 				item := items[idx]
 
@@ -887,18 +896,21 @@ func (b *MultiverseStore) UpsertProofLeafBatch(ctx context.Context,
 
 				// Upsert into the specific universe tree to
 				// start with.
-				uniProof, _, err := universeUpsertProofLeaf(
-					ctx, store, item.ID.String(),
-					item.ID.ProofType,
-					item.ID.GroupKey, item.Key, item.Leaf,
-					item.MetaReveal, blockHeight,
-				)
+				uniProof, status, err :=
+					universeUpsertProofLeaf(
+						ctx, store, item.ID.String(),
+						item.ID.ProofType,
+						item.ID.GroupKey, item.Key,
+						item.Leaf, item.MetaReveal,
+						blockHeight,
+					)
 				if err != nil {
 					return fmt.Errorf("failed universe "+
 						"upsert for item %d: %w",
 						idx, err)
 				}
 				uniProofs[idx] = uniProof
+				rootStatuses[idx] = status
 
 				// Next we'll, attempt to insert the universe
 				// root into the main multiverse tree.
@@ -927,14 +939,21 @@ func (b *MultiverseStore) UpsertProofLeafBatch(ctx context.Context,
 		return dbErr
 	}
 
-	// TODO(roasbeef): want to write thru but then need db query again?
-
-	b.rootNodeCache.wipeCache()
+	// If any of the inserted leaves created a new universe, the
+	// composition of paginated root queries changed and the page cache as
+	// a whole is stale. Pure updates only change the value of already
+	// placed roots, so it's enough to evict the pages containing them,
+	// which we do in one pass after the loop below.
+	wiped := slices.Contains(rootStatuses, universeRootCreated)
+	if wiped {
+		b.rootNodeCache.wipeCache()
+	}
 
 	// Notify subscribers about the new proof leaves, now that we're sure we
 	// have written them to the database. But we only care about transfer
 	// proofs, as the events are received by the custodian to finalize
 	// inbound transfers.
+	newRoots := make([]universe.Root, len(items))
 	for idx := range items {
 		if items[idx].ID.ProofType == universe.ProofTypeTransfer {
 			b.transferProofDistributor.NotifySubscribers(
@@ -942,16 +961,26 @@ func (b *MultiverseStore) UpsertProofLeafBatch(ctx context.Context,
 			)
 		}
 
-		// Update the syncer cache with the new root node.
-		b.syncerCache.addOrReplace(universe.Root{
+		newRoots[idx] = universe.Root{
 			ID:        items[idx].ID,
 			AssetName: items[idx].Leaf.Asset.Tag,
 			Node:      uniProofs[idx].UniverseRoot,
-		})
+		}
+
+		// Update the syncer cache with the new root node.
+		b.syncerCache.addOrReplace(newRoots[idx])
 	}
 
-	// Invalidate the root node cache for all the assets we just
-	// inserted. Each insert changes the root of its universe tree,
+	// Evict the cached pages that contain any of the updated roots. If
+	// the cache was wiped above there is nothing to evict: any page
+	// refilled since the wipe was read from post-commit state and is
+	// already fresh.
+	if !wiped {
+		b.rootNodeCache.evictRoots(newRoots)
+	}
+
+	// Invalidate the proof and leaf key caches for all the universes we
+	// just touched. Each insert changes the root of its universe tree,
 	// which invalidates the UniverseRoot snapshot embedded in every
 	// previously cached proof under that universe, so we evict by
 	// universe id rather than per leaf key.

--- a/tapdb/multiverse.go
+++ b/tapdb/multiverse.go
@@ -850,8 +850,6 @@ func (b *MultiverseStore) UpsertProofLeaf(ctx context.Context,
 		Node:      uniProof.UniverseRoot,
 	})
 
-	b.leafKeysCache.wipeCache(id.String())
-
 	// Notify subscribers about the new proof leaf, now that we're sure we
 	// have written it to the database. But we only care about transfer
 	// proofs, as the events are received by the custodian to finalize

--- a/tapdb/multiverse.go
+++ b/tapdb/multiverse.go
@@ -805,7 +805,7 @@ func (b *MultiverseStore) UpsertProofLeaf(ctx context.Context,
 			return err
 		}
 
-		uniProof, err = universeUpsertProofLeaf(
+		uniProof, _, err = universeUpsertProofLeaf(
 			ctx, dbTx, id.String(), id.ProofType,
 			id.GroupKey, key, leaf, metaReveal, blockHeight,
 		)
@@ -887,7 +887,7 @@ func (b *MultiverseStore) UpsertProofLeafBatch(ctx context.Context,
 
 				// Upsert into the specific universe tree to
 				// start with.
-				uniProof, err := universeUpsertProofLeaf(
+				uniProof, _, err := universeUpsertProofLeaf(
 					ctx, store, item.ID.String(),
 					item.ID.ProofType,
 					item.ID.GroupKey, item.Key, item.Leaf,

--- a/tapdb/multiverse_cache.go
+++ b/tapdb/multiverse_cache.go
@@ -719,6 +719,77 @@ func (r *rootNodeCache) wipeCache() {
 	r.allRoots.wipe(r.cacheSize)
 }
 
+// handleRootUpdate updates the cached roots after a proof leaf was inserted
+// into the universe identified by root.ID. Creating a new universe changes
+// which roots appear on which page of paginated root queries, so the whole
+// page cache is invalidated. Updating an existing universe only changes the
+// value of a single, already placed root, so only the cached pages
+// containing that root are evicted and all other pages stay warm.
+func (r *rootNodeCache) handleRootUpdate(root universe.Root,
+	status universeRootStatus) {
+
+	switch status {
+	case universeRootCreated:
+		r.wipeCache()
+
+	case universeRootUpdated:
+		r.evictRoots([]universe.Root{root})
+	}
+}
+
+// evictRoots removes all cached pages that contain any of the given universe
+// roots. Pages are keyed by pagination parameters only and the backing query
+// orders by the stable universe_roots.id column, so updating an existing
+// universe never changes which page its root appears on. Cached pages that
+// don't contain any of the roots therefore remain valid, and absence of a
+// root from all cached pages means there is nothing to invalidate for it.
+//
+// The affected pages are evicted rather than patched with the new root
+// value: eviction is idempotent, so concurrent updates of the same universe
+// can apply in any order without ever leaving a value in the cache that is
+// older than the database state. It also keeps query-derived fields honest:
+// a grouped universe's asset name, for example, is frozen to its first
+// member by the backing query and would diverge if we patched in the latest
+// leaf's tag.
+func (r *rootNodeCache) evictRoots(roots []universe.Root) {
+	// The lock serializes us with the cache fill in RootNodes, which
+	// holds it across both its database read and cacheRoots. Without it
+	// we could evict between the two, and the fill would then install a
+	// page that was read before our root update committed.
+	r.Lock()
+	defer r.Unlock()
+
+	keys := make(map[universe.IdentifierKey]struct{}, len(roots))
+	for _, root := range roots {
+		keys[root.ID.Key()] = struct{}{}
+	}
+
+	rootPages := r.allRoots.Load()
+
+	// We first collect the affected pages, as mutating the cache while
+	// iterating over it isn't safe.
+	var evicted []rootPageQueryKey
+	rootPages.Range(func(key rootPageQueryKey,
+		page universeRootPage) bool {
+
+		stale := slices.ContainsFunc(
+			page, func(cached universe.Root) bool {
+				_, ok := keys[cached.ID.Key()]
+				return ok
+			},
+		)
+		if stale {
+			evicted = append(evicted, key)
+		}
+
+		return true
+	})
+
+	for _, key := range evicted {
+		rootPages.Delete(key)
+	}
+}
+
 // cachedLeafKeys is used to cache the set of leaf keys for a given universe.
 type cachedLeafKeys []universe.LeafKey
 

--- a/tapdb/multiverse_cache.go
+++ b/tapdb/multiverse_cache.go
@@ -688,6 +688,10 @@ func (r *rootNodeCache) fetchRoots(q universe.RootNodesQuery,
 }
 
 // cacheRoots stores the given roots in the cache.
+//
+// NOTE: This method must be called while holding the rootNodeCache lock, so
+// that the page installed here can't be made stale by a concurrent wipe or
+// eviction running between the caller's database read and this call.
 func (r *rootNodeCache) cacheRoots(q universe.RootNodesQuery,
 	rootNodes []universe.Root) {
 
@@ -703,6 +707,14 @@ func (r *rootNodeCache) cacheRoots(q universe.RootNodesQuery,
 // wipeCache wipes all the cached roots.
 func (r *rootNodeCache) wipeCache() {
 	log.Debugf("Wiping universe root node cache")
+
+	// The lock serializes us with the cache fill in RootNodes, which
+	// holds it across both its database read and cacheRoots. Without it
+	// we could wipe between the two, and the fill would then install a
+	// page into the fresh cache that was read before the write that
+	// triggered this wipe committed.
+	r.Lock()
+	defer r.Unlock()
 
 	r.allRoots.wipe(r.cacheSize)
 }

--- a/tapdb/multiverse_cache.go
+++ b/tapdb/multiverse_cache.go
@@ -11,7 +11,6 @@ import (
 	"github.com/dustin/go-humanize"
 	"github.com/lightninglabs/neutrino/cache/lru"
 	"github.com/lightninglabs/taproot-assets/universe"
-	"github.com/lightningnetwork/lnd/lnutils"
 )
 
 const (
@@ -380,25 +379,6 @@ func (r *rootPageCache) wipe(cacheSize uint64) {
 	r.Store(rootCache)
 }
 
-// rootIndex maps a tree ID to a universe root.
-type rootIndex struct {
-	atomic.Pointer[lnutils.SyncMap[universeIDKey, *universe.Root]]
-}
-
-// newRootIndex creates a new atomic root index.
-func newRootIndex() *rootIndex {
-	var a rootIndex
-	a.wipe()
-
-	return &a
-}
-
-// wipe wipes the cache.
-func (r *rootIndex) wipe() {
-	var idx lnutils.SyncMap[universeIDKey, *universe.Root]
-	r.Store(&idx)
-}
-
 // syncerRootNodeCache is used to cache the set of active root nodes for the
 // multiverse tree, which is specifically kept for the universe sync.
 type syncerRootNodeCache struct {
@@ -666,8 +646,6 @@ type rootNodeCache struct {
 
 	cacheSize uint64
 
-	rootIndex *rootIndex
-
 	allRoots *rootPageCache
 
 	*cacheLogger
@@ -679,7 +657,6 @@ type rootNodeCache struct {
 func newRootNodeCache(cacheSize uint64) *rootNodeCache {
 	return &rootNodeCache{
 		cacheSize:   cacheSize,
-		rootIndex:   newRootIndex(),
 		allRoots:    newRootPageCache(cacheSize),
 		cacheLogger: newCacheLogger("universe_roots"),
 	}
@@ -716,17 +693,10 @@ func (r *rootNodeCache) cacheRoots(q universe.RootNodesQuery,
 
 	log.Debugf("Caching root node (count=%v)", len(rootNodes))
 
-	// Store the main root pointer, then update the root index.
 	rootPageCache := r.allRoots.Load()
 	_, err := rootPageCache.Put(newRootPageQuery(q), rootNodes)
 	if err != nil {
 		log.Errorf("unable to insert into root cache: %v", err)
-	}
-
-	rootIndex := r.rootIndex.Load()
-	for _, rootNode := range rootNodes {
-		rootNode := rootNode
-		rootIndex.Store(rootNode.ID.String(), &rootNode)
 	}
 }
 
@@ -735,7 +705,6 @@ func (r *rootNodeCache) wipeCache() {
 	log.Debugf("Wiping universe root node cache")
 
 	r.allRoots.wipe(r.cacheSize)
-	r.rootIndex.wipe()
 }
 
 // cachedLeafKeys is used to cache the set of leaf keys for a given universe.

--- a/tapdb/multiverse_cache_test.go
+++ b/tapdb/multiverse_cache_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"slices"
+	"sync"
 	"testing"
 	"time"
 
@@ -275,6 +276,30 @@ func TestRootNodeCacheTargetedInvalidation(t *testing.T) {
 	require.Equal(t, before+6, misses())
 	require.Len(t, roots, numAssets+2)
 	requireSameRoots(t, freshView(), roots)
+
+	// Deleting the last leaf of a universe removes the universe
+	// entirely, which also wipes the page cache. Re-inserting the same
+	// universe afterwards must be detected as a creation and wipe the
+	// refilled pages again, even though a root with the same ID existed
+	// before the deletion.
+	victim := items[5]
+	_, err = multiverse.DeleteProofLeaf(ctx, victim.ID, victim.Key)
+	require.NoError(t, err)
+
+	roots = queryRoots(t, multiverse, pageSize)
+	require.Len(t, roots, numAssets+1)
+	requireSameRoots(t, freshView(), roots)
+
+	before = misses()
+	_, err = multiverse.UpsertProofLeaf(
+		ctx, victim.ID, victim.Key, victim.Leaf, nil,
+	)
+	require.NoError(t, err)
+
+	roots = queryRoots(t, multiverse, pageSize)
+	require.Equal(t, before+6, misses())
+	require.Len(t, roots, numAssets+2)
+	requireSameRoots(t, freshView(), roots)
 }
 
 // TestRootNodeCacheProperties is a model-based property test for the
@@ -411,6 +436,21 @@ func TestRootNodeCacheProperties(t *testing.T) {
 				)
 			},
 
+			// Delete a universe: its root disappears, which
+			// shifts the page composition. The store handles
+			// both deletion paths with a full cache wipe.
+			"delete": func(rt *rapid.T) {
+				if len(db) == 0 {
+					return
+				}
+
+				idx := rapid.IntRange(0, len(db)-1).Draw(
+					rt, "victim",
+				)
+				db = slices.Delete(db, idx, idx+1)
+				cache.wipeCache()
+			},
+
 			// Invariant check, run after every action: the cache
 			// may miss on any tracked query, but a page it does
 			// serve must match a fresh database read.
@@ -441,6 +481,178 @@ func TestRootNodeCacheProperties(t *testing.T) {
 			},
 		})
 	})
+}
+
+// TestRootNodeCacheConcurrency exercises the root node page cache with
+// concurrent writers and readers. Invalidation runs after the database
+// transaction commits, so a reader may briefly observe a page that predates
+// a concurrent commit; once all writers are done, however, the cache must
+// have converged: every page it still serves has to match a fresh database
+// read. Under the race detector this also validates the locking of the
+// fill, wipe and eviction paths.
+func TestRootNodeCacheConcurrency(t *testing.T) {
+	ctx := context.Background()
+	db := NewTestDB(t)
+	multiverse, _ := newTestMultiverseWithDb(t, db.BaseDB)
+
+	// The concurrency is deliberately modest: postgres runs these
+	// transactions under serializable isolation, and too many overlapping
+	// writers and readers exhaust the default predicate lock allowance
+	// of the test fixture (SQLSTATE 53200), which is not a retryable
+	// serialization failure.
+	const (
+		numSeed    = 16
+		pageSize   = int32(4)
+		numWriters = 2
+		numReaders = 2
+		numOps     = 20
+	)
+
+	// Seed a set of universes for the update operations to target.
+	seed := make([]*universe.Item, numSeed)
+	for i := range seed {
+		seed[i] = genRandomAsset(t)
+		_, err := multiverse.UpsertProofLeaf(
+			ctx, seed[i].ID, seed[i].Key, seed[i].Leaf, nil,
+		)
+		require.NoError(t, err)
+	}
+
+	// The test helpers draw their randomness through the test object, so
+	// we pre-generate every writer's workload on the main goroutine.
+	// Most operations update an existing universe, with an occasional
+	// creation sprinkled in so wipes race with fills and evictions.
+	newUpdate := func(src *universe.Item) *universe.Item {
+		leaf := randMintingLeaf(t, src.Leaf.Genesis, src.ID.GroupKey)
+		return &universe.Item{
+			ID:   src.ID,
+			Key:  randLeafKey(t),
+			Leaf: &leaf,
+		}
+	}
+	workloads := make([][]*universe.Item, numWriters)
+	for w := range workloads {
+		workloads[w] = make([]*universe.Item, numOps)
+		for op := range workloads[w] {
+			if op%5 == 0 {
+				workloads[w][op] = genRandomAsset(t)
+				continue
+			}
+
+			workloads[w][op] = newUpdate(seed[(w+op)%numSeed])
+		}
+	}
+
+	pageQuery := func(offset int32) universe.RootNodesQuery {
+		return universe.RootNodesQuery{
+			SortDirection: universe.SortAscending,
+			Offset:        offset,
+			Limit:         pageSize,
+		}
+	}
+
+	// readAll pages through all roots, filling the cache as it goes.
+	readAll := func() error {
+		for offset := int32(0); ; offset += pageSize {
+			page, err := multiverse.RootNodes(
+				ctx, pageQuery(offset),
+			)
+			if err != nil {
+				return err
+			}
+			if int32(len(page)) < pageSize {
+				return nil
+			}
+		}
+	}
+
+	errs := make(chan error, numWriters+numReaders)
+
+	// Half the writers upsert leaves one at a time, the other half in
+	// batches, so both invalidation paths run concurrently.
+	var writers sync.WaitGroup
+	for w := 0; w < numWriters; w++ {
+		writers.Add(1)
+		go func(ops []*universe.Item, useBatch bool) {
+			defer writers.Done()
+
+			if useBatch {
+				const chunk = 5
+				for i := 0; i < len(ops); i += chunk {
+					end := min(i+chunk, len(ops))
+					err := multiverse.UpsertProofLeafBatch(
+						ctx, ops[i:end],
+					)
+					if err != nil {
+						errs <- err
+						return
+					}
+				}
+
+				return
+			}
+
+			for _, op := range ops {
+				_, err := multiverse.UpsertProofLeaf(
+					ctx, op.ID, op.Key, op.Leaf, nil,
+				)
+				if err != nil {
+					errs <- err
+					return
+				}
+			}
+		}(workloads[w], w%2 == 1)
+	}
+
+	// Readers keep paging through the roots until the writers are done.
+	done := make(chan struct{})
+	var readers sync.WaitGroup
+	for r := 0; r < numReaders; r++ {
+		readers.Add(1)
+		go func() {
+			defer readers.Done()
+
+			for {
+				select {
+				case <-done:
+					return
+				case <-time.After(time.Millisecond):
+				}
+
+				if err := readAll(); err != nil {
+					errs <- err
+					return
+				}
+			}
+		}()
+	}
+
+	writers.Wait()
+	close(done)
+	readers.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+
+	// With all writers done, every page the cache still serves must
+	// match what a fresh store reads from the database.
+	fresh, _ := newTestMultiverseWithDb(t, db.BaseDB)
+	for offset := int32(0); ; offset += pageSize {
+		q := pageQuery(offset)
+
+		cachedPage, err := multiverse.RootNodes(ctx, q)
+		require.NoError(t, err)
+
+		freshPage, err := fresh.RootNodes(ctx, q)
+		require.NoError(t, err)
+
+		requireSameRoots(t, freshPage, cachedPage)
+
+		if int32(len(freshPage)) < pageSize {
+			break
+		}
+	}
 }
 
 // TestMultiverseSyncerCache tests the syncer cache of the multiverse store.

--- a/tapdb/multiverse_cache_test.go
+++ b/tapdb/multiverse_cache_test.go
@@ -2,7 +2,9 @@ package tapdb
 
 import (
 	"context"
+	"encoding/binary"
 	"fmt"
+	"slices"
 	"testing"
 	"time"
 
@@ -12,6 +14,7 @@ import (
 	"github.com/lightninglabs/taproot-assets/mssmt"
 	"github.com/lightninglabs/taproot-assets/universe"
 	"github.com/stretchr/testify/require"
+	"pgregory.net/rapid"
 )
 
 // TestMultiverseRootsCachePerformance tests the cache hit vs. miss ratio of the
@@ -88,6 +91,356 @@ func TestMultiverseRootsCachePerformance(t *testing.T) {
 	// other queries should be hits.
 	require.EqualValues(t, 2, multiverse.syncerCache.miss.Load())
 	require.EqualValues(t, numHits, multiverse.syncerCache.hit.Load())
+}
+
+// requireSameRoots asserts that two root slices are semantically equal:
+// same order, identity, name and root node value. We can't use
+// require.Equal directly, since the concrete mssmt.Node type behind a root
+// differs depending on how the root was constructed.
+func requireSameRoots(t require.TestingT, want, got []universe.Root) {
+	require.Len(t, got, len(want))
+	for i := range want {
+		require.Equal(t, want[i].ID.Key(), got[i].ID.Key())
+		require.Equal(t, want[i].AssetName, got[i].AssetName)
+		require.Equal(
+			t, want[i].Node.NodeHash(), got[i].Node.NodeHash(),
+		)
+		require.Equal(t, want[i].Node.NodeSum(), got[i].Node.NodeSum())
+	}
+}
+
+// TestRootNodeCacheTargetedInvalidation tests that inserting a proof leaf
+// into an existing universe only evicts the cached pages containing that
+// universe's root, keeping all other pages warm, while inserting a leaf
+// that creates a new universe invalidates the whole page cache.
+func TestRootNodeCacheTargetedInvalidation(t *testing.T) {
+	ctx := context.Background()
+	db := NewTestDB(t)
+	multiverse, _ := newTestMultiverseWithDb(t, db.BaseDB)
+
+	misses := func() int64 {
+		return multiverse.rootNodeCache.miss.Load()
+	}
+
+	// freshView reads all roots through a second store over the same
+	// database. Its cache starts cold, so it always serves the ground
+	// truth to compare the cached view against.
+	const pageSize = 4
+	freshView := func() []universe.Root {
+		fresh, _ := newTestMultiverseWithDb(t, db.BaseDB)
+		return queryRoots(t, fresh, pageSize)
+	}
+
+	// We insert a handful of assets, each one creating its own universe.
+	const numAssets = 9
+	items := make([]*universe.Item, numAssets)
+	for i := range items {
+		items[i] = genRandomAsset(t)
+		_, err := multiverse.UpsertProofLeaf(
+			ctx, items[i].ID, items[i].Key, items[i].Leaf, nil,
+		)
+		require.NoError(t, err)
+	}
+
+	// upsertLeaf inserts an additional leaf into the universe of the
+	// given item, which is an update of an existing universe root.
+	upsertLeaf := func(item *universe.Item) *universe.Proof {
+		leaf := randMintingLeaf(
+			t, item.Leaf.Genesis, item.ID.GroupKey,
+		)
+		uniProof, err := multiverse.UpsertProofLeaf(
+			ctx, item.ID, randLeafKey(t), &leaf, nil,
+		)
+		require.NoError(t, err)
+
+		return uniProof
+	}
+
+	// Page through all roots once to fill the page cache, then re-read
+	// to make sure the pages are served from the cache.
+	roots := queryRoots(t, multiverse, pageSize)
+	require.Len(t, roots, numAssets)
+	missesAfterFill := misses()
+
+	roots = queryRoots(t, multiverse, pageSize)
+	require.Equal(t, missesAfterFill, misses())
+	requireSameRoots(t, freshView(), roots)
+
+	// Inserting a second leaf into an existing universe must evict only
+	// the page containing that universe's root. Re-reading all roots
+	// then costs exactly one page refill (a refill counts two misses:
+	// one before and one after taking the write lock), the other pages
+	// stay warm, and the refilled page serves the new root value.
+	// items[0] was inserted first, so its root sits on the first page.
+	target := items[0]
+	newProof := upsertLeaf(target)
+
+	before := misses()
+	roots = queryRoots(t, multiverse, pageSize)
+	require.Equal(t, before+2, misses())
+	requireSameRoots(t, freshView(), roots)
+
+	found := false
+	for _, root := range roots {
+		if root.ID.Bytes() == target.ID.Bytes() {
+			require.Equal(
+				t, newProof.UniverseRoot.NodeHash(),
+				root.Node.NodeHash(),
+			)
+			require.Equal(
+				t, newProof.UniverseRoot.NodeSum(),
+				root.Node.NodeSum(),
+			)
+			found = true
+		}
+	}
+	require.True(t, found)
+
+	// Inserting a proof that creates a new universe changes the page
+	// composition, so it must invalidate all cached pages: re-reading
+	// refills all three of them.
+	newItem := genRandomAsset(t)
+	_, err := multiverse.UpsertProofLeaf(
+		ctx, newItem.ID, newItem.Key, newItem.Leaf, nil,
+	)
+	require.NoError(t, err)
+
+	before = misses()
+	roots = queryRoots(t, multiverse, pageSize)
+	require.Equal(t, before+6, misses())
+	require.Len(t, roots, numAssets+1)
+	requireSameRoots(t, freshView(), roots)
+
+	// Pages that carry grouped asset amounts are evicted on update just
+	// like plain pages, while pages not containing the updated root
+	// stay warm.
+	amountsQuery := universe.RootNodesQuery{
+		WithAmountsById: true,
+		SortDirection:   universe.SortAscending,
+		Offset:          0,
+		Limit:           pageSize,
+	}
+	_, err = multiverse.RootNodes(ctx, amountsQuery)
+	require.NoError(t, err)
+
+	upsertLeaf(target)
+
+	before = misses()
+	roots = queryRoots(t, multiverse, pageSize)
+	require.Equal(t, before+2, misses())
+	requireSameRoots(t, freshView(), roots)
+
+	before = misses()
+	_, err = multiverse.RootNodes(ctx, amountsQuery)
+	require.NoError(t, err)
+	require.Equal(t, before+2, misses())
+
+	// A batch consisting purely of updates must also evict only the
+	// pages containing the updated roots. Both updated universes sit on
+	// the first page, so re-reading costs a single page refill.
+	updateItems := make([]*universe.Item, 2)
+	for i := range updateItems {
+		src := items[i+1]
+		leaf := randMintingLeaf(t, src.Leaf.Genesis, src.ID.GroupKey)
+		updateItems[i] = &universe.Item{
+			ID:   src.ID,
+			Key:  randLeafKey(t),
+			Leaf: &leaf,
+		}
+	}
+	require.NoError(t, multiverse.UpsertProofLeafBatch(ctx, updateItems))
+
+	before = misses()
+	roots = queryRoots(t, multiverse, pageSize)
+	require.Equal(t, before+2, misses())
+	requireSameRoots(t, freshView(), roots)
+
+	// A batch that contains at least one universe creation must
+	// invalidate all cached pages.
+	leaf := randMintingLeaf(
+		t, items[3].Leaf.Genesis, items[3].ID.GroupKey,
+	)
+	mixedBatch := []*universe.Item{
+		genRandomAsset(t),
+		{
+			ID:   items[3].ID,
+			Key:  randLeafKey(t),
+			Leaf: &leaf,
+		},
+	}
+	require.NoError(t, multiverse.UpsertProofLeafBatch(ctx, mixedBatch))
+
+	before = misses()
+	roots = queryRoots(t, multiverse, pageSize)
+	require.Equal(t, before+6, misses())
+	require.Len(t, roots, numAssets+2)
+	requireSameRoots(t, freshView(), roots)
+}
+
+// TestRootNodeCacheProperties is a model-based property test for the
+// targeted invalidation of the root node page cache. The model is a
+// database of universe roots in insertion (universe_roots.id) order. The
+// central invariant is that the cache never serves a stale page: any page
+// it returns must be identical to what a fresh database read would
+// produce. Additionally, pages handed out to readers must never be
+// mutated afterwards.
+func TestRootNodeCacheProperties(t *testing.T) {
+	t.Parallel()
+
+	rapid.Check(t, func(rt *rapid.T) {
+		cache := newRootNodeCache(10_000)
+
+		// db models the universe_roots table: roots in insertion
+		// order, with the invariant-relevant behavior that updates
+		// change a row's value but never its position, while
+		// creations append.
+		var db []universe.Root
+
+		// nonce makes generated identities and node values unique
+		// and deterministic, which keeps rapid's shrinking stable.
+		var nonce uint32
+		newNode := func() mssmt.Node {
+			nonce++
+			var hash mssmt.NodeHash
+			binary.BigEndian.PutUint32(hash[:4], nonce)
+
+			return mssmt.NewComputedBranch(hash, uint64(nonce))
+		}
+		newRoot := func() universe.Root {
+			nonce++
+			var id universe.Identifier
+			binary.BigEndian.PutUint32(id.AssetID[:4], nonce)
+			id.ProofType = universe.ProofTypeIssuance
+
+			return universe.Root{
+				ID:        id,
+				AssetName: fmt.Sprintf("asset-%d", nonce),
+				Node:      newNode(),
+			}
+		}
+
+		// pageFor computes the page a fresh database read would
+		// return for the given query.
+		pageFor := func(q universe.RootNodesQuery) []universe.Root {
+			ordered := slices.Clone(db)
+			if q.SortDirection == universe.SortDescending {
+				slices.Reverse(ordered)
+			}
+
+			start := int(q.Offset)
+			if start >= len(ordered) {
+				return nil
+			}
+			end := min(start+int(q.Limit), len(ordered))
+
+			return slices.Clone(ordered[start:end])
+		}
+
+		// tracked accumulates every query whose page was ever
+		// cached. The cache is free to no longer hold any of them
+		// (wipes and evictions are always allowed), but if it does
+		// serve a page for one, that page must be fresh.
+		tracked := make(map[rootPageQueryKey]universe.RootNodesQuery)
+
+		// handed retains pages previously returned by the cache
+		// together with a snapshot of their content, to assert that
+		// the cache never mutates a page it already handed out.
+		type handedPage struct {
+			live []universe.Root
+			snap []universe.Root
+		}
+		var handed []handedPage
+
+		drawQuery := func(rt *rapid.T) universe.RootNodesQuery {
+			return universe.RootNodesQuery{
+				WithAmountsById: rapid.Bool().Draw(
+					rt, "withAmounts",
+				),
+				SortDirection: rapid.SampledFrom(
+					[]universe.SortDirection{
+						universe.SortAscending,
+						universe.SortDescending,
+					},
+				).Draw(rt, "dir"),
+				Offset: rapid.Int32Range(
+					0, int32(len(db)-1),
+				).Draw(rt, "offset"),
+				Limit: rapid.Int32Range(1, 5).Draw(
+					rt, "limit",
+				),
+			}
+		}
+
+		rt.Repeat(map[string]func(*rapid.T){
+			// Cache a page, as the fill path in RootNodes does
+			// after a cache miss.
+			"fill": func(rt *rapid.T) {
+				if len(db) == 0 {
+					return
+				}
+
+				q := drawQuery(rt)
+				page := pageFor(q)
+				cache.cacheRoots(q, page)
+				tracked[newRootPageQuery(q)] = q
+			},
+
+			// Insert a leaf into an existing universe: its root
+			// changes value but keeps its position.
+			"update": func(rt *rapid.T) {
+				if len(db) == 0 {
+					return
+				}
+
+				idx := rapid.IntRange(0, len(db)-1).Draw(
+					rt, "target",
+				)
+				db[idx].Node = newNode()
+				cache.handleRootUpdate(
+					db[idx], universeRootUpdated,
+				)
+			},
+
+			// Insert the first leaf of a new universe: a new root
+			// appears and shifts the page composition.
+			"create": func(rt *rapid.T) {
+				root := newRoot()
+				db = append(db, root)
+				cache.handleRootUpdate(
+					root, universeRootCreated,
+				)
+			},
+
+			// Invariant check, run after every action: the cache
+			// may miss on any tracked query, but a page it does
+			// serve must match a fresh database read.
+			"": func(rt *rapid.T) {
+				for _, q := range tracked {
+					got := cache.fetchRoots(q, false)
+					if len(got) == 0 {
+						continue
+					}
+
+					requireSameRoots(rt, pageFor(q), got)
+
+					handed = append(handed, handedPage{
+						live: got,
+						snap: slices.Clone(got),
+					})
+				}
+
+				// Cap the retained pages to keep the check
+				// cheap.
+				if len(handed) > 50 {
+					handed = handed[len(handed)-50:]
+				}
+
+				for _, h := range handed {
+					requireSameRoots(rt, h.snap, h.live)
+				}
+			},
+		})
+	})
 }
 
 // TestMultiverseSyncerCache tests the syncer cache of the multiverse store.

--- a/tapdb/supply_tree.go
+++ b/tapdb/supply_tree.go
@@ -469,7 +469,7 @@ func registerMintSupplyInternal(ctx context.Context, dbTx BaseUniverseStore,
 			"to universe proof type: %w", err)
 	}
 
-	mintSupplyProof, err := universeUpsertProofLeaf(
+	mintSupplyProof, _, err := universeUpsertProofLeaf(
 		ctx, dbTx, subNs, uniProofType, groupKey,
 		key, leaf, metaReveal, blockHeight,
 	)

--- a/tapdb/universe.go
+++ b/tapdb/universe.go
@@ -765,7 +765,7 @@ func (b *BaseUniverseTree) UpsertProofLeaf(ctx context.Context,
 			return err
 		}
 
-		issuanceProof, err := universeUpsertProofLeaf(
+		issuanceProof, _, err := universeUpsertProofLeaf(
 			ctx, dbTx, namespace, b.id.ProofType,
 			b.id.GroupKey, key, leaf, metaReveal, blockHeight,
 		)
@@ -885,12 +885,33 @@ func upsertMultiverseLeafEntry(ctx context.Context, dbTx BaseUniverseStore,
 	return finalMultiverseRoot, multiverseInclusionProof, nil
 }
 
+// universeRootStatus indicates whether upserting a proof leaf into a
+// universe tree created that tree or updated an existing one. The distinction
+// drives cache invalidation: creating a universe changes which roots appear
+// on which page of paginated root queries, while an update only changes the
+// value of a single, already placed root.
+type universeRootStatus uint8
+
+const (
+	// universeRootCreated indicates that the upsert inserted the first
+	// leaf of the universe tree, creating it. This is deliberately the
+	// zero value, so that a status that was never explicitly set drives
+	// the safe, over-invalidating cache path (a full page cache wipe)
+	// rather than the targeted one.
+	universeRootCreated universeRootStatus = iota
+
+	// universeRootUpdated indicates that the universe tree already
+	// existed before the upsert.
+	universeRootUpdated
+)
+
 // universeUpsertProofLeaf upserts a proof leaf within the universe tree (stored
 // at the proof leaf key). It handles the insertion into the specific universe's
 // SMT and updates the relevant database tables for that universe.
 //
-// This function returns the inserted/updated proof leaf and the new universe
-// root. It does NOT insert into the top-level multiverse tree.
+// This function returns the inserted/updated proof leaf and whether the
+// upsert created the universe tree. It does NOT insert into the top-level
+// multiverse tree.
 //
 // NOTE: This function accepts a db transaction, as it's used when making
 // broader DB updates.
@@ -898,7 +919,8 @@ func universeUpsertProofLeaf(ctx context.Context, dbTx BaseUniverseStore,
 	namespace string, proofType universe.ProofType,
 	groupKey *btcec.PublicKey,
 	key universe.LeafKey, leaf *universe.Leaf, metaReveal *proof.MetaReveal,
-	blockHeight lfn.Option[uint32]) (*universe.Proof, error) {
+	blockHeight lfn.Option[uint32]) (*universe.Proof, universeRootStatus,
+	error) {
 
 	// With the tree store created, we'll now obtain byte representation of
 	// the minting key, as that'll be the key in the SMT itself.
@@ -913,9 +935,15 @@ func universeUpsertProofLeaf(ctx context.Context, dbTx BaseUniverseStore,
 		groupKeyBytes = schnorr.SerializePubKey(groupKey)
 	}
 
+	// rootStatus reports whether this upsert created the universe tree.
+	// The zero value is the safe, over-invalidating universeRootCreated,
+	// which is what all error returns below hand back; the status is
+	// only meaningful when the upsert succeeds.
+	var rootStatus universeRootStatus
+
 	mintingPointBytes, err := encodeOutpoint(key.LeafOutPoint())
 	if err != nil {
-		return nil, err
+		return nil, rootStatus, err
 	}
 
 	var (
@@ -929,11 +957,25 @@ func universeUpsertProofLeaf(ctx context.Context, dbTx BaseUniverseStore,
 		newTreeStoreWrapperTx(dbTx, namespace),
 	)
 
+	// Determine whether this upsert creates the universe tree, at the
+	// cost of one extra tree root read per upsert. An empty root is
+	// equivalent to the tree being absent: deleting the last leaf of a
+	// universe removes the whole tree (see
+	// MultiverseStore.DeleteProofLeaf), so an existing tree always has a
+	// non-empty root.
+	existingRoot, err := universeTree.Root(ctx)
+	if err != nil {
+		return nil, rootStatus, err
+	}
+	if existingRoot.NodeHash() != mssmt.EmptyTreeRootHash {
+		rootStatus = universeRootUpdated
+	}
+
 	// Now that we have a tree instance linked to this DB transaction, we'll
 	// insert the leaf into the tree based on its SMT key.
 	_, err = universeTree.Insert(ctx, smtKey, leafNode)
 	if err != nil {
-		return nil, err
+		return nil, rootStatus, err
 	}
 
 	// Next, we'll upsert the universe root in the DB, which gives us the
@@ -945,7 +987,7 @@ func universeUpsertProofLeaf(ctx context.Context, dbTx BaseUniverseStore,
 		ProofType:     sqlStr(proofType.String()),
 	})
 	if err != nil {
-		return nil, err
+		return nil, rootStatus, err
 	}
 
 	// Before we insert the asset genesis, we'll insert the meta first. The
@@ -953,13 +995,14 @@ func universeUpsertProofLeaf(ctx context.Context, dbTx BaseUniverseStore,
 	// meta blob on disk.
 	_, err = maybeUpsertAssetMeta(ctx, dbTx, &leaf.Genesis, metaReveal)
 	if err != nil {
-		return nil, err
+		return nil, rootStatus, err
 	}
 
 	var leafProof proof.Proof
 	err = leafProof.Decode(bytes.NewReader(leaf.RawProof))
 	if err != nil {
-		return nil, fmt.Errorf("unable to decode proof: %w", err)
+		return nil, rootStatus, fmt.Errorf("unable to decode proof: %w",
+			err)
 	}
 
 	// Upsert into the DB: the genesis point, asset genesis,
@@ -969,7 +1012,7 @@ func universeUpsertProofLeaf(ctx context.Context, dbTx BaseUniverseStore,
 		ctx, dbTx, leaf.Genesis, leaf.GroupKey, &leafProof,
 	)
 	if err != nil {
-		return nil, err
+		return nil, rootStatus, err
 	}
 
 	// If the asset group supports supply commitments and this is an
@@ -979,7 +1022,7 @@ func universeUpsertProofLeaf(ctx context.Context, dbTx BaseUniverseStore,
 		ctx, dbTx, proofType, leafProof, metaReveal,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("unable to upsert supply "+
+		return nil, rootStatus, fmt.Errorf("unable to upsert supply "+
 			"pre-commit: %w", err)
 	}
 
@@ -1010,21 +1053,21 @@ func universeUpsertProofLeaf(ctx context.Context, dbTx BaseUniverseStore,
 		BlockHeight:       sqlBlockHeight,
 	})
 	if err != nil {
-		return nil, err
+		return nil, rootStatus, err
 	}
 
 	// Finally, we'll obtain the merkle proof from the tree for the leaf we
 	// just inserted.
 	leafInclusionProof, err = universeTree.MerkleProof(ctx, smtKey)
 	if err != nil {
-		return nil, err
+		return nil, rootStatus, err
 	}
 
 	// With the insertion complete, we'll now fetch the root of the tree as
 	// it stands and return it to the caller.
 	universeRoot, err = universeTree.Root(ctx)
 	if err != nil {
-		return nil, err
+		return nil, rootStatus, err
 	}
 
 	// Return the proof containing only universe-level information.
@@ -1034,7 +1077,7 @@ func universeUpsertProofLeaf(ctx context.Context, dbTx BaseUniverseStore,
 		UniverseRoot:           universeRoot,
 		UniverseInclusionProof: leafInclusionProof,
 		Leaf:                   leaf,
-	}, nil
+	}, rootStatus, nil
 }
 
 // FetchProof retrieves a universe proof corresponding to the given key. If the


### PR DESCRIPTION
Previously, every proof leaf insert wiped the root node page cache across all universes, so any server ingesting proofs at a steady rate served AssetRoots pagination permanently cold; every page request fell through to the database.

The fix is targeted invalidation: inserting into an existing universe can't change which page its root appears on, so the insert now evicts only the cached pages containing that root, leaving the rest of the cache warm; only universe creation and deletion still wipe the cache. Eviction rather than patching keeps the cache coherent under concurrent inserts, since a refill always reads committed state. A property test pins the invariant that the cache may miss, but never serves a page that differs from a fresh database read.
