### PR TITLE
universe+tapdb: decode each ingested proof exactly once

### DIFF
--- a/tapdb/multiverse.go
+++ b/tapdb/multiverse.go
@@ -17,6 +17,7 @@ import (
 	"github.com/lightninglabs/taproot-assets/proof"
 	"github.com/lightninglabs/taproot-assets/tapdb/sqlc"
 	"github.com/lightninglabs/taproot-assets/universe"
+	lfn "github.com/lightningnetwork/lnd/fn/v2"
 )
 
 const (
@@ -802,16 +803,13 @@ func (b *MultiverseStore) UpsertProofLeaf(ctx context.Context,
 
 	execTxFunc := func(dbTx BaseMultiverseStore) error {
 		// Register issuance in the asset (group) specific universe
-		// tree. We don't need to decode the whole proof, we just
-		// need the block height.
-		blockHeight, err := SparseDecodeBlockHeight(leaf.RawProof)
-		if err != nil {
-			return err
-		}
-
+		// tree. The block height is extracted from the decoded proof
+		// by universeUpsertProofLeaf itself.
+		var err error
 		uniProof, rootStatus, err = universeUpsertProofLeaf(
 			ctx, dbTx, id.String(), id.ProofType,
-			id.GroupKey, key, leaf, metaReveal, blockHeight,
+			id.GroupKey, key, leaf, metaReveal,
+			lfn.None[uint32](),
 		)
 		if err != nil {
 			return fmt.Errorf("failed universe upsert: %w", err)
@@ -887,24 +885,17 @@ func (b *MultiverseStore) UpsertProofLeafBatch(ctx context.Context,
 			for idx := range items {
 				item := items[idx]
 
-				// We don't need to decode the whole proof, we
-				// just need the block height.
-				blockHeight, err := SparseDecodeBlockHeight(
-					item.Leaf.RawProof,
-				)
-				if err != nil {
-					return err
-				}
-
 				// Upsert into the specific universe tree to
-				// start with.
+				// start with. The block height is extracted
+				// from the decoded proof by
+				// universeUpsertProofLeaf itself.
 				uniProof, status, err :=
 					universeUpsertProofLeaf(
 						ctx, store, item.ID.String(),
 						item.ID.ProofType,
 						item.ID.GroupKey, item.Key,
 						item.Leaf, item.MetaReveal,
-						blockHeight,
+						lfn.None[uint32](),
 					)
 				if err != nil {
 					return fmt.Errorf("failed universe "+

--- a/tapdb/sqlutils.go
+++ b/tapdb/sqlutils.go
@@ -1,7 +1,6 @@
 package tapdb
 
 import (
-	"bytes"
 	"context"
 	"database/sql"
 	"encoding/binary"
@@ -15,9 +14,7 @@ import (
 	"github.com/btcsuite/btcd/wire/v2"
 	"github.com/lightninglabs/taproot-assets/fn"
 	"github.com/lightninglabs/taproot-assets/internal/test"
-	"github.com/lightninglabs/taproot-assets/proof"
 	"github.com/lightninglabs/taproot-assets/tapdb/sqlc"
-	lfn "github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/constraints"
 )
@@ -134,25 +131,6 @@ func sqlTime(t time.Time) sql.NullTime {
 		Time:  t,
 		Valid: true,
 	}
-}
-
-// SparseDecodeBlockHeight sparse decodes a proof to extract the block height.
-func SparseDecodeBlockHeight(rawProof []byte) (lfn.Option[uint32], error) {
-	var blockHeightVal uint32
-	err := proof.SparseDecode(
-		bytes.NewReader(rawProof),
-		proof.BlockHeightRecord(&blockHeightVal),
-	)
-	if err != nil {
-		return lfn.None[uint32](), fmt.Errorf("unable to "+
-			"sparse decode proof: %w", err)
-	}
-
-	if blockHeightVal == 0 {
-		return lfn.None[uint32](), nil
-	}
-
-	return lfn.Some(blockHeightVal), nil
 }
 
 // extractSqlInt64 turns a NullInt64 into a numerical type. This can be useful

--- a/tapdb/supply_tree.go
+++ b/tapdb/supply_tree.go
@@ -501,17 +501,12 @@ func (s *SupplyTreeStore) RegisterMintSupply(ctx context.Context,
 		newRootSupplyRoot mssmt.Node
 	)
 	dbErr := s.db.ExecTx(ctx, &writeTx, func(dbTx BaseUniverseStore) error {
-		// We don't need to decode the whole proof, we just need the
-		// block height.
-		blockHeight, err := SparseDecodeBlockHeight(leaf.RawProof)
-		if err != nil {
-			return err
-		}
-
 		// Upsert the leaf into the mint supply sub-tree SMT and DB
-		// first.
+		// first. The block height is extracted from the decoded proof
+		// by universeUpsertProofLeaf itself.
+		var err error
 		mintSupplyProof, err = registerMintSupplyInternal(
-			ctx, dbTx, spec, key, leaf, nil, blockHeight,
+			ctx, dbTx, spec, key, leaf, nil, lfn.None[uint32](),
 		)
 		if err != nil {
 			return fmt.Errorf("failed mint supply universe "+

--- a/tapdb/universe.go
+++ b/tapdb/universe.go
@@ -998,18 +998,19 @@ func universeUpsertProofLeaf(ctx context.Context, dbTx BaseUniverseStore,
 		return nil, rootStatus, err
 	}
 
-	var leafProof proof.Proof
-	err = leafProof.Decode(bytes.NewReader(leaf.RawProof))
+	// On the ingest path the archive has already decoded and memoized the
+	// proof, so this avoids re-decoding the raw blob inside the write
+	// transaction.
+	leafProof, err := leaf.DecodedProof()
 	if err != nil {
-		return nil, rootStatus, fmt.Errorf("unable to decode proof: %w",
-			err)
+		return nil, rootStatus, err
 	}
 
 	// Upsert into the DB: the genesis point, asset genesis,
 	// group key reveal, and the anchoring transaction for the issuance or
 	// transfer.
 	assetGenID, err := upsertAssetGen(
-		ctx, dbTx, leaf.Genesis, leaf.GroupKey, &leafProof,
+		ctx, dbTx, leaf.Genesis, leaf.GroupKey, leafProof,
 	)
 	if err != nil {
 		return nil, rootStatus, err
@@ -1019,7 +1020,7 @@ func universeUpsertProofLeaf(ctx context.Context, dbTx BaseUniverseStore,
 	// issuance proof, then we may need to log the supply pre-commitment
 	// output.
 	err = maybeUpsertSupplyPreCommit(
-		ctx, dbTx, proofType, leafProof, metaReveal,
+		ctx, dbTx, proofType, *leafProof, metaReveal,
 	)
 	if err != nil {
 		return nil, rootStatus, fmt.Errorf("unable to upsert supply "+

--- a/tapdb/universe.go
+++ b/tapdb/universe.go
@@ -758,16 +758,12 @@ func (b *BaseUniverseTree) UpsertProofLeaf(ctx context.Context,
 	dbErr := b.db.ExecTx(ctx, &writeTx, func(dbTx BaseUniverseStore) error {
 		namespace := b.id.String()
 
-		// We don't need to decode the whole proof, we just need the
-		// block height.
-		blockHeight, err := SparseDecodeBlockHeight(leaf.RawProof)
-		if err != nil {
-			return err
-		}
-
+		// The block height is extracted from the decoded proof by
+		// universeUpsertProofLeaf itself.
 		issuanceProof, _, err := universeUpsertProofLeaf(
 			ctx, dbTx, namespace, b.id.ProofType,
-			b.id.GroupKey, key, leaf, metaReveal, blockHeight,
+			b.id.GroupKey, key, leaf, metaReveal,
+			lfn.None[uint32](),
 		)
 		if err != nil {
 			return fmt.Errorf("failed universe upsert: %w", err)

--- a/universe/archive.go
+++ b/universe/archive.go
@@ -284,9 +284,11 @@ func (a *Archive) UpsertProofLeaf(ctx context.Context, id Identifier,
 		return nil, err
 	}
 
-	// We need to decode the new proof now.
-	var newProof proof.Proof
-	if err := newProof.Decode(bytes.NewReader(leaf.RawProof)); err != nil {
+	// We need to decode the new proof now. The result is memoized on the
+	// leaf, so the database layer below can reuse it instead of decoding
+	// the raw proof again inside the write transaction.
+	newProof, err := leaf.DecodedProof()
+	if err != nil {
 		return nil, err
 	}
 
@@ -338,7 +340,7 @@ func (a *Archive) UpsertProofLeaf(ctx context.Context, id Identifier,
 	}
 
 	assetSnapshot, err := a.verifyIssuanceProof(
-		ctx, id, key, &newProof, prevAssetSnapshot,
+		ctx, id, key, newProof, prevAssetSnapshot,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("unable to verify proof: %w", err)
@@ -458,7 +460,6 @@ func (a *Archive) UpsertProofLeafBatch(ctx context.Context,
 	// proper verification of re-issuances, which may be in this batch.
 	var anchorItems []*Item
 	nonAnchorItems := make([]*Item, 0, len(items))
-	assetProofs := make(map[LeafKey]*proof.Proof)
 	for ind := range items {
 		item := items[ind]
 
@@ -482,14 +483,13 @@ func (a *Archive) UpsertProofLeafBatch(ctx context.Context,
 		}
 
 		// At this point, we'll need to decode the proof so we can
-		// partition it below.
-		var assetProof proof.Proof
-		err = assetProof.Decode(bytes.NewReader(item.Leaf.RawProof))
+		// partition it below. The result is memoized on the leaf, so
+		// verification and the database layer can reuse it without
+		// decoding the raw proof again.
+		assetProof, err := item.Leaf.DecodedProof()
 		if err != nil {
 			return fmt.Errorf("unable to decode proof: %w", err)
 		}
-
-		assetProofs[item.Key] = &assetProof
 
 		// Any group anchor issuance proof must have a group key reveal
 		// attached, so that can be used to partition anchor assets and
@@ -518,10 +518,13 @@ func (a *Archive) UpsertProofLeafBatch(ctx context.Context,
 						"snapshot: %w", err)
 				}
 
-				assetProof, ok := assetProofs[i.Key]
-				if !ok {
-					return fmt.Errorf("missing proof "+
-						"for key=%v", i.Key)
+				// The decode was memoized when the items were
+				// partitioned above, so this is a pure cache
+				// read.
+				assetProof, err := i.Leaf.DecodedProof()
+				if err != nil {
+					return fmt.Errorf("unable to decode "+
+						"proof: %w", err)
 				}
 
 				assetSnapshot, err := a.verifyIssuanceProof(

--- a/universe/interface.go
+++ b/universe/interface.go
@@ -248,6 +248,31 @@ type Leaf struct {
 	// IsBurn is a boolean that indicates whether the leaf represents a burn
 	// or not.
 	IsBurn bool
+
+	// decodedProof is the memoized result of decoding RawProof. It is
+	// only ever populated by DecodedProof, which guarantees it always
+	// matches RawProof.
+	decodedProof *proof.Proof
+}
+
+// DecodedProof returns the decoded form of RawProof. The result is memoized,
+// so the raw proof is decoded at most once per leaf.
+//
+// NOTE: Memoization is not synchronized, so the first call must not race
+// with other calls on the same leaf.
+func (m *Leaf) DecodedProof() (*proof.Proof, error) {
+	if m.decodedProof != nil {
+		return m.decodedProof, nil
+	}
+
+	var p proof.Proof
+	if err := p.Decode(bytes.NewReader(m.RawProof)); err != nil {
+		return nil, fmt.Errorf("unable to decode proof: %w", err)
+	}
+
+	m.decodedProof = &p
+
+	return &p, nil
 }
 
 // SmtLeafNode returns the SMT leaf node for the given leaf.

--- a/universe/interface_test.go
+++ b/universe/interface_test.go
@@ -1,0 +1,119 @@
+package universe
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/lightninglabs/taproot-assets/asset"
+	"github.com/lightninglabs/taproot-assets/proof"
+	lfn "github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/lightningnetwork/lnd/lnutils"
+	"github.com/stretchr/testify/require"
+	"pgregory.net/rapid"
+)
+
+// randLeafProofGen generates an encodable proof with the optional TLV
+// surface (block height, meta reveal, challenge witness, genesis reveal,
+// alt leaves) varied by rapid draws.
+func randLeafProofGen(t *rapid.T) *proof.Proof {
+	proofAsset := asset.AssetGen.Draw(t, "asset")
+
+	sliceGen := rapid.SliceOfN(rapid.Byte(), 32, 32)
+	witnessData := sliceGen.Draw(t, "witness_data")
+	pkScript := sliceGen.Draw(t, "pk_script")
+
+	p := &proof.Proof{
+		PrevOut: wire.OutPoint{},
+		BlockHeader: wire.BlockHeader{
+			Timestamp: time.Unix(1e9, 0),
+		},
+		BlockHeight: rapid.Uint32().Draw(t, "block_height"),
+		AnchorTx: wire.MsgTx{
+			Version: 2,
+			TxIn: []*wire.TxIn{{
+				Witness: [][]byte{witnessData},
+			}},
+			TxOut: []*wire.TxOut{{
+				PkScript: pkScript,
+				Value:    1000,
+			}},
+		},
+		TxMerkleProof: proof.TxMerkleProof{},
+		Asset:         proofAsset,
+		InclusionProof: proof.TaprootProof{
+			InternalKey: asset.PubKeyGen.Draw(t, "internal_key"),
+		},
+	}
+
+	if rapid.Bool().Draw(t, "meta_reveal") {
+		p.MetaReveal = &proof.MetaReveal{
+			Type: proof.MetaOpaque,
+			Data: rapid.SliceOfN(
+				rapid.Byte(), 1, 32,
+			).Draw(t, "meta_data"),
+		}
+	}
+
+	if rapid.Bool().Draw(t, "challenge_witness") {
+		p.ChallengeWitness = wire.TxWitness{
+			rapid.SliceOfN(
+				rapid.Byte(), 1, 32,
+			).Draw(t, "challenge"),
+		}
+	}
+
+	if rapid.Bool().Draw(t, "genesis_reveal") {
+		p.GenesisReveal = &proofAsset.Genesis
+	}
+
+	if rapid.Bool().Draw(t, "alt_leaves") {
+		altAssets := rapid.SliceOfN[asset.Asset](
+			asset.AltLeafGen(t), 1, 5,
+		).Draw(t, "alt_assets")
+		p.AltLeaves = asset.ToAltLeaves(
+			lfn.Map(altAssets, lnutils.Ptr),
+		)
+	}
+
+	return p
+}
+
+// TestLeafDecodedProof asserts that DecodedProof agrees with a fresh decode
+// of RawProof for proofs across the encodable value space, and that the
+// decode is memoized.
+func TestLeafDecodedProof(t *testing.T) {
+	t.Parallel()
+
+	rapid.Check(t, func(t *rapid.T) {
+		p := randLeafProofGen(t)
+
+		var buf bytes.Buffer
+		require.NoError(t, p.Encode(&buf))
+
+		leaf := &Leaf{
+			GenesisWithGroup: GenesisWithGroup{
+				Genesis: p.Asset.Genesis,
+			},
+			RawProof: buf.Bytes(),
+			Asset:    &p.Asset,
+			Amt:      p.Asset.Amount,
+		}
+
+		var fresh proof.Proof
+		require.NoError(
+			t, fresh.Decode(bytes.NewReader(leaf.RawProof)),
+		)
+
+		decoded, err := leaf.DecodedProof()
+		require.NoError(t, err)
+		require.Equal(t, &fresh, decoded)
+
+		// The decode must be memoized: subsequent calls return the
+		// same object.
+		again, err := leaf.DecodedProof()
+		require.NoError(t, err)
+		require.Same(t, decoded, again)
+	})
+}


### PR DESCRIPTION
(N.b., I started this as a performance enhancement attempt, but it wound up being a simplification/hardening piece that seemed worth pulling in. Fable's summary follows.)

Previously, every proof accepted into the universe was decoded from its raw bytes multiple times on its way to disk: once at the archive boundary for verification, once again inside the database write transaction, and once more to extract the block height, with the batch path repeating the same pattern for every leaf.

The fix is to decode once and share the result: universe.Leaf gains a lazily-memoized DecodedProof accessor whose cache can only be populated by decoding the leaf's own RawProof, so the decoded and raw forms cannot diverge by construction. The archive decodes at entry and every layer below reuses the memo, which also makes the batch path's proof side-map and all sparse block-height decodes redundant; both are removed. A rapid property test pins the accessor's agreement with the codec.

This is primarily a simplification and lock-hygiene change — measured end-to-end ingest throughput is unchanged, as transaction cost is dominated elsewhere.