### PR TITLE
tapdb: parallelize universe proof ingest

### DIFF
--- a/cmd/tapd-integrated/main.go
+++ b/cmd/tapd-integrated/main.go
@@ -163,7 +163,19 @@ func run() error {
 	// Step 2: Wrap the shell in AuxComponents. These fn.Option[T] values
 	// point to the shell. Once ConfigureSubServer fills it in, the same
 	// pointer provides real behavior.
-	ctx := context.Background()
+	// A context that ends when the interceptor signals shutdown, so
+	// long-running startup work can be interrupted.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		select {
+		case <-interceptor.ShutdownChannel():
+			cancel()
+
+		case <-ctx.Done():
+		}
+	}()
+
 	auxComponents, cleanup, err := integration.BuildAuxComponents(
 		ctx, tapServer,
 	)
@@ -283,7 +295,7 @@ func run() error {
 	// integration, etc.
 	tapErrChan := make(chan error, 1)
 	err = tapcfg.ConfigureSubServer(
-		tapServer, cfg.TaprootAssets, tapdLog,
+		ctx, tapServer, cfg.TaprootAssets, tapdLog,
 		&lndServices.LndServices, true, tapErrChan,
 	)
 	if err != nil {

--- a/docs/release-notes/release-notes-0.8.2.md
+++ b/docs/release-notes/release-notes-0.8.2.md
@@ -45,11 +45,14 @@
 
 ## Performance Improvements
 
+- [PR#2183](https://github.com/lightninglabs/taproot-assets/pull/2183)
+  dramatically improves the performance of MS-SMT proof verification.
+
 - [PR#2184](https://github.com/lightninglabs/taproot-assets/pull/2184)
   dramatically improves the performance of universe federation proof push.
 
-- [PR#2183](https://github.com/lightninglabs/taproot-assets/pull/2183)
-  dramatically improves the performance of MS-SMT proof verification.
+- [PR#2194](https://github.com/lightninglabs/taproot-assets/pull/2194)
+  significantly improves concurrent universe proof ingest on Postgres.
 
 - [PR#2188](https://github.com/lightninglabs/taproot-assets/pull/2188)
   dramatically improves the performance of batched MS-SMT insertions.

--- a/mssmt/tree_prop_test.go
+++ b/mssmt/tree_prop_test.go
@@ -1,0 +1,99 @@
+package mssmt_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/lightninglabs/taproot-assets/mssmt"
+	"github.com/stretchr/testify/require"
+	"pgregory.net/rapid"
+)
+
+// testInsertLastWriteWins asserts that insertion is last-write-wins per
+// key: applying a sequence of inserts that reuses keys produces the
+// same tree as inserting only the final leaf observed for each key.
+// This is the invariant that allows coalescing consecutive updates to
+// the same key into a single insert of the latest value.
+func testInsertLastWriteWins(t *rapid.T) {
+	ctx := context.Background()
+
+	// Draw a small pool of keys so the insertion sequence is likely
+	// to hit the same key several times. Duplicate draws within the
+	// pool are harmless; they only shrink the effective pool.
+	numKeys := rapid.IntRange(1, 8).Draw(t, "num_keys")
+	keys := make([][hashSize]byte, numKeys)
+	for i := range keys {
+		keyBytes := rapid.SliceOfN(
+			rapid.Byte(), hashSize, hashSize,
+		).Draw(t, "key")
+		copy(keys[i][:], keyBytes)
+	}
+
+	// Draw the insertion sequence. Sums are bounded well below the
+	// point where the tree's uint64 sum overflow check could
+	// trigger.
+	numInserts := rapid.IntRange(1, 32).Draw(t, "num_inserts")
+	sequence := make([]treeLeaf, numInserts)
+	for i := range sequence {
+		keyIdx := rapid.IntRange(0, numKeys-1).Draw(t, "key_idx")
+		value := rapid.SliceOfN(rapid.Byte(), 1, 64).Draw(t, "value")
+		sum := rapid.Uint64Range(0, 1<<32).Draw(t, "sum")
+
+		sequence[i] = treeLeaf{
+			key:  keys[keyIdx],
+			leaf: mssmt.NewLeafNode(value, sum),
+		}
+	}
+
+	// Apply the full sequence in order.
+	full := mssmt.NewCompactedTree(mssmt.NewDefaultStore())
+	for _, item := range sequence {
+		_, err := full.Insert(ctx, item.key, item.leaf)
+		require.NoError(t, err)
+	}
+
+	// Reduce the sequence to the final leaf per key, keeping the
+	// order of each key's first occurrence, and apply only those.
+	finalLeaves := make(map[[hashSize]byte]*mssmt.LeafNode)
+	var keyOrder [][hashSize]byte
+	for _, item := range sequence {
+		if _, ok := finalLeaves[item.key]; !ok {
+			keyOrder = append(keyOrder, item.key)
+		}
+		finalLeaves[item.key] = item.leaf
+	}
+
+	coalesced := mssmt.NewCompactedTree(mssmt.NewDefaultStore())
+	for _, key := range keyOrder {
+		_, err := coalesced.Insert(ctx, key, finalLeaves[key])
+		require.NoError(t, err)
+	}
+
+	fullRoot, err := full.Root(ctx)
+	require.NoError(t, err)
+	coalescedRoot, err := coalesced.Root(ctx)
+	require.NoError(t, err)
+
+	require.True(
+		t, mssmt.IsEqualNode(fullRoot, coalescedRoot),
+		"full root %v != coalesced root %v", fullRoot, coalescedRoot,
+	)
+
+	// Each key's final leaf must carry a valid inclusion proof in
+	// the fully-inserted tree.
+	for _, key := range keyOrder {
+		proof, err := full.MerkleProof(ctx, key)
+		require.NoError(t, err)
+		require.True(t, mssmt.VerifyMerkleProof(
+			key, finalLeaves[key], proof, fullRoot,
+		))
+	}
+}
+
+// TestInsertLastWriteWins runs the last-write-wins insertion property
+// against the compacted tree.
+func TestInsertLastWriteWins(t *testing.T) {
+	t.Parallel()
+
+	rapid.Check(t, testInsertLastWriteWins)
+}

--- a/rpcserver/rpcserver.go
+++ b/rpcserver/rpcserver.go
@@ -7659,6 +7659,18 @@ func (r *RPCServer) QueryProof(ctx context.Context,
 
 	firstProof, err := r.queryProof(ctx, universeID, leafKey)
 	if err != nil {
+		// Transient contention on the universe — concurrent inserts
+		// holding the read-inconsistency window open — is reported
+		// as Unavailable, so sync clients know to simply retry
+		// rather than treating the proof as unservable.
+		if errors.Is(err, tapdb.ErrMultiverseInconsistent) {
+			return nil, status.Errorf(codes.Unavailable,
+				"universe %v busy, retry query "+
+					"(leaf_key=%x): %v",
+				universeID.StringForLog(),
+				leafKey.UniverseKey(), err)
+		}
+
 		return nil, fmt.Errorf("query proof "+
 			"(uni=%v, leaf_key=%x): %w",
 			universeID.StringForLog(),

--- a/server.go
+++ b/server.go
@@ -900,6 +900,12 @@ func (s *Server) Stop() error {
 		}
 	}
 
+	// Every subsystem that writes universe proofs has stopped, so wind
+	// down the multiverse store's background flusher. Any multiverse
+	// update it abandons is repaired by startup reconciliation on the
+	// next run.
+	s.cfg.DatabaseConfig.Multiverse.Stop()
+
 	close(s.quit)
 
 	s.wg.Wait()

--- a/tapcfg/server.go
+++ b/tapcfg/server.go
@@ -196,6 +196,15 @@ func genServerConfig(cfg *Config, cfgLogger btclog.Logger,
 		return nil, fmt.Errorf("create multiverse store: %w", err)
 	}
 
+	// The multiverse trees are derived from the universe roots; repair any
+	// entries that diverged, for example because the daemon stopped
+	// between a proof insert committing and its multiverse update being
+	// written.
+	err = multiverse.ReconcileMultiverse(context.Background())
+	if err != nil {
+		return nil, fmt.Errorf("reconcile multiverse: %w", err)
+	}
+
 	uniStatsDB := tapdb.NewTransactionExecutor(
 		db, func(tx *sql.Tx) tapdb.UniverseStatsStore {
 			return db.WithTx(tx)

--- a/tapcfg/server.go
+++ b/tapcfg/server.go
@@ -45,8 +45,9 @@ import (
 //
 // NOTE: The RPCConfig and SignalInterceptor fields must be set by the caller
 // after generating the server config.
-func genServerConfig(cfg *Config, cfgLogger btclog.Logger,
-	lndServices *lndclient.LndServices, enableChannelFeatures bool,
+func genServerConfig(ctx context.Context, cfg *Config,
+	cfgLogger btclog.Logger, lndServices *lndclient.LndServices,
+	enableChannelFeatures bool,
 	mainErrChan chan<- error) (*tapconfig.Config, error) {
 
 	var (
@@ -194,6 +195,16 @@ func genServerConfig(cfg *Config, cfgLogger btclog.Logger,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("create multiverse store: %w", err)
+	}
+
+	// The multiverse trees are derived from the universe roots; repair any
+	// entries that diverged, for example because the daemon stopped
+	// between a proof insert committing and its multiverse update being
+	// written. The context is shutdown-derived, so an operator can
+	// interrupt a long-running reconcile.
+	err = multiverse.ReconcileMultiverse(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("reconcile multiverse: %w", err)
 	}
 
 	uniStatsDB := tapdb.NewTransactionExecutor(
@@ -946,9 +957,23 @@ func CreateServerFromConfig(cfg *Config, cfgLogger btclog.Logger,
 
 	cfgLogger.Infof("lnd connection initialized")
 
+	// Derive a context that ends when the interceptor signals
+	// shutdown, so long-running startup work — the multiverse
+	// reconcile in particular — can be interrupted.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		select {
+		case <-shutdownInterceptor.ShutdownChannel():
+			cancel()
+
+		case <-ctx.Done():
+		}
+	}()
+
 	serverCfg, err := genServerConfig(
-		cfg, cfgLogger, &lndConn.LndServices, enableChannelFeatures,
-		mainErrChan,
+		ctx, cfg, cfgLogger, &lndConn.LndServices,
+		enableChannelFeatures, mainErrChan,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("unable to generate server config: %w",
@@ -1052,12 +1077,15 @@ func mboxOutpointChecker(
 }
 
 // ConfigureSubServer updates a Taproot Asset server with the given CLI config.
-func ConfigureSubServer(srv *tap.Server, cfg *Config, cfgLogger btclog.Logger,
-	lndServices *lndclient.LndServices, litdIntegrated bool,
-	mainErrChan chan<- error) error {
+// The context bounds the startup work done here, the multiverse
+// reconcile in particular, and should be derived from the daemon's
+// shutdown signal.
+func ConfigureSubServer(ctx context.Context, srv *tap.Server, cfg *Config,
+	cfgLogger btclog.Logger, lndServices *lndclient.LndServices,
+	litdIntegrated bool, mainErrChan chan<- error) error {
 
 	serverCfg, err := genServerConfig(
-		cfg, cfgLogger, lndServices, litdIntegrated, mainErrChan,
+		ctx, cfg, cfgLogger, lndServices, litdIntegrated, mainErrChan,
 	)
 	if err != nil {
 		return fmt.Errorf("unable to generate server config: %w", err)

--- a/tapdb/interfaces.go
+++ b/tapdb/interfaces.go
@@ -322,13 +322,30 @@ type BaseDB struct {
 	*sqlc.Queries
 }
 
+// TxIsolationOverrider is an optional interface that TxOptions can implement
+// to override the default serializable isolation level a transaction is
+// started with. The override is only honored on the Postgres backend;
+// SQLite's driver only supports its default isolation.
+type TxIsolationOverrider interface {
+	// TxIsolation returns the isolation level to start the transaction
+	// with.
+	TxIsolation() sql.IsolationLevel
+}
+
 // BeginTx wraps the normal sql specific BeginTx method with the TxOptions
 // interface. This interface is then mapped to the concrete sql tx options
 // struct.
 func (s *BaseDB) BeginTx(ctx context.Context, opts TxOptions) (*sql.Tx, error) {
+	isolation := sql.LevelSerializable
+	if o, ok := opts.(TxIsolationOverrider); ok &&
+		s.Backend() == sqlc.BackendTypePostgres {
+
+		isolation = o.TxIsolation()
+	}
+
 	sqlOptions := sql.TxOptions{
 		ReadOnly:  opts.ReadOnly(),
-		Isolation: sql.LevelSerializable,
+		Isolation: isolation,
 	}
 	return s.DB.BeginTx(ctx, &sqlOptions)
 }

--- a/tapdb/multiverse.go
+++ b/tapdb/multiverse.go
@@ -701,7 +701,9 @@ func (b *MultiverseStore) FetchProofLeaf(ctx context.Context,
 			return proofs, nil
 		}
 
-		_, err = b.rootCoalescer.updateRoot(ctx, id)
+		err = b.rootCoalescer.updateRoots(
+			ctx, []universe.Identifier{id},
+		)
 		if err != nil {
 			return nil, fmt.Errorf("failed multiverse heal "+
 				"for %v: %w", id.String(), err)
@@ -1001,6 +1003,12 @@ func (b *MultiverseStore) UpsertProofLeaf(ctx context.Context,
 
 // UpsertProofLeafBatch upserts a proof leaf batch within the multiverse tree
 // and the universe tree that corresponds to the given key(s).
+//
+// The universe leaves commit first, in their own transaction, and the
+// shared multiverse tree is updated afterwards. An error return may
+// therefore mean the leaves are durably stored while the multiverse
+// update failed; in that case each universe's multiverse entry is
+// healed by its next successful update.
 func (b *MultiverseStore) UpsertProofLeafBatch(ctx context.Context,
 	items []*universe.Item) error {
 
@@ -1009,13 +1017,10 @@ func (b *MultiverseStore) UpsertProofLeafBatch(ctx context.Context,
 		uniProofs    []*universe.Proof
 		rootStatuses []universeRootStatus
 	)
-	// Track the final universe root per universe, so the shared
-	// multiverse tree is updated once per universe with its latest root,
-	// rather than once per item.
-	type multiverseUpdate struct {
-		id   universe.Identifier
-		root mssmt.Node
-	}
+	// Track the universes the batch touches, in first-touch order, so
+	// the shared multiverse tree is refreshed once per universe rather
+	// than once per item.
+	var dirtyUniverses []universe.Identifier
 
 	dbErr := b.db.ExecTx(
 		ctx, &writeTx, func(store BaseMultiverseStore) error {
@@ -1024,11 +1029,10 @@ func (b *MultiverseStore) UpsertProofLeafBatch(ctx context.Context,
 				[]universeRootStatus, len(items),
 			)
 
-			finalRoots := make(
-				map[universeIDKey]*multiverseUpdate,
-				len(items),
+			dirtyUniverses = make(
+				[]universe.Identifier, 0, len(items),
 			)
-			var updateOrder []universeIDKey
+			seen := make(map[universeIDKey]struct{}, len(items))
 
 			for idx := range items {
 				item := items[idx]
@@ -1054,25 +1058,11 @@ func (b *MultiverseStore) UpsertProofLeafBatch(ctx context.Context,
 				rootStatuses[idx] = status
 
 				key := item.ID.String()
-				if _, ok := finalRoots[key]; !ok {
-					updateOrder = append(updateOrder, key)
-				}
-				finalRoots[key] = &multiverseUpdate{
-					id:   item.ID,
-					root: uniProof.UniverseRoot,
-				}
-			}
-
-			// Next, we'll insert each universe's final root into
-			// the main multiverse tree.
-			for _, key := range updateOrder {
-				update := finalRoots[key]
-				err := upsertMultiverseLeafEntry(
-					ctx, store, update.id, update.root,
-				)
-				if err != nil {
-					return fmt.Errorf("failed multiverse "+
-						"upsert for %v: %w", key, err)
+				if _, ok := seen[key]; !ok {
+					seen[key] = struct{}{}
+					dirtyUniverses = append(
+						dirtyUniverses, item.ID,
+					)
 				}
 			}
 
@@ -1083,6 +1073,11 @@ func (b *MultiverseStore) UpsertProofLeafBatch(ctx context.Context,
 		return dbErr
 	}
 
+	// The universe leaves are now durably committed, so run the
+	// bookkeeping tied to that commit before the multiverse update: a
+	// failed or slow multiverse flush must not leave caches stale or
+	// keep the custodian from learning about stored transfer proofs.
+	//
 	// If any of the inserted leaves created a new universe, the
 	// composition of paginated root queries changed and the page cache as
 	// a whole is stale. Pure updates only change the value of already
@@ -1105,14 +1100,16 @@ func (b *MultiverseStore) UpsertProofLeafBatch(ctx context.Context,
 			)
 		}
 
+		// The syncer cache is deliberately not updated here: it
+		// installs values rather than evicting them, and the
+		// unordered post-commit sections of concurrent inserts
+		// could install roots out of commit order. It is fed from
+		// the coalescer's flush callback instead.
 		newRoots[idx] = universe.Root{
 			ID:        items[idx].ID,
 			AssetName: items[idx].Leaf.Asset.Tag,
 			Node:      uniProofs[idx].UniverseRoot,
 		}
-
-		// Update the syncer cache with the new root node.
-		b.syncerCache.addOrReplace(newRoots[idx])
 	}
 
 	// Evict the cached pages that contain any of the updated roots. If
@@ -1138,6 +1135,19 @@ func (b *MultiverseStore) UpsertProofLeafBatch(ctx context.Context,
 
 		b.leafKeysCache.wipeCache(idStr)
 		b.proofCache.RemoveUniverseProofs(items[idx].ID)
+	}
+
+	// Finally, reflect each universe's new root in the shared
+	// multiverse tree, through the root coalescer rather than the
+	// transaction above: the multiverse rows are contended by every
+	// insert into every universe, so writing them under the batch's
+	// own transaction would collide with concurrent inserts. If this
+	// fails, the universe leaves above remain committed, and each
+	// universe's multiverse entry is healed by its next successful
+	// update.
+	err := b.rootCoalescer.updateRoots(ctx, dirtyUniverses)
+	if err != nil {
+		return fmt.Errorf("failed multiverse upsert: %w", err)
 	}
 
 	return nil

--- a/tapdb/multiverse.go
+++ b/tapdb/multiverse.go
@@ -34,6 +34,14 @@ var (
 	// ErrNoMultiverseRoot is returned when no universe root is found for
 	// the target proof type.
 	ErrNoMultiverseRoot = errors.New("no multiverse root found")
+
+	// ErrMultiverseInconsistent is returned when a fetched multiverse
+	// proof repeatedly fails to commit to the universe root fetched
+	// in the same snapshot, even after awaiting multiverse flushes of
+	// the universe.
+	ErrMultiverseInconsistent = errors.New(
+		"multiverse proof inconsistent with universe root",
+	)
 )
 
 type (
@@ -664,15 +672,85 @@ func (b *MultiverseStore) FetchProofLeaf(ctx context.Context,
 		return proofsFromCache, nil
 	}
 
-	var (
-		readTx = NewBaseUniverseReadTx()
-		proofs []*universe.Proof
-	)
-
 	multiverseNS, err := namespaceForProof(id.ProofType)
 	if err != nil {
 		return nil, err
 	}
+
+	// A universe insert commits before its multiverse update is
+	// flushed, so a snapshot taken in that window legitimately holds
+	// the new universe root next to a stale (or missing) multiverse
+	// leaf, and proofs assembled from it would not compose. On
+	// detecting that, wait for a multiverse flush of this universe to
+	// commit — outside the read transaction, whose snapshot would
+	// never observe it — and read again from a fresh snapshot.
+	const maxFetchAttempts = 3
+	for attempt := 0; attempt < maxFetchAttempts; attempt++ {
+		proofs, err := b.fetchProofLeafSnapshot(
+			ctx, id, universeKey, multiverseNS,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		if multiverseProofsConsistent(id, proofs) {
+			// Insert the proofs we just read up into the main
+			// cache. Only consistent proofs are ever cached.
+			b.proofCache.insertProofs(id, universeKey, proofs)
+
+			return proofs, nil
+		}
+
+		_, err = b.rootCoalescer.updateRoot(ctx, id)
+		if err != nil {
+			return nil, fmt.Errorf("failed multiverse heal "+
+				"for %v: %w", id.String(), err)
+		}
+	}
+
+	return nil, fmt.Errorf("%w: universe %v", ErrMultiverseInconsistent,
+		id.String())
+}
+
+// multiverseProofsConsistent reports whether the multiverse proof
+// attached to each of the given fetched proofs commits to the universe
+// root fetched in the same snapshot.
+func multiverseProofsConsistent(id universe.Identifier,
+	proofs []*universe.Proof) bool {
+
+	for _, p := range proofs {
+		// Proof types without a multiverse tree carry no
+		// multiverse proof; there is nothing to compose.
+		if p.MultiverseRoot == nil ||
+			p.MultiverseInclusionProof == nil {
+
+			continue
+		}
+
+		leaf := multiverseLeafNode(id, p.UniverseRoot)
+		valid := mssmt.VerifyMerkleProof(
+			id.Bytes(), leaf, p.MultiverseInclusionProof,
+			p.MultiverseRoot,
+		)
+		if !valid {
+			return false
+		}
+	}
+
+	return true
+}
+
+// fetchProofLeafSnapshot reads the proofs for the given key, along with
+// the multiverse root and inclusion proof for the universe, from a
+// single database snapshot.
+func (b *MultiverseStore) fetchProofLeafSnapshot(ctx context.Context,
+	id universe.Identifier, universeKey universe.LeafKey,
+	multiverseNS string) ([]*universe.Proof, error) {
+
+	var (
+		readTx = NewBaseUniverseReadTx()
+		proofs []*universe.Proof
+	)
 
 	dbErr := b.db.ExecTx(ctx, &readTx, func(tx BaseMultiverseStore) error {
 		var err error
@@ -727,9 +805,6 @@ func (b *MultiverseStore) FetchProofLeaf(ctx context.Context,
 	if dbErr != nil {
 		return nil, dbErr
 	}
-
-	// Insert the proofs we just read up into the main cache.
-	b.proofCache.insertProofs(id, universeKey, proofs)
 
 	return proofs, nil
 }
@@ -810,16 +885,26 @@ func (b *MultiverseStore) FetchProof(ctx context.Context,
 
 // UpsertProofLeaf upserts a proof leaf within the multiverse tree and the
 // universe tree that corresponds to the given key.
+//
+// The universe leaf commits first, in its own transaction, and the
+// shared multiverse tree is updated afterwards. An error return may
+// therefore mean the leaf is durably stored while the multiverse
+// update failed; in that case the universe's multiverse entry is
+// healed by its next successful update.
+//
+// The returned proof always composes: its multiverse proof commits to
+// its universe root. If a concurrent insert into the same universe
+// superseded this one before the multiverse update was flushed, the
+// receipt is rebuilt from the newer state, so its universe root may be
+// fresher than the root this call's own transaction committed.
 func (b *MultiverseStore) UpsertProofLeaf(ctx context.Context,
 	id universe.Identifier, key universe.LeafKey, leaf *universe.Leaf,
 	metaReveal *proof.MetaReveal) (*universe.Proof, error) {
 
 	var (
-		writeTx         BaseMultiverseOptions
-		uniProof        *universe.Proof
-		rootStatus      universeRootStatus
-		multiverseRoot  mssmt.Node
-		multiverseProof *mssmt.Proof
+		writeTx    BaseMultiverseOptions
+		uniProof   *universe.Proof
+		rootStatus universeRootStatus
 	)
 
 	execTxFunc := func(dbTx BaseMultiverseStore) error {
@@ -836,23 +921,6 @@ func (b *MultiverseStore) UpsertProofLeaf(ctx context.Context,
 			return fmt.Errorf("failed universe upsert: %w", err)
 		}
 
-		// Now, attempt to insert the universe root into the main
-		// multiverse tree.
-		err = upsertMultiverseLeafEntry(
-			ctx, dbTx, id, uniProof.UniverseRoot,
-		)
-		if err != nil {
-			return fmt.Errorf("failed multiverse upsert: %w", err)
-		}
-
-		multiverseRoot, multiverseProof, err = multiverseRootAndProof(
-			ctx, dbTx, id,
-		)
-		if err != nil {
-			return fmt.Errorf("failed multiverse root fetch: %w",
-				err)
-		}
-
 		return nil
 	}
 	dbErr := b.db.ExecTx(ctx, &writeTx, execTxFunc)
@@ -860,18 +928,21 @@ func (b *MultiverseStore) UpsertProofLeaf(ctx context.Context,
 		return nil, dbErr
 	}
 
-	// Populate the multiverse fields in the proof object now that the
-	// transaction is complete.
-	uniProof.MultiverseRoot = multiverseRoot
-	uniProof.MultiverseInclusionProof = multiverseProof
-
-	// The transaction is committed, so invalidate the affected caches.
+	// The universe leaf is now durably committed, so run the
+	// bookkeeping tied to that commit before the multiverse update: a
+	// failed or slow multiverse flush must not leave caches stale or
+	// keep the custodian from learning about a stored transfer proof.
+	//
 	// The root node page cache is wiped if the upsert created the
 	// universe, and only has the pages containing the universe's root
 	// evicted otherwise. Every previously cached proof under this
 	// universe embeds the UniverseRoot at the time it was fetched;
 	// inserting a new leaf changes the root, so all of the universe's
-	// proofs and leaf keys are evicted, not just the one we wrote.
+	// proofs and leaf keys are evicted, not just the one we wrote. The
+	// syncer cache is deliberately absent here: it installs values
+	// rather than evicting them, and the unordered post-commit
+	// sections of concurrent inserts could install roots out of commit
+	// order. It is fed from the coalescer's flush callback instead.
 	newRoot := universe.Root{
 		ID:        id,
 		AssetName: leaf.Asset.Tag,
@@ -880,7 +951,6 @@ func (b *MultiverseStore) UpsertProofLeaf(ctx context.Context,
 	b.rootNodeCache.handleRootUpdate(newRoot, rootStatus)
 	b.proofCache.RemoveUniverseProofs(id)
 	b.leafKeysCache.wipeCache(id.String())
-	b.syncerCache.addOrReplace(newRoot)
 
 	// Notify subscribers about the new proof leaf, now that we're sure we
 	// have written it to the database. But we only care about transfer
@@ -889,6 +959,42 @@ func (b *MultiverseStore) UpsertProofLeaf(ctx context.Context,
 	if id.ProofType == universe.ProofTypeTransfer {
 		b.transferProofDistributor.NotifySubscribers(leaf.RawProof)
 	}
+
+	// Now reflect the universe's new root in the shared multiverse tree,
+	// through the root coalescer rather than the transaction above: the
+	// multiverse rows are contended by every insert into every universe,
+	// so writing them under the insert's own transaction would serialize
+	// ingest across universes. If this fails, the universe leaf above
+	// remains committed, and the universe's multiverse entry is healed by
+	// its next successful update.
+	update, err := b.rootCoalescer.updateRoot(ctx, id)
+	if err != nil {
+		return nil, fmt.Errorf("failed multiverse upsert: %w", err)
+	}
+
+	// If a concurrent insert into the same universe committed between
+	// our transaction and the flush, the flush derived and committed
+	// the newer root, and the multiverse proof it returned does not
+	// compose with the universe proof assembled above. Rebuild the
+	// whole receipt from one consistent snapshot instead.
+	if !mssmt.IsEqualNode(update.universeRoot, uniProof.UniverseRoot) {
+		proofs, err := b.FetchProofLeaf(ctx, id, key)
+		if err != nil {
+			return nil, fmt.Errorf("failed superseded proof "+
+				"fetch: %w", err)
+		}
+		if len(proofs) != 1 {
+			return nil, fmt.Errorf("expected one proof for "+
+				"superseded upsert, got %d", len(proofs))
+		}
+
+		return proofs[0], nil
+	}
+
+	// Populate the multiverse fields in the proof object now that the
+	// update is complete.
+	uniProof.MultiverseRoot = update.multiverseRoot
+	uniProof.MultiverseInclusionProof = update.inclusionProof
 
 	return uniProof, nil
 }

--- a/tapdb/multiverse.go
+++ b/tapdb/multiverse.go
@@ -817,13 +817,19 @@ func (b *MultiverseStore) UpsertProofLeaf(ctx context.Context,
 
 		// Now, attempt to insert the universe root into the main
 		// multiverse tree.
-		//
-		// nolint:lll
-		multiverseRoot, multiverseProof, err = upsertMultiverseLeafEntry(
+		err = upsertMultiverseLeafEntry(
 			ctx, dbTx, id, uniProof.UniverseRoot,
 		)
 		if err != nil {
 			return fmt.Errorf("failed multiverse upsert: %w", err)
+		}
+
+		multiverseRoot, multiverseProof, err = multiverseRootAndProof(
+			ctx, dbTx, id,
+		)
+		if err != nil {
+			return fmt.Errorf("failed multiverse root fetch: %w",
+				err)
 		}
 
 		return nil
@@ -876,12 +882,27 @@ func (b *MultiverseStore) UpsertProofLeafBatch(ctx context.Context,
 		uniProofs    []*universe.Proof
 		rootStatuses []universeRootStatus
 	)
+	// Track the final universe root per universe, so the shared
+	// multiverse tree is updated once per universe with its latest root,
+	// rather than once per item.
+	type multiverseUpdate struct {
+		id   universe.Identifier
+		root mssmt.Node
+	}
+
 	dbErr := b.db.ExecTx(
 		ctx, &writeTx, func(store BaseMultiverseStore) error {
 			uniProofs = make([]*universe.Proof, len(items))
 			rootStatuses = make(
 				[]universeRootStatus, len(items),
 			)
+
+			finalRoots := make(
+				map[universeIDKey]*multiverseUpdate,
+				len(items),
+			)
+			var updateOrder []universeIDKey
+
 			for idx := range items {
 				item := items[idx]
 
@@ -905,24 +926,27 @@ func (b *MultiverseStore) UpsertProofLeafBatch(ctx context.Context,
 				uniProofs[idx] = uniProof
 				rootStatuses[idx] = status
 
-				// Next we'll, attempt to insert the universe
-				// root into the main multiverse tree.
-				//
-				//nolint:lll
-				multiRoot, multiProof, err := upsertMultiverseLeafEntry(
-					ctx, store, item.ID,
-					uniProof.UniverseRoot,
+				key := item.ID.String()
+				if _, ok := finalRoots[key]; !ok {
+					updateOrder = append(updateOrder, key)
+				}
+				finalRoots[key] = &multiverseUpdate{
+					id:   item.ID,
+					root: uniProof.UniverseRoot,
+				}
+			}
+
+			// Next, we'll insert each universe's final root into
+			// the main multiverse tree.
+			for _, key := range updateOrder {
+				update := finalRoots[key]
+				err := upsertMultiverseLeafEntry(
+					ctx, store, update.id, update.root,
 				)
 				if err != nil {
 					return fmt.Errorf("failed multiverse "+
-						"upsert for item %d: %w",
-						idx, err)
+						"upsert for %v: %w", key, err)
 				}
-
-				// Update the proof object with multiverse
-				// details.
-				uniProofs[idx].MultiverseRoot = multiRoot
-				uniProofs[idx].MultiverseInclusionProof = multiProof //nolint:lll
 			}
 
 			return nil
@@ -1080,7 +1104,7 @@ func (b *MultiverseStore) DeleteProofLeaf(ctx context.Context,
 
 			// Otherwise, update the multiverse entry with the
 			// new universe root.
-			_, _, err = upsertMultiverseLeafEntry(
+			err = upsertMultiverseLeafEntry(
 				ctx, tx, id, newRoot,
 			)
 			if err != nil {

--- a/tapdb/multiverse.go
+++ b/tapdb/multiverse.go
@@ -134,6 +134,11 @@ type MultiverseStore struct {
 
 	leafKeysCache *universeLeafPageCache
 
+	// rootCoalescer batches all writes to the shared multiverse
+	// trees, so proof insert transactions never touch rows that are
+	// contended across universes.
+	rootCoalescer *multiverseRootCoalescer
+
 	// transferProofDistributor is an event distributor that will be used to
 	// notify subscribers about new proof leaves that are added to the
 	// multiverse. This is used to notify the custodian about new incoming
@@ -151,7 +156,7 @@ func NewMultiverseStore(db BatchedMultiverse,
 		return nil, fmt.Errorf("parse max proof cache size: %w", err)
 	}
 
-	return &MultiverseStore{
+	store := &MultiverseStore{
 		db:  db,
 		cfg: cfg,
 		syncerCache: newSyncerRootNodeCache(
@@ -167,7 +172,22 @@ func NewMultiverseStore(db BatchedMultiverse,
 			cfg.Caches.LeavesPerUniverse,
 		),
 		transferProofDistributor: fn.NewEventDistributor[proof.Blob](),
-	}, nil
+	}
+	store.rootCoalescer = newMultiverseRootCoalescer(db)
+
+	// Install flushed roots into the syncer cache from the flush
+	// callback: flushes run one at a time and derive the current
+	// root, so installs done here arrive in commit order per
+	// universe and can never regress a cached root, unlike installs
+	// from the unordered post-commit sections of concurrent inserts.
+	store.rootCoalescer.onRefresh = store.syncerCache.addOrReplace
+
+	// A failed flush never reports its universes through onRefresh,
+	// so their cached roots would stay stale until their universes
+	// are written again. Rebuild the cache from the database instead.
+	store.rootCoalescer.onFlushError = store.syncerCache.invalidate
+
+	return store, nil
 }
 
 // namespaceForProof returns the multiverse namespace used for the given proof
@@ -269,9 +289,9 @@ func (b *MultiverseStore) UniverseRootNode(ctx context.Context,
 		return *rootNode, nil
 	}
 
-	// If the cache is still empty, we'll populate it now, given it is
-	// enabled.
-	if b.syncerCache.isEmpty() && b.cfg.Caches.SyncerCacheEnabled {
+	// If the cache hasn't been filled yet, we'll populate it now,
+	// given it is enabled.
+	if b.syncerCache.needsFill() && b.cfg.Caches.SyncerCacheEnabled {
 		// We attempt to acquire the write lock to fill the cache. If
 		// another goroutine is already filling the cache, we'll wait
 		// for it to finish that way.
@@ -404,8 +424,9 @@ func (b *MultiverseStore) RootNodes(ctx context.Context,
 			return rootNodes, nil
 		}
 
-		// If the cache is still empty, we'll populate it now.
-		if b.syncerCache.isEmpty() {
+		// If the cache hasn't been filled yet, we'll populate it
+		// now.
+		if b.syncerCache.needsFill() {
 			// We attempt to acquire the write lock to fill the
 			// cache. If another goroutine is already filling the
 			// cache, we'll wait for it to finish that way.

--- a/tapdb/multiverse.go
+++ b/tapdb/multiverse.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"sync"
 	"time"
 
 	"github.com/btcsuite/btcd/btcec/v2"
@@ -152,6 +153,14 @@ type MultiverseStore struct {
 	// to defaultReconcileBatchSize and is only overridden in tests.
 	reconcileBatchSize int
 
+	// multiverseWriteMu serializes all multiverse writes in this
+	// process: the coalescer's flushes and the deletion paths. This
+	// mutual exclusion is what makes it safe for flushes to run
+	// below serializable isolation. The lock is in-process only, so
+	// this assumes exactly one tapd process writes to the database;
+	// a second process would be an unsynchronized multiverse writer.
+	multiverseWriteMu sync.Mutex
+
 	// transferProofDistributor is an event distributor that will be used to
 	// notify subscribers about new proof leaves that are added to the
 	// multiverse. This is used to notify the custodian about new incoming
@@ -187,7 +196,9 @@ func NewMultiverseStore(db BatchedMultiverse,
 		transferProofDistributor: fn.NewEventDistributor[proof.Blob](),
 		reconcileBatchSize:       defaultReconcileBatchSize,
 	}
-	store.rootCoalescer = newMultiverseRootCoalescer(db)
+	store.rootCoalescer = newMultiverseRootCoalescer(
+		db, &store.multiverseWriteMu,
+	)
 
 	// Install flushed roots into the syncer cache from the flush
 	// callback: flushes run one at a time and derive the current
@@ -1167,6 +1178,12 @@ func (b *MultiverseStore) DeleteUniverse(ctx context.Context,
 
 	var writeTx BaseUniverseStoreOptions
 
+	// Deleting touches the shared multiverse tree, so take the
+	// multiverse write lock to stay mutually exclusive with the root
+	// coalescer's flushes.
+	b.multiverseWriteMu.Lock()
+	defer b.multiverseWriteMu.Unlock()
+
 	dbErr := b.db.ExecTx(ctx, &writeTx, func(tx BaseMultiverseStore) error {
 		multiverseNS, err := namespaceForProof(id.ProofType)
 		if err != nil {
@@ -1207,6 +1224,12 @@ func (b *MultiverseStore) DeleteProofLeaf(ctx context.Context,
 	key universe.LeafKey) (string, error) {
 
 	var writeTx BaseMultiverseOptions
+
+	// Deleting touches the shared multiverse tree, so take the
+	// multiverse write lock to stay mutually exclusive with the root
+	// coalescer's flushes.
+	b.multiverseWriteMu.Lock()
+	defer b.multiverseWriteMu.Unlock()
 
 	dbErr := b.db.ExecTx(
 		ctx, &writeTx, func(tx BaseMultiverseStore) error {

--- a/tapdb/multiverse.go
+++ b/tapdb/multiverse.go
@@ -147,6 +147,11 @@ type MultiverseStore struct {
 	// contended across universes.
 	rootCoalescer *multiverseRootCoalescer
 
+	// reconcileBatchSize is the number of universes repaired per
+	// coalescer submission during startup reconciliation. It defaults
+	// to defaultReconcileBatchSize and is only overridden in tests.
+	reconcileBatchSize int
+
 	// transferProofDistributor is an event distributor that will be used to
 	// notify subscribers about new proof leaves that are added to the
 	// multiverse. This is used to notify the custodian about new incoming
@@ -180,6 +185,7 @@ func NewMultiverseStore(db BatchedMultiverse,
 			cfg.Caches.LeavesPerUniverse,
 		),
 		transferProofDistributor: fn.NewEventDistributor[proof.Blob](),
+		reconcileBatchSize:       defaultReconcileBatchSize,
 	}
 	store.rootCoalescer = newMultiverseRootCoalescer(db)
 
@@ -892,7 +898,8 @@ func (b *MultiverseStore) FetchProof(ctx context.Context,
 // shared multiverse tree is updated afterwards. An error return may
 // therefore mean the leaf is durably stored while the multiverse
 // update failed; in that case the universe's multiverse entry is
-// healed by its next successful update.
+// healed by its next successful update, or by ReconcileMultiverse at
+// the next startup.
 //
 // The returned proof always composes: its multiverse proof commits to
 // its universe root. If a concurrent insert into the same universe
@@ -1008,7 +1015,8 @@ func (b *MultiverseStore) UpsertProofLeaf(ctx context.Context,
 // shared multiverse tree is updated afterwards. An error return may
 // therefore mean the leaves are durably stored while the multiverse
 // update failed; in that case each universe's multiverse entry is
-// healed by its next successful update.
+// healed by its next successful update, or by ReconcileMultiverse at
+// the next startup.
 func (b *MultiverseStore) UpsertProofLeafBatch(ctx context.Context,
 	items []*universe.Item) error {
 

--- a/tapdb/multiverse.go
+++ b/tapdb/multiverse.go
@@ -734,10 +734,26 @@ func (b *MultiverseStore) FetchProofLeaf(ctx context.Context,
 	id universe.Identifier,
 	universeKey universe.LeafKey) ([]*universe.Proof, error) {
 
-	// First, check the cached to see if we already have this proof.
-	proofsFromCache := b.proofCache.fetchProof(id, universeKey)
-	if len(proofsFromCache) > 0 {
-		return proofsFromCache, nil
+	return b.fetchProofLeaf(ctx, id, universeKey, false)
+}
+
+// fetchProofLeaf implements FetchProofLeaf. With skipCache set, the
+// proof cache is not consulted and the proofs are read from a fresh
+// database snapshot; a consistent result is still installed into the
+// cache. Callers that must observe their own committed writes — the
+// superseded-receipt rebuild — need the bypass, because a concurrent
+// reader may legitimately repopulate the cache from a snapshot
+// predating those writes.
+func (b *MultiverseStore) fetchProofLeaf(ctx context.Context,
+	id universe.Identifier, universeKey universe.LeafKey,
+	skipCache bool) ([]*universe.Proof, error) {
+
+	// First, check the cache to see if we already have this proof.
+	if !skipCache {
+		proofsFromCache := b.proofCache.fetchProof(id, universeKey)
+		if len(proofsFromCache) > 0 {
+			return proofsFromCache, nil
+		}
 	}
 
 	multiverseNS, err := namespaceForProof(id.ProofType)
@@ -1061,9 +1077,13 @@ func (b *MultiverseStore) UpsertProofLeaf(ctx context.Context,
 	// our transaction and the flush, the flush derived and committed
 	// the newer root, and the multiverse proof it returned does not
 	// compose with the universe proof assembled above. Rebuild the
-	// whole receipt from one consistent snapshot instead.
+	// whole receipt from one consistent snapshot instead, bypassing
+	// the proof cache: a concurrent reader may have repopulated it,
+	// after the eviction above, from a snapshot predating this call's
+	// own insert, and that receipt would not reflect the leaf this
+	// call committed.
 	if !mssmt.IsEqualNode(update.universeRoot, uniProof.UniverseRoot) {
-		proofs, err := b.FetchProofLeaf(ctx, id, key)
+		proofs, err := b.fetchProofLeaf(ctx, id, key, true)
 		if err != nil {
 			return nil, fmt.Errorf("failed superseded proof "+
 				"fetch: %w", err)

--- a/tapdb/multiverse.go
+++ b/tapdb/multiverse.go
@@ -73,6 +73,14 @@ type BaseMultiverseStore interface {
 	UniverseRoots(ctx context.Context,
 		params UniverseRootsParams) ([]BaseUniverseRoot, error)
 
+	// UniverseRootsAfterID returns a page of universe roots ordered
+	// by their table id, starting after the given id. Unlike the
+	// offset pagination of UniverseRoots, this keyset form costs the
+	// same for every page.
+	UniverseRootsAfterID(ctx context.Context,
+		arg sqlc.UniverseRootsAfterIDParams) (
+		[]sqlc.UniverseRootsAfterIDRow, error)
+
 	// QueryMultiverseLeaves is used to query for the set of leaves that
 	// reside in a multiverse tree.
 	QueryMultiverseLeaves(ctx context.Context,
@@ -147,6 +155,16 @@ type MultiverseStore struct {
 	// contended across universes.
 	rootCoalescer *multiverseRootCoalescer
 
+	// reconcileBatchSize is the number of universes repaired per
+	// coalescer submission during startup reconciliation. It defaults
+	// to defaultReconcileBatchSize and is only overridden in tests.
+	reconcileBatchSize int
+
+	// reconcilePageSize is the number of universe roots the
+	// reconciliation divergence scan reads per page. It defaults to
+	// universe.RequestPageSize and is only overridden in tests.
+	reconcilePageSize int32
+
 	// transferProofDistributor is an event distributor that will be used to
 	// notify subscribers about new proof leaves that are added to the
 	// multiverse. This is used to notify the custodian about new incoming
@@ -180,6 +198,8 @@ func NewMultiverseStore(db BatchedMultiverse,
 			cfg.Caches.LeavesPerUniverse,
 		),
 		transferProofDistributor: fn.NewEventDistributor[proof.Blob](),
+		reconcileBatchSize:       defaultReconcileBatchSize,
+		reconcilePageSize:        universe.RequestPageSize,
 	}
 	store.rootCoalescer = newMultiverseRootCoalescer(db)
 
@@ -892,7 +912,8 @@ func (b *MultiverseStore) FetchProof(ctx context.Context,
 // shared multiverse tree is updated afterwards. An error return may
 // therefore mean the leaf is durably stored while the multiverse
 // update failed; in that case the universe's multiverse entry is
-// healed by its next successful update.
+// healed by its next successful update, or by ReconcileMultiverse at
+// the next startup.
 //
 // The returned proof always composes: its multiverse proof commits to
 // its universe root. If a concurrent insert into the same universe
@@ -1008,7 +1029,8 @@ func (b *MultiverseStore) UpsertProofLeaf(ctx context.Context,
 // shared multiverse tree is updated afterwards. An error return may
 // therefore mean the leaves are durably stored while the multiverse
 // update failed; in that case each universe's multiverse entry is
-// healed by its next successful update.
+// healed by its next successful update, or by ReconcileMultiverse at
+// the next startup.
 func (b *MultiverseStore) UpsertProofLeafBatch(ctx context.Context,
 	items []*universe.Item) error {
 

--- a/tapdb/multiverse.go
+++ b/tapdb/multiverse.go
@@ -1321,7 +1321,15 @@ func (b *MultiverseStore) DeleteProofLeaf(ctx context.Context,
 	b.rootNodeCache.wipeCache()
 	b.proofCache.RemoveUniverseProofs(id)
 	b.leafKeysCache.wipeCache(id.String())
-	b.syncerCache.remove(id.Key())
+
+	// The universe may or may not have survived the deletion: if the
+	// deleted leaf was its last, the whole universe was cleaned up,
+	// otherwise it lives on under a new root. Removing its syncer
+	// cache entry unconditionally would make a surviving universe
+	// invisible to syncers, so invalidate the cache wholesale and let
+	// the next syncer query repopulate it from post-deletion state.
+	// Deletions are rare enough that the refill cost is irrelevant.
+	b.syncerCache.invalidate()
 
 	return id.String(), nil
 }

--- a/tapdb/multiverse.go
+++ b/tapdb/multiverse.go
@@ -360,29 +360,16 @@ func (b *MultiverseStore) UniverseRootNode(ctx context.Context,
 	// root node, as that shouldn't happen (unless the cache is empty).
 	// This will always return nil if the cache is disabled, so we don't
 	// need an extra indentation for that check here.
-	rootNode := b.syncerCache.fetchRoot(id, false)
+	rootNode := b.syncerCache.fetchRoot(id)
 	if rootNode != nil {
 		return *rootNode, nil
 	}
 
 	// If the cache hasn't been filled yet, we'll populate it now,
-	// given it is enabled.
+	// given it is enabled. Fills are serialized internally, and the
+	// filler holds no cache lock across its database reads, so
+	// concurrent cache maintenance never stalls behind this.
 	if b.syncerCache.needsFill() && b.cfg.Caches.SyncerCacheEnabled {
-		// We attempt to acquire the write lock to fill the cache. If
-		// another goroutine is already filling the cache, we'll wait
-		// for it to finish that way.
-		b.syncerCache.Lock()
-		defer b.syncerCache.Unlock()
-
-		// Because another goroutine might have filled the cache while
-		// we were waiting for the lock, we'll check again if the item
-		// is now in the cache.
-		rootNode = b.syncerCache.fetchRoot(id, true)
-		if rootNode != nil {
-			return *rootNode, nil
-		}
-
-		// Populate the cache with all the root nodes.
 		err := b.fillSyncerCache(ctx)
 		if err != nil {
 			return universe.Root{}, fmt.Errorf("error filling "+
@@ -390,14 +377,14 @@ func (b *MultiverseStore) UniverseRootNode(ctx context.Context,
 		}
 
 		// We now try again to fetch the root node from the cache.
-		rootNode = b.syncerCache.fetchRoot(id, true)
+		rootNode = b.syncerCache.fetchRoot(id)
 		if rootNode != nil {
 			return *rootNode, nil
 		}
 
-		// Still no luck with the cache (this should really never
-		// happen), so we'll go to the secondary cache or the disk to
-		// fetch it.
+		// Still no luck with the cache (a discarded fill, or a
+		// universe unknown to the database), so we'll go to the
+		// secondary cache or the disk to fetch it.
 		log.Warnf("Fetching root node from disk for id %v, cache miss "+
 			"even after filling the cache", id)
 	}
@@ -495,29 +482,16 @@ func (b *MultiverseStore) RootNodes(ctx context.Context,
 	if isQueryForSyncerCache(q) && b.cfg.Caches.SyncerCacheEnabled {
 		// First, check to see if we have the root nodes cached in the
 		// syncer cache.
-		rootNodes, emptyPage := b.syncerCache.fetchRoots(q, false)
+		rootNodes, emptyPage := b.syncerCache.fetchRoots(q)
 		if len(rootNodes) > 0 || emptyPage {
 			return rootNodes, nil
 		}
 
 		// If the cache hasn't been filled yet, we'll populate it
-		// now.
+		// now. Fills are serialized internally, and the filler holds
+		// no cache lock across its database reads, so concurrent
+		// cache maintenance never stalls behind this.
 		if b.syncerCache.needsFill() {
-			// We attempt to acquire the write lock to fill the
-			// cache. If another goroutine is already filling the
-			// cache, we'll wait for it to finish that way.
-			b.syncerCache.Lock()
-			defer b.syncerCache.Unlock()
-
-			// Because another goroutine might have filled the cache
-			// while we were waiting for the lock, we'll check again
-			// if the item is now in the cache.
-			rootNodes, emptyPage = b.syncerCache.fetchRoots(q, true)
-			if len(rootNodes) > 0 || emptyPage {
-				return rootNodes, nil
-			}
-
-			// Populate the cache with all the root nodes.
 			err := b.fillSyncerCache(ctx)
 			if err != nil {
 				return nil, fmt.Errorf("error filling syncer "+
@@ -526,14 +500,14 @@ func (b *MultiverseStore) RootNodes(ctx context.Context,
 
 			// We now try again to fetch the root nodes page from
 			// the cache.
-			rootNodes, emptyPage = b.syncerCache.fetchRoots(q, true)
+			rootNodes, emptyPage = b.syncerCache.fetchRoots(q)
 			if len(rootNodes) > 0 || emptyPage {
 				return rootNodes, nil
 			}
 
-			// Still no luck with the cache (this should really
-			// never happen), so we'll go to the secondary cache or
-			// disk to fetch it.
+			// Still no luck with the cache (a discarded fill, or
+			// a page past the end), so we'll go to the secondary
+			// cache or disk to fetch it.
 			log.Warnf("Fetching root nodes page from disk for "+
 				"query %v, cache miss even after filling the "+
 				"cache", q)
@@ -690,10 +664,26 @@ func (b *MultiverseStore) queryRootNodes(ctx context.Context,
 // currently known. This is used to quickly serve the syncer with the root nodes
 // it needs to sync the multiverse.
 //
-// NOTE: This method must be called while holding the syncer cache lock.
+// Concurrent fillers are serialized: the first performs the paginated
+// database read and the rest wait for it, then return without reading
+// again. The cache's own lock is never held across the reads —
+// incremental maintenance arriving from the coalescer's flush
+// callbacks or the deletion paths while the fill runs is buffered by
+// the cache and replayed onto the snapshot when it is installed.
 func (b *MultiverseStore) fillSyncerCache(ctx context.Context) error {
+	b.syncerCache.fillMu.Lock()
+	defer b.syncerCache.fillMu.Unlock()
+
+	// Whoever held the fill lock before us may have completed the
+	// fill already.
+	if !b.syncerCache.needsFill() {
+		return nil
+	}
+
 	now := time.Now()
 	log.Infof("Populating syncer root cache...")
+
+	gen := b.syncerCache.beginFill()
 
 	params := sqlc.UniverseRootsParams{
 		SortDirection: sqlInt16(universe.SortAscending),
@@ -707,6 +697,7 @@ func (b *MultiverseStore) fillSyncerCache(ctx context.Context) error {
 	for {
 		newRoots, err := b.queryRootNodes(ctx, params, false)
 		if err != nil {
+			b.syncerCache.abortFill()
 			return err
 		}
 
@@ -718,10 +709,18 @@ func (b *MultiverseStore) fillSyncerCache(ctx context.Context) error {
 		}
 	}
 
+	if !b.syncerCache.completeFill(gen, allRoots) {
+		// The cache was invalidated while the fill read: the
+		// snapshot's pages may straddle the invalidating event, so
+		// it was discarded. The next syncer query starts afresh.
+		log.Debugf("Syncer cache fill discarded after concurrent " +
+			"invalidation")
+
+		return nil
+	}
+
 	log.Debugf("Populating %v root nodes into syncer cache, took=%v",
 		len(allRoots), time.Since(now))
-
-	b.syncerCache.replaceCache(allRoots)
 
 	return nil
 }

--- a/tapdb/multiverse.go
+++ b/tapdb/multiverse.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"sync"
 	"time"
 
 	"github.com/btcsuite/btcd/btcec/v2"
@@ -165,6 +166,16 @@ type MultiverseStore struct {
 	// universe.RequestPageSize and is only overridden in tests.
 	reconcilePageSize int32
 
+	// multiverseWriteMu serializes all multiverse writes in this
+	// process: the coalescer's flushes and the deletion paths. It
+	// keeps the post-commit cache maintenance of those writers in
+	// commit order, and keeps their transactions from aborting each
+	// other under serializable isolation. It is not what makes
+	// concurrent multiverse writes safe: that is the database's
+	// serializable isolation, which also covers writers outside this
+	// process, such as a second tapd sharing the database.
+	multiverseWriteMu sync.Mutex
+
 	// transferProofDistributor is an event distributor that will be used to
 	// notify subscribers about new proof leaves that are added to the
 	// multiverse. This is used to notify the custodian about new incoming
@@ -201,7 +212,9 @@ func NewMultiverseStore(db BatchedMultiverse,
 		reconcileBatchSize:       defaultReconcileBatchSize,
 		reconcilePageSize:        universe.RequestPageSize,
 	}
-	store.rootCoalescer = newMultiverseRootCoalescer(db)
+	store.rootCoalescer = newMultiverseRootCoalescer(
+		db, &store.multiverseWriteMu,
+	)
 
 	// Install flushed roots into the syncer cache from the flush
 	// callback: flushes run one at a time and derive the current
@@ -216,6 +229,15 @@ func NewMultiverseStore(db BatchedMultiverse,
 	store.rootCoalescer.onFlushError = store.syncerCache.invalidate
 
 	return store, nil
+}
+
+// Stop winds down the store's background multiverse flusher. A flush
+// transaction already in flight completes or fails on its own; callers
+// still awaiting a flush receive an error. Universe leaves already
+// committed stay durable, and multiverse updates abandoned here are
+// repaired by ReconcileMultiverse at the next startup.
+func (b *MultiverseStore) Stop() {
+	b.rootCoalescer.stop()
 }
 
 // namespaceForProof returns the multiverse namespace used for the given proof
@@ -909,11 +931,12 @@ func (b *MultiverseStore) FetchProof(ctx context.Context,
 // universe tree that corresponds to the given key.
 //
 // The universe leaf commits first, in its own transaction, and the
-// shared multiverse tree is updated afterwards. An error return may
-// therefore mean the leaf is durably stored while the multiverse
-// update failed; in that case the universe's multiverse entry is
-// healed by its next successful update, or by ReconcileMultiverse at
-// the next startup.
+// shared multiverse tree is updated afterwards. An error wrapping
+// universe.ErrMultiversePending therefore means the leaf is durably
+// stored while its multiverse update is still outstanding; the
+// coalescer retries the update in the background until it commits,
+// and ReconcileMultiverse repairs any update abandoned by a shutdown
+// at the next startup.
 //
 // The returned proof always composes: its multiverse proof commits to
 // its universe root. If a concurrent insert into the same universe
@@ -988,8 +1011,8 @@ func (b *MultiverseStore) UpsertProofLeaf(ctx context.Context,
 	// multiverse rows are contended by every insert into every universe,
 	// so writing them under the insert's own transaction would serialize
 	// ingest across universes. If this fails, the universe leaf above
-	// remains committed, and the universe's multiverse entry is healed by
-	// its next successful update.
+	// remains committed, and the coalescer keeps retrying the multiverse
+	// update in the background.
 	update, err := b.rootCoalescer.updateRoot(ctx, id)
 	if err != nil {
 		return nil, fmt.Errorf("failed multiverse upsert: %w", err)
@@ -1026,11 +1049,12 @@ func (b *MultiverseStore) UpsertProofLeaf(ctx context.Context,
 // and the universe tree that corresponds to the given key(s).
 //
 // The universe leaves commit first, in their own transaction, and the
-// shared multiverse tree is updated afterwards. An error return may
-// therefore mean the leaves are durably stored while the multiverse
-// update failed; in that case each universe's multiverse entry is
-// healed by its next successful update, or by ReconcileMultiverse at
-// the next startup.
+// shared multiverse tree is updated afterwards. An error wrapping
+// universe.ErrMultiversePending therefore means the leaves are durably
+// stored while their multiverse updates are still outstanding; the
+// coalescer retries the updates in the background until they commit,
+// and ReconcileMultiverse repairs any update abandoned by a shutdown
+// at the next startup.
 func (b *MultiverseStore) UpsertProofLeafBatch(ctx context.Context,
 	items []*universe.Item) error {
 
@@ -1164,9 +1188,9 @@ func (b *MultiverseStore) UpsertProofLeafBatch(ctx context.Context,
 	// transaction above: the multiverse rows are contended by every
 	// insert into every universe, so writing them under the batch's
 	// own transaction would collide with concurrent inserts. If this
-	// fails, the universe leaves above remain committed, and each
-	// universe's multiverse entry is healed by its next successful
-	// update.
+	// fails, the universe leaves above remain committed, and the
+	// coalescer keeps retrying the multiverse updates in the
+	// background.
 	err := b.rootCoalescer.updateRoots(ctx, dirtyUniverses)
 	if err != nil {
 		return fmt.Errorf("failed multiverse upsert: %w", err)
@@ -1180,6 +1204,12 @@ func (b *MultiverseStore) DeleteUniverse(ctx context.Context,
 	id universe.Identifier) (string, error) {
 
 	var writeTx BaseUniverseStoreOptions
+
+	// Deleting touches the shared multiverse tree, so take the
+	// multiverse write lock to stay mutually exclusive with the root
+	// coalescer's flushes.
+	b.multiverseWriteMu.Lock()
+	defer b.multiverseWriteMu.Unlock()
 
 	dbErr := b.db.ExecTx(ctx, &writeTx, func(tx BaseMultiverseStore) error {
 		multiverseNS, err := namespaceForProof(id.ProofType)
@@ -1221,6 +1251,12 @@ func (b *MultiverseStore) DeleteProofLeaf(ctx context.Context,
 	key universe.LeafKey) (string, error) {
 
 	var writeTx BaseMultiverseOptions
+
+	// Deleting touches the shared multiverse tree, so take the
+	// multiverse write lock to stay mutually exclusive with the root
+	// coalescer's flushes.
+	b.multiverseWriteMu.Lock()
+	defer b.multiverseWriteMu.Unlock()
 
 	dbErr := b.db.ExecTx(
 		ctx, &writeTx, func(tx BaseMultiverseStore) error {

--- a/tapdb/multiverse.go
+++ b/tapdb/multiverse.go
@@ -39,10 +39,30 @@ var (
 	// ErrMultiverseInconsistent is returned when a fetched multiverse
 	// proof repeatedly fails to commit to the universe root fetched
 	// in the same snapshot, even after awaiting multiverse flushes of
-	// the universe.
+	// the universe. It marks transient contention — concurrent
+	// inserts into the universe holding the inconsistency window open
+	// — not corruption: the fetch is retryable, and the RPC layer
+	// maps this error to a transient status rather than a permanent
+	// failure.
 	ErrMultiverseInconsistent = errors.New(
 		"multiverse proof inconsistent with universe root",
 	)
+)
+
+const (
+	// maxFetchAttempts bounds the number of snapshot reads a proof
+	// fetch performs before reporting the universe as transiently
+	// inconsistent.
+	maxFetchAttempts = 5
+
+	// fetchRetryInitialBackoff is the delay before the second proof
+	// fetch attempt. It doubles per attempt, up to
+	// fetchRetryMaxBackoff.
+	fetchRetryInitialBackoff = 20 * time.Millisecond
+
+	// fetchRetryMaxBackoff caps the backoff between proof fetch
+	// attempts.
+	fetchRetryMaxBackoff = 250 * time.Millisecond
 )
 
 type (
@@ -161,6 +181,11 @@ type MultiverseStore struct {
 	// to defaultReconcileBatchSize and is only overridden in tests.
 	reconcileBatchSize int
 
+	// fetchRetryBackoff is the delay before the second proof fetch
+	// attempt on an inconsistent snapshot. It defaults to
+	// fetchRetryInitialBackoff and is only overridden in tests.
+	fetchRetryBackoff time.Duration
+
 	// reconcilePageSize is the number of universe roots the
 	// reconciliation divergence scan reads per page. It defaults to
 	// universe.RequestPageSize and is only overridden in tests.
@@ -211,6 +236,7 @@ func NewMultiverseStore(db BatchedMultiverse,
 		transferProofDistributor: fn.NewEventDistributor[proof.Blob](),
 		reconcileBatchSize:       defaultReconcileBatchSize,
 		reconcilePageSize:        universe.RequestPageSize,
+		fetchRetryBackoff:        fetchRetryInitialBackoff,
 	}
 	store.rootCoalescer = newMultiverseRootCoalescer(
 		db, &store.multiverseWriteMu,
@@ -725,9 +751,22 @@ func (b *MultiverseStore) FetchProofLeaf(ctx context.Context,
 	// leaf, and proofs assembled from it would not compose. On
 	// detecting that, wait for a multiverse flush of this universe to
 	// commit — outside the read transaction, whose snapshot would
-	// never observe it — and read again from a fresh snapshot.
-	const maxFetchAttempts = 3
+	// never observe it — and read again from a fresh snapshot. Under
+	// sustained same-universe ingest each healed snapshot can race the
+	// next insert, so retry with backoff, checking the caller's
+	// context between attempts, and report exhaustion with a typed,
+	// retryable error rather than looping indefinitely.
+	backoff := b.fetchRetryBackoff
 	for attempt := 0; attempt < maxFetchAttempts; attempt++ {
+		if attempt > 0 {
+			select {
+			case <-time.After(backoff):
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+			backoff = min(2*backoff, fetchRetryMaxBackoff)
+		}
+
 		proofs, err := b.fetchProofLeafSnapshot(
 			ctx, id, universeKey, multiverseNS,
 		)

--- a/tapdb/multiverse.go
+++ b/tapdb/multiverse.go
@@ -34,6 +34,14 @@ var (
 	// ErrNoMultiverseRoot is returned when no universe root is found for
 	// the target proof type.
 	ErrNoMultiverseRoot = errors.New("no multiverse root found")
+
+	// ErrMultiverseInconsistent is returned when a fetched multiverse
+	// proof repeatedly fails to commit to the universe root fetched
+	// in the same snapshot, even after awaiting multiverse flushes of
+	// the universe.
+	ErrMultiverseInconsistent = errors.New(
+		"multiverse proof inconsistent with universe root",
+	)
 )
 
 type (
@@ -664,15 +672,87 @@ func (b *MultiverseStore) FetchProofLeaf(ctx context.Context,
 		return proofsFromCache, nil
 	}
 
-	var (
-		readTx = NewBaseUniverseReadTx()
-		proofs []*universe.Proof
-	)
-
 	multiverseNS, err := namespaceForProof(id.ProofType)
 	if err != nil {
 		return nil, err
 	}
+
+	// A universe insert commits before its multiverse update is
+	// flushed, so a snapshot taken in that window legitimately holds
+	// the new universe root next to a stale (or missing) multiverse
+	// leaf, and proofs assembled from it would not compose. On
+	// detecting that, wait for a multiverse flush of this universe to
+	// commit — outside the read transaction, whose snapshot would
+	// never observe it — and read again from a fresh snapshot.
+	const maxFetchAttempts = 3
+	for attempt := 0; attempt < maxFetchAttempts; attempt++ {
+		proofs, err := b.fetchProofLeafSnapshot(
+			ctx, id, universeKey, multiverseNS,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		if multiverseProofsConsistent(id, proofs) {
+			// Insert the proofs we just read up into the main
+			// cache. Only consistent proofs are ever cached.
+			b.proofCache.insertProofs(id, universeKey, proofs)
+
+			return proofs, nil
+		}
+
+		err = b.rootCoalescer.updateRoots(
+			ctx, []universe.Identifier{id},
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed multiverse heal "+
+				"for %v: %w", id.String(), err)
+		}
+	}
+
+	return nil, fmt.Errorf("%w: universe %v", ErrMultiverseInconsistent,
+		id.String())
+}
+
+// multiverseProofsConsistent reports whether the multiverse proof
+// attached to each of the given fetched proofs commits to the universe
+// root fetched in the same snapshot.
+func multiverseProofsConsistent(id universe.Identifier,
+	proofs []*universe.Proof) bool {
+
+	for _, p := range proofs {
+		// Proof types without a multiverse tree carry no
+		// multiverse proof; there is nothing to compose.
+		if p.MultiverseRoot == nil ||
+			p.MultiverseInclusionProof == nil {
+
+			continue
+		}
+
+		leaf := multiverseLeafNode(id, p.UniverseRoot)
+		valid := mssmt.VerifyMerkleProof(
+			id.Bytes(), leaf, p.MultiverseInclusionProof,
+			p.MultiverseRoot,
+		)
+		if !valid {
+			return false
+		}
+	}
+
+	return true
+}
+
+// fetchProofLeafSnapshot reads the proofs for the given key, along with
+// the multiverse root and inclusion proof for the universe, from a
+// single database snapshot.
+func (b *MultiverseStore) fetchProofLeafSnapshot(ctx context.Context,
+	id universe.Identifier, universeKey universe.LeafKey,
+	multiverseNS string) ([]*universe.Proof, error) {
+
+	var (
+		readTx = NewBaseUniverseReadTx()
+		proofs []*universe.Proof
+	)
 
 	dbErr := b.db.ExecTx(ctx, &readTx, func(tx BaseMultiverseStore) error {
 		var err error
@@ -727,9 +807,6 @@ func (b *MultiverseStore) FetchProofLeaf(ctx context.Context,
 	if dbErr != nil {
 		return nil, dbErr
 	}
-
-	// Insert the proofs we just read up into the main cache.
-	b.proofCache.insertProofs(id, universeKey, proofs)
 
 	return proofs, nil
 }
@@ -810,16 +887,26 @@ func (b *MultiverseStore) FetchProof(ctx context.Context,
 
 // UpsertProofLeaf upserts a proof leaf within the multiverse tree and the
 // universe tree that corresponds to the given key.
+//
+// The universe leaf commits first, in its own transaction, and the
+// shared multiverse tree is updated afterwards. An error return may
+// therefore mean the leaf is durably stored while the multiverse
+// update failed; in that case the universe's multiverse entry is
+// healed by its next successful update.
+//
+// The returned proof always composes: its multiverse proof commits to
+// its universe root. If a concurrent insert into the same universe
+// superseded this one before the multiverse update was flushed, the
+// receipt is rebuilt from the newer state, so its universe root may be
+// fresher than the root this call's own transaction committed.
 func (b *MultiverseStore) UpsertProofLeaf(ctx context.Context,
 	id universe.Identifier, key universe.LeafKey, leaf *universe.Leaf,
 	metaReveal *proof.MetaReveal) (*universe.Proof, error) {
 
 	var (
-		writeTx         BaseMultiverseOptions
-		uniProof        *universe.Proof
-		rootStatus      universeRootStatus
-		multiverseRoot  mssmt.Node
-		multiverseProof *mssmt.Proof
+		writeTx    BaseMultiverseOptions
+		uniProof   *universe.Proof
+		rootStatus universeRootStatus
 	)
 
 	execTxFunc := func(dbTx BaseMultiverseStore) error {
@@ -836,23 +923,6 @@ func (b *MultiverseStore) UpsertProofLeaf(ctx context.Context,
 			return fmt.Errorf("failed universe upsert: %w", err)
 		}
 
-		// Now, attempt to insert the universe root into the main
-		// multiverse tree.
-		err = upsertMultiverseLeafEntry(
-			ctx, dbTx, id, uniProof.UniverseRoot,
-		)
-		if err != nil {
-			return fmt.Errorf("failed multiverse upsert: %w", err)
-		}
-
-		multiverseRoot, multiverseProof, err = multiverseRootAndProof(
-			ctx, dbTx, id,
-		)
-		if err != nil {
-			return fmt.Errorf("failed multiverse root fetch: %w",
-				err)
-		}
-
 		return nil
 	}
 	dbErr := b.db.ExecTx(ctx, &writeTx, execTxFunc)
@@ -860,18 +930,21 @@ func (b *MultiverseStore) UpsertProofLeaf(ctx context.Context,
 		return nil, dbErr
 	}
 
-	// Populate the multiverse fields in the proof object now that the
-	// transaction is complete.
-	uniProof.MultiverseRoot = multiverseRoot
-	uniProof.MultiverseInclusionProof = multiverseProof
-
-	// The transaction is committed, so invalidate the affected caches.
+	// The universe leaf is now durably committed, so run the
+	// bookkeeping tied to that commit before the multiverse update: a
+	// failed or slow multiverse flush must not leave caches stale or
+	// keep the custodian from learning about a stored transfer proof.
+	//
 	// The root node page cache is wiped if the upsert created the
 	// universe, and only has the pages containing the universe's root
 	// evicted otherwise. Every previously cached proof under this
 	// universe embeds the UniverseRoot at the time it was fetched;
 	// inserting a new leaf changes the root, so all of the universe's
-	// proofs and leaf keys are evicted, not just the one we wrote.
+	// proofs and leaf keys are evicted, not just the one we wrote. The
+	// syncer cache is deliberately absent here: it installs values
+	// rather than evicting them, and the unordered post-commit
+	// sections of concurrent inserts could install roots out of commit
+	// order. It is fed from the coalescer's flush callback instead.
 	newRoot := universe.Root{
 		ID:        id,
 		AssetName: leaf.Asset.Tag,
@@ -880,7 +953,6 @@ func (b *MultiverseStore) UpsertProofLeaf(ctx context.Context,
 	b.rootNodeCache.handleRootUpdate(newRoot, rootStatus)
 	b.proofCache.RemoveUniverseProofs(id)
 	b.leafKeysCache.wipeCache(id.String())
-	b.syncerCache.addOrReplace(newRoot)
 
 	// Notify subscribers about the new proof leaf, now that we're sure we
 	// have written it to the database. But we only care about transfer
@@ -890,11 +962,53 @@ func (b *MultiverseStore) UpsertProofLeaf(ctx context.Context,
 		b.transferProofDistributor.NotifySubscribers(leaf.RawProof)
 	}
 
+	// Now reflect the universe's new root in the shared multiverse tree,
+	// through the root coalescer rather than the transaction above: the
+	// multiverse rows are contended by every insert into every universe,
+	// so writing them under the insert's own transaction would serialize
+	// ingest across universes. If this fails, the universe leaf above
+	// remains committed, and the universe's multiverse entry is healed by
+	// its next successful update.
+	update, err := b.rootCoalescer.updateRoot(ctx, id)
+	if err != nil {
+		return nil, fmt.Errorf("failed multiverse upsert: %w", err)
+	}
+
+	// If a concurrent insert into the same universe committed between
+	// our transaction and the flush, the flush derived and committed
+	// the newer root, and the multiverse proof it returned does not
+	// compose with the universe proof assembled above. Rebuild the
+	// whole receipt from one consistent snapshot instead.
+	if !mssmt.IsEqualNode(update.universeRoot, uniProof.UniverseRoot) {
+		proofs, err := b.FetchProofLeaf(ctx, id, key)
+		if err != nil {
+			return nil, fmt.Errorf("failed superseded proof "+
+				"fetch: %w", err)
+		}
+		if len(proofs) != 1 {
+			return nil, fmt.Errorf("expected one proof for "+
+				"superseded upsert, got %d", len(proofs))
+		}
+
+		return proofs[0], nil
+	}
+
+	// Populate the multiverse fields in the proof object now that the
+	// update is complete.
+	uniProof.MultiverseRoot = update.multiverseRoot
+	uniProof.MultiverseInclusionProof = update.inclusionProof
+
 	return uniProof, nil
 }
 
 // UpsertProofLeafBatch upserts a proof leaf batch within the multiverse tree
 // and the universe tree that corresponds to the given key(s).
+//
+// The universe leaves commit first, in their own transaction, and the
+// shared multiverse tree is updated afterwards. An error return may
+// therefore mean the leaves are durably stored while the multiverse
+// update failed; in that case each universe's multiverse entry is
+// healed by its next successful update.
 func (b *MultiverseStore) UpsertProofLeafBatch(ctx context.Context,
 	items []*universe.Item) error {
 
@@ -903,13 +1017,10 @@ func (b *MultiverseStore) UpsertProofLeafBatch(ctx context.Context,
 		uniProofs    []*universe.Proof
 		rootStatuses []universeRootStatus
 	)
-	// Track the final universe root per universe, so the shared
-	// multiverse tree is updated once per universe with its latest root,
-	// rather than once per item.
-	type multiverseUpdate struct {
-		id   universe.Identifier
-		root mssmt.Node
-	}
+	// Track the universes the batch touches, in first-touch order, so
+	// the shared multiverse tree is refreshed once per universe rather
+	// than once per item.
+	var dirtyUniverses []universe.Identifier
 
 	dbErr := b.db.ExecTx(
 		ctx, &writeTx, func(store BaseMultiverseStore) error {
@@ -918,11 +1029,10 @@ func (b *MultiverseStore) UpsertProofLeafBatch(ctx context.Context,
 				[]universeRootStatus, len(items),
 			)
 
-			finalRoots := make(
-				map[universeIDKey]*multiverseUpdate,
-				len(items),
+			dirtyUniverses = make(
+				[]universe.Identifier, 0, len(items),
 			)
-			var updateOrder []universeIDKey
+			seen := make(map[universeIDKey]struct{}, len(items))
 
 			for idx := range items {
 				item := items[idx]
@@ -948,25 +1058,11 @@ func (b *MultiverseStore) UpsertProofLeafBatch(ctx context.Context,
 				rootStatuses[idx] = status
 
 				key := item.ID.String()
-				if _, ok := finalRoots[key]; !ok {
-					updateOrder = append(updateOrder, key)
-				}
-				finalRoots[key] = &multiverseUpdate{
-					id:   item.ID,
-					root: uniProof.UniverseRoot,
-				}
-			}
-
-			// Next, we'll insert each universe's final root into
-			// the main multiverse tree.
-			for _, key := range updateOrder {
-				update := finalRoots[key]
-				err := upsertMultiverseLeafEntry(
-					ctx, store, update.id, update.root,
-				)
-				if err != nil {
-					return fmt.Errorf("failed multiverse "+
-						"upsert for %v: %w", key, err)
+				if _, ok := seen[key]; !ok {
+					seen[key] = struct{}{}
+					dirtyUniverses = append(
+						dirtyUniverses, item.ID,
+					)
 				}
 			}
 
@@ -977,6 +1073,11 @@ func (b *MultiverseStore) UpsertProofLeafBatch(ctx context.Context,
 		return dbErr
 	}
 
+	// The universe leaves are now durably committed, so run the
+	// bookkeeping tied to that commit before the multiverse update: a
+	// failed or slow multiverse flush must not leave caches stale or
+	// keep the custodian from learning about stored transfer proofs.
+	//
 	// If any of the inserted leaves created a new universe, the
 	// composition of paginated root queries changed and the page cache as
 	// a whole is stale. Pure updates only change the value of already
@@ -999,14 +1100,16 @@ func (b *MultiverseStore) UpsertProofLeafBatch(ctx context.Context,
 			)
 		}
 
+		// The syncer cache is deliberately not updated here: it
+		// installs values rather than evicting them, and the
+		// unordered post-commit sections of concurrent inserts
+		// could install roots out of commit order. It is fed from
+		// the coalescer's flush callback instead.
 		newRoots[idx] = universe.Root{
 			ID:        items[idx].ID,
 			AssetName: items[idx].Leaf.Asset.Tag,
 			Node:      uniProofs[idx].UniverseRoot,
 		}
-
-		// Update the syncer cache with the new root node.
-		b.syncerCache.addOrReplace(newRoots[idx])
 	}
 
 	// Evict the cached pages that contain any of the updated roots. If
@@ -1032,6 +1135,19 @@ func (b *MultiverseStore) UpsertProofLeafBatch(ctx context.Context,
 
 		b.leafKeysCache.wipeCache(idStr)
 		b.proofCache.RemoveUniverseProofs(items[idx].ID)
+	}
+
+	// Finally, reflect each universe's new root in the shared
+	// multiverse tree, through the root coalescer rather than the
+	// transaction above: the multiverse rows are contended by every
+	// insert into every universe, so writing them under the batch's
+	// own transaction would collide with concurrent inserts. If this
+	// fails, the universe leaves above remain committed, and each
+	// universe's multiverse entry is healed by its next successful
+	// update.
+	err := b.rootCoalescer.updateRoots(ctx, dirtyUniverses)
+	if err != nil {
+		return fmt.Errorf("failed multiverse upsert: %w", err)
 	}
 
 	return nil

--- a/tapdb/multiverse.go
+++ b/tapdb/multiverse.go
@@ -1081,15 +1081,21 @@ func (b *MultiverseStore) UpsertProofLeaf(ctx context.Context,
 	// after the eviction above, from a snapshot predating this call's
 	// own insert, and that receipt would not reflect the leaf this
 	// call committed.
+	// Every rebuild failure below carries ErrMultiversePending: the
+	// caller's leaf and the flushed multiverse update are both durable
+	// by now, so an error here means only that a composing receipt
+	// could not be assembled, never that the proof failed to store.
 	if !mssmt.IsEqualNode(update.universeRoot, uniProof.UniverseRoot) {
 		proofs, err := b.fetchProofLeaf(ctx, id, key, true)
 		if err != nil {
-			return nil, fmt.Errorf("failed superseded proof "+
-				"fetch: %w", err)
+			return nil, fmt.Errorf("%w: failed superseded "+
+				"proof fetch: %w",
+				universe.ErrMultiversePending, err)
 		}
 		if len(proofs) != 1 {
-			return nil, fmt.Errorf("expected one proof for "+
-				"superseded upsert, got %d", len(proofs))
+			return nil, fmt.Errorf("%w: expected one proof "+
+				"for superseded upsert, got %d",
+				universe.ErrMultiversePending, len(proofs))
 		}
 
 		return proofs[0], nil

--- a/tapdb/multiverse_cache.go
+++ b/tapdb/multiverse_cache.go
@@ -387,6 +387,13 @@ type syncerRootNodeCache struct {
 	// enabled is a flag that indicates if the cache is enabled.
 	enabled bool
 
+	// initialized indicates that the cache has been populated with the
+	// complete set of universe roots. Both serving and incremental
+	// maintenance are gated on it: the read path treats the cache as
+	// the authoritative full set, so a partially seeded cache must
+	// never be observable.
+	initialized bool
+
 	// preAllocSize is the pre-allocated size of the cache.
 	preAllocSize uint64
 
@@ -469,8 +476,11 @@ func (r *syncerRootNodeCache) fetchRoots(q universe.RootNodesQuery,
 		defer r.RUnlock()
 	}
 
-	// If the cache is empty, we'll short-cut as well.
-	if len(r.universeRoots) == 0 {
+	// If the cache has not been populated wholesale yet, we can't
+	// serve from it: it may hold a subset of roots installed by flush
+	// callbacks, and the pagination below treats the cache as the
+	// complete set.
+	if !r.initialized {
 		// This is a miss, but we'll return nil to indicate that we
 		// don't have any roots.
 		r.Miss()
@@ -583,6 +593,8 @@ func (r *syncerRootNodeCache) replaceCache(newRoots []universe.Root) {
 	}
 
 	r.sortKeys()
+
+	r.initialized = true
 }
 
 // addOrReplace adds a single root to the cache if it isn't already present or
@@ -594,6 +606,13 @@ func (r *syncerRootNodeCache) addOrReplace(root universe.Root) {
 
 	r.Lock()
 	defer r.Unlock()
+
+	// Until the cache has been populated wholesale, incremental
+	// installs must not apply: they would seed a partial cache that
+	// the read path would then serve as the complete set.
+	if !r.initialized {
+		return
+	}
 
 	if _, ok := r.universeRoots[root.ID.Key()]; ok {
 		// If the root is already in the cache, we'll just replace it in
@@ -619,6 +638,12 @@ func (r *syncerRootNodeCache) remove(key universe.IdentifierKey) {
 	r.Lock()
 	defer r.Unlock()
 
+	// An uninitialized cache holds nothing to remove; it will be
+	// populated from post-deletion state when it is next filled.
+	if !r.initialized {
+		return
+	}
+
 	idx := sort.Search(len(r.universeKeyList), func(i int) bool {
 		return bytes.Compare(r.universeKeyList[i][:], key[:]) >= 0
 	})
@@ -631,12 +656,32 @@ func (r *syncerRootNodeCache) remove(key universe.IdentifierKey) {
 	}
 }
 
-// isEmpty returns true if the cache is empty.
-func (r *syncerRootNodeCache) isEmpty() bool {
+// needsFill returns true if the cache has not yet been populated with
+// the complete set of universe roots.
+func (r *syncerRootNodeCache) needsFill() bool {
 	r.RLock()
 	defer r.RUnlock()
 
-	return len(r.universeKeyList) == 0
+	return !r.initialized
+}
+
+// invalidate empties the cache and marks it uninitialized, so the next
+// syncer query repopulates it wholesale from the database. This is the
+// recovery path for failed multiverse flushes: the flush callback that
+// maintains the cache incrementally only runs for flushes that commit,
+// so the roots of a failed round would otherwise stay stale until
+// their universes are written again.
+func (r *syncerRootNodeCache) invalidate() {
+	if !r.enabled {
+		return
+	}
+
+	r.Lock()
+	defer r.Unlock()
+
+	r.universeKeyList = nil
+	r.universeRoots = make(map[universe.IdentifierKey]universe.Root)
+	r.initialized = false
 }
 
 // rootNodeCache is used to cache the set of active root nodes for the

--- a/tapdb/multiverse_cache.go
+++ b/tapdb/multiverse_cache.go
@@ -379,6 +379,22 @@ func (r *rootPageCache) wipe(cacheSize uint64) {
 	r.Store(rootCache)
 }
 
+// syncerCacheOp is a buffered incremental mutation of the syncer
+// cache: an install of a root, or a removal of a universe. Mutations
+// arriving while a wholesale fill is reading the database are buffered
+// and replayed onto the snapshot at install time, so the fill never
+// needs to hold the cache's write lock across its reads.
+type syncerCacheOp struct {
+	// remove is true for a removal, false for an install.
+	remove bool
+
+	// key is the universe being removed, when remove is true.
+	key universe.IdentifierKey
+
+	// root is the root being installed, when remove is false.
+	root universe.Root
+}
+
 // syncerRootNodeCache is used to cache the set of active root nodes for the
 // multiverse tree, which is specifically kept for the universe sync.
 type syncerRootNodeCache struct {
@@ -393,6 +409,32 @@ type syncerRootNodeCache struct {
 	// the authoritative full set, so a partially seeded cache must
 	// never be observable.
 	initialized bool
+
+	// fillMu serializes wholesale fills of the cache: the first
+	// caller to need a fill performs the paginated database read, and
+	// every concurrent caller waits here for it instead of scanning
+	// the database again. It is never held by the incremental
+	// maintenance paths, so a slow fill cannot stall them.
+	fillMu sync.Mutex
+
+	// filling is true while a wholesale fill is reading the database.
+	// Incremental installs and removals arriving in that window are
+	// buffered in pendingOps rather than applied or dropped.
+	filling bool
+
+	// generation counts invalidations. A fill started under one
+	// generation installs nothing if the cache was invalidated while
+	// it read: its snapshot may straddle the invalidating event.
+	generation uint64
+
+	// pendingOps buffers the incremental mutations that arrived while
+	// a fill was reading the database, in arrival order. They are
+	// replayed onto the snapshot at install time: their values are
+	// flush-derived or post-deletion state, so replaying them moves
+	// entries toward the present, and any entry it could briefly
+	// regress is corrected by a later flush callback already ordered
+	// behind them.
+	pendingOps []syncerCacheOp
 
 	// preAllocSize is the pre-allocated size of the cache.
 	preAllocSize uint64
@@ -458,8 +500,8 @@ func isQueryForSyncerCache(q universe.RootNodesQuery) bool {
 // are needed, then we return nothing so we go to the database to fetch the
 // information. The boolean indicates if there are more roots available because
 // the caller has reached the end of the list with the given offset.
-func (r *syncerRootNodeCache) fetchRoots(q universe.RootNodesQuery,
-	haveWriteLock bool) ([]universe.Root, bool) {
+func (r *syncerRootNodeCache) fetchRoots(
+	q universe.RootNodesQuery) ([]universe.Root, bool) {
 
 	// We shouldn't be called for a query that can't be served from the
 	// cache. But in case we are, we'll just short-cut here.
@@ -467,14 +509,8 @@ func (r *syncerRootNodeCache) fetchRoots(q universe.RootNodesQuery,
 		return nil, false
 	}
 
-	// If we've acquired the write lock because we're doing a last lookup
-	// before potentially populating the cache, we don't need to acquire the
-	// read lock. If we're just normally reading from the cache, we'll need
-	// to acquire the read lock.
-	if !haveWriteLock {
-		r.RLock()
-		defer r.RUnlock()
-	}
+	r.RLock()
+	defer r.RUnlock()
 
 	// If the cache has not been populated wholesale yet, we can't
 	// serve from it: it may hold a subset of roots installed by flush
@@ -537,21 +573,15 @@ func (r *syncerRootNodeCache) fetchRoots(q universe.RootNodesQuery,
 }
 
 // fetchRoot reads the cached root for the given ID.
-func (r *syncerRootNodeCache) fetchRoot(id universe.Identifier,
-	haveWriteLock bool) *universe.Root {
+func (r *syncerRootNodeCache) fetchRoot(
+	id universe.Identifier) *universe.Root {
 
 	if !r.enabled {
 		return nil
 	}
 
-	// If we've acquired the write lock because we're doing a last lookup
-	// before potentially populating the cache, we don't need to acquire the
-	// read lock. If we're just normally reading from the cache, we'll need
-	// to acquire the read lock.
-	if !haveWriteLock {
-		r.RLock()
-		defer r.RUnlock()
-	}
+	r.RLock()
+	defer r.RUnlock()
 
 	root, ok := r.universeRoots[id.Key()]
 	if !ok {
@@ -607,6 +637,14 @@ func (r *syncerRootNodeCache) addOrReplace(root universe.Root) {
 	r.Lock()
 	defer r.Unlock()
 
+	// While a wholesale fill reads the database, buffer the install:
+	// the fill replays it onto its snapshot, which may predate the
+	// flush this root stems from.
+	if r.filling {
+		r.pendingOps = append(r.pendingOps, syncerCacheOp{root: root})
+		return
+	}
+
 	// Until the cache has been populated wholesale, incremental
 	// installs must not apply: they would seed a partial cache that
 	// the read path would then serve as the complete set.
@@ -614,6 +652,14 @@ func (r *syncerRootNodeCache) addOrReplace(root universe.Root) {
 		return
 	}
 
+	r.addOrReplaceLocked(root)
+}
+
+// addOrReplaceLocked installs a single root.
+//
+// NOTE: This method must be called while holding the syncer cache
+// lock.
+func (r *syncerRootNodeCache) addOrReplaceLocked(root universe.Root) {
 	if _, ok := r.universeRoots[root.ID.Key()]; ok {
 		// If the root is already in the cache, we'll just replace it in
 		// the map. The key list doesn't need to be updated, as the key
@@ -638,12 +684,31 @@ func (r *syncerRootNodeCache) remove(key universe.IdentifierKey) {
 	r.Lock()
 	defer r.Unlock()
 
+	// While a wholesale fill reads the database, buffer the removal:
+	// the fill replays it onto its snapshot, whose pages may have
+	// been read before the deletion committed.
+	if r.filling {
+		r.pendingOps = append(r.pendingOps, syncerCacheOp{
+			remove: true,
+			key:    key,
+		})
+		return
+	}
+
 	// An uninitialized cache holds nothing to remove; it will be
 	// populated from post-deletion state when it is next filled.
 	if !r.initialized {
 		return
 	}
 
+	r.removeLocked(key)
+}
+
+// removeLocked removes a single root.
+//
+// NOTE: This method must be called while holding the syncer cache
+// lock.
+func (r *syncerRootNodeCache) removeLocked(key universe.IdentifierKey) {
 	idx := sort.Search(len(r.universeKeyList), func(i int) bool {
 		return bytes.Compare(r.universeKeyList[i][:], key[:]) >= 0
 	})
@@ -654,6 +719,64 @@ func (r *syncerRootNodeCache) remove(key universe.IdentifierKey) {
 		// Remove the entry from the map.
 		delete(r.universeRoots, key)
 	}
+}
+
+// beginFill marks a wholesale fill as in progress and returns the
+// generation it started under. From here until the fill completes or
+// aborts, incremental installs and removals are buffered rather than
+// applied, and the cache's write lock is free for them: the fill's
+// database reads happen without it.
+func (r *syncerRootNodeCache) beginFill() uint64 {
+	r.Lock()
+	defer r.Unlock()
+
+	r.filling = true
+	r.pendingOps = nil
+
+	return r.generation
+}
+
+// completeFill atomically installs the snapshot a fill read, replaying
+// the mutations buffered while it ran, and marks the cache
+// initialized. It installs nothing and returns false if the cache was
+// invalidated after beginFill: the snapshot's pages may straddle the
+// invalidating event, so the next syncer query starts a fresh fill.
+func (r *syncerRootNodeCache) completeFill(gen uint64,
+	newRoots []universe.Root) bool {
+
+	r.Lock()
+	defer r.Unlock()
+
+	r.filling = false
+	ops := r.pendingOps
+	r.pendingOps = nil
+
+	if r.generation != gen {
+		return false
+	}
+
+	r.replaceCache(newRoots)
+
+	for _, op := range ops {
+		if op.remove {
+			r.removeLocked(op.key)
+			continue
+		}
+
+		r.addOrReplaceLocked(op.root)
+	}
+
+	return true
+}
+
+// abortFill abandons an in-progress fill, discarding the buffered
+// mutations, and leaves the cache uninitialized.
+func (r *syncerRootNodeCache) abortFill() {
+	r.Lock()
+	defer r.Unlock()
+
+	r.filling = false
+	r.pendingOps = nil
 }
 
 // needsFill returns true if the cache has not yet been populated with
@@ -667,10 +790,13 @@ func (r *syncerRootNodeCache) needsFill() bool {
 
 // invalidate empties the cache and marks it uninitialized, so the next
 // syncer query repopulates it wholesale from the database. This is the
-// recovery path for failed multiverse flushes: the flush callback that
-// maintains the cache incrementally only runs for flushes that commit,
-// so the roots of a failed round would otherwise stay stale until
-// their universes are written again.
+// recovery path for failed multiverse flushes — the flush callback
+// that maintains the cache incrementally only runs for flushes that
+// commit, so the roots of a failed round would otherwise stay stale
+// until their universes are written again — and for partial leaf
+// deletions, where the deleted universe may or may not survive. It
+// also discards any fill in flight: the fill's snapshot may straddle
+// the event that forced the invalidation.
 func (r *syncerRootNodeCache) invalidate() {
 	if !r.enabled {
 		return
@@ -682,6 +808,8 @@ func (r *syncerRootNodeCache) invalidate() {
 	r.universeKeyList = nil
 	r.universeRoots = make(map[universe.IdentifierKey]universe.Root)
 	r.initialized = false
+	r.generation++
+	r.pendingOps = nil
 }
 
 // rootNodeCache is used to cache the set of active root nodes for the

--- a/tapdb/multiverse_cache_test.go
+++ b/tapdb/multiverse_cache_test.go
@@ -682,11 +682,14 @@ func TestMultiverseSyncerCache(t *testing.T) {
 	require.Len(t, originalRoots, numAssets)
 	assertAllLeavesInRoots(t, allLeaves, originalRoots)
 
-	// Because we've enabled the cache from the beginning, the leaves
-	// inserted into the DB above should already be in the cache. That means
-	// we should have zero misses.
+	// The cache only serves once it has been populated wholesale, so
+	// the first page query filled it (its two pre-fill lookups are the
+	// two misses); every page after that was served from the cache.
+	// The inserts above did not seed the cache: incremental installs
+	// apply only to an initialized cache, as a partially seeded cache
+	// would be served as though it were complete.
 	hitsPerFetch := numAssets / pageSize
-	require.EqualValues(t, 0, multiverse.syncerCache.miss.Load())
+	require.EqualValues(t, 2, multiverse.syncerCache.miss.Load())
 	require.EqualValues(t, hitsPerFetch, multiverse.syncerCache.hit.Load())
 
 	// We now randomly remove and re-insert some of the assets. The result
@@ -716,9 +719,10 @@ func TestMultiverseSyncerCache(t *testing.T) {
 		require.Equal(t, originalRoots, roots)
 
 		// No matter how we manipulate the entries, we should always hit
-		// the cache for syncer queries.
+		// the cache for syncer queries; the miss count stays at the
+		// two pre-fill lookups of the very first query.
 		hits := hitsPerFetch * (i + 2)
-		require.EqualValues(t, 0, multiverse.syncerCache.miss.Load())
+		require.EqualValues(t, 2, multiverse.syncerCache.miss.Load())
 		require.EqualValues(t, hits, multiverse.syncerCache.hit.Load())
 	}
 }

--- a/tapdb/multiverse_cache_test.go
+++ b/tapdb/multiverse_cache_test.go
@@ -87,10 +87,9 @@ func TestMultiverseRootsCachePerformance(t *testing.T) {
 		t, numMisses, multiverse.rootNodeCache.miss.Load(),
 	)
 
-	// The new syncer cache should only have two misses, one from when the
-	// cache was empty, one from after acquiring the write lock and all
-	// other queries should be hits.
-	require.EqualValues(t, 2, multiverse.syncerCache.miss.Load())
+	// The new syncer cache should only have a single miss, from when
+	// the cache was still empty; all other queries should be hits.
+	require.EqualValues(t, 1, multiverse.syncerCache.miss.Load())
 	require.EqualValues(t, numHits, multiverse.syncerCache.hit.Load())
 }
 
@@ -683,13 +682,13 @@ func TestMultiverseSyncerCache(t *testing.T) {
 	assertAllLeavesInRoots(t, allLeaves, originalRoots)
 
 	// The cache only serves once it has been populated wholesale, so
-	// the first page query filled it (its two pre-fill lookups are the
-	// two misses); every page after that was served from the cache.
+	// the first page query filled it (its one pre-fill lookup is the
+	// only miss); every page after that was served from the cache.
 	// The inserts above did not seed the cache: incremental installs
 	// apply only to an initialized cache, as a partially seeded cache
 	// would be served as though it were complete.
 	hitsPerFetch := numAssets / pageSize
-	require.EqualValues(t, 2, multiverse.syncerCache.miss.Load())
+	require.EqualValues(t, 1, multiverse.syncerCache.miss.Load())
 	require.EqualValues(t, hitsPerFetch, multiverse.syncerCache.hit.Load())
 
 	// We now randomly remove and re-insert some of the assets. The result
@@ -720,11 +719,97 @@ func TestMultiverseSyncerCache(t *testing.T) {
 
 		// No matter how we manipulate the entries, we should always hit
 		// the cache for syncer queries; the miss count stays at the
-		// two pre-fill lookups of the very first query.
+		// single pre-fill lookup of the very first query.
 		hits := hitsPerFetch * (i + 2)
-		require.EqualValues(t, 2, multiverse.syncerCache.miss.Load())
+		require.EqualValues(t, 1, multiverse.syncerCache.miss.Load())
 		require.EqualValues(t, hits, multiverse.syncerCache.hit.Load())
 	}
+}
+
+// syncerTestRoot builds a distinct universe root for direct syncer
+// cache tests.
+func syncerTestRoot(seed byte, sum uint64) universe.Root {
+	var id universe.Identifier
+	id.AssetID[0] = seed
+	id.ProofType = universe.ProofTypeIssuance
+
+	var hash mssmt.NodeHash
+	hash[0] = seed
+	hash[1] = byte(sum)
+
+	return universe.Root{
+		ID:   id,
+		Node: mssmt.NewComputedBranch(hash, sum),
+	}
+}
+
+// TestSyncerCacheFillBuffersMutations asserts that incremental installs
+// and removals arriving while a wholesale fill reads the database are
+// neither dropped nor stalled: they are buffered and replayed onto the
+// snapshot when the fill installs it, so the installed cache reflects
+// them even where the snapshot's pages predate them.
+func TestSyncerCacheFillBuffersMutations(t *testing.T) {
+	t.Parallel()
+
+	cache := newSyncerRootNodeCache(true, 10)
+
+	rootA := syncerTestRoot(1, 1)
+	rootB := syncerTestRoot(2, 1)
+	rootC := syncerTestRoot(3, 1)
+
+	// A fill begins; its snapshot will hold A and a stale B.
+	gen := cache.beginFill()
+
+	// While the fill reads, a flush installs a fresh B and a new C,
+	// and a deletion removes A. None of these may block, and none may
+	// be lost.
+	freshB := syncerTestRoot(2, 7)
+	cache.addOrReplace(freshB)
+	cache.addOrReplace(rootC)
+	cache.remove(rootA.ID.Key())
+
+	// Install the stale snapshot: the buffered operations must win
+	// over it.
+	installed := cache.completeFill(gen, []universe.Root{rootA, rootB})
+	require.True(t, installed)
+	require.False(t, cache.needsFill())
+
+	require.Nil(t, cache.fetchRoot(rootA.ID))
+
+	gotB := cache.fetchRoot(rootB.ID)
+	require.NotNil(t, gotB)
+	require.True(t, mssmt.IsEqualNode(freshB.Node, gotB.Node))
+
+	require.NotNil(t, cache.fetchRoot(rootC.ID))
+}
+
+// TestSyncerCacheFillDiscardedOnInvalidate asserts that a fill whose
+// read window contained an invalidation installs nothing: its snapshot
+// may straddle the invalidating event, so the cache stays uninitialized
+// and the next fill starts afresh.
+func TestSyncerCacheFillDiscardedOnInvalidate(t *testing.T) {
+	t.Parallel()
+
+	cache := newSyncerRootNodeCache(true, 10)
+
+	gen := cache.beginFill()
+	cache.invalidate()
+
+	installed := cache.completeFill(gen, []universe.Root{
+		syncerTestRoot(1, 1),
+	})
+	require.False(t, installed)
+	require.True(t, cache.needsFill())
+	require.Nil(t, cache.fetchRoot(syncerTestRoot(1, 1).ID))
+
+	// A subsequent, uninterrupted fill installs normally.
+	gen = cache.beginFill()
+	installed = cache.completeFill(gen, []universe.Root{
+		syncerTestRoot(2, 1),
+	})
+	require.True(t, installed)
+	require.False(t, cache.needsFill())
+	require.NotNil(t, cache.fetchRoot(syncerTestRoot(2, 1).ID))
 }
 
 // TestSyncerCacheDeleteProofLeaf asserts that deleting a single proof

--- a/tapdb/multiverse_cache_test.go
+++ b/tapdb/multiverse_cache_test.go
@@ -727,6 +727,113 @@ func TestMultiverseSyncerCache(t *testing.T) {
 	}
 }
 
+// TestSyncerCacheDeleteProofLeaf asserts that deleting a single proof
+// leaf keeps the syncer cache consistent with the database: a universe
+// that survives the deletion must remain visible to syncer queries
+// under its new root, and a universe whose last leaf was deleted must
+// disappear.
+func TestSyncerCacheDeleteProofLeaf(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	multiverse, _ := newTestMultiverse(t)
+	multiverse.syncerCache.enabled = true
+	multiverse.cfg.Caches.SyncerCacheEnabled = true
+
+	// One universe with two leaves, plus a few other universes so the
+	// cache stays populated throughout: a cache that drained to empty
+	// and refilled would mask an erroneous eviction.
+	items := genUniverseItemsWithType(t, universe.ProofTypeIssuance, 2)
+	id := items[0].ID
+	for _, item := range items {
+		_, err := multiverse.UpsertProofLeaf(
+			ctx, item.ID, item.Key, item.Leaf, item.MetaReveal,
+		)
+		require.NoError(t, err)
+	}
+
+	const numOthers = 3
+	for i := 0; i < numOthers; i++ {
+		other := genRandomAsset(t)
+		_, err := multiverse.UpsertProofLeaf(
+			ctx, other.ID, other.Key, other.Leaf,
+			other.MetaReveal,
+		)
+		require.NoError(t, err)
+	}
+
+	// Fill the syncer cache and pin the universe's pre-deletion root.
+	q := universe.RootNodesQuery{
+		SortDirection: universe.SortAscending,
+		Limit:         universe.RequestPageSize,
+	}
+	roots, err := multiverse.RootNodes(ctx, q)
+	require.NoError(t, err)
+	require.Len(t, roots, numOthers+1)
+	require.False(t, multiverse.syncerCache.needsFill())
+
+	findRoot := func(roots []universe.Root) *universe.Root {
+		for i := range roots {
+			if roots[i].ID.Key() == id.Key() {
+				return &roots[i]
+			}
+		}
+
+		return nil
+	}
+	preDeletion := findRoot(roots)
+	require.NotNil(t, preDeletion)
+
+	// Delete one of the universe's two leaves. The universe survives
+	// under a new root, and syncer queries must keep returning it.
+	_, err = multiverse.DeleteProofLeaf(ctx, id, items[0].Key)
+	require.NoError(t, err)
+
+	roots, err = multiverse.RootNodes(ctx, q)
+	require.NoError(t, err)
+	require.Len(t, roots, numOthers+1)
+
+	surviving := findRoot(roots)
+	require.NotNil(t, surviving, "surviving universe missing from "+
+		"syncer query after partial deletion")
+	require.False(t, mssmt.IsEqualNode(preDeletion.Node, surviving.Node))
+
+	// The served root must be the universe's actual post-deletion
+	// root.
+	var dbRoot UniverseRoot
+	readTx := NewBaseUniverseReadTx()
+	err = multiverse.db.ExecTx(
+		ctx, &readTx, func(db BaseMultiverseStore) error {
+			var err error
+			dbRoot, err = db.FetchUniverseRoot(ctx, id.String())
+			return err
+		},
+	)
+	require.NoError(t, err)
+
+	var expectedHash mssmt.NodeHash
+	copy(expectedHash[:], dbRoot.RootHash[:])
+	require.Equal(t, expectedHash, surviving.Node.NodeHash())
+
+	// Single-root lookups must agree.
+	single, err := multiverse.UniverseRootNode(ctx, id)
+	require.NoError(t, err)
+	require.True(t, mssmt.IsEqualNode(surviving.Node, single.Node))
+
+	// Delete the final leaf: now the whole universe is cleaned up and
+	// must disappear from syncer queries.
+	_, err = multiverse.DeleteProofLeaf(ctx, id, items[1].Key)
+	require.NoError(t, err)
+
+	roots, err = multiverse.RootNodes(ctx, q)
+	require.NoError(t, err)
+	require.Len(t, roots, numOthers)
+	require.Nil(t, findRoot(roots))
+
+	_, err = multiverse.UniverseRootNode(ctx, id)
+	require.ErrorIs(t, err, universe.ErrNoUniverseRoot)
+}
+
 func genRandomAsset(t *testing.T) *universe.Item {
 	proofType := universe.ProofTypeIssuance
 	if test.RandBool() {

--- a/tapdb/multiverse_coalescer.go
+++ b/tapdb/multiverse_coalescer.go
@@ -1,0 +1,384 @@
+package tapdb
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"runtime/debug"
+	"sync"
+	"time"
+
+	"github.com/lightninglabs/taproot-assets/mssmt"
+	"github.com/lightninglabs/taproot-assets/universe"
+)
+
+// defaultFlushTimeout bounds a single flush transaction. Flushes run on
+// a background context, decoupled from any caller's deadline, so
+// without a bound a stalled database would pin the flusher role — and
+// every caller awaiting it — indefinitely.
+const defaultFlushTimeout = time.Minute
+
+// maxFlushBatchSize bounds the number of universes applied in a single
+// flush transaction, so that no flush can grow into a transaction
+// large enough to overrun the flush timeout wholesale. Excess pending
+// updates simply roll over into the next round.
+const maxFlushBatchSize = 2048
+
+// errUniverseDeleted is delivered to waiters whose universe no longer
+// exists by the time the flush reads it back: the universe was deleted
+// after the update was submitted. Deletion removes the universe's
+// multiverse leaf in the same transaction as its tree, so there is
+// nothing left to refresh.
+var errUniverseDeleted = errors.New(
+	"universe deleted during multiverse update",
+)
+
+// multiverseRootUpdate is the outcome of a flushed multiverse root
+// update: the universe root the flush derived and committed, the
+// multiverse root after the flush that carried the update, and the
+// inclusion proof for the universe's leaf within that root.
+type multiverseRootUpdate struct {
+	// universeRoot is the universe root the flush derived inside its
+	// transaction and committed to the multiverse leaf. It may be
+	// fresher than the root a waiter's own transaction committed, if
+	// a concurrent insert into the same universe landed in between.
+	universeRoot mssmt.Node
+
+	// multiverseRoot is the root of the multiverse tree after the
+	// flush.
+	multiverseRoot mssmt.Node
+
+	// inclusionProof is the inclusion proof of the universe's leaf
+	// within multiverseRoot.
+	inclusionProof *mssmt.Proof
+}
+
+// flushResult is what a waiter receives once the flush carrying its
+// update has completed, or failed.
+type flushResult struct {
+	update multiverseRootUpdate
+	err    error
+}
+
+// pendingRootUpdate is a universe awaiting a refresh of its multiverse
+// leaf, along with every caller awaiting a flush that carries the
+// refresh. Keeping at most one pending entry per universe is what
+// coalesces redundant multiverse writes: the flush derives the
+// universe's current root itself, so a single write covers every
+// caller.
+type pendingRootUpdate struct {
+	id      universe.Identifier
+	waiters []chan flushResult
+}
+
+// multiverseRootCoalescer serializes all writes to the shared
+// multiverse trees through a single flusher, coalescing concurrent
+// updates into one write transaction.
+//
+// Every proof leaf insert must reflect its universe's new root in the
+// shared multiverse tree for its proof type. Doing that write inside
+// each insert's own transaction makes any two concurrent inserts
+// collide on the multiverse root rows: under Postgres serializable
+// isolation one of them aborts and retries with backoff, effectively
+// serializing ingest across universes. Routing the updates through the
+// coalescer removes the shared rows from the insert transactions
+// entirely: inserts commit in parallel, and their multiverse updates
+// are applied by at most one flusher at a time, batched together.
+//
+// The flusher role is leader-based rather than a dedicated goroutine:
+// the first caller to find the coalescer idle flushes pending updates
+// in rounds until none remain, while every other caller just awaits
+// its result. This yields group commit without any lifecycle
+// management: at low load an update flushes immediately, and under
+// load updates accumulate while a flush is in flight and are applied
+// together in the next round.
+type multiverseRootCoalescer struct {
+	db BatchedMultiverse
+
+	// onRefresh, if set, is invoked after a flush commits, once per
+	// refreshed universe, with the universe root the flush derived.
+	// Flushes execute strictly one at a time, so invocations for the
+	// same universe arrive in commit order; this makes the callback a
+	// safe place to install roots into caches, which the unordered
+	// post-commit sections of concurrent inserts are not.
+	onRefresh func(root universe.Root)
+
+	// onFlushError, if set, is invoked after a flush fails, including
+	// by panic. The universes of the failed round may hold committed
+	// universe roots that were never reported through onRefresh, so
+	// state maintained incrementally from that callback must be
+	// rebuilt.
+	onFlushError func()
+
+	mu sync.Mutex
+
+	// pending holds the universes awaiting a multiverse leaf refresh.
+	// The map keying enforces at most one pending update per
+	// universe.
+	pending map[universeIDKey]*pendingRootUpdate
+
+	// order tracks the first-submission order of pending universes,
+	// so flushes apply updates deterministically.
+	order []universeIDKey
+
+	// flushing is true while some caller holds the flusher role.
+	flushing bool
+
+	// flushBatchSize is the maximum number of universes applied per
+	// flush transaction. It defaults to maxFlushBatchSize and is only
+	// overridden in tests.
+	flushBatchSize int
+}
+
+// newMultiverseRootCoalescer creates a new coalescer that writes
+// through the given db handle.
+func newMultiverseRootCoalescer(
+	db BatchedMultiverse) *multiverseRootCoalescer {
+
+	return &multiverseRootCoalescer{
+		db:             db,
+		pending:        make(map[universeIDKey]*pendingRootUpdate),
+		flushBatchSize: maxFlushBatchSize,
+	}
+}
+
+// updateRoot marks the given universe's multiverse leaf as needing a
+// refresh and returns once a flush carrying the refresh has committed,
+// returning the universe root the flush derived along with the
+// multiverse root and the universe leaf's inclusion proof from that
+// flush.
+//
+// The flush derives the universe's current root inside its own
+// transaction rather than trusting a value submitted here: callers
+// submit after their universe transaction commits, so submission order
+// does not track commit order, and the latest submission may carry a
+// stale root. Deriving at flush time guarantees the leaf written is at
+// least as fresh as the root committed by any caller it covers.
+func (c *multiverseRootCoalescer) updateRoot(ctx context.Context,
+	id universe.Identifier) (multiverseRootUpdate, error) {
+
+	result := make(chan flushResult, 1)
+
+	c.mu.Lock()
+	key := id.String()
+	update, ok := c.pending[key]
+	if !ok {
+		update = &pendingRootUpdate{id: id}
+		c.pending[key] = update
+		c.order = append(c.order, key)
+	}
+	update.waiters = append(update.waiters, result)
+
+	lead := !c.flushing
+	if lead {
+		c.flushing = true
+	}
+	c.mu.Unlock()
+
+	if lead {
+		c.flush()
+	}
+
+	select {
+	case res := <-result:
+		return res.update, res.err
+
+	case <-ctx.Done():
+		return multiverseRootUpdate{}, ctx.Err()
+	}
+}
+
+// flush drains pending updates in rounds until none remain, applying
+// each round in a single write transaction.
+func (c *multiverseRootCoalescer) flush() {
+	for {
+		c.mu.Lock()
+		if len(c.order) == 0 {
+			c.flushing = false
+			c.mu.Unlock()
+			return
+		}
+
+		n := min(len(c.order), c.flushBatchSize)
+		batch := make([]*pendingRootUpdate, 0, n)
+		for _, key := range c.order[:n] {
+			batch = append(batch, c.pending[key])
+			delete(c.pending, key)
+		}
+		c.order = c.order[n:]
+		c.mu.Unlock()
+
+		c.flushBatch(batch)
+	}
+}
+
+// flushBatch applies one round of updates in a single write transaction
+// and delivers the outcome to every waiter of the round.
+func (c *multiverseRootCoalescer) flushBatch(batch []*pendingRootUpdate) {
+	// A panic during the flush must not strand the round's waiters or
+	// unwind past the flusher role's bookkeeping: were the panic
+	// recovered further up the stack, the coalescer would be blocked
+	// for every future update. Convert it into an error for every
+	// waiter of the round instead, and let the flusher continue.
+	defer func() {
+		r := recover()
+		if r == nil {
+			return
+		}
+
+		log.Criticalf("Multiverse flush panic: %v\n%s", r,
+			debug.Stack())
+
+		if c.onFlushError != nil {
+			c.onFlushError()
+		}
+
+		res := flushResult{
+			err: fmt.Errorf("multiverse flush panic: %v", r),
+		}
+		for _, update := range batch {
+			// The waiter channels are buffered, so a send only
+			// fails if the waiter was already served by the
+			// normal delivery path below.
+			for _, waiter := range update.waiters {
+				select {
+				case waiter <- res:
+				default:
+				}
+			}
+		}
+	}()
+
+	// The flush must not be tied to any single caller's context: the
+	// universe transactions the updates stem from have already
+	// committed, and other callers in the round await this write. It
+	// must still be bounded, so a stalled database cannot pin the
+	// flusher forever.
+	ctx, cancel := context.WithTimeout(
+		context.Background(), defaultFlushTimeout,
+	)
+	defer cancel()
+
+	var (
+		writeTx BaseMultiverseOptions
+		results = make([]multiverseRootUpdate, len(batch))
+		missing = make([]bool, len(batch))
+		roots   = make([]universe.Root, len(batch))
+	)
+	err := c.db.ExecTx(
+		ctx, &writeTx, func(store BaseMultiverseStore) error {
+			// The transaction may retry the closure wholesale,
+			// so reset the per-entry state it populates.
+			for i := range missing {
+				missing[i] = false
+			}
+
+			// Refresh every universe's multiverse leaf first,
+			// then read back the resulting root and one
+			// inclusion proof per universe.
+			for i, update := range batch {
+				// Derive the universe's current root here,
+				// inside the flush transaction, rather than
+				// using a submitted value: submissions
+				// follow their universe transactions'
+				// commits, so submission order does not
+				// track commit order, and the latest
+				// submitted root may be stale.
+				uniRoot, err := store.FetchUniverseRoot(
+					ctx, update.id.String(),
+				)
+				switch {
+				case errors.Is(err, sql.ErrNoRows):
+					// The universe was deleted after
+					// being marked dirty. Its waiters
+					// receive a typed error below.
+					missing[i] = true
+					continue
+
+				case err != nil:
+					return fmt.Errorf("failed universe "+
+						"root fetch for %v: %w",
+						update.id.String(), err)
+				}
+
+				var rootHash mssmt.NodeHash
+				copy(rootHash[:], uniRoot.RootHash[:])
+				root := mssmt.NewComputedNode(
+					rootHash, uint64(uniRoot.RootSum),
+				)
+				roots[i] = universe.Root{
+					ID:        update.id,
+					AssetName: uniRoot.AssetName,
+					Node:      root,
+				}
+
+				err = upsertMultiverseLeafEntry(
+					ctx, store, update.id, root,
+				)
+				if err != nil {
+					return fmt.Errorf("failed multiverse "+
+						"upsert for %v: %w",
+						update.id.String(), err)
+				}
+			}
+
+			for i, update := range batch {
+				if missing[i] {
+					continue
+				}
+
+				root, proof, err := multiverseRootAndProof(
+					ctx, store, update.id,
+				)
+				if err != nil {
+					return fmt.Errorf("failed multiverse "+
+						"root fetch for %v: %w",
+						update.id.String(), err)
+				}
+
+				results[i] = multiverseRootUpdate{
+					universeRoot:   roots[i].Node,
+					multiverseRoot: root,
+					inclusionProof: proof,
+				}
+			}
+
+			return nil
+		},
+	)
+
+	// The flush has committed: report the derived roots before
+	// delivering results. Flushes run strictly one at a time, so
+	// these arrive in commit order per universe.
+	if err == nil && c.onRefresh != nil {
+		for i := range batch {
+			if missing[i] {
+				continue
+			}
+
+			c.onRefresh(roots[i])
+		}
+	}
+	if err != nil && c.onFlushError != nil {
+		c.onFlushError()
+	}
+
+	for i, update := range batch {
+		res := flushResult{err: err}
+		switch {
+		case err == nil && missing[i]:
+			res.err = errUniverseDeleted
+
+		case err == nil:
+			res.update = results[i]
+		}
+
+		// Every waiter channel is buffered, so delivery never
+		// blocks the flusher, even if a waiter has abandoned its
+		// call due to context cancellation.
+		for _, waiter := range update.waiters {
+			waiter <- res
+		}
+	}
+}

--- a/tapdb/multiverse_coalescer.go
+++ b/tapdb/multiverse_coalescer.go
@@ -61,6 +61,14 @@ type flushResult struct {
 	err    error
 }
 
+// flushWaiter is a caller awaiting the flush of a pending update. Only
+// waiters that want the multiverse root and inclusion proof cause them
+// to be generated; batch callers skip that work.
+type flushWaiter struct {
+	result    chan flushResult
+	wantProof bool
+}
+
 // pendingRootUpdate is a universe awaiting a refresh of its multiverse
 // leaf, along with every caller awaiting a flush that carries the
 // refresh. Keeping at most one pending entry per universe is what
@@ -69,7 +77,7 @@ type flushResult struct {
 // caller.
 type pendingRootUpdate struct {
 	id      universe.Identifier
-	waiters []chan flushResult
+	waiters []flushWaiter
 }
 
 // multiverseRootCoalescer serializes all writes to the shared
@@ -158,18 +166,8 @@ func newMultiverseRootCoalescer(
 func (c *multiverseRootCoalescer) updateRoot(ctx context.Context,
 	id universe.Identifier) (multiverseRootUpdate, error) {
 
-	result := make(chan flushResult, 1)
-
 	c.mu.Lock()
-	key := id.String()
-	update, ok := c.pending[key]
-	if !ok {
-		update = &pendingRootUpdate{id: id}
-		c.pending[key] = update
-		c.order = append(c.order, key)
-	}
-	update.waiters = append(update.waiters, result)
-
+	result := c.enqueue(id, true)
 	lead := !c.flushing
 	if lead {
 		c.flushing = true
@@ -187,6 +185,73 @@ func (c *multiverseRootCoalescer) updateRoot(ctx context.Context,
 	case <-ctx.Done():
 		return multiverseRootUpdate{}, ctx.Err()
 	}
+}
+
+// updateRoots marks each given universe's multiverse leaf as needing a
+// refresh and returns once a flush carrying every refresh has
+// committed. Unlike updateRoot, it does not cause multiverse roots or
+// inclusion proofs to be generated, as batch callers do not consume
+// them.
+func (c *multiverseRootCoalescer) updateRoots(ctx context.Context,
+	ids []universe.Identifier) error {
+
+	if len(ids) == 0 {
+		return nil
+	}
+
+	waiters := make([]chan flushResult, len(ids))
+
+	c.mu.Lock()
+	for i, id := range ids {
+		waiters[i] = c.enqueue(id, false)
+	}
+	lead := !c.flushing
+	if lead {
+		c.flushing = true
+	}
+	c.mu.Unlock()
+
+	if lead {
+		c.flush()
+	}
+
+	for _, waiter := range waiters {
+		select {
+		case res := <-waiter:
+			if res.err != nil {
+				return res.err
+			}
+
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+
+	return nil
+}
+
+// enqueue marks the given universe's multiverse leaf as needing a
+// refresh and registers a waiter for the flush that carries it.
+//
+// NOTE: The caller must hold c.mu.
+func (c *multiverseRootCoalescer) enqueue(id universe.Identifier,
+	wantProof bool) chan flushResult {
+
+	result := make(chan flushResult, 1)
+
+	key := id.String()
+	update, ok := c.pending[key]
+	if !ok {
+		update = &pendingRootUpdate{id: id}
+		c.pending[key] = update
+		c.order = append(c.order, key)
+	}
+	update.waiters = append(update.waiters, flushWaiter{
+		result:    result,
+		wantProof: wantProof,
+	})
+
+	return result
 }
 
 // flush drains pending updates in rounds until none remain, applying
@@ -243,7 +308,7 @@ func (c *multiverseRootCoalescer) flushBatch(batch []*pendingRootUpdate) {
 			// normal delivery path below.
 			for _, waiter := range update.waiters {
 				select {
-				case waiter <- res:
+				case waiter.result <- res:
 				default:
 				}
 			}
@@ -259,6 +324,16 @@ func (c *multiverseRootCoalescer) flushBatch(batch []*pendingRootUpdate) {
 		context.Background(), defaultFlushTimeout,
 	)
 	defer cancel()
+
+	wantProof := func(update *pendingRootUpdate) bool {
+		for _, waiter := range update.waiters {
+			if waiter.wantProof {
+				return true
+			}
+		}
+
+		return false
+	}
 
 	var (
 		writeTx BaseMultiverseOptions
@@ -276,7 +351,8 @@ func (c *multiverseRootCoalescer) flushBatch(batch []*pendingRootUpdate) {
 
 			// Refresh every universe's multiverse leaf first,
 			// then read back the resulting root and one
-			// inclusion proof per universe.
+			// inclusion proof per universe that has a waiter
+			// consuming them.
 			for i, update := range batch {
 				// Derive the universe's current root here,
 				// inside the flush transaction, rather than
@@ -324,7 +400,7 @@ func (c *multiverseRootCoalescer) flushBatch(batch []*pendingRootUpdate) {
 			}
 
 			for i, update := range batch {
-				if missing[i] {
+				if missing[i] || !wantProof(update) {
 					continue
 				}
 
@@ -378,7 +454,7 @@ func (c *multiverseRootCoalescer) flushBatch(batch []*pendingRootUpdate) {
 		// blocks the flusher, even if a waiter has abandoned its
 		// call due to context cancellation.
 		for _, waiter := range update.waiters {
-			waiter <- res
+			waiter.result <- res
 		}
 	}
 }

--- a/tapdb/multiverse_coalescer.go
+++ b/tapdb/multiverse_coalescer.go
@@ -34,6 +34,32 @@ var errUniverseDeleted = errors.New(
 	"universe deleted during multiverse update",
 )
 
+// multiverseFlushTx is the transaction options for the coalescer's
+// flushes. The flush is the sole writer of the multiverse namespaces
+// (enforced by the single-flusher role plus the multiverse write mutex
+// shared with the deletion paths), so serializable isolation buys it
+// nothing. Running it at read committed on Postgres means it takes no
+// predicate locks, and, since only serializable writers flag conflicts
+// on serializable readers, it can neither abort nor be aborted by the
+// concurrent universe insert transactions.
+//
+// Abort-freedom alone is not what makes the downgrade safe, though: a
+// read-committed writer can invalidate a concurrent serializable
+// transaction's reads without either of them aborting. Safety rests on
+// write disjointness: the flush writes only multiverse rows, which the
+// serializable insert transactions neither read nor write.
+type multiverseFlushTx struct{}
+
+// ReadOnly returns false: flushes write.
+func (multiverseFlushTx) ReadOnly() bool {
+	return false
+}
+
+// TxIsolation overrides the flush transaction's isolation level.
+func (multiverseFlushTx) TxIsolation() sql.IsolationLevel {
+	return sql.LevelReadCommitted
+}
+
 // multiverseRootUpdate is the outcome of a flushed multiverse root
 // update: the universe root the flush derived and committed, the
 // multiverse root after the flush that carried the update, and the
@@ -119,6 +145,13 @@ type multiverseRootCoalescer struct {
 	// rebuilt.
 	onFlushError func()
 
+	// writeMu serializes all multiverse writes in this process. The
+	// flusher holds it for the duration of a flush transaction, and
+	// the deletion paths hold it around theirs. This mutual
+	// exclusion is what makes it safe to run flushes below
+	// serializable isolation.
+	writeMu sync.Locker
+
 	mu sync.Mutex
 
 	// pending holds the universes awaiting a multiverse leaf refresh.
@@ -140,12 +173,14 @@ type multiverseRootCoalescer struct {
 }
 
 // newMultiverseRootCoalescer creates a new coalescer that writes
-// through the given db handle.
-func newMultiverseRootCoalescer(
-	db BatchedMultiverse) *multiverseRootCoalescer {
+// through the given db handle. The given lock must be held by every
+// other multiverse writer in the process.
+func newMultiverseRootCoalescer(db BatchedMultiverse,
+	writeMu sync.Locker) *multiverseRootCoalescer {
 
 	return &multiverseRootCoalescer{
 		db:             db,
+		writeMu:        writeMu,
 		pending:        make(map[universeIDKey]*pendingRootUpdate),
 		flushBatchSize: maxFlushBatchSize,
 	}
@@ -335,14 +370,17 @@ func (c *multiverseRootCoalescer) flushBatch(batch []*pendingRootUpdate) {
 		return false
 	}
 
+	c.writeMu.Lock()
+	defer c.writeMu.Unlock()
+
 	var (
-		writeTx BaseMultiverseOptions
 		results = make([]multiverseRootUpdate, len(batch))
 		missing = make([]bool, len(batch))
 		roots   = make([]universe.Root, len(batch))
 	)
+	flushTx := multiverseFlushTx{}
 	err := c.db.ExecTx(
-		ctx, &writeTx, func(store BaseMultiverseStore) error {
+		ctx, flushTx, func(store BaseMultiverseStore) error {
 			// The transaction may retry the closure wholesale,
 			// so reset the per-entry state it populates.
 			for i := range missing {

--- a/tapdb/multiverse_coalescer.go
+++ b/tapdb/multiverse_coalescer.go
@@ -25,6 +25,16 @@ const defaultFlushTimeout = time.Minute
 // updates simply roll over into the next round.
 const maxFlushBatchSize = 2048
 
+// defaultFlushRetryBackoff is the initial delay before the universes
+// of a failed flush round are retried. It doubles per consecutive
+// failure, up to maxFlushRetryBackoff.
+const defaultFlushRetryBackoff = time.Second
+
+// maxFlushRetryBackoff caps the exponential backoff between retries of
+// failing flush rounds, so a database outage is probed at a bounded,
+// unhurried rate for however long it lasts.
+const maxFlushRetryBackoff = time.Minute
+
 // errUniverseDeleted is delivered to waiters whose universe no longer
 // exists by the time the flush reads it back: the universe was deleted
 // after the update was submitted. Deletion removes the universe's
@@ -33,6 +43,36 @@ const maxFlushBatchSize = 2048
 var errUniverseDeleted = errors.New(
 	"universe deleted during multiverse update",
 )
+
+// errCoalescerStopped is delivered to waiters, and returned to new
+// submitters, once the coalescer has been stopped. Universe leaves
+// already committed stay durable; their multiverse entries are
+// repaired by startup reconciliation on the next run.
+var errCoalescerStopped = errors.New("multiverse coalescer stopped")
+
+// errFlushPanicked wraps a panic recovered during a flush. Unlike an
+// error returned by the database, a panic is presumed to be a bug
+// rather than a transient failure, so panicked rounds are not retried.
+var errFlushPanicked = errors.New("multiverse flush panic")
+
+// multiverseFlushTx is the transaction options for the coalescer's
+// flushes. It is a distinct type so flush transactions are
+// recognizable as such, in particular by tests acting at the boundary
+// between a universe commit and its multiverse flush.
+//
+// Flushes run at the default serializable isolation, so consistency of
+// the multiverse trees is enforced by the database itself, against
+// every writer — including ones outside this process, such as a second
+// tapd sharing the database during a rolling restart. The in-process
+// write mutex is not what makes concurrent writes safe; its role is
+// confined to ordering the post-commit cache maintenance of the
+// writers within this process.
+type multiverseFlushTx struct{}
+
+// ReadOnly returns false: flushes write.
+func (multiverseFlushTx) ReadOnly() bool {
+	return false
+}
 
 // multiverseRootUpdate is the outcome of a flushed multiverse root
 // update: the universe root the flush derived and committed, the
@@ -94,13 +134,21 @@ type pendingRootUpdate struct {
 // entirely: inserts commit in parallel, and their multiverse updates
 // are applied by at most one flusher at a time, batched together.
 //
-// The flusher role is leader-based rather than a dedicated goroutine:
-// the first caller to find the coalescer idle flushes pending updates
-// in rounds until none remain, while every other caller just awaits
-// its result. This yields group commit without any lifecycle
-// management: at low load an update flushes immediately, and under
+// The flusher is an on-demand background goroutine: the first caller
+// to find the coalescer idle starts it, and it flushes pending
+// updates in rounds until none remain, then exits. Callers await only
+// the result of the flush carrying their own update, never the drain
+// of the whole queue. At low load an update flushes immediately; under
 // load updates accumulate while a flush is in flight and are applied
 // together in the next round.
+//
+// A failed round is not dropped: its waiters receive an error typed as
+// universe.ErrMultiversePending, its universes are re-marked dirty,
+// and the flusher retries them with bounded exponential backoff until
+// the database recovers or the coalescer is stopped. Universe leaves
+// are committed before their updates are submitted here, so retrying
+// is what heals the gap between durable universe state and the shared
+// multiverse trees without requiring further writes or a restart.
 type multiverseRootCoalescer struct {
 	db BatchedMultiverse
 
@@ -119,6 +167,16 @@ type multiverseRootCoalescer struct {
 	// rebuilt.
 	onFlushError func()
 
+	// writeMu serializes all multiverse writes in this process. The
+	// flusher holds it for the duration of a flush transaction and
+	// its post-commit callbacks, and the deletion paths hold it
+	// around theirs. This keeps the cache maintenance done after
+	// those transactions in commit order — without it, a flush could
+	// reinstall a cached root for a universe whose deletion committed
+	// after the flush did — and keeps flushes and deletions from
+	// aborting each other under serializable isolation.
+	writeMu sync.Locker
+
 	mu sync.Mutex
 
 	// pending holds the universes awaiting a multiverse leaf refresh.
@@ -130,24 +188,50 @@ type multiverseRootCoalescer struct {
 	// so flushes apply updates deterministically.
 	order []universeIDKey
 
-	// flushing is true while some caller holds the flusher role.
+	// flushing is true while the background flusher goroutine is
+	// running.
 	flushing bool
+
+	// stopped is set once stop has been called; from then on new
+	// submissions fail fast and the flusher winds down.
+	stopped bool
+
+	// quit is closed by stop to interrupt the flusher's retry
+	// backoff.
+	quit chan struct{}
+
+	// wg tracks the background flusher goroutine.
+	wg sync.WaitGroup
 
 	// flushBatchSize is the maximum number of universes applied per
 	// flush transaction. It defaults to maxFlushBatchSize and is only
 	// overridden in tests.
 	flushBatchSize int
+
+	// initialRetryBackoff is the delay before the first retry of a
+	// failed flush round. It defaults to defaultFlushRetryBackoff and
+	// is only overridden in tests.
+	initialRetryBackoff time.Duration
+
+	// maxRetryBackoff caps the exponential retry backoff. It defaults
+	// to maxFlushRetryBackoff and is only overridden in tests.
+	maxRetryBackoff time.Duration
 }
 
 // newMultiverseRootCoalescer creates a new coalescer that writes
-// through the given db handle.
-func newMultiverseRootCoalescer(
-	db BatchedMultiverse) *multiverseRootCoalescer {
+// through the given db handle. The given lock must be held by every
+// other multiverse writer in the process.
+func newMultiverseRootCoalescer(db BatchedMultiverse,
+	writeMu sync.Locker) *multiverseRootCoalescer {
 
 	return &multiverseRootCoalescer{
-		db:             db,
-		pending:        make(map[universeIDKey]*pendingRootUpdate),
-		flushBatchSize: maxFlushBatchSize,
+		db:                  db,
+		writeMu:             writeMu,
+		pending:             make(map[universeIDKey]*pendingRootUpdate),
+		quit:                make(chan struct{}),
+		flushBatchSize:      maxFlushBatchSize,
+		initialRetryBackoff: defaultFlushRetryBackoff,
+		maxRetryBackoff:     maxFlushRetryBackoff,
 	}
 }
 
@@ -167,16 +251,13 @@ func (c *multiverseRootCoalescer) updateRoot(ctx context.Context,
 	id universe.Identifier) (multiverseRootUpdate, error) {
 
 	c.mu.Lock()
+	if c.stopped {
+		c.mu.Unlock()
+		return multiverseRootUpdate{}, errCoalescerStopped
+	}
 	result := c.enqueue(id, true)
-	lead := !c.flushing
-	if lead {
-		c.flushing = true
-	}
+	c.maybeStartFlusher()
 	c.mu.Unlock()
-
-	if lead {
-		c.flush()
-	}
 
 	select {
 	case res := <-result:
@@ -202,18 +283,15 @@ func (c *multiverseRootCoalescer) updateRoots(ctx context.Context,
 	waiters := make([]chan flushResult, len(ids))
 
 	c.mu.Lock()
+	if c.stopped {
+		c.mu.Unlock()
+		return errCoalescerStopped
+	}
 	for i, id := range ids {
 		waiters[i] = c.enqueue(id, false)
 	}
-	lead := !c.flushing
-	if lead {
-		c.flushing = true
-	}
+	c.maybeStartFlusher()
 	c.mu.Unlock()
-
-	if lead {
-		c.flush()
-	}
 
 	for _, waiter := range waiters {
 		select {
@@ -254,12 +332,37 @@ func (c *multiverseRootCoalescer) enqueue(id universe.Identifier,
 	return result
 }
 
-// flush drains pending updates in rounds until none remain, applying
-// each round in a single write transaction.
-func (c *multiverseRootCoalescer) flush() {
+// maybeStartFlusher starts the background flusher goroutine if none is
+// running.
+//
+// NOTE: The caller must hold c.mu.
+func (c *multiverseRootCoalescer) maybeStartFlusher() {
+	if c.flushing {
+		return
+	}
+
+	c.flushing = true
+	c.wg.Add(1)
+	go c.runFlusher()
+}
+
+// runFlusher drains pending updates in rounds until none remain,
+// applying each round in a single write transaction, then exits. It
+// runs in its own goroutine, so no caller is ever conscripted into
+// draining the queue: each awaits only its own result, bounded by its
+// own context.
+//
+// A failed round keeps its universes dirty and is retried with
+// bounded exponential backoff, so the gap between committed universe
+// leaves and the shared multiverse trees closes on its own once the
+// database recovers.
+func (c *multiverseRootCoalescer) runFlusher() {
+	defer c.wg.Done()
+
+	backoff := c.initialRetryBackoff
 	for {
 		c.mu.Lock()
-		if len(c.order) == 0 {
+		if len(c.order) == 0 || c.stopped {
 			c.flushing = false
 			c.mu.Unlock()
 			return
@@ -272,35 +375,134 @@ func (c *multiverseRootCoalescer) flush() {
 			delete(c.pending, key)
 		}
 		c.order = c.order[n:]
+		queued := len(c.order)
 		c.mu.Unlock()
 
-		c.flushBatch(batch)
+		err := c.flushBatch(batch, queued)
+		if err == nil {
+			backoff = c.initialRetryBackoff
+			continue
+		}
+
+		// A panic is presumed to be a bug rather than a transient
+		// database failure; retrying would re-trigger it at every
+		// backoff. The round's universes stay diverged until their
+		// next update or startup reconciliation.
+		if errors.Is(err, errFlushPanicked) {
+			continue
+		}
+
+		// The round's waiters have been served the typed error, but
+		// its universes still hold committed roots the multiverse
+		// does not commit to. Re-mark them dirty and retry after
+		// the backoff, so recovery requires no further writes.
+		c.requeue(batch)
+
+		log.Warnf("Retrying multiverse flush of %d universes in %v",
+			len(batch), backoff)
+
+		select {
+		case <-time.After(backoff):
+		case <-c.quit:
+			c.mu.Lock()
+			c.flushing = false
+			c.mu.Unlock()
+			return
+		}
+
+		backoff = min(2*backoff, c.maxRetryBackoff)
 	}
 }
 
+// requeue re-marks the universes of a failed round as dirty. Their
+// waiters have already been served, so the fresh entries carry none;
+// universes re-submitted while the failed flush ran already have
+// entries of their own, which absorb these.
+func (c *multiverseRootCoalescer) requeue(batch []*pendingRootUpdate) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// The failed round predates everything queued behind it, so its
+	// universes return to the front, preserving first-submission
+	// order.
+	keys := make([]universeIDKey, 0, len(batch))
+	for _, update := range batch {
+		key := update.id.String()
+		if _, ok := c.pending[key]; ok {
+			continue
+		}
+
+		c.pending[key] = &pendingRootUpdate{id: update.id}
+		keys = append(keys, key)
+	}
+	c.order = append(keys, c.order...)
+}
+
+// stop rejects new submissions, winds down the flusher and fails every
+// pending waiter. A flush transaction already in flight completes or
+// fails on its own; stop blocks until the flusher has exited, bounded
+// by the flush timeout. Universe leaves already committed stay
+// durable, and multiverse updates abandoned here are repaired by
+// startup reconciliation on the next run.
+func (c *multiverseRootCoalescer) stop() {
+	c.mu.Lock()
+	if c.stopped {
+		c.mu.Unlock()
+		return
+	}
+	c.stopped = true
+	close(c.quit)
+
+	pending := c.pending
+	c.pending = make(map[universeIDKey]*pendingRootUpdate)
+	c.order = nil
+	c.mu.Unlock()
+
+	res := flushResult{err: errCoalescerStopped}
+	for _, update := range pending {
+		for _, waiter := range update.waiters {
+			// Waiter channels are buffered, so this never
+			// blocks.
+			waiter.result <- res
+		}
+	}
+
+	c.wg.Wait()
+}
+
 // flushBatch applies one round of updates in a single write transaction
-// and delivers the outcome to every waiter of the round.
-func (c *multiverseRootCoalescer) flushBatch(batch []*pendingRootUpdate) {
+// and delivers the outcome to every waiter of the round. It returns
+// the flush error, if any, wrapped in errFlushPanicked when the flush
+// panicked rather than failing.
+func (c *multiverseRootCoalescer) flushBatch(batch []*pendingRootUpdate,
+	queued int) (flushErr error) {
+
+	start := time.Now()
+
 	// A panic during the flush must not strand the round's waiters or
-	// unwind past the flusher role's bookkeeping: were the panic
-	// recovered further up the stack, the coalescer would be blocked
-	// for every future update. Convert it into an error for every
-	// waiter of the round instead, and let the flusher continue.
+	// unwind into the flusher's loop: were the panic recovered further
+	// up the stack, the coalescer would be blocked for every future
+	// update. Convert it into an error for every waiter of the round
+	// instead, and let the flusher continue.
 	defer func() {
 		r := recover()
 		if r == nil {
 			return
 		}
 
-		log.Criticalf("Multiverse flush panic: %v\n%s", r,
-			debug.Stack())
+		log.Criticalf("Multiverse flush panic (batch_size=%d, "+
+			"queue_depth=%d, duration=%v): %v\n%s", len(batch),
+			queued, time.Since(start), r, debug.Stack())
+
+		flushErr = fmt.Errorf("%w: %v", errFlushPanicked, r)
 
 		if c.onFlushError != nil {
 			c.onFlushError()
 		}
 
 		res := flushResult{
-			err: fmt.Errorf("multiverse flush panic: %v", r),
+			err: fmt.Errorf("%w: %w", universe.ErrMultiversePending,
+				flushErr),
 		}
 		for _, update := range batch {
 			// The waiter channels are buffered, so a send only
@@ -335,14 +537,17 @@ func (c *multiverseRootCoalescer) flushBatch(batch []*pendingRootUpdate) {
 		return false
 	}
 
+	c.writeMu.Lock()
+	defer c.writeMu.Unlock()
+
 	var (
-		writeTx BaseMultiverseOptions
 		results = make([]multiverseRootUpdate, len(batch))
 		missing = make([]bool, len(batch))
 		roots   = make([]universe.Root, len(batch))
 	)
+	flushTx := multiverseFlushTx{}
 	err := c.db.ExecTx(
-		ctx, &writeTx, func(store BaseMultiverseStore) error {
+		ctx, flushTx, func(store BaseMultiverseStore) error {
 			// The transaction may retry the closure wholesale,
 			// so reset the per-entry state it populates.
 			for i := range missing {
@@ -440,13 +645,34 @@ func (c *multiverseRootCoalescer) flushBatch(batch []*pendingRootUpdate) {
 		c.onFlushError()
 	}
 
+	switch {
+	case err != nil:
+		log.Errorf("Multiverse flush failed (batch_size=%d, "+
+			"queue_depth=%d, duration=%v): %v", len(batch),
+			queued, time.Since(start), err)
+
+	default:
+		log.Debugf("Multiverse flush committed (batch_size=%d, "+
+			"queue_depth=%d, duration=%v)", len(batch), queued,
+			time.Since(start))
+	}
+
 	for i, update := range batch {
 		res := flushResult{err: err}
 		switch {
-		case err == nil && missing[i]:
+		case err != nil:
+			// The universe transactions behind this round have
+			// already committed; only the multiverse update is
+			// outstanding, and the flusher keeps retrying it.
+			// Give waiters that typed context along with the
+			// cause.
+			res.err = fmt.Errorf("%w: %w",
+				universe.ErrMultiversePending, err)
+
+		case missing[i]:
 			res.err = errUniverseDeleted
 
-		case err == nil:
+		default:
 			res.update = results[i]
 		}
 
@@ -457,4 +683,6 @@ func (c *multiverseRootCoalescer) flushBatch(batch []*pendingRootUpdate) {
 			waiter.result <- res
 		}
 	}
+
+	return err
 }

--- a/tapdb/multiverse_coalescer.go
+++ b/tapdb/multiverse_coalescer.go
@@ -554,10 +554,14 @@ func (c *multiverseRootCoalescer) flushBatch(batch []*pendingRootUpdate,
 				missing[i] = false
 			}
 
-			// Refresh every universe's multiverse leaf first,
-			// then read back the resulting root and one
-			// inclusion proof per universe that has a waiter
+			// Derive every universe's current root first, then
+			// refresh all their multiverse leaves in one grouped
+			// write, and finally read back the resulting root and
+			// one inclusion proof per universe that has a waiter
 			// consuming them.
+			refreshes := make(
+				[]multiverseLeafRefresh, 0, len(batch),
+			)
 			for i, update := range batch {
 				// Derive the universe's current root here,
 				// inside the flush transaction, rather than
@@ -594,14 +598,24 @@ func (c *multiverseRootCoalescer) flushBatch(batch []*pendingRootUpdate,
 					Node:      root,
 				}
 
-				err = upsertMultiverseLeafEntry(
-					ctx, store, update.id, root,
+				refreshes = append(
+					refreshes, multiverseLeafRefresh{
+						id:   update.id,
+						root: root,
+					},
 				)
-				if err != nil {
-					return fmt.Errorf("failed multiverse "+
-						"upsert for %v: %w",
-						update.id.String(), err)
-				}
+			}
+
+			// The grouped write applies the whole round through
+			// InsertMany per proof type: internal tree nodes
+			// shared by the round are computed once, which is
+			// what keeps large rounds within the flush timeout.
+			err := upsertMultiverseLeafEntries(
+				ctx, store, refreshes,
+			)
+			if err != nil {
+				return fmt.Errorf("failed multiverse "+
+					"upsert: %w", err)
 			}
 
 			for i, update := range batch {

--- a/tapdb/multiverse_coalescer.go
+++ b/tapdb/multiverse_coalescer.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/lightninglabs/taproot-assets/fn"
 	"github.com/lightninglabs/taproot-assets/mssmt"
 	"github.com/lightninglabs/taproot-assets/universe"
 )
@@ -386,20 +387,32 @@ func (c *multiverseRootCoalescer) runFlusher() {
 
 		// A panic is presumed to be a bug rather than a transient
 		// database failure; retrying would re-trigger it at every
-		// backoff. The round's universes stay diverged until their
-		// next update or startup reconciliation.
+		// backoff, so the round is dropped instead of requeued.
+		// Its universes stay diverged until their next update or
+		// startup reconciliation, so name them. The backoff below
+		// still applies: without it, continuous ingest would feed
+		// a deterministically panicking flush a tight loop of new
+		// rounds.
 		if errors.Is(err, errFlushPanicked) {
-			continue
+			ids := fn.Map(
+				batch, func(u *pendingRootUpdate) string {
+					return u.id.StringForLog()
+				},
+			)
+			log.Criticalf("Multiverse flush panicked; dropping "+
+				"round, universes diverged until their next "+
+				"update or restart: %v", ids)
+		} else {
+			// The round's waiters have been served the typed
+			// error, but its universes still hold committed
+			// roots the multiverse does not commit to. Re-mark
+			// them dirty and retry after the backoff, so
+			// recovery requires no further writes.
+			c.requeue(batch)
+
+			log.Warnf("Retrying multiverse flush of %d "+
+				"universes in %v", len(batch), backoff)
 		}
-
-		// The round's waiters have been served the typed error, but
-		// its universes still hold committed roots the multiverse
-		// does not commit to. Re-mark them dirty and retry after
-		// the backoff, so recovery requires no further writes.
-		c.requeue(batch)
-
-		log.Warnf("Retrying multiverse flush of %d universes in %v",
-			len(batch), backoff)
 
 		select {
 		case <-time.After(backoff):

--- a/tapdb/multiverse_coalescer_test.go
+++ b/tapdb/multiverse_coalescer_test.go
@@ -2,6 +2,8 @@ package tapdb
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 	"sync"
 	"testing"
 
@@ -107,6 +109,20 @@ func multiverseLeafForRoot(id universe.Identifier,
 	}
 
 	return mssmt.NewLeafNode(rootHash[:], sum)
+}
+
+// assertReceiptComposes asserts that an upsert or fetch receipt is
+// internally consistent: its leaf is included in its universe root, and
+// the multiverse leaf committing to that universe root is included in
+// its multiverse root.
+func assertReceiptComposes(t require.TestingT, id universe.Identifier,
+	p *universe.Proof) {
+
+	require.True(t, p.VerifyRoot(p.UniverseRoot))
+	require.True(t, mssmt.VerifyMerkleProof(
+		id.Bytes(), multiverseLeafNode(id, p.UniverseRoot),
+		p.MultiverseInclusionProof, p.MultiverseRoot,
+	))
 }
 
 // assertOracleRoot asserts that the multiverse root stored for the
@@ -439,4 +455,219 @@ func TestMultiverseRootCoalescerMissingUniverse(t *testing.T) {
 		ctx, universe.ProofTypeIssuance,
 	)
 	require.ErrorIs(t, err, ErrNoMultiverseRoot)
+}
+
+// TestUpsertProofLeafSameUniverseConcurrent asserts that concurrent
+// inserts into the same universe leave the multiverse leaf committing
+// to the universe's current root. Submission order to the coalescer
+// does not track universe commit order, so this holds only because the
+// flush derives the root itself rather than trusting submitted values.
+func TestUpsertProofLeafSameUniverseConcurrent(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	multiverse, _ := newTestMultiverse(t)
+
+	const numLeaves = 8
+	items := genUniverseItems(t, numLeaves)
+	id := items[0].ID
+
+	var (
+		wg       sync.WaitGroup
+		receipts = make([]*universe.Proof, numLeaves)
+		errs     = make([]error, numLeaves)
+	)
+	for i := range items {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+
+			receipts[i], errs[i] = multiverse.UpsertProofLeaf(
+				ctx, items[i].ID, items[i].Key,
+				items[i].Leaf, items[i].MetaReveal,
+			)
+		}(i)
+	}
+	wg.Wait()
+
+	// Every returned receipt must compose, whichever flush round
+	// served it and whether or not it was superseded by a concurrent
+	// insert.
+	for i, err := range errs {
+		require.NoError(t, err)
+		assertReceiptComposes(t, id, receipts[i])
+	}
+
+	// The multiverse leaf must commit to the universe's current root,
+	// not to whichever root happened to be submitted last.
+	var (
+		uniRoot mssmt.Node
+		mvRoot  mssmt.Node
+		mvProof *mssmt.Proof
+	)
+	readTx := NewBaseMultiverseReadTx()
+	err := multiverse.db.ExecTx(
+		ctx, &readTx, func(db BaseMultiverseStore) error {
+			dbRoot, err := db.FetchUniverseRoot(ctx, id.String())
+			if err != nil {
+				return err
+			}
+
+			var rootHash mssmt.NodeHash
+			copy(rootHash[:], dbRoot.RootHash[:])
+			uniRoot = mssmt.NewComputedNode(
+				rootHash, uint64(dbRoot.RootSum),
+			)
+
+			mvRoot, mvProof, err = multiverseRootAndProof(
+				ctx, db, id,
+			)
+			return err
+		},
+	)
+	require.NoError(t, err)
+
+	require.True(t, mssmt.VerifyMerkleProof(
+		id.Bytes(), multiverseLeafForRoot(id, uniRoot), mvProof, mvRoot,
+	))
+}
+
+// TestFetchProofLeafHealsMultiverse asserts that fetching a proof in
+// the window between a universe commit and its multiverse flush returns
+// a consistent composite: the read path detects the missing or stale
+// multiverse leaf, waits for a healing flush, and reads again.
+func TestFetchProofLeafHealsMultiverse(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	multiverse, _ := newTestMultiverse(t)
+
+	items := genUniverseItems(t, 2)
+	id := items[0].ID
+
+	// A committed universe leaf with no multiverse update is exactly
+	// the state a fetcher observes in the gap, with the multiverse
+	// leaf missing entirely.
+	_, err := insertUniverseLeafOnly(ctx, multiverse, items[0])
+	require.NoError(t, err)
+
+	proofs, err := multiverse.FetchProofLeaf(ctx, id, items[0].Key)
+	require.NoError(t, err)
+	require.Len(t, proofs, 1)
+	assertReceiptComposes(t, id, proofs[0])
+
+	// The heal above flushed the multiverse leaf; a second universe
+	// commit without its multiverse update now leaves the leaf
+	// present but stale.
+	_, err = insertUniverseLeafOnly(ctx, multiverse, items[1])
+	require.NoError(t, err)
+
+	proofs, err = multiverse.FetchProofLeaf(ctx, id, items[1].Key)
+	require.NoError(t, err)
+	require.Len(t, proofs, 1)
+	assertReceiptComposes(t, id, proofs[0])
+}
+
+// TestUpsertProofLeafConcurrentDelete asserts that inserts racing a
+// deletion of their universe either succeed with a composing receipt or
+// fail outright, and that the persisted multiverse state is consistent
+// with the universe state whatever the interleaving.
+func TestUpsertProofLeafConcurrentDelete(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	multiverse, _ := newTestMultiverse(t)
+
+	const numLeaves = 8
+	items := genUniverseItems(t, numLeaves)
+	id := items[0].ID
+
+	// Seed the universe so the deletion has something to delete.
+	_, err := multiverse.UpsertProofLeaf(
+		ctx, items[0].ID, items[0].Key, items[0].Leaf,
+		items[0].MetaReveal,
+	)
+	require.NoError(t, err)
+
+	var (
+		wg       sync.WaitGroup
+		receipts = make([]*universe.Proof, numLeaves)
+		errs     = make([]error, numLeaves)
+		delErr   error
+	)
+	for i := 1; i < numLeaves; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+
+			receipts[i], errs[i] = multiverse.UpsertProofLeaf(
+				ctx, items[i].ID, items[i].Key,
+				items[i].Leaf, items[i].MetaReveal,
+			)
+		}(i)
+	}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		_, delErr = multiverse.DeleteUniverse(ctx, id)
+	}()
+	wg.Wait()
+
+	require.NoError(t, delErr)
+
+	// An insert that reported success must have returned a composing
+	// receipt; failures (universe deleted under the insert's
+	// multiverse update or receipt fetch) are acceptable.
+	for i := 1; i < numLeaves; i++ {
+		if errs[i] != nil {
+			continue
+		}
+
+		assertReceiptComposes(t, id, receipts[i])
+	}
+
+	// Whatever the interleaving, the persisted multiverse leaf must
+	// agree with the persisted universe state: absent if the universe
+	// is gone, committing to its current root otherwise.
+	var (
+		exists  bool
+		uniRoot mssmt.Node
+		mvRoot  mssmt.Node
+		mvProof *mssmt.Proof
+	)
+	readTx := NewBaseMultiverseReadTx()
+	err = multiverse.db.ExecTx(
+		ctx, &readTx, func(db BaseMultiverseStore) error {
+			dbRoot, err := db.FetchUniverseRoot(ctx, id.String())
+			switch {
+			case errors.Is(err, sql.ErrNoRows):
+
+			case err != nil:
+				return err
+
+			default:
+				exists = true
+				var rootHash mssmt.NodeHash
+				copy(rootHash[:], dbRoot.RootHash[:])
+				uniRoot = mssmt.NewComputedNode(
+					rootHash, uint64(dbRoot.RootSum),
+				)
+			}
+
+			mvRoot, mvProof, err = multiverseRootAndProof(
+				ctx, db, id,
+			)
+			return err
+		},
+	)
+	require.NoError(t, err)
+
+	expected := mssmt.EmptyLeafNode
+	if exists {
+		expected = multiverseLeafNode(id, uniRoot)
+	}
+	require.True(t, mssmt.VerifyMerkleProof(
+		id.Bytes(), expected, mvProof, mvRoot,
+	))
 }

--- a/tapdb/multiverse_coalescer_test.go
+++ b/tapdb/multiverse_coalescer_test.go
@@ -1,0 +1,442 @@
+package tapdb
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/lightninglabs/taproot-assets/asset"
+	"github.com/lightninglabs/taproot-assets/internal/test"
+	"github.com/lightninglabs/taproot-assets/mssmt"
+	"github.com/lightninglabs/taproot-assets/universe"
+	lfn "github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/stretchr/testify/require"
+	"pgregory.net/rapid"
+)
+
+// genUniverseItems generates n universe items that all target the same
+// universe of a random proof type, each carrying a distinct leaf.
+func genUniverseItems(t *testing.T, n int) []*universe.Item {
+	proofType := universe.ProofTypeIssuance
+	if test.RandBool() {
+		proofType = universe.ProofTypeTransfer
+	}
+
+	return genUniverseItemsWithType(t, proofType, n)
+}
+
+// genUniverseItemsWithType generates n universe items that all target
+// the same universe of the given proof type, each carrying a distinct
+// leaf.
+func genUniverseItemsWithType(t *testing.T, proofType universe.ProofType,
+	n int) []*universe.Item {
+
+	assetGen := asset.RandGenesis(t, asset.Normal)
+	id := randUniverseID(t, test.RandBool(), withProofType(proofType))
+
+	items := make([]*universe.Item, n)
+	for i := range items {
+		leaf := randMintingLeaf(t, assetGen, id.GroupKey)
+		id.AssetID = leaf.Asset.ID()
+
+		// For transfer proofs, the witness must look like a
+		// transfer rather than a genesis witness.
+		if proofType == universe.ProofTypeTransfer {
+			prevWitnesses := leaf.Asset.PrevWitnesses
+			prevWitnesses[0].TxWitness = [][]byte{
+				{1}, {1}, {1},
+			}
+			prevID := prevWitnesses[0].PrevID
+			prevID.OutPoint.Hash = [32]byte{1}
+		}
+
+		items[i] = &universe.Item{
+			ID:   id,
+			Key:  randLeafKey(t),
+			Leaf: &leaf,
+		}
+	}
+
+	return items
+}
+
+// insertUniverseLeafOnly commits a proof leaf into its universe tree
+// without updating the shared multiverse tree, returning the universe
+// root after the insert. This is the committed-but-not-yet-flushed
+// state the coalescer's callers are in when they submit an update.
+func insertUniverseLeafOnly(ctx context.Context,
+	multiverse *MultiverseStore, item *universe.Item) (mssmt.Node, error) {
+
+	var (
+		writeTx BaseMultiverseOptions
+		root    mssmt.Node
+	)
+	err := multiverse.db.ExecTx(
+		ctx, &writeTx, func(store BaseMultiverseStore) error {
+			uniProof, _, err := universeUpsertProofLeaf(
+				ctx, store, item.ID.String(),
+				item.ID.ProofType, item.ID.GroupKey, item.Key,
+				item.Leaf, item.MetaReveal, lfn.None[uint32](),
+			)
+			if err != nil {
+				return err
+			}
+			root = uniProof.UniverseRoot
+
+			return nil
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return root, nil
+}
+
+// multiverseLeafForRoot builds the multiverse leaf that must commit to
+// the given universe root, mirroring the sum rule of the production
+// insert path: issuance leaves carry a sum of one, transfer leaves
+// carry the universe root's sum.
+func multiverseLeafForRoot(id universe.Identifier,
+	root mssmt.Node) *mssmt.LeafNode {
+
+	rootHash := root.NodeHash()
+	sum := root.NodeSum()
+	if id.ProofType == universe.ProofTypeIssuance {
+		sum = 1
+	}
+
+	return mssmt.NewLeafNode(rootHash[:], sum)
+}
+
+// assertOracleRoot asserts that the multiverse root stored for the
+// given proof type matches the root of the given in-memory oracle
+// tree.
+func assertOracleRoot(t require.TestingT, ctx context.Context,
+	multiverse *MultiverseStore, oracle *mssmt.CompactedTree,
+	proofType universe.ProofType) {
+
+	oracleRoot, err := oracle.Root(ctx)
+	require.NoError(t, err)
+
+	storeRoot, err := multiverse.MultiverseRootNode(ctx, proofType)
+	require.NoError(t, err)
+	require.True(t, storeRoot.IsSome())
+
+	storeRoot.WhenSome(func(r universe.MultiverseRoot) {
+		require.Equal(
+			t, oracleRoot.NodeHash(), r.Node.NodeHash(),
+			"proof type %v: root hash mismatch", proofType,
+		)
+		require.Equal(
+			t, oracleRoot.NodeSum(), r.Node.NodeSum(),
+			"proof type %v: root sum mismatch", proofType,
+		)
+	})
+}
+
+// TestMultiverseRootCoalescer asserts that concurrent root updates for
+// distinct universes all succeed, return self-verifying inclusion
+// proofs, and leave the multiverse trees identical to inserting the
+// same leaves directly.
+func TestMultiverseRootCoalescer(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	multiverse, _ := newTestMultiverse(t)
+
+	const numUniverses = 16
+
+	items := make([]*universe.Item, numUniverses)
+	roots := make([]mssmt.Node, numUniverses)
+	for i := range items {
+		items[i] = genRandomAsset(t)
+
+		var err error
+		roots[i], err = insertUniverseLeafOnly(
+			ctx, multiverse, items[i],
+		)
+		require.NoError(t, err)
+	}
+
+	var (
+		wg      sync.WaitGroup
+		results = make([]multiverseRootUpdate, numUniverses)
+		errs    = make([]error, numUniverses)
+	)
+	for i := range items {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+
+			coalescer := multiverse.rootCoalescer
+			results[i], errs[i] = coalescer.updateRoot(
+				ctx, items[i].ID,
+			)
+		}(i)
+	}
+	wg.Wait()
+
+	// Every update must have succeeded and returned an inclusion
+	// proof for the leaf committing to the universe's root, valid
+	// against the returned multiverse root.
+	for i := range items {
+		require.NoError(t, errs[i])
+
+		// The flush must have derived exactly the root committed
+		// for the universe; nothing else wrote to it.
+		require.True(t, mssmt.IsEqualNode(
+			roots[i], results[i].universeRoot,
+		))
+
+		leaf := multiverseLeafForRoot(items[i].ID, roots[i])
+		require.True(t, mssmt.VerifyMerkleProof(
+			items[i].ID.Bytes(), leaf, results[i].inclusionProof,
+			results[i].multiverseRoot,
+		))
+	}
+
+	// The final multiverse roots must equal those of oracle trees
+	// built directly from the expected leaves.
+	oracles := map[universe.ProofType]*mssmt.CompactedTree{
+		universe.ProofTypeIssuance: mssmt.NewCompactedTree(
+			mssmt.NewDefaultStore(),
+		),
+		universe.ProofTypeTransfer: mssmt.NewCompactedTree(
+			mssmt.NewDefaultStore(),
+		),
+	}
+	touched := make(map[universe.ProofType]bool)
+	for i := range items {
+		id := items[i].ID
+		leaf := multiverseLeafForRoot(id, roots[i])
+		_, err := oracles[id.ProofType].Insert(ctx, id.Bytes(), leaf)
+		require.NoError(t, err)
+		touched[id.ProofType] = true
+	}
+	for proofType, oracle := range oracles {
+		if !touched[proofType] {
+			continue
+		}
+
+		assertOracleRoot(t, ctx, multiverse, oracle, proofType)
+	}
+}
+
+// TestMultiverseRootCoalescerProps property-tests the coalescer against
+// an in-memory oracle: for any schedule of concurrent per-universe
+// insert sequences, the flushed multiverse roots must equal the oracle
+// trees holding each universe's final root, and every returned
+// inclusion proof must verify. The store and oracles persist across
+// property iterations, so the comparison also covers cumulative state.
+func TestMultiverseRootCoalescerProps(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	multiverse, _ := newTestMultiverse(t)
+
+	oracles := map[universe.ProofType]*mssmt.CompactedTree{
+		universe.ProofTypeIssuance: mssmt.NewCompactedTree(
+			mssmt.NewDefaultStore(),
+		),
+		universe.ProofTypeTransfer: mssmt.NewCompactedTree(
+			mssmt.NewDefaultStore(),
+		),
+	}
+	touched := make(map[universe.ProofType]bool)
+
+	rapid.Check(t, func(rt *rapid.T) {
+		// Draw a set of universes, each with a sequence of leaf
+		// inserts. A universe's inserts are applied in order by a
+		// single goroutine, which is what entitles each update to
+		// a proof of the root it just committed below. Concurrent
+		// same-universe traffic is exercised elsewhere, not here.
+		numUniverses := rapid.IntRange(1, 4).Draw(rt, "num_universes")
+		universeItems := make([][]*universe.Item, numUniverses)
+		for i := range universeItems {
+			numInserts := rapid.IntRange(
+				1, 3,
+			).Draw(rt, "num_inserts")
+			universeItems[i] = genUniverseItems(t, numInserts)
+		}
+
+		// Run each universe's insert-then-update sequence in its
+		// own goroutine, all universes concurrently.
+		type outcome struct {
+			// root is the universe root right after the
+			// insert this update was submitted for.
+			root   mssmt.Node
+			update multiverseRootUpdate
+			err    error
+		}
+		outcomes := make([][]outcome, numUniverses)
+		var wg sync.WaitGroup
+		for i := range universeItems {
+			outcomes[i] = make([]outcome, len(universeItems[i]))
+
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+
+				coalescer := multiverse.rootCoalescer
+				for j, item := range universeItems[i] {
+					root, err := insertUniverseLeafOnly(
+						ctx, multiverse, item,
+					)
+					if err != nil {
+						outcomes[i][j] = outcome{
+							err: err,
+						}
+						return
+					}
+
+					update, err := coalescer.updateRoot(
+						ctx, item.ID,
+					)
+					outcomes[i][j] = outcome{
+						root:   root,
+						update: update,
+						err:    err,
+					}
+				}
+			}(i)
+		}
+		wg.Wait()
+
+		// Every update must succeed with a proof of the leaf
+		// committing to the universe root its caller had just
+		// committed.
+		for i := range universeItems {
+			id := universeItems[i][0].ID
+			for j := range universeItems[i] {
+				out := outcomes[i][j]
+				require.NoError(rt, out.err)
+
+				// Only this goroutine writes the universe,
+				// so the flush must have derived exactly
+				// the root committed by this insert.
+				require.True(rt, mssmt.IsEqualNode(
+					out.root, out.update.universeRoot,
+				))
+
+				leaf := multiverseLeafForRoot(id, out.root)
+				require.True(rt, mssmt.VerifyMerkleProof(
+					id.Bytes(), leaf,
+					out.update.inclusionProof,
+					out.update.multiverseRoot,
+				))
+			}
+		}
+
+		// Feed each universe's final root to the oracle and
+		// compare full roots per touched proof type.
+		for i := range universeItems {
+			id := universeItems[i][0].ID
+			final := outcomes[i][len(outcomes[i])-1].root
+			_, err := oracles[id.ProofType].Insert(
+				ctx, id.Bytes(),
+				multiverseLeafForRoot(id, final),
+			)
+			require.NoError(rt, err)
+			touched[id.ProofType] = true
+		}
+
+		for proofType, oracle := range oracles {
+			if !touched[proofType] {
+				continue
+			}
+
+			assertOracleRoot(
+				rt, ctx, multiverse, oracle, proofType,
+			)
+		}
+	})
+}
+
+// panicFlushDB is a BatchedMultiverse whose write transactions always
+// panic, simulating an unexpected failure inside a flush.
+type panicFlushDB struct {
+	BatchedMultiverse
+}
+
+func (panicFlushDB) ExecTx(context.Context, TxOptions,
+	func(BaseMultiverseStore) error) error {
+
+	panic("flush boom")
+}
+
+// TestMultiverseRootCoalescerFlushPanic asserts that a panic during a
+// flush is contained: every waiter of the round receives an error, the
+// flusher role is surrendered and no pending state leaks, so the
+// coalescer keeps functioning for future updates.
+func TestMultiverseRootCoalescerFlushPanic(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	coalescer := newMultiverseRootCoalescer(panicFlushDB{})
+
+	newID := func() universe.Identifier {
+		var id universe.Identifier
+		id.ProofType = universe.ProofTypeIssuance
+		copy(id.AssetID[:], test.RandBytes(32))
+		return id
+	}
+
+	// Enqueue a waiter by hand, so the panicking flush has a waiter
+	// beyond the leading caller itself.
+	waiterChan := make(chan flushResult, 1)
+	waiterID := newID()
+	coalescer.mu.Lock()
+	coalescer.pending[waiterID.String()] = &pendingRootUpdate{
+		id:      waiterID,
+		waiters: []chan flushResult{waiterChan},
+	}
+	coalescer.order = append(coalescer.order, waiterID.String())
+	coalescer.mu.Unlock()
+
+	// The leading caller must receive the panic as an error, not a
+	// stuck call or an unwound stack.
+	_, err := coalescer.updateRoot(ctx, newID())
+	require.ErrorContains(t, err, "panic")
+
+	// The bystander waiter must have been failed as well.
+	select {
+	case res := <-waiterChan:
+		require.ErrorContains(t, res.err, "panic")
+	default:
+		t.Fatal("waiter was not notified of the failed flush")
+	}
+
+	// The flusher role and the pending queue must be clean, so
+	// future updates are not blocked.
+	coalescer.mu.Lock()
+	require.False(t, coalescer.flushing)
+	require.Empty(t, coalescer.pending)
+	require.Empty(t, coalescer.order)
+	coalescer.mu.Unlock()
+}
+
+// TestMultiverseRootCoalescerMissingUniverse asserts that an update for
+// a universe with no committed root — the state left behind by a
+// concurrent universe deletion — fails with a typed error rather than
+// delivering an exclusion proof as though it were an inclusion proof.
+func TestMultiverseRootCoalescerMissingUniverse(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	multiverse, _ := newTestMultiverse(t)
+
+	var id universe.Identifier
+	id.ProofType = universe.ProofTypeIssuance
+	copy(id.AssetID[:], test.RandBytes(32))
+
+	_, err := multiverse.rootCoalescer.updateRoot(ctx, id)
+	require.ErrorIs(t, err, errUniverseDeleted)
+
+	// The failed refresh must not have created a multiverse leaf: the
+	// multiverse tree must still be missing entirely.
+	_, err = multiverse.MultiverseRootNode(
+		ctx, universe.ProofTypeIssuance,
+	)
+	require.ErrorIs(t, err, ErrNoMultiverseRoot)
+}

--- a/tapdb/multiverse_coalescer_test.go
+++ b/tapdb/multiverse_coalescer_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/lightninglabs/taproot-assets/asset"
@@ -239,6 +240,106 @@ func TestMultiverseRootCoalescer(t *testing.T) {
 	}
 }
 
+// TestMultiverseRootCoalescerBatch asserts that batch root updates,
+// interleaved with concurrent single updates, leave the multiverse
+// trees identical to inserting the same leaves directly.
+func TestMultiverseRootCoalescerBatch(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	multiverse, _ := newTestMultiverse(t)
+
+	// A pending universe holds one committed leaf, awaiting its
+	// multiverse update.
+	type pendingUniverse struct {
+		id   universe.Identifier
+		root mssmt.Node
+	}
+	newBatch := func(n int) ([]pendingUniverse, []universe.Identifier) {
+		pending := make([]pendingUniverse, n)
+		ids := make([]universe.Identifier, n)
+		for i := range pending {
+			item := genRandomAsset(t)
+			root, err := insertUniverseLeafOnly(
+				ctx, multiverse, item,
+			)
+			require.NoError(t, err)
+
+			pending[i] = pendingUniverse{
+				id:   item.ID,
+				root: root,
+			}
+			ids[i] = item.ID
+		}
+
+		return pending, ids
+	}
+
+	// Two batches and a handful of single updates, all submitted
+	// concurrently.
+	batchA, idsA := newBatch(8)
+	batchB, idsB := newBatch(8)
+	singles, _ := newBatch(4)
+
+	var (
+		wg         sync.WaitGroup
+		batchErrs  = make([]error, 2)
+		singleErrs = make([]error, len(singles))
+	)
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		batchErrs[0] = multiverse.rootCoalescer.updateRoots(ctx, idsA)
+	}()
+	go func() {
+		defer wg.Done()
+		batchErrs[1] = multiverse.rootCoalescer.updateRoots(ctx, idsB)
+	}()
+	for i := range singles {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			_, singleErrs[i] = multiverse.rootCoalescer.updateRoot(
+				ctx, singles[i].id,
+			)
+		}(i)
+	}
+	wg.Wait()
+
+	for _, err := range batchErrs {
+		require.NoError(t, err)
+	}
+	for _, err := range singleErrs {
+		require.NoError(t, err)
+	}
+
+	oracles := map[universe.ProofType]*mssmt.CompactedTree{
+		universe.ProofTypeIssuance: mssmt.NewCompactedTree(
+			mssmt.NewDefaultStore(),
+		),
+		universe.ProofTypeTransfer: mssmt.NewCompactedTree(
+			mssmt.NewDefaultStore(),
+		),
+	}
+	touched := make(map[universe.ProofType]bool)
+	allUpdates := append(append(batchA, batchB...), singles...)
+	for _, update := range allUpdates {
+		_, err := oracles[update.id.ProofType].Insert(
+			ctx, update.id.Bytes(),
+			multiverseLeafForRoot(update.id, update.root),
+		)
+		require.NoError(t, err)
+		touched[update.id.ProofType] = true
+	}
+	for proofType, oracle := range oracles {
+		if !touched[proofType] {
+			continue
+		}
+
+		assertOracleRoot(t, ctx, multiverse, oracle, proofType)
+	}
+}
+
 // TestMultiverseRootCoalescerProps property-tests the coalescer against
 // an in-memory oracle: for any schedule of concurrent per-universe
 // insert sequences, the flushed multiverse roots must equal the oracle
@@ -404,8 +505,11 @@ func TestMultiverseRootCoalescerFlushPanic(t *testing.T) {
 	waiterID := newID()
 	coalescer.mu.Lock()
 	coalescer.pending[waiterID.String()] = &pendingRootUpdate{
-		id:      waiterID,
-		waiters: []chan flushResult{waiterChan},
+		id: waiterID,
+		waiters: []flushWaiter{{
+			result:    waiterChan,
+			wantProof: true,
+		}},
 	}
 	coalescer.order = append(coalescer.order, waiterID.String())
 	coalescer.mu.Unlock()
@@ -669,5 +773,163 @@ func TestUpsertProofLeafConcurrentDelete(t *testing.T) {
 	}
 	require.True(t, mssmt.VerifyMerkleProof(
 		id.Bytes(), expected, mvProof, mvRoot,
+	))
+}
+
+// countTxDB is a BatchedMultiverse that counts the transactions
+// executed through it.
+type countTxDB struct {
+	BatchedMultiverse
+
+	count atomic.Int32
+}
+
+func (c *countTxDB) ExecTx(ctx context.Context, opts TxOptions,
+	txBody func(BaseMultiverseStore) error) error {
+
+	c.count.Add(1)
+
+	return c.BatchedMultiverse.ExecTx(ctx, opts, txBody)
+}
+
+// TestMultiverseRootCoalescerRollover asserts that a submission larger
+// than the flush batch size is applied across several bounded rounds
+// of one transaction each: every waiter is served, a refresh callback
+// arrives for every universe in submission order, and the multiverse
+// state matches the oracle.
+func TestMultiverseRootCoalescerRollover(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	multiverse, _ := newTestMultiverse(t)
+
+	// Shrink the per-round cap so a small submission spans several
+	// rounds, and capture the refresh callbacks.
+	multiverse.rootCoalescer.flushBatchSize = 4
+
+	var (
+		refreshMu sync.Mutex
+		refreshed []universe.Root
+	)
+	multiverse.rootCoalescer.onRefresh = func(root universe.Root) {
+		refreshMu.Lock()
+		defer refreshMu.Unlock()
+
+		refreshed = append(refreshed, root)
+	}
+
+	const numUniverses = 9
+
+	ids := make([]universe.Identifier, numUniverses)
+	roots := make([]mssmt.Node, numUniverses)
+	for i := 0; i < numUniverses; i++ {
+		item := genRandomAsset(t)
+
+		root, err := insertUniverseLeafOnly(ctx, multiverse, item)
+		require.NoError(t, err)
+
+		ids[i] = item.ID
+		roots[i] = root
+	}
+
+	// Count the flush transactions from here on: the coalescer's
+	// handle only ever executes flushes, so wrapping it counts exactly
+	// those.
+	counter := &countTxDB{
+		BatchedMultiverse: multiverse.rootCoalescer.db,
+	}
+	multiverse.rootCoalescer.db = counter
+
+	require.NoError(t, multiverse.rootCoalescer.updateRoots(ctx, ids))
+
+	// Nine universes at a cap of four must have flushed in exactly
+	// three rounds, one transaction each. An implementation that
+	// ignored the cap would apply them in a single transaction.
+	require.EqualValues(t, 3, counter.count.Load())
+
+	// Every universe must have been refreshed exactly once, in
+	// submission order: rounds are taken from the front of the
+	// pending queue, which preserves first-submission order.
+	require.Len(t, refreshed, numUniverses)
+	for i, root := range refreshed {
+		require.Equal(t, ids[i].Bytes(), root.ID.Bytes())
+		require.True(t, mssmt.IsEqualNode(roots[i], root.Node))
+	}
+
+	// The multiverse trees must match oracles fed the same roots.
+	oracles := map[universe.ProofType]*mssmt.CompactedTree{
+		universe.ProofTypeIssuance: mssmt.NewCompactedTree(
+			mssmt.NewDefaultStore(),
+		),
+		universe.ProofTypeTransfer: mssmt.NewCompactedTree(
+			mssmt.NewDefaultStore(),
+		),
+	}
+	touched := make(map[universe.ProofType]bool)
+	for i, id := range ids {
+		_, err := oracles[id.ProofType].Insert(
+			ctx, id.Bytes(), multiverseLeafForRoot(id, roots[i]),
+		)
+		require.NoError(t, err)
+		touched[id.ProofType] = true
+	}
+	for proofType, oracle := range oracles {
+		if !touched[proofType] {
+			continue
+		}
+
+		assertOracleRoot(t, ctx, multiverse, oracle, proofType)
+	}
+}
+
+// TestMultiverseRootCoalescerMixedDeleted asserts that a flush round
+// containing both a missing universe and a healthy one commits the
+// healthy refresh while failing only the missing universe's waiters
+// with the typed error.
+func TestMultiverseRootCoalescerMixedDeleted(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	multiverse, _ := newTestMultiverse(t)
+
+	// One healthy universe with a committed leaf, and one universe
+	// identifier with no committed state, as left behind by a
+	// concurrent deletion.
+	item := genRandomAsset(t)
+	rootX, err := insertUniverseLeafOnly(ctx, multiverse, item)
+	require.NoError(t, err)
+
+	var missing universe.Identifier
+	missing.ProofType = item.ID.ProofType
+	copy(missing.AssetID[:], test.RandBytes(32))
+
+	// Both universes are submitted together, so they land in the same
+	// flush round and transaction.
+	err = multiverse.rootCoalescer.updateRoots(
+		ctx, []universe.Identifier{missing, item.ID},
+	)
+	require.ErrorIs(t, err, errUniverseDeleted)
+
+	// The healthy universe's refresh must have committed in that same
+	// round regardless.
+	var (
+		mvRoot  mssmt.Node
+		mvProof *mssmt.Proof
+	)
+	readTx := NewBaseMultiverseReadTx()
+	err = multiverse.db.ExecTx(
+		ctx, &readTx, func(db BaseMultiverseStore) error {
+			var err error
+			mvRoot, mvProof, err = multiverseRootAndProof(
+				ctx, db, item.ID,
+			)
+			return err
+		},
+	)
+	require.NoError(t, err)
+
+	require.True(t, mssmt.VerifyMerkleProof(
+		item.ID.Bytes(), multiverseLeafForRoot(item.ID, rootX),
+		mvProof, mvRoot,
 	))
 }

--- a/tapdb/multiverse_coalescer_test.go
+++ b/tapdb/multiverse_coalescer_test.go
@@ -4,13 +4,17 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/lightninglabs/taproot-assets/asset"
+	"github.com/lightninglabs/taproot-assets/fn"
 	"github.com/lightninglabs/taproot-assets/internal/test"
 	"github.com/lightninglabs/taproot-assets/mssmt"
+	"github.com/lightninglabs/taproot-assets/proof"
 	"github.com/lightninglabs/taproot-assets/universe"
 	lfn "github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/stretchr/testify/require"
@@ -490,7 +494,9 @@ func TestMultiverseRootCoalescerFlushPanic(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	coalescer := newMultiverseRootCoalescer(panicFlushDB{})
+
+	var writeMu sync.Mutex
+	coalescer := newMultiverseRootCoalescer(panicFlushDB{}, &writeMu)
 
 	newID := func() universe.Identifier {
 		var id universe.Identifier
@@ -534,6 +540,11 @@ func TestMultiverseRootCoalescerFlushPanic(t *testing.T) {
 	require.Empty(t, coalescer.pending)
 	require.Empty(t, coalescer.order)
 	coalescer.mu.Unlock()
+
+	// The multiverse write lock must have been released on the way
+	// out, or the deletion paths would deadlock.
+	require.True(t, writeMu.TryLock())
+	writeMu.Unlock()
 }
 
 // TestMultiverseRootCoalescerMissingUniverse asserts that an update for
@@ -932,4 +943,413 @@ func TestMultiverseRootCoalescerMixedDeleted(t *testing.T) {
 		item.ID.Bytes(), multiverseLeafForRoot(item.ID, rootX),
 		mvProof, mvRoot,
 	))
+}
+
+// failFlushDB is a BatchedMultiverse that fails coalescer flush
+// transactions — recognized by their isolation override — while letting
+// every other transaction through, simulating a database that becomes
+// unavailable between a universe commit and its multiverse flush.
+type failFlushDB struct {
+	BatchedMultiverse
+
+	failing atomic.Bool
+}
+
+func (f *failFlushDB) ExecTx(ctx context.Context, opts TxOptions,
+	txBody func(BaseMultiverseStore) error) error {
+
+	if _, isFlush := opts.(TxIsolationOverrider); isFlush &&
+		f.failing.Load() {
+
+		return fmt.Errorf("flush unavailable")
+	}
+
+	return f.BatchedMultiverse.ExecTx(ctx, opts, txBody)
+}
+
+// TestUpsertProofLeafFlushFailure asserts that when the multiverse
+// flush fails after the universe transaction has committed, the
+// commit-tied bookkeeping has still run: stale cached proofs are
+// evicted and the custodian notification for the stored transfer proof
+// is emitted, even though the call reports the flush error.
+func TestUpsertProofLeafFlushFailure(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	db := NewTestDB(t)
+	failDB := &failFlushDB{
+		BatchedMultiverse: NewTransactionExecutor(
+			db, func(tx *sql.Tx) BaseMultiverseStore {
+				return db.WithTx(tx)
+			},
+		),
+	}
+	cfg := DefaultMultiverseStoreConfig()
+	cfg.Caches.SyncerCacheEnabled = true
+	multiverse, err := NewMultiverseStore(failDB, cfg)
+	require.NoError(t, err)
+
+	items := genUniverseItemsWithType(t, universe.ProofTypeTransfer, 2)
+	id := items[0].ID
+
+	// Insert a first leaf and fetch it, so the proof cache holds an
+	// entry that the failing insert below must evict.
+	_, err = multiverse.UpsertProofLeaf(
+		ctx, items[0].ID, items[0].Key, items[0].Leaf,
+		items[0].MetaReveal,
+	)
+	require.NoError(t, err)
+
+	proofs, err := multiverse.FetchProofLeaf(ctx, id, items[0].Key)
+	require.NoError(t, err)
+	require.Len(t, proofs, 1)
+	require.NotEmpty(t, multiverse.proofCache.fetchProof(
+		id, items[0].Key,
+	))
+
+	// Initialize the syncer cache and pin the universe root it now
+	// serves.
+	rootsQuery := universe.RootNodesQuery{
+		SortDirection: universe.SortAscending,
+		Limit:         universe.RequestPageSize,
+	}
+	roots, err := multiverse.RootNodes(ctx, rootsQuery)
+	require.NoError(t, err)
+	require.Len(t, roots, 1)
+	staleRoot := roots[0].Node
+
+	receiver := fn.NewEventReceiver[proof.Blob](fn.DefaultQueueSize)
+	require.NoError(t, multiverse.RegisterSubscriber(
+		receiver, false, nil,
+	))
+
+	// Insert a second leaf with the flush failing: the call must
+	// report the error, as the multiverse update did not commit.
+	failDB.failing.Store(true)
+	_, err = multiverse.UpsertProofLeaf(
+		ctx, items[1].ID, items[1].Key, items[1].Leaf,
+		items[1].MetaReveal,
+	)
+	require.ErrorContains(t, err, "flush unavailable")
+
+	// The universe commit went through, so the bookkeeping tied to it
+	// must have run regardless: the previously cached proof, stale as
+	// of the new leaf, is gone, and the stored transfer proof was
+	// delivered to subscribers.
+	require.Empty(t, multiverse.proofCache.fetchProof(id, items[0].Key))
+
+	select {
+	case blob := <-receiver.NewItemCreated.ChanOut():
+		require.Equal(
+			t, []byte(items[1].Leaf.RawProof), []byte(blob),
+		)
+
+	case <-time.After(time.Second):
+		t.Fatal("no transfer proof notification received")
+	}
+
+	// The failed flush must have invalidated the syncer cache: the
+	// next syncer query repopulates from the database and serves the
+	// universe root committed by the failed call, not the stale one
+	// installed before it.
+	roots, err = multiverse.RootNodes(ctx, rootsQuery)
+	require.NoError(t, err)
+	require.Len(t, roots, 1)
+	require.False(t, mssmt.IsEqualNode(staleRoot, roots[0].Node))
+
+	// Once the database recovers, the read path heals the multiverse
+	// on the next fetch.
+	failDB.failing.Store(false)
+	proofs, err = multiverse.FetchProofLeaf(ctx, id, items[1].Key)
+	require.NoError(t, err)
+	require.Len(t, proofs, 1)
+	assertReceiptComposes(t, id, proofs[0])
+}
+
+// hookFlushDB is a BatchedMultiverse that recognizes coalescer flush
+// transactions by their isolation override, letting tests act
+// deterministically at the boundary between a universe commit and its
+// multiverse flush: it counts flushes, runs a one-shot hook right
+// before a flush executes, and can fail flushes from a given ordinal
+// onwards.
+type hookFlushDB struct {
+	BatchedMultiverse
+
+	// beforeFlush, if armed, runs exactly once, right before the next
+	// flush transaction executes. The flusher holds the multiverse
+	// write lock at that point, so work done here is already
+	// serialized against the flush itself.
+	beforeFlush atomic.Pointer[func()]
+
+	// flushCount is the number of flush transactions attempted.
+	flushCount atomic.Int32
+
+	// failFrom, if positive, fails every flush whose ordinal (from
+	// one) is greater than or equal to it.
+	failFrom atomic.Int32
+}
+
+func (h *hookFlushDB) ExecTx(ctx context.Context, opts TxOptions,
+	txBody func(BaseMultiverseStore) error) error {
+
+	if _, isFlush := opts.(TxIsolationOverrider); isFlush {
+		n := h.flushCount.Add(1)
+
+		if hook := h.beforeFlush.Swap(nil); hook != nil {
+			(*hook)()
+		}
+
+		if from := h.failFrom.Load(); from > 0 && n >= from {
+			return fmt.Errorf("flush unavailable")
+		}
+	}
+
+	return h.BatchedMultiverse.ExecTx(ctx, opts, txBody)
+}
+
+// newHookedMultiverse creates a multiverse store whose flush
+// transactions pass through a hookFlushDB.
+func newHookedMultiverse(t *testing.T) (*MultiverseStore, *hookFlushDB) {
+	db := NewTestDB(t)
+	hookDB := &hookFlushDB{
+		BatchedMultiverse: NewTransactionExecutor(
+			db, func(tx *sql.Tx) BaseMultiverseStore {
+				return db.WithTx(tx)
+			},
+		),
+	}
+	multiverse, err := NewMultiverseStore(
+		hookDB, DefaultMultiverseStoreConfig(),
+	)
+	require.NoError(t, err)
+
+	return multiverse, hookDB
+}
+
+// TestUpsertProofLeafSuperseded deterministically forces the
+// superseded-receipt path: a second leaf commits into the universe
+// after the first caller's transaction but before its flush, so the
+// flush derives the newer root and the first caller's receipt must be
+// rebuilt against it.
+func TestUpsertProofLeafSuperseded(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	multiverse, hookDB := newHookedMultiverse(t)
+
+	items := genUniverseItems(t, 2)
+	id := items[0].ID
+
+	// Arm the hook: right before the first insert's flush runs, a
+	// second leaf commits into the same universe.
+	var (
+		superseding mssmt.Node
+		hookErr     error
+	)
+	hook := func() {
+		superseding, hookErr = insertUniverseLeafOnly(
+			ctx, multiverse, items[1],
+		)
+	}
+	hookDB.beforeFlush.Store(&hook)
+
+	receipt, err := multiverse.UpsertProofLeaf(
+		ctx, items[0].ID, items[0].Key, items[0].Leaf,
+		items[0].MetaReveal,
+	)
+	require.NoError(t, err)
+	require.NoError(t, hookErr)
+	require.NotNil(t, superseding)
+
+	// The receipt must compose, and it must commit to the superseding
+	// root rather than the root of the caller's own transaction.
+	assertReceiptComposes(t, id, receipt)
+	require.True(t, mssmt.IsEqualNode(superseding, receipt.UniverseRoot))
+}
+
+// TestUpsertProofLeafDeletedInGap deterministically forces a universe
+// deletion into the gap between a caller's universe commit and its
+// multiverse flush: the flush finds the universe gone, the caller
+// receives the typed error, and no multiverse leaf is resurrected.
+func TestUpsertProofLeafDeletedInGap(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	multiverse, hookDB := newHookedMultiverse(t)
+
+	items := genUniverseItems(t, 1)
+	id := items[0].ID
+
+	// Arm the hook: right before the insert's flush runs, the
+	// universe is deleted. The flusher holds the multiverse write
+	// lock here, so the deletion is already serialized with the
+	// flush.
+	var hookErr error
+	hook := func() {
+		var writeTx BaseMultiverseOptions
+		hookErr = multiverse.db.ExecTx(
+			ctx, &writeTx,
+			func(store BaseMultiverseStore) error {
+				multiverseNS, err := namespaceForProof(
+					id.ProofType,
+				)
+				if err != nil {
+					return err
+				}
+
+				multiverseTree := mssmt.NewCompactedTree(
+					newTreeStoreWrapperTx(
+						store, multiverseNS,
+					),
+				)
+				_, err = multiverseTree.Delete(
+					ctx, id.Bytes(),
+				)
+				if err != nil {
+					return err
+				}
+
+				return deleteUniverseTree(ctx, store, id)
+			},
+		)
+	}
+	hookDB.beforeFlush.Store(&hook)
+
+	_, err := multiverse.UpsertProofLeaf(
+		ctx, items[0].ID, items[0].Key, items[0].Leaf,
+		items[0].MetaReveal,
+	)
+	require.ErrorIs(t, err, errUniverseDeleted)
+	require.NoError(t, hookErr)
+
+	// The skipped flush must not have resurrected any multiverse
+	// state for the deleted universe.
+	_, err = multiverse.MultiverseRootNode(ctx, id.ProofType)
+	require.ErrorIs(t, err, ErrNoMultiverseRoot)
+}
+
+// TestMultiverseRootCoalescerCoalesces proves that updates enqueued
+// while a flush is in flight are applied together: with the first flush
+// blocked, several universes are submitted, and releasing the flush
+// must drain all of them in exactly one further flush transaction.
+func TestMultiverseRootCoalescerCoalesces(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	multiverse, hookDB := newHookedMultiverse(t)
+
+	const numQueued = 4
+
+	leader := genRandomAsset(t)
+	_, err := insertUniverseLeafOnly(ctx, multiverse, leader)
+	require.NoError(t, err)
+
+	queued := make([]*universe.Item, numQueued)
+	for i := range queued {
+		queued[i] = genRandomAsset(t)
+		_, err := insertUniverseLeafOnly(ctx, multiverse, queued[i])
+		require.NoError(t, err)
+	}
+
+	// Block the leader's flush until the queued universes are
+	// pending.
+	inFlush := make(chan struct{})
+	release := make(chan struct{})
+	hook := func() {
+		close(inFlush)
+		<-release
+	}
+	hookDB.beforeFlush.Store(&hook)
+
+	var (
+		wg        sync.WaitGroup
+		leaderErr error
+		queueErrs = make([]error, numQueued)
+	)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		_, leaderErr = multiverse.rootCoalescer.updateRoot(
+			ctx, leader.ID,
+		)
+	}()
+	<-inFlush
+
+	for i := range queued {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+
+			_, queueErrs[i] = multiverse.rootCoalescer.updateRoot(
+				ctx, queued[i].ID,
+			)
+		}(i)
+	}
+
+	// Wait until all queued universes are registered as pending, then
+	// let the blocked flush proceed.
+	coalescer := multiverse.rootCoalescer
+	require.Eventually(t, func() bool {
+		coalescer.mu.Lock()
+		defer coalescer.mu.Unlock()
+
+		return len(coalescer.order) == numQueued
+	}, time.Second, time.Millisecond)
+	close(release)
+
+	wg.Wait()
+	require.NoError(t, leaderErr)
+	for _, err := range queueErrs {
+		require.NoError(t, err)
+	}
+
+	// The leader's round plus exactly one coalesced round for the
+	// queued universes.
+	require.EqualValues(t, 2, hookDB.flushCount.Load())
+}
+
+// TestReconcileMultiverseChunkFailure asserts that chunked startup
+// repairs make durable forward progress: a failure in the second chunk
+// leaves the first chunk's repairs committed, and a subsequent
+// reconcile completes from the remaining divergence.
+func TestReconcileMultiverseChunkFailure(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	multiverse, hookDB := newHookedMultiverse(t)
+
+	// Repair three universes per chunk, with seven diverged: chunks
+	// of 3, 3 and 1.
+	multiverse.reconcileBatchSize = 3
+
+	const numDiverged = 7
+	for i := 0; i < numDiverged; i++ {
+		_, err := insertUniverseLeafOnly(
+			ctx, multiverse, genRandomAsset(t),
+		)
+		require.NoError(t, err)
+	}
+
+	// The first chunk's flush succeeds, everything after fails.
+	hookDB.failFrom.Store(2)
+
+	err := multiverse.ReconcileMultiverse(ctx)
+	require.ErrorContains(t, err, "flush unavailable")
+
+	// The first chunk must have committed: only the remaining four
+	// universes still diverge.
+	diverged, err := multiverse.multiverseDivergence(ctx)
+	require.NoError(t, err)
+	require.Len(t, diverged, numDiverged-3)
+
+	// Once the database recovers, reconciliation completes from where
+	// it left off.
+	hookDB.failFrom.Store(0)
+	require.NoError(t, multiverse.ReconcileMultiverse(ctx))
+
+	diverged, err = multiverse.multiverseDivergence(ctx)
+	require.NoError(t, err)
+	require.Empty(t, diverged)
 }

--- a/tapdb/multiverse_coalescer_test.go
+++ b/tapdb/multiverse_coalescer_test.go
@@ -2,7 +2,10 @@ package tapdb
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/lightninglabs/taproot-assets/asset"
@@ -109,6 +112,20 @@ func multiverseLeafForRoot(id universe.Identifier,
 	return mssmt.NewLeafNode(rootHash[:], sum)
 }
 
+// assertReceiptComposes asserts that an upsert or fetch receipt is
+// internally consistent: its leaf is included in its universe root, and
+// the multiverse leaf committing to that universe root is included in
+// its multiverse root.
+func assertReceiptComposes(t require.TestingT, id universe.Identifier,
+	p *universe.Proof) {
+
+	require.True(t, p.VerifyRoot(p.UniverseRoot))
+	require.True(t, mssmt.VerifyMerkleProof(
+		id.Bytes(), multiverseLeafNode(id, p.UniverseRoot),
+		p.MultiverseInclusionProof, p.MultiverseRoot,
+	))
+}
+
 // assertOracleRoot asserts that the multiverse root stored for the
 // given proof type matches the root of the given in-memory oracle
 // tree.
@@ -213,6 +230,106 @@ func TestMultiverseRootCoalescer(t *testing.T) {
 		_, err := oracles[id.ProofType].Insert(ctx, id.Bytes(), leaf)
 		require.NoError(t, err)
 		touched[id.ProofType] = true
+	}
+	for proofType, oracle := range oracles {
+		if !touched[proofType] {
+			continue
+		}
+
+		assertOracleRoot(t, ctx, multiverse, oracle, proofType)
+	}
+}
+
+// TestMultiverseRootCoalescerBatch asserts that batch root updates,
+// interleaved with concurrent single updates, leave the multiverse
+// trees identical to inserting the same leaves directly.
+func TestMultiverseRootCoalescerBatch(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	multiverse, _ := newTestMultiverse(t)
+
+	// A pending universe holds one committed leaf, awaiting its
+	// multiverse update.
+	type pendingUniverse struct {
+		id   universe.Identifier
+		root mssmt.Node
+	}
+	newBatch := func(n int) ([]pendingUniverse, []universe.Identifier) {
+		pending := make([]pendingUniverse, n)
+		ids := make([]universe.Identifier, n)
+		for i := range pending {
+			item := genRandomAsset(t)
+			root, err := insertUniverseLeafOnly(
+				ctx, multiverse, item,
+			)
+			require.NoError(t, err)
+
+			pending[i] = pendingUniverse{
+				id:   item.ID,
+				root: root,
+			}
+			ids[i] = item.ID
+		}
+
+		return pending, ids
+	}
+
+	// Two batches and a handful of single updates, all submitted
+	// concurrently.
+	batchA, idsA := newBatch(8)
+	batchB, idsB := newBatch(8)
+	singles, _ := newBatch(4)
+
+	var (
+		wg         sync.WaitGroup
+		batchErrs  = make([]error, 2)
+		singleErrs = make([]error, len(singles))
+	)
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		batchErrs[0] = multiverse.rootCoalescer.updateRoots(ctx, idsA)
+	}()
+	go func() {
+		defer wg.Done()
+		batchErrs[1] = multiverse.rootCoalescer.updateRoots(ctx, idsB)
+	}()
+	for i := range singles {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			_, singleErrs[i] = multiverse.rootCoalescer.updateRoot(
+				ctx, singles[i].id,
+			)
+		}(i)
+	}
+	wg.Wait()
+
+	for _, err := range batchErrs {
+		require.NoError(t, err)
+	}
+	for _, err := range singleErrs {
+		require.NoError(t, err)
+	}
+
+	oracles := map[universe.ProofType]*mssmt.CompactedTree{
+		universe.ProofTypeIssuance: mssmt.NewCompactedTree(
+			mssmt.NewDefaultStore(),
+		),
+		universe.ProofTypeTransfer: mssmt.NewCompactedTree(
+			mssmt.NewDefaultStore(),
+		),
+	}
+	touched := make(map[universe.ProofType]bool)
+	allUpdates := append(append(batchA, batchB...), singles...)
+	for _, update := range allUpdates {
+		_, err := oracles[update.id.ProofType].Insert(
+			ctx, update.id.Bytes(),
+			multiverseLeafForRoot(update.id, update.root),
+		)
+		require.NoError(t, err)
+		touched[update.id.ProofType] = true
 	}
 	for proofType, oracle := range oracles {
 		if !touched[proofType] {
@@ -388,8 +505,11 @@ func TestMultiverseRootCoalescerFlushPanic(t *testing.T) {
 	waiterID := newID()
 	coalescer.mu.Lock()
 	coalescer.pending[waiterID.String()] = &pendingRootUpdate{
-		id:      waiterID,
-		waiters: []chan flushResult{waiterChan},
+		id: waiterID,
+		waiters: []flushWaiter{{
+			result:    waiterChan,
+			wantProof: true,
+		}},
 	}
 	coalescer.order = append(coalescer.order, waiterID.String())
 	coalescer.mu.Unlock()
@@ -439,4 +559,377 @@ func TestMultiverseRootCoalescerMissingUniverse(t *testing.T) {
 		ctx, universe.ProofTypeIssuance,
 	)
 	require.ErrorIs(t, err, ErrNoMultiverseRoot)
+}
+
+// TestUpsertProofLeafSameUniverseConcurrent asserts that concurrent
+// inserts into the same universe leave the multiverse leaf committing
+// to the universe's current root. Submission order to the coalescer
+// does not track universe commit order, so this holds only because the
+// flush derives the root itself rather than trusting submitted values.
+func TestUpsertProofLeafSameUniverseConcurrent(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	multiverse, _ := newTestMultiverse(t)
+
+	const numLeaves = 8
+	items := genUniverseItems(t, numLeaves)
+	id := items[0].ID
+
+	var (
+		wg       sync.WaitGroup
+		receipts = make([]*universe.Proof, numLeaves)
+		errs     = make([]error, numLeaves)
+	)
+	for i := range items {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+
+			receipts[i], errs[i] = multiverse.UpsertProofLeaf(
+				ctx, items[i].ID, items[i].Key,
+				items[i].Leaf, items[i].MetaReveal,
+			)
+		}(i)
+	}
+	wg.Wait()
+
+	// Every returned receipt must compose, whichever flush round
+	// served it and whether or not it was superseded by a concurrent
+	// insert.
+	for i, err := range errs {
+		require.NoError(t, err)
+		assertReceiptComposes(t, id, receipts[i])
+	}
+
+	// The multiverse leaf must commit to the universe's current root,
+	// not to whichever root happened to be submitted last.
+	var (
+		uniRoot mssmt.Node
+		mvRoot  mssmt.Node
+		mvProof *mssmt.Proof
+	)
+	readTx := NewBaseMultiverseReadTx()
+	err := multiverse.db.ExecTx(
+		ctx, &readTx, func(db BaseMultiverseStore) error {
+			dbRoot, err := db.FetchUniverseRoot(ctx, id.String())
+			if err != nil {
+				return err
+			}
+
+			var rootHash mssmt.NodeHash
+			copy(rootHash[:], dbRoot.RootHash[:])
+			uniRoot = mssmt.NewComputedNode(
+				rootHash, uint64(dbRoot.RootSum),
+			)
+
+			mvRoot, mvProof, err = multiverseRootAndProof(
+				ctx, db, id,
+			)
+			return err
+		},
+	)
+	require.NoError(t, err)
+
+	require.True(t, mssmt.VerifyMerkleProof(
+		id.Bytes(), multiverseLeafForRoot(id, uniRoot), mvProof, mvRoot,
+	))
+}
+
+// TestFetchProofLeafHealsMultiverse asserts that fetching a proof in
+// the window between a universe commit and its multiverse flush returns
+// a consistent composite: the read path detects the missing or stale
+// multiverse leaf, waits for a healing flush, and reads again.
+func TestFetchProofLeafHealsMultiverse(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	multiverse, _ := newTestMultiverse(t)
+
+	items := genUniverseItems(t, 2)
+	id := items[0].ID
+
+	// A committed universe leaf with no multiverse update is exactly
+	// the state a fetcher observes in the gap, with the multiverse
+	// leaf missing entirely.
+	_, err := insertUniverseLeafOnly(ctx, multiverse, items[0])
+	require.NoError(t, err)
+
+	proofs, err := multiverse.FetchProofLeaf(ctx, id, items[0].Key)
+	require.NoError(t, err)
+	require.Len(t, proofs, 1)
+	assertReceiptComposes(t, id, proofs[0])
+
+	// The heal above flushed the multiverse leaf; a second universe
+	// commit without its multiverse update now leaves the leaf
+	// present but stale.
+	_, err = insertUniverseLeafOnly(ctx, multiverse, items[1])
+	require.NoError(t, err)
+
+	proofs, err = multiverse.FetchProofLeaf(ctx, id, items[1].Key)
+	require.NoError(t, err)
+	require.Len(t, proofs, 1)
+	assertReceiptComposes(t, id, proofs[0])
+}
+
+// TestUpsertProofLeafConcurrentDelete asserts that inserts racing a
+// deletion of their universe either succeed with a composing receipt or
+// fail outright, and that the persisted multiverse state is consistent
+// with the universe state whatever the interleaving.
+func TestUpsertProofLeafConcurrentDelete(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	multiverse, _ := newTestMultiverse(t)
+
+	const numLeaves = 8
+	items := genUniverseItems(t, numLeaves)
+	id := items[0].ID
+
+	// Seed the universe so the deletion has something to delete.
+	_, err := multiverse.UpsertProofLeaf(
+		ctx, items[0].ID, items[0].Key, items[0].Leaf,
+		items[0].MetaReveal,
+	)
+	require.NoError(t, err)
+
+	var (
+		wg       sync.WaitGroup
+		receipts = make([]*universe.Proof, numLeaves)
+		errs     = make([]error, numLeaves)
+		delErr   error
+	)
+	for i := 1; i < numLeaves; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+
+			receipts[i], errs[i] = multiverse.UpsertProofLeaf(
+				ctx, items[i].ID, items[i].Key,
+				items[i].Leaf, items[i].MetaReveal,
+			)
+		}(i)
+	}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		_, delErr = multiverse.DeleteUniverse(ctx, id)
+	}()
+	wg.Wait()
+
+	require.NoError(t, delErr)
+
+	// An insert that reported success must have returned a composing
+	// receipt; failures (universe deleted under the insert's
+	// multiverse update or receipt fetch) are acceptable.
+	for i := 1; i < numLeaves; i++ {
+		if errs[i] != nil {
+			continue
+		}
+
+		assertReceiptComposes(t, id, receipts[i])
+	}
+
+	// Whatever the interleaving, the persisted multiverse leaf must
+	// agree with the persisted universe state: absent if the universe
+	// is gone, committing to its current root otherwise.
+	var (
+		exists  bool
+		uniRoot mssmt.Node
+		mvRoot  mssmt.Node
+		mvProof *mssmt.Proof
+	)
+	readTx := NewBaseMultiverseReadTx()
+	err = multiverse.db.ExecTx(
+		ctx, &readTx, func(db BaseMultiverseStore) error {
+			dbRoot, err := db.FetchUniverseRoot(ctx, id.String())
+			switch {
+			case errors.Is(err, sql.ErrNoRows):
+
+			case err != nil:
+				return err
+
+			default:
+				exists = true
+				var rootHash mssmt.NodeHash
+				copy(rootHash[:], dbRoot.RootHash[:])
+				uniRoot = mssmt.NewComputedNode(
+					rootHash, uint64(dbRoot.RootSum),
+				)
+			}
+
+			mvRoot, mvProof, err = multiverseRootAndProof(
+				ctx, db, id,
+			)
+			return err
+		},
+	)
+	require.NoError(t, err)
+
+	expected := mssmt.EmptyLeafNode
+	if exists {
+		expected = multiverseLeafNode(id, uniRoot)
+	}
+	require.True(t, mssmt.VerifyMerkleProof(
+		id.Bytes(), expected, mvProof, mvRoot,
+	))
+}
+
+// countTxDB is a BatchedMultiverse that counts the transactions
+// executed through it.
+type countTxDB struct {
+	BatchedMultiverse
+
+	count atomic.Int32
+}
+
+func (c *countTxDB) ExecTx(ctx context.Context, opts TxOptions,
+	txBody func(BaseMultiverseStore) error) error {
+
+	c.count.Add(1)
+
+	return c.BatchedMultiverse.ExecTx(ctx, opts, txBody)
+}
+
+// TestMultiverseRootCoalescerRollover asserts that a submission larger
+// than the flush batch size is applied across several bounded rounds
+// of one transaction each: every waiter is served, a refresh callback
+// arrives for every universe in submission order, and the multiverse
+// state matches the oracle.
+func TestMultiverseRootCoalescerRollover(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	multiverse, _ := newTestMultiverse(t)
+
+	// Shrink the per-round cap so a small submission spans several
+	// rounds, and capture the refresh callbacks.
+	multiverse.rootCoalescer.flushBatchSize = 4
+
+	var (
+		refreshMu sync.Mutex
+		refreshed []universe.Root
+	)
+	multiverse.rootCoalescer.onRefresh = func(root universe.Root) {
+		refreshMu.Lock()
+		defer refreshMu.Unlock()
+
+		refreshed = append(refreshed, root)
+	}
+
+	const numUniverses = 9
+
+	ids := make([]universe.Identifier, numUniverses)
+	roots := make([]mssmt.Node, numUniverses)
+	for i := 0; i < numUniverses; i++ {
+		item := genRandomAsset(t)
+
+		root, err := insertUniverseLeafOnly(ctx, multiverse, item)
+		require.NoError(t, err)
+
+		ids[i] = item.ID
+		roots[i] = root
+	}
+
+	// Count the flush transactions from here on: the coalescer's
+	// handle only ever executes flushes, so wrapping it counts exactly
+	// those.
+	counter := &countTxDB{
+		BatchedMultiverse: multiverse.rootCoalescer.db,
+	}
+	multiverse.rootCoalescer.db = counter
+
+	require.NoError(t, multiverse.rootCoalescer.updateRoots(ctx, ids))
+
+	// Nine universes at a cap of four must have flushed in exactly
+	// three rounds, one transaction each. An implementation that
+	// ignored the cap would apply them in a single transaction.
+	require.EqualValues(t, 3, counter.count.Load())
+
+	// Every universe must have been refreshed exactly once, in
+	// submission order: rounds are taken from the front of the
+	// pending queue, which preserves first-submission order.
+	require.Len(t, refreshed, numUniverses)
+	for i, root := range refreshed {
+		require.Equal(t, ids[i].Bytes(), root.ID.Bytes())
+		require.True(t, mssmt.IsEqualNode(roots[i], root.Node))
+	}
+
+	// The multiverse trees must match oracles fed the same roots.
+	oracles := map[universe.ProofType]*mssmt.CompactedTree{
+		universe.ProofTypeIssuance: mssmt.NewCompactedTree(
+			mssmt.NewDefaultStore(),
+		),
+		universe.ProofTypeTransfer: mssmt.NewCompactedTree(
+			mssmt.NewDefaultStore(),
+		),
+	}
+	touched := make(map[universe.ProofType]bool)
+	for i, id := range ids {
+		_, err := oracles[id.ProofType].Insert(
+			ctx, id.Bytes(), multiverseLeafForRoot(id, roots[i]),
+		)
+		require.NoError(t, err)
+		touched[id.ProofType] = true
+	}
+	for proofType, oracle := range oracles {
+		if !touched[proofType] {
+			continue
+		}
+
+		assertOracleRoot(t, ctx, multiverse, oracle, proofType)
+	}
+}
+
+// TestMultiverseRootCoalescerMixedDeleted asserts that a flush round
+// containing both a missing universe and a healthy one commits the
+// healthy refresh while failing only the missing universe's waiters
+// with the typed error.
+func TestMultiverseRootCoalescerMixedDeleted(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	multiverse, _ := newTestMultiverse(t)
+
+	// One healthy universe with a committed leaf, and one universe
+	// identifier with no committed state, as left behind by a
+	// concurrent deletion.
+	item := genRandomAsset(t)
+	rootX, err := insertUniverseLeafOnly(ctx, multiverse, item)
+	require.NoError(t, err)
+
+	var missing universe.Identifier
+	missing.ProofType = item.ID.ProofType
+	copy(missing.AssetID[:], test.RandBytes(32))
+
+	// Both universes are submitted together, so they land in the same
+	// flush round and transaction.
+	err = multiverse.rootCoalescer.updateRoots(
+		ctx, []universe.Identifier{missing, item.ID},
+	)
+	require.ErrorIs(t, err, errUniverseDeleted)
+
+	// The healthy universe's refresh must have committed in that same
+	// round regardless.
+	var (
+		mvRoot  mssmt.Node
+		mvProof *mssmt.Proof
+	)
+	readTx := NewBaseMultiverseReadTx()
+	err = multiverse.db.ExecTx(
+		ctx, &readTx, func(db BaseMultiverseStore) error {
+			var err error
+			mvRoot, mvProof, err = multiverseRootAndProof(
+				ctx, db, item.ID,
+			)
+			return err
+		},
+	)
+	require.NoError(t, err)
+
+	require.True(t, mssmt.VerifyMerkleProof(
+		item.ID.Bytes(), multiverseLeafForRoot(item.ID, rootX),
+		mvProof, mvRoot,
+	))
 }

--- a/tapdb/multiverse_coalescer_test.go
+++ b/tapdb/multiverse_coalescer_test.go
@@ -4,13 +4,17 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/lightninglabs/taproot-assets/asset"
+	"github.com/lightninglabs/taproot-assets/fn"
 	"github.com/lightninglabs/taproot-assets/internal/test"
 	"github.com/lightninglabs/taproot-assets/mssmt"
+	"github.com/lightninglabs/taproot-assets/proof"
 	"github.com/lightninglabs/taproot-assets/universe"
 	lfn "github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/stretchr/testify/require"
@@ -490,7 +494,9 @@ func TestMultiverseRootCoalescerFlushPanic(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	coalescer := newMultiverseRootCoalescer(panicFlushDB{})
+
+	var writeMu sync.Mutex
+	coalescer := newMultiverseRootCoalescer(panicFlushDB{}, &writeMu)
 
 	newID := func() universe.Identifier {
 		var id universe.Identifier
@@ -527,13 +533,21 @@ func TestMultiverseRootCoalescerFlushPanic(t *testing.T) {
 		t.Fatal("waiter was not notified of the failed flush")
 	}
 
-	// The flusher role and the pending queue must be clean, so
-	// future updates are not blocked.
-	coalescer.mu.Lock()
-	require.False(t, coalescer.flushing)
-	require.Empty(t, coalescer.pending)
-	require.Empty(t, coalescer.order)
-	coalescer.mu.Unlock()
+	// The flusher must surrender its role and leave no pending state:
+	// a panic is presumed to be a bug, so the round is not retried,
+	// and future updates must not be blocked.
+	require.Eventually(t, func() bool {
+		coalescer.mu.Lock()
+		defer coalescer.mu.Unlock()
+
+		return !coalescer.flushing && len(coalescer.pending) == 0 &&
+			len(coalescer.order) == 0
+	}, time.Second, time.Millisecond)
+
+	// The multiverse write lock must have been released on the way
+	// out, or the deletion paths would deadlock.
+	require.True(t, writeMu.TryLock())
+	writeMu.Unlock()
 }
 
 // TestMultiverseRootCoalescerMissingUniverse asserts that an update for
@@ -932,4 +946,780 @@ func TestMultiverseRootCoalescerMixedDeleted(t *testing.T) {
 		item.ID.Bytes(), multiverseLeafForRoot(item.ID, rootX),
 		mvProof, mvRoot,
 	))
+}
+
+// failFlushDB is a BatchedMultiverse that fails coalescer flush
+// transactions — recognized by their distinct options type — while
+// letting every other transaction through, simulating a database that
+// becomes unavailable between a universe commit and its multiverse
+// flush.
+type failFlushDB struct {
+	BatchedMultiverse
+
+	failing atomic.Bool
+}
+
+func (f *failFlushDB) ExecTx(ctx context.Context, opts TxOptions,
+	txBody func(BaseMultiverseStore) error) error {
+
+	if _, isFlush := opts.(multiverseFlushTx); isFlush &&
+		f.failing.Load() {
+
+		return fmt.Errorf("flush unavailable")
+	}
+
+	return f.BatchedMultiverse.ExecTx(ctx, opts, txBody)
+}
+
+// TestUpsertProofLeafFlushFailure asserts that when the multiverse
+// flush fails after the universe transaction has committed, the
+// commit-tied bookkeeping has still run: stale cached proofs are
+// evicted and the custodian notification for the stored transfer proof
+// is emitted, even though the call reports the flush error.
+func TestUpsertProofLeafFlushFailure(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	db := NewTestDB(t)
+	failDB := &failFlushDB{
+		BatchedMultiverse: NewTransactionExecutor(
+			db, func(tx *sql.Tx) BaseMultiverseStore {
+				return db.WithTx(tx)
+			},
+		),
+	}
+	cfg := DefaultMultiverseStoreConfig()
+	cfg.Caches.SyncerCacheEnabled = true
+	multiverse, err := NewMultiverseStore(failDB, cfg)
+	require.NoError(t, err)
+	t.Cleanup(multiverse.Stop)
+
+	// Fast retry pacing: the background retries simply keep failing
+	// until the database recovers below.
+	multiverse.rootCoalescer.initialRetryBackoff = 5 * time.Millisecond
+	multiverse.rootCoalescer.maxRetryBackoff = 20 * time.Millisecond
+
+	items := genUniverseItemsWithType(t, universe.ProofTypeTransfer, 2)
+	id := items[0].ID
+
+	// Insert a first leaf and fetch it, so the proof cache holds an
+	// entry that the failing insert below must evict.
+	_, err = multiverse.UpsertProofLeaf(
+		ctx, items[0].ID, items[0].Key, items[0].Leaf,
+		items[0].MetaReveal,
+	)
+	require.NoError(t, err)
+
+	proofs, err := multiverse.FetchProofLeaf(ctx, id, items[0].Key)
+	require.NoError(t, err)
+	require.Len(t, proofs, 1)
+	require.NotEmpty(t, multiverse.proofCache.fetchProof(
+		id, items[0].Key,
+	))
+
+	// Initialize the syncer cache and pin the universe root it now
+	// serves.
+	rootsQuery := universe.RootNodesQuery{
+		SortDirection: universe.SortAscending,
+		Limit:         universe.RequestPageSize,
+	}
+	roots, err := multiverse.RootNodes(ctx, rootsQuery)
+	require.NoError(t, err)
+	require.Len(t, roots, 1)
+	staleRoot := roots[0].Node
+
+	receiver := fn.NewEventReceiver[proof.Blob](fn.DefaultQueueSize)
+	require.NoError(t, multiverse.RegisterSubscriber(
+		receiver, false, nil,
+	))
+
+	// Insert a second leaf with the flush failing: the call must
+	// report the typed partial-commit error, as the universe leaf
+	// committed while the multiverse update did not.
+	failDB.failing.Store(true)
+	_, err = multiverse.UpsertProofLeaf(
+		ctx, items[1].ID, items[1].Key, items[1].Leaf,
+		items[1].MetaReveal,
+	)
+	require.ErrorIs(t, err, universe.ErrMultiversePending)
+	require.ErrorContains(t, err, "flush unavailable")
+
+	// The universe commit went through, so the bookkeeping tied to it
+	// must have run regardless: the previously cached proof, stale as
+	// of the new leaf, is gone, and the stored transfer proof was
+	// delivered to subscribers.
+	require.Empty(t, multiverse.proofCache.fetchProof(id, items[0].Key))
+
+	select {
+	case blob := <-receiver.NewItemCreated.ChanOut():
+		require.Equal(
+			t, []byte(items[1].Leaf.RawProof), []byte(blob),
+		)
+
+	case <-time.After(time.Second):
+		t.Fatal("no transfer proof notification received")
+	}
+
+	// The failed flush must have invalidated the syncer cache: the
+	// next syncer query repopulates from the database and serves the
+	// universe root committed by the failed call, not the stale one
+	// installed before it.
+	roots, err = multiverse.RootNodes(ctx, rootsQuery)
+	require.NoError(t, err)
+	require.Len(t, roots, 1)
+	require.False(t, mssmt.IsEqualNode(staleRoot, roots[0].Node))
+
+	// Once the database recovers, the read path heals the multiverse
+	// on the next fetch.
+	failDB.failing.Store(false)
+	proofs, err = multiverse.FetchProofLeaf(ctx, id, items[1].Key)
+	require.NoError(t, err)
+	require.Len(t, proofs, 1)
+	assertReceiptComposes(t, id, proofs[0])
+}
+
+// hookFlushDB is a BatchedMultiverse that recognizes coalescer flush
+// transactions by their distinct options type, letting tests act
+// deterministically at the boundary between a universe commit and its
+// multiverse flush: it counts flushes, runs a one-shot hook right
+// before a flush executes, and can fail flushes from a given ordinal
+// onwards.
+type hookFlushDB struct {
+	BatchedMultiverse
+
+	// beforeFlush, if armed, runs exactly once, right before the next
+	// flush transaction executes. The flusher holds the multiverse
+	// write lock at that point, so work done here is already
+	// serialized against the flush itself.
+	beforeFlush atomic.Pointer[func()]
+
+	// flushCount is the number of flush transactions attempted.
+	flushCount atomic.Int32
+
+	// failFrom, if positive, fails every flush whose ordinal (from
+	// one) is greater than or equal to it.
+	failFrom atomic.Int32
+}
+
+func (h *hookFlushDB) ExecTx(ctx context.Context, opts TxOptions,
+	txBody func(BaseMultiverseStore) error) error {
+
+	if _, isFlush := opts.(multiverseFlushTx); isFlush {
+		n := h.flushCount.Add(1)
+
+		if hook := h.beforeFlush.Swap(nil); hook != nil {
+			(*hook)()
+		}
+
+		if from := h.failFrom.Load(); from > 0 && n >= from {
+			return fmt.Errorf("flush unavailable")
+		}
+	}
+
+	return h.BatchedMultiverse.ExecTx(ctx, opts, txBody)
+}
+
+// newHookedMultiverse creates a multiverse store whose flush
+// transactions pass through a hookFlushDB.
+func newHookedMultiverse(t *testing.T) (*MultiverseStore, *hookFlushDB) {
+	db := NewTestDB(t)
+	hookDB := &hookFlushDB{
+		BatchedMultiverse: NewTransactionExecutor(
+			db, func(tx *sql.Tx) BaseMultiverseStore {
+				return db.WithTx(tx)
+			},
+		),
+	}
+	multiverse, err := NewMultiverseStore(
+		hookDB, DefaultMultiverseStoreConfig(),
+	)
+	require.NoError(t, err)
+	t.Cleanup(multiverse.Stop)
+
+	return multiverse, hookDB
+}
+
+// TestUpsertProofLeafSuperseded deterministically forces the
+// superseded-receipt path: a second leaf commits into the universe
+// after the first caller's transaction but before its flush, so the
+// flush derives the newer root and the first caller's receipt must be
+// rebuilt against it.
+func TestUpsertProofLeafSuperseded(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	multiverse, hookDB := newHookedMultiverse(t)
+
+	items := genUniverseItems(t, 2)
+	id := items[0].ID
+
+	// Arm the hook: right before the first insert's flush runs, a
+	// second leaf commits into the same universe.
+	var (
+		superseding mssmt.Node
+		hookErr     error
+	)
+	hook := func() {
+		superseding, hookErr = insertUniverseLeafOnly(
+			ctx, multiverse, items[1],
+		)
+	}
+	hookDB.beforeFlush.Store(&hook)
+
+	receipt, err := multiverse.UpsertProofLeaf(
+		ctx, items[0].ID, items[0].Key, items[0].Leaf,
+		items[0].MetaReveal,
+	)
+	require.NoError(t, err)
+	require.NoError(t, hookErr)
+	require.NotNil(t, superseding)
+
+	// The receipt must compose, and it must commit to the superseding
+	// root rather than the root of the caller's own transaction.
+	assertReceiptComposes(t, id, receipt)
+	require.True(t, mssmt.IsEqualNode(superseding, receipt.UniverseRoot))
+}
+
+// TestUpsertProofLeafDeletedInGap deterministically forces a universe
+// deletion into the gap between a caller's universe commit and its
+// multiverse flush: the flush finds the universe gone, the caller
+// receives the typed error, and no multiverse leaf is resurrected.
+func TestUpsertProofLeafDeletedInGap(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	multiverse, hookDB := newHookedMultiverse(t)
+
+	items := genUniverseItems(t, 1)
+	id := items[0].ID
+
+	// Arm the hook: right before the insert's flush runs, the
+	// universe is deleted. The flusher holds the multiverse write
+	// lock here, so the deletion is already serialized with the
+	// flush.
+	var hookErr error
+	hook := func() {
+		var writeTx BaseMultiverseOptions
+		hookErr = multiverse.db.ExecTx(
+			ctx, &writeTx,
+			func(store BaseMultiverseStore) error {
+				multiverseNS, err := namespaceForProof(
+					id.ProofType,
+				)
+				if err != nil {
+					return err
+				}
+
+				multiverseTree := mssmt.NewCompactedTree(
+					newTreeStoreWrapperTx(
+						store, multiverseNS,
+					),
+				)
+				_, err = multiverseTree.Delete(
+					ctx, id.Bytes(),
+				)
+				if err != nil {
+					return err
+				}
+
+				return deleteUniverseTree(ctx, store, id)
+			},
+		)
+	}
+	hookDB.beforeFlush.Store(&hook)
+
+	_, err := multiverse.UpsertProofLeaf(
+		ctx, items[0].ID, items[0].Key, items[0].Leaf,
+		items[0].MetaReveal,
+	)
+	require.ErrorIs(t, err, errUniverseDeleted)
+	require.NoError(t, hookErr)
+
+	// The skipped flush must not have resurrected any multiverse
+	// state for the deleted universe.
+	_, err = multiverse.MultiverseRootNode(ctx, id.ProofType)
+	require.ErrorIs(t, err, ErrNoMultiverseRoot)
+}
+
+// TestMultiverseRootCoalescerCoalesces proves that updates enqueued
+// while a flush is in flight are applied together: with the first flush
+// blocked, several universes are submitted, and releasing the flush
+// must drain all of them in exactly one further flush transaction.
+func TestMultiverseRootCoalescerCoalesces(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	multiverse, hookDB := newHookedMultiverse(t)
+
+	const numQueued = 4
+
+	leader := genRandomAsset(t)
+	_, err := insertUniverseLeafOnly(ctx, multiverse, leader)
+	require.NoError(t, err)
+
+	queued := make([]*universe.Item, numQueued)
+	for i := range queued {
+		queued[i] = genRandomAsset(t)
+		_, err := insertUniverseLeafOnly(ctx, multiverse, queued[i])
+		require.NoError(t, err)
+	}
+
+	// Block the leader's flush until the queued universes are
+	// pending.
+	inFlush := make(chan struct{})
+	release := make(chan struct{})
+	hook := func() {
+		close(inFlush)
+		<-release
+	}
+	hookDB.beforeFlush.Store(&hook)
+
+	var (
+		wg        sync.WaitGroup
+		leaderErr error
+		queueErrs = make([]error, numQueued)
+	)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		_, leaderErr = multiverse.rootCoalescer.updateRoot(
+			ctx, leader.ID,
+		)
+	}()
+	<-inFlush
+
+	for i := range queued {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+
+			_, queueErrs[i] = multiverse.rootCoalescer.updateRoot(
+				ctx, queued[i].ID,
+			)
+		}(i)
+	}
+
+	// Wait until all queued universes are registered as pending, then
+	// let the blocked flush proceed.
+	coalescer := multiverse.rootCoalescer
+	require.Eventually(t, func() bool {
+		coalescer.mu.Lock()
+		defer coalescer.mu.Unlock()
+
+		return len(coalescer.order) == numQueued
+	}, time.Second, time.Millisecond)
+	close(release)
+
+	wg.Wait()
+	require.NoError(t, leaderErr)
+	for _, err := range queueErrs {
+		require.NoError(t, err)
+	}
+
+	// The leader's round plus exactly one coalesced round for the
+	// queued universes.
+	require.EqualValues(t, 2, hookDB.flushCount.Load())
+}
+
+// TestMultiverseCoalescerCallerDecoupled asserts that the caller that
+// starts the flusher is not conscripted into draining the queue: it
+// returns as soon as its own result — or its context — permits, while
+// updates queued behind it are flushed by the background flusher
+// rather than stranded.
+func TestMultiverseCoalescerCallerDecoupled(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	multiverse, hookDB := newHookedMultiverse(t)
+
+	first := genRandomAsset(t)
+	second := genRandomAsset(t)
+	for _, item := range []*universe.Item{first, second} {
+		_, err := insertUniverseLeafOnly(ctx, multiverse, item)
+		require.NoError(t, err)
+	}
+
+	// Block the first flush round, so the second update queues behind
+	// it while the first caller is already waiting.
+	inFlush := make(chan struct{})
+	release := make(chan struct{})
+	hook := func() {
+		close(inFlush)
+		<-release
+	}
+	hookDB.beforeFlush.Store(&hook)
+
+	callerCtx, cancelCaller := context.WithCancel(ctx)
+	defer cancelCaller()
+
+	firstDone := make(chan error, 1)
+	go func() {
+		_, err := multiverse.rootCoalescer.updateRoot(
+			callerCtx, first.ID,
+		)
+		firstDone <- err
+	}()
+	<-inFlush
+
+	secondDone := make(chan error, 1)
+	go func() {
+		_, err := multiverse.rootCoalescer.updateRoot(ctx, second.ID)
+		secondDone <- err
+	}()
+
+	// Wait until the second update is registered as pending.
+	coalescer := multiverse.rootCoalescer
+	require.Eventually(t, func() bool {
+		coalescer.mu.Lock()
+		defer coalescer.mu.Unlock()
+
+		return len(coalescer.order) == 1
+	}, time.Second, time.Millisecond)
+
+	// Cancelling the first caller must return it promptly, even
+	// though it started the flusher and the queue behind it is
+	// non-empty: draining is not its responsibility.
+	cancelCaller()
+	select {
+	case err := <-firstDone:
+		require.ErrorIs(t, err, context.Canceled)
+
+	case <-time.After(time.Second):
+		t.Fatal("caller pinned by the flusher after cancellation")
+	}
+
+	// The queued update must not be stranded by the departed caller:
+	// once the blocked round completes, the flusher applies it.
+	close(release)
+	select {
+	case err := <-secondDone:
+		require.NoError(t, err)
+
+	case <-time.After(5 * time.Second):
+		t.Fatal("queued update stranded after caller departure")
+	}
+
+	// The flusher must wind down once the queue drains.
+	require.Eventually(t, func() bool {
+		coalescer.mu.Lock()
+		defer coalescer.mu.Unlock()
+
+		return !coalescer.flushing && len(coalescer.pending) == 0
+	}, time.Second, time.Millisecond)
+}
+
+// TestMultiverseCoalescerStop asserts that stopping the store fails
+// pending waiters, lets an in-flight flush complete on its own,
+// rejects new submissions, and leaves the flusher wound down rather
+// than permanently marked active.
+func TestMultiverseCoalescerStop(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	multiverse, hookDB := newHookedMultiverse(t)
+
+	first := genRandomAsset(t)
+	queued := genRandomAsset(t)
+	for _, item := range []*universe.Item{first, queued} {
+		_, err := insertUniverseLeafOnly(ctx, multiverse, item)
+		require.NoError(t, err)
+	}
+
+	// Block the first flush round and queue another update behind it,
+	// then stop the store while both are outstanding.
+	inFlush := make(chan struct{})
+	release := make(chan struct{})
+	hook := func() {
+		close(inFlush)
+		<-release
+	}
+	hookDB.beforeFlush.Store(&hook)
+
+	firstDone := make(chan error, 1)
+	go func() {
+		_, err := multiverse.rootCoalescer.updateRoot(ctx, first.ID)
+		firstDone <- err
+	}()
+	<-inFlush
+
+	queuedDone := make(chan error, 1)
+	go func() {
+		_, err := multiverse.rootCoalescer.updateRoot(ctx, queued.ID)
+		queuedDone <- err
+	}()
+
+	coalescer := multiverse.rootCoalescer
+	require.Eventually(t, func() bool {
+		coalescer.mu.Lock()
+		defer coalescer.mu.Unlock()
+
+		return len(coalescer.order) == 1
+	}, time.Second, time.Millisecond)
+
+	stopDone := make(chan struct{})
+	go func() {
+		multiverse.Stop()
+		close(stopDone)
+	}()
+
+	// The waiter still pending — not part of the in-flight round —
+	// must be failed promptly, without waiting for the blocked flush.
+	select {
+	case err := <-queuedDone:
+		require.ErrorIs(t, err, errCoalescerStopped)
+
+	case <-time.After(time.Second):
+		t.Fatal("pending waiter not failed by stop")
+	}
+
+	// The in-flight round is not torn down: released, it completes
+	// and serves its waiter normally.
+	close(release)
+	select {
+	case err := <-firstDone:
+		require.NoError(t, err)
+
+	case <-time.After(5 * time.Second):
+		t.Fatal("in-flight round did not complete under stop")
+	}
+
+	select {
+	case <-stopDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("stop did not return after flusher exit")
+	}
+
+	// The flusher must be wound down, not left marked active.
+	coalescer.mu.Lock()
+	require.False(t, coalescer.flushing)
+	coalescer.mu.Unlock()
+
+	// New submissions must fail fast on a stopped coalescer.
+	_, err := multiverse.rootCoalescer.updateRoot(ctx, first.ID)
+	require.ErrorIs(t, err, errCoalescerStopped)
+}
+
+// TestUpsertProofLeafFlushRecovery asserts that a flush failure after
+// the universe commit surfaces as the typed pending error, and that
+// the background flusher heals the divergence on its own once the
+// database recovers — with no further proof insert and no restart.
+func TestUpsertProofLeafFlushRecovery(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	multiverse, hookDB := newHookedMultiverse(t)
+
+	// Fast retry pacing, so recovery is observable in test time.
+	multiverse.rootCoalescer.initialRetryBackoff = 5 * time.Millisecond
+	multiverse.rootCoalescer.maxRetryBackoff = 20 * time.Millisecond
+
+	item := genRandomAsset(t)
+
+	// Every flush fails, as under a database outage.
+	hookDB.failFrom.Store(1)
+
+	_, err := multiverse.UpsertProofLeaf(
+		ctx, item.ID, item.Key, item.Leaf, item.MetaReveal,
+	)
+	require.ErrorIs(t, err, universe.ErrMultiversePending)
+
+	// The universe leaf is durable, its divergence visible, and it
+	// stays that way while the database remains down: the retries
+	// keep failing.
+	diverged, err := multiverse.multiverseDivergence(ctx)
+	require.NoError(t, err)
+	require.Len(t, diverged, 1)
+
+	// Once the database recovers, the retrying flusher repairs the
+	// multiverse without any further write.
+	hookDB.failFrom.Store(0)
+	require.Eventually(t, func() bool {
+		diverged, err := multiverse.multiverseDivergence(ctx)
+		return err == nil && len(diverged) == 0
+	}, 10*time.Second, 10*time.Millisecond)
+
+	// The flusher winds down once the queue is drained.
+	require.Eventually(t, func() bool {
+		coalescer := multiverse.rootCoalescer
+		coalescer.mu.Lock()
+		defer coalescer.mu.Unlock()
+
+		return !coalescer.flushing
+	}, time.Second, time.Millisecond)
+
+	// And the read path returns a composing receipt.
+	proofs, err := multiverse.FetchProofLeaf(ctx, item.ID, item.Key)
+	require.NoError(t, err)
+	require.Len(t, proofs, 1)
+	assertReceiptComposes(t, item.ID, proofs[0])
+}
+
+// TestMultiverseConcurrentStores emulates two tapd processes sharing
+// one database: two MultiverseStore instances with independent write
+// mutexes update distinct universes of the same proof type
+// concurrently, so nothing but the database's isolation serializes
+// their multiverse flushes against each other. Every universe's leaf
+// must end up reachable under the final multiverse root: a lost update
+// between the two flushers tears the shared tree at the branch level,
+// which leaf-level reconciliation cannot detect, so composition is
+// verified directly rather than trusting an empty divergence report.
+// The interesting backend is Postgres, where flushes genuinely
+// interleave; on SQLite the driver serializes them.
+func TestMultiverseConcurrentStores(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	db := NewTestDB(t)
+	storeA, _ := newTestMultiverseWithDb(t, db.BaseDB)
+	storeB, _ := newTestMultiverseWithDb(t, db.BaseDB)
+
+	const numPerStore = 12
+	proofType := universe.ProofTypeIssuance
+
+	newItems := func(n int) []*universe.Item {
+		items := make([]*universe.Item, n)
+		for i := range items {
+			items[i] = genUniverseItemsWithType(t, proofType, 1)[0]
+		}
+
+		return items
+	}
+	itemsA := newItems(numPerStore)
+	itemsB := newItems(numPerStore)
+
+	// Each universe is inserted and flushed through its store, all
+	// universes of both stores concurrently.
+	var (
+		wg      sync.WaitGroup
+		updates = make([]multiverseRootUpdate, 2*numPerStore)
+		errs    = make([]error, 2*numPerStore)
+	)
+	run := func(store *MultiverseStore, item *universe.Item, slot int) {
+		defer wg.Done()
+
+		_, err := insertUniverseLeafOnly(ctx, store, item)
+		if err != nil {
+			errs[slot] = err
+			return
+		}
+
+		updates[slot], errs[slot] = store.rootCoalescer.updateRoot(
+			ctx, item.ID,
+		)
+	}
+	for i := range itemsA {
+		wg.Add(2)
+		go run(storeA, itemsA[i], i)
+		go run(storeB, itemsB[i], numPerStore+i)
+	}
+	wg.Wait()
+
+	allItems := append(append([]*universe.Item{}, itemsA...), itemsB...)
+	for i, item := range allItems {
+		require.NoError(t, errs[i])
+
+		// The receipt returned to each caller must compose with the
+		// multiverse root of the flush that carried it.
+		leaf := multiverseLeafForRoot(
+			item.ID, updates[i].universeRoot,
+		)
+		require.True(t, mssmt.VerifyMerkleProof(
+			item.ID.Bytes(), leaf, updates[i].inclusionProof,
+			updates[i].multiverseRoot,
+		))
+	}
+
+	// Every universe's current root must be committed to by the final
+	// multiverse tree. This is the direct detector for a lost update:
+	// a torn branch leaves some leaf unreachable even though its
+	// leaf-level value looks intact.
+	readTx := NewBaseMultiverseReadTx()
+	err := storeA.db.ExecTx(
+		ctx, &readTx, func(dbtx BaseMultiverseStore) error {
+			for _, item := range allItems {
+				id := item.ID
+				dbRoot, err := dbtx.FetchUniverseRoot(
+					ctx, id.String(),
+				)
+				if err != nil {
+					return err
+				}
+
+				var rootHash mssmt.NodeHash
+				copy(rootHash[:], dbRoot.RootHash[:])
+				uniRoot := mssmt.NewComputedNode(
+					rootHash, uint64(dbRoot.RootSum),
+				)
+
+				mvRoot, mvProof, err := multiverseRootAndProof(
+					ctx, dbtx, id,
+				)
+				if err != nil {
+					return err
+				}
+
+				require.True(t, mssmt.VerifyMerkleProof(
+					id.Bytes(),
+					multiverseLeafForRoot(id, uniRoot),
+					mvProof, mvRoot,
+				), "universe %v unreachable under final "+
+					"multiverse root", id.String())
+			}
+
+			return nil
+		},
+	)
+	require.NoError(t, err)
+
+	// And the leaf-level view must agree that nothing diverged.
+	diverged, err := storeA.multiverseDivergence(ctx)
+	require.NoError(t, err)
+	require.Empty(t, diverged)
+}
+
+// TestReconcileMultiverseChunkFailure asserts that chunked startup
+// repairs make durable forward progress: a failure in the second chunk
+// leaves the first chunk's repairs committed, and a subsequent
+// reconcile completes from the remaining divergence.
+func TestReconcileMultiverseChunkFailure(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	multiverse, hookDB := newHookedMultiverse(t)
+
+	// Repair three universes per chunk, with seven diverged: chunks
+	// of 3, 3 and 1.
+	multiverse.reconcileBatchSize = 3
+
+	const numDiverged = 7
+	for i := 0; i < numDiverged; i++ {
+		_, err := insertUniverseLeafOnly(
+			ctx, multiverse, genRandomAsset(t),
+		)
+		require.NoError(t, err)
+	}
+
+	// The first chunk's flush succeeds, everything after fails.
+	hookDB.failFrom.Store(2)
+
+	err := multiverse.ReconcileMultiverse(ctx)
+	require.ErrorContains(t, err, "flush unavailable")
+
+	// The first chunk must have committed: only the remaining four
+	// universes still diverge.
+	diverged, err := multiverse.multiverseDivergence(ctx)
+	require.NoError(t, err)
+	require.Len(t, diverged, numDiverged-3)
+
+	// Once the database recovers, reconciliation completes from where
+	// it left off.
+	hookDB.failFrom.Store(0)
+	require.NoError(t, multiverse.ReconcileMultiverse(ctx))
+
+	diverged, err = multiverse.multiverseDivergence(ctx)
+	require.NoError(t, err)
+	require.Empty(t, diverged)
 }

--- a/tapdb/multiverse_coalescer_test.go
+++ b/tapdb/multiverse_coalescer_test.go
@@ -686,6 +686,193 @@ func TestFetchProofLeafHealsMultiverse(t *testing.T) {
 	assertReceiptComposes(t, id, proofs[0])
 }
 
+// skipFlushDB is a BatchedMultiverse that silently skips coalescer
+// flush transactions while reporting success, so universe and
+// multiverse state stay diverged no matter how many heals a reader
+// awaits. This models the reader-visible worst case of sustained
+// same-universe ingest: every healed snapshot is immediately stale
+// again.
+type skipFlushDB struct {
+	BatchedMultiverse
+}
+
+func (s *skipFlushDB) ExecTx(ctx context.Context, opts TxOptions,
+	txBody func(BaseMultiverseStore) error) error {
+
+	if _, isFlush := opts.(multiverseFlushTx); isFlush {
+		return nil
+	}
+
+	return s.BatchedMultiverse.ExecTx(ctx, opts, txBody)
+}
+
+// newSkipFlushMultiverse creates a multiverse store whose flushes
+// silently do nothing.
+func newSkipFlushMultiverse(t *testing.T) *MultiverseStore {
+	db := NewTestDB(t)
+	skipDB := &skipFlushDB{
+		BatchedMultiverse: NewTransactionExecutor(
+			db, func(tx *sql.Tx) BaseMultiverseStore {
+				return db.WithTx(tx)
+			},
+		),
+	}
+	multiverse, err := NewMultiverseStore(
+		skipDB, DefaultMultiverseStoreConfig(),
+	)
+	require.NoError(t, err)
+	t.Cleanup(multiverse.Stop)
+
+	return multiverse
+}
+
+// TestFetchProofLeafExhaustsRetries asserts that a reader facing
+// persistent inconsistency gives up after its bounded retry budget
+// with the typed, retryable error rather than looping or returning an
+// opaque failure.
+func TestFetchProofLeafExhaustsRetries(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	multiverse := newSkipFlushMultiverse(t)
+	multiverse.fetchRetryBackoff = time.Millisecond
+
+	items := genUniverseItems(t, 1)
+	_, err := insertUniverseLeafOnly(ctx, multiverse, items[0])
+	require.NoError(t, err)
+
+	_, err = multiverse.FetchProofLeaf(ctx, items[0].ID, items[0].Key)
+	require.ErrorIs(t, err, ErrMultiverseInconsistent)
+}
+
+// TestFetchProofLeafRetryCancellation asserts that a reader awaiting
+// its retry backoff honours its context and exits promptly when the
+// context ends, rather than sleeping out the backoff.
+func TestFetchProofLeafRetryCancellation(t *testing.T) {
+	t.Parallel()
+
+	multiverse := newSkipFlushMultiverse(t)
+
+	// A backoff far beyond the caller's deadline: only the context
+	// check can end the wait in test time.
+	multiverse.fetchRetryBackoff = time.Hour
+
+	items := genUniverseItems(t, 1)
+	ctx := context.Background()
+	_, err := insertUniverseLeafOnly(ctx, multiverse, items[0])
+	require.NoError(t, err)
+
+	fetchCtx, cancel := context.WithTimeout(ctx, 150*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	_, err = multiverse.FetchProofLeaf(fetchCtx, items[0].ID, items[0].Key)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.Less(t, time.Since(start), 30*time.Second)
+}
+
+// TestFetchProofLeafUnderConcurrentInserts asserts the read-path
+// contract under sustained same-universe ingest: every read either
+// returns a composing proof or the typed, retryable inconsistency
+// error — never a non-composing proof and never any other failure.
+func TestFetchProofLeafUnderConcurrentInserts(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	multiverse, _ := newTestMultiverse(t)
+
+	const numLeaves = 10
+	items := genUniverseItems(t, numLeaves)
+	id := items[0].ID
+
+	_, err := multiverse.UpsertProofLeaf(
+		ctx, items[0].ID, items[0].Key, items[0].Leaf,
+		items[0].MetaReveal,
+	)
+	require.NoError(t, err)
+
+	var (
+		writerDone = make(chan struct{})
+		failures   = make(chan error, 8)
+	)
+	go func() {
+		defer close(writerDone)
+
+		for _, item := range items[1:] {
+			_, err := multiverse.UpsertProofLeaf(
+				ctx, item.ID, item.Key, item.Leaf,
+				item.MetaReveal,
+			)
+			if err != nil {
+				failures <- fmt.Errorf("writer: %w", err)
+				return
+			}
+		}
+	}()
+
+	const numReaders = 4
+	var wg sync.WaitGroup
+	for r := 0; r < numReaders; r++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			for {
+				select {
+				case <-writerDone:
+					return
+				default:
+				}
+
+				proofs, err := multiverse.FetchProofLeaf(
+					ctx, id, items[0].Key,
+				)
+				switch {
+				// Transient contention is acceptable, and
+				// the only acceptable error.
+				case errors.Is(
+					err, ErrMultiverseInconsistent,
+				):
+					continue
+
+				case err != nil:
+					failures <- fmt.Errorf(
+						"reader: %w", err,
+					)
+					return
+				}
+
+				for _, p := range proofs {
+					if p.MultiverseRoot == nil {
+						continue
+					}
+
+					leaf := multiverseLeafNode(
+						id, p.UniverseRoot,
+					)
+					if !mssmt.VerifyMerkleProof(
+						id.Bytes(), leaf,
+						p.MultiverseInclusionProof,
+						p.MultiverseRoot,
+					) {
+
+						failures <- fmt.Errorf(
+							"non-composing read",
+						)
+						return
+					}
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
+	close(failures)
+	for err := range failures {
+		t.Errorf("unexpected failure: %v", err)
+	}
+}
+
 // TestUpsertProofLeafConcurrentDelete asserts that inserts racing a
 // deletion of their universe either succeed with a composing receipt or
 // fail outright, and that the persisted multiverse state is consistent

--- a/tapdb/multiverse_coalescer_test.go
+++ b/tapdb/multiverse_coalescer_test.go
@@ -1287,6 +1287,10 @@ type hookFlushDB struct {
 	// failFrom, if positive, fails every flush whose ordinal (from
 	// one) is greater than or equal to it.
 	failFrom atomic.Int32
+
+	// failReads, if set, fails every read-only transaction, leaving
+	// write and flush transactions untouched.
+	failReads atomic.Bool
 }
 
 func (h *hookFlushDB) ExecTx(ctx context.Context, opts TxOptions,
@@ -1302,6 +1306,10 @@ func (h *hookFlushDB) ExecTx(ctx context.Context, opts TxOptions,
 		if from := h.failFrom.Load(); from > 0 && n >= from {
 			return fmt.Errorf("flush unavailable")
 		}
+	}
+
+	if h.failReads.Load() && opts.ReadOnly() {
+		return fmt.Errorf("reads unavailable")
 	}
 
 	return h.BatchedMultiverse.ExecTx(ctx, opts, txBody)
@@ -1366,6 +1374,55 @@ func TestUpsertProofLeafSuperseded(t *testing.T) {
 	// root rather than the root of the caller's own transaction.
 	assertReceiptComposes(t, id, receipt)
 	require.True(t, mssmt.IsEqualNode(superseding, receipt.UniverseRoot))
+}
+
+// TestUpsertProofLeafSupersededRebuildFailure forces the rebuild of a
+// superseded receipt to fail and asserts the returned error carries
+// universe.ErrMultiversePending: the caller's leaf and the flushed
+// multiverse update are both durable by then, so the error must not
+// read as a failure to store the proof.
+func TestUpsertProofLeafSupersededRebuildFailure(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	multiverse, hookDB := newHookedMultiverse(t)
+
+	items := genUniverseItems(t, 2)
+	id := items[0].ID
+
+	// Arm the hook: a second leaf supersedes the caller's before its
+	// flush, and every read transaction fails from then on, so the
+	// superseded-receipt rebuild cannot run. The flush itself is a
+	// write transaction and commits unhindered.
+	var (
+		superseding mssmt.Node
+		hookErr     error
+	)
+	hook := func() {
+		superseding, hookErr = insertUniverseLeafOnly(
+			ctx, multiverse, items[1],
+		)
+		hookDB.failReads.Store(true)
+	}
+	hookDB.beforeFlush.Store(&hook)
+
+	_, err := multiverse.UpsertProofLeaf(
+		ctx, items[0].ID, items[0].Key, items[0].Leaf,
+		items[0].MetaReveal,
+	)
+	require.NoError(t, hookErr)
+	require.NotNil(t, superseding)
+	require.ErrorIs(t, err, universe.ErrMultiversePending)
+	require.ErrorContains(t, err, "reads unavailable")
+
+	// Once reads recover, the caller's leaf must be served under a
+	// composing receipt without any further write: the failure was in
+	// assembling the receipt, not in storing the proof.
+	hookDB.failReads.Store(false)
+	receipts, err := multiverse.FetchProofLeaf(ctx, id, items[0].Key)
+	require.NoError(t, err)
+	require.Len(t, receipts, 1)
+	assertReceiptComposes(t, id, receipts[0])
 }
 
 // TestUpsertProofLeafSupersededStaleCache asserts that the

--- a/tapdb/multiverse_coalescer_test.go
+++ b/tapdb/multiverse_coalescer_test.go
@@ -478,11 +478,16 @@ func TestMultiverseRootCoalescerProps(t *testing.T) {
 // panic, simulating an unexpected failure inside a flush.
 type panicFlushDB struct {
 	BatchedMultiverse
+
+	// flushCount is the number of transactions attempted, every one
+	// of which panics.
+	flushCount atomic.Int32
 }
 
-func (panicFlushDB) ExecTx(context.Context, TxOptions,
+func (p *panicFlushDB) ExecTx(context.Context, TxOptions,
 	func(BaseMultiverseStore) error) error {
 
+	p.flushCount.Add(1)
 	panic("flush boom")
 }
 
@@ -496,7 +501,12 @@ func TestMultiverseRootCoalescerFlushPanic(t *testing.T) {
 	ctx := context.Background()
 
 	var writeMu sync.Mutex
-	coalescer := newMultiverseRootCoalescer(panicFlushDB{}, &writeMu)
+	coalescer := newMultiverseRootCoalescer(&panicFlushDB{}, &writeMu)
+
+	// The panic path applies the retry backoff before the flusher
+	// winds down; keep it short so the assertions below see the
+	// settled state promptly.
+	coalescer.initialRetryBackoff = time.Millisecond
 
 	newID := func() universe.Identifier {
 		var id universe.Identifier
@@ -548,6 +558,80 @@ func TestMultiverseRootCoalescerFlushPanic(t *testing.T) {
 	// out, or the deletion paths would deadlock.
 	require.True(t, writeMu.TryLock())
 	writeMu.Unlock()
+}
+
+// TestMultiverseRootCoalescerPanicBackoff asserts that a panicked
+// round is dropped rather than retried, that the flusher then waits
+// out the retry backoff before touching any further work — a
+// deterministically panicking flush must not burn a tight loop of
+// failing transactions under continuous ingest — and that stop cuts
+// the wait short.
+func TestMultiverseRootCoalescerPanicBackoff(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	var writeMu sync.Mutex
+	db := &panicFlushDB{}
+	coalescer := newMultiverseRootCoalescer(db, &writeMu)
+
+	// A backoff far beyond the test's lifetime: any flush attempt
+	// after the panic means the backoff was skipped.
+	coalescer.initialRetryBackoff = time.Hour
+	coalescer.maxRetryBackoff = time.Hour
+
+	newID := func() universe.Identifier {
+		var id universe.Identifier
+		id.ProofType = universe.ProofTypeIssuance
+		copy(id.AssetID[:], test.RandBytes(32))
+		return id
+	}
+
+	_, err := coalescer.updateRoot(ctx, newID())
+	require.ErrorContains(t, err, "panic")
+	require.EqualValues(t, 1, db.flushCount.Load())
+
+	// The panicked round must have been dropped, not requeued, and
+	// the flusher must still hold its role, parked in the backoff.
+	coalescer.mu.Lock()
+	require.Empty(t, coalescer.pending)
+	require.Empty(t, coalescer.order)
+	require.True(t, coalescer.flushing)
+	coalescer.mu.Unlock()
+
+	// An update queued behind the backoff must not trigger another
+	// flush attempt while the flusher waits.
+	resultChan := make(chan error, 1)
+	go func() {
+		_, err := coalescer.updateRoot(ctx, newID())
+		resultChan <- err
+	}()
+
+	require.Never(t, func() bool {
+		return db.flushCount.Load() > 1
+	}, 100*time.Millisecond, 10*time.Millisecond)
+
+	// Stop must interrupt the backoff promptly, failing the queued
+	// waiter without ever flushing it.
+	stopped := make(chan struct{})
+	go func() {
+		coalescer.stop()
+		close(stopped)
+	}()
+
+	select {
+	case <-stopped:
+	case <-time.After(5 * time.Second):
+		t.Fatal("stop did not interrupt the panic backoff")
+	}
+
+	select {
+	case err := <-resultChan:
+		require.ErrorIs(t, err, errCoalescerStopped)
+	case <-time.After(time.Second):
+		t.Fatal("queued waiter was not failed on stop")
+	}
+	require.EqualValues(t, 1, db.flushCount.Load())
 }
 
 // TestMultiverseRootCoalescerMissingUniverse asserts that an update for

--- a/tapdb/multiverse_coalescer_test.go
+++ b/tapdb/multiverse_coalescer_test.go
@@ -1368,6 +1368,72 @@ func TestUpsertProofLeafSuperseded(t *testing.T) {
 	require.True(t, mssmt.IsEqualNode(superseding, receipt.UniverseRoot))
 }
 
+// TestUpsertProofLeafSupersededStaleCache asserts that the
+// superseded-receipt rebuild does not trust the proof cache: a
+// concurrent reader may repopulate the cache — after the upsert's own
+// eviction — from a snapshot predating the upsert's insert, and the
+// rebuilt receipt must nonetheless reflect the caller's committed
+// leaf and compose with the superseding state.
+func TestUpsertProofLeafSupersededStaleCache(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	multiverse, hookDB := newHookedMultiverse(t)
+
+	items := genUniverseItems(t, 3)
+	id := items[0].ID
+
+	// The second item replaces the first at the same leaf key; the
+	// third supersedes the second's root at a distinct key.
+	items[1].Key = items[0].Key
+
+	// Store and fetch the first version of the leaf, so a receipt
+	// predating everything below exists to poison the cache with.
+	_, err := multiverse.UpsertProofLeaf(
+		ctx, items[0].ID, items[0].Key, items[0].Leaf,
+		items[0].MetaReveal,
+	)
+	require.NoError(t, err)
+
+	stale, err := multiverse.FetchProofLeaf(ctx, id, items[0].Key)
+	require.NoError(t, err)
+	require.Len(t, stale, 1)
+
+	// Arm the hook: while the second upsert awaits its flush, a
+	// concurrent insert supersedes its root, and the old receipt
+	// lands back in the proof cache — after the upsert's commit-tied
+	// eviction has already run.
+	var (
+		superseding mssmt.Node
+		hookErr     error
+	)
+	hook := func() {
+		superseding, hookErr = insertUniverseLeafOnly(
+			ctx, multiverse, items[2],
+		)
+		multiverse.proofCache.insertProofs(id, items[0].Key, stale)
+	}
+	hookDB.beforeFlush.Store(&hook)
+
+	receipt, err := multiverse.UpsertProofLeaf(
+		ctx, items[1].ID, items[1].Key, items[1].Leaf,
+		items[1].MetaReveal,
+	)
+	require.NoError(t, err)
+	require.NoError(t, hookErr)
+	require.NotNil(t, superseding)
+
+	// The rebuilt receipt must carry the leaf this call committed —
+	// not the cached pre-insert version — and compose with the
+	// superseding universe root.
+	assertReceiptComposes(t, id, receipt)
+	require.Equal(
+		t, []byte(items[1].Leaf.RawProof),
+		[]byte(receipt.Leaf.RawProof),
+	)
+	require.True(t, mssmt.IsEqualNode(superseding, receipt.UniverseRoot))
+}
+
 // TestUpsertProofLeafDeletedInGap deterministically forces a universe
 // deletion into the gap between a caller's universe commit and its
 // multiverse flush: the flush finds the universe gone, the caller

--- a/tapdb/multiverse_flush_bench_test.go
+++ b/tapdb/multiverse_flush_bench_test.go
@@ -1,0 +1,84 @@
+package tapdb
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/lightninglabs/taproot-assets/asset"
+	"github.com/lightninglabs/taproot-assets/universe"
+	"github.com/stretchr/testify/require"
+)
+
+// BenchmarkMultiverseFlushRound measures the wall-clock cost of one
+// coalescer flush transaction by the number of distinct dirty
+// universes it carries. Its purpose is sizing maxFlushBatchSize
+// against defaultFlushTimeout for a given backend: every timed
+// operation is exactly one flush round in one database transaction.
+//
+// Run with a bounded iteration count, on the backend of interest:
+//
+//	go test ./tapdb -tags="test_db_postgres" \
+//	    -bench MultiverseFlushRound -benchtime 3x -run '^$'
+func BenchmarkMultiverseFlushRound(b *testing.B) {
+	ctx := context.Background()
+
+	for _, size := range []int{64, 256, 1024, 2048} {
+		b.Run(fmt.Sprintf("universes_%d", size), func(b *testing.B) {
+			benchmarkFlushRound(b, ctx, size)
+		})
+	}
+}
+
+// benchmarkFlushRound times flush rounds carrying size distinct
+// universes each.
+func benchmarkFlushRound(b *testing.B, ctx context.Context, size int) {
+	multiverse, _ := newTestMultiverse(b)
+
+	// One universe per slot, each holding one committed leaf and one
+	// flushed multiverse entry, as on a node that has synced these
+	// universes before.
+	gens := make([]asset.Genesis, size)
+	ids := make([]universe.Identifier, size)
+	for i := range ids {
+		gens[i] = asset.RandGenesis(b, asset.Normal)
+		id := randUniverseID(
+			b, false, withProofType(universe.ProofTypeIssuance),
+		)
+		leaf := randMintingLeaf(b, gens[i], id.GroupKey)
+		id.AssetID = leaf.Asset.ID()
+		ids[i] = id
+
+		item := &universe.Item{
+			ID:   id,
+			Key:  randLeafKey(b),
+			Leaf: &leaf,
+		}
+		_, err := insertUniverseLeafOnly(ctx, multiverse, item)
+		require.NoError(b, err)
+	}
+	require.NoError(b, multiverse.rootCoalescer.updateRoots(ctx, ids))
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		// Dirty every universe with a fresh committed leaf, outside
+		// the timed section: the flush is what is being measured.
+		b.StopTimer()
+		for i := range ids {
+			leaf := randMintingLeaf(b, gens[i], ids[i].GroupKey)
+			item := &universe.Item{
+				ID:   ids[i],
+				Key:  randLeafKey(b),
+				Leaf: &leaf,
+			}
+			_, err := insertUniverseLeafOnly(ctx, multiverse, item)
+			require.NoError(b, err)
+		}
+		b.StartTimer()
+
+		// One submission of every universe: a single flush round in
+		// a single transaction.
+		err := multiverse.rootCoalescer.updateRoots(ctx, ids)
+		require.NoError(b, err)
+	}
+}

--- a/tapdb/multiverse_reconcile.go
+++ b/tapdb/multiverse_reconcile.go
@@ -1,0 +1,173 @@
+package tapdb
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"fmt"
+
+	"github.com/lightninglabs/taproot-assets/tapdb/sqlc"
+	"github.com/lightninglabs/taproot-assets/universe"
+)
+
+// defaultReconcileBatchSize bounds the number of universes repaired
+// per coalescer submission during startup reconciliation, so repairs
+// make durable forward progress in bounded steps.
+const defaultReconcileBatchSize = 512
+
+// ReconcileMultiverse verifies that the shared multiverse trees commit
+// to the current root of every universe, and repairs any entries that
+// diverged. The multiverse trees are fully derived from the universe
+// roots, so a daemon that stopped between a proof insert committing
+// and its multiverse update being flushed is always repairable here.
+// This is intended to run at startup, before the store serves
+// concurrent traffic.
+func (b *MultiverseStore) ReconcileMultiverse(ctx context.Context) error {
+	log.Infof("Checking multiverse trees for divergence")
+
+	diverged, err := b.multiverseDivergence(ctx)
+	if err != nil {
+		return fmt.Errorf("unable to check multiverse "+
+			"divergence: %w", err)
+	}
+
+	if len(diverged) == 0 {
+		log.Infof("Multiverse reconcile: no divergence found")
+		return nil
+	}
+
+	log.Warnf("Repairing %d diverged multiverse entries", len(diverged))
+
+	// Repair in bounded chunks, each committing independently: a
+	// failure part-way through preserves the chunks already repaired,
+	// so a restart resumes with strictly less divergence rather than
+	// re-attempting one wholesale repair forever.
+	batchSize := b.reconcileBatchSize
+	for start := 0; start < len(diverged); start += batchSize {
+		end := min(start+batchSize, len(diverged))
+
+		err = b.rootCoalescer.updateRoots(ctx, diverged[start:end])
+		if err != nil {
+			return fmt.Errorf("unable to repair multiverse "+
+				"entries %d-%d of %d: %w", start, end-1,
+				len(diverged), err)
+		}
+
+		log.Infof("Multiverse reconcile: repaired %d/%d entries",
+			end, len(diverged))
+	}
+
+	return nil
+}
+
+// committedMultiverseLeaf is the universe root value a multiverse leaf
+// currently commits to.
+type committedMultiverseLeaf struct {
+	rootHash []byte
+	rootSum  uint64
+}
+
+// multiverseDivergence returns the identifier of every universe whose
+// current root is not committed to by its multiverse leaf, either
+// because the leaf is missing or because it holds a stale root.
+func (b *MultiverseStore) multiverseDivergence(
+	ctx context.Context) ([]universe.Identifier, error) {
+
+	// Load the committed multiverse leaves for both proof types,
+	// keyed the same way multiverse leaf keys are derived (asset ID,
+	// or hash of the schnorr-serialized group key).
+	proofTypes := []universe.ProofType{
+		universe.ProofTypeIssuance, universe.ProofTypeTransfer,
+	}
+	committed := make(
+		map[universe.ProofType]map[[32]byte]committedMultiverseLeaf,
+		len(proofTypes),
+	)
+
+	readTx := NewBaseMultiverseReadTx()
+	dbErr := b.db.ExecTx(
+		ctx, &readTx, func(db BaseMultiverseStore) error {
+			for _, proofType := range proofTypes {
+				leaves, err := db.QueryMultiverseLeaves(
+					ctx, QueryMultiverseLeaves{
+						ProofType: proofType.String(),
+					},
+				)
+				if err != nil {
+					return err
+				}
+
+				byKey := make(
+					map[[32]byte]committedMultiverseLeaf,
+					len(leaves),
+				)
+				for _, leaf := range leaves {
+					var key [32]byte
+					if len(leaf.GroupKey) > 0 {
+						key = sha256.Sum256(
+							leaf.GroupKey,
+						)
+					} else {
+						copy(key[:], leaf.AssetID)
+					}
+
+					sum := uint64(leaf.UniverseRootSum)
+					byKey[key] = committedMultiverseLeaf{
+						rootHash: leaf.UniverseRootHash,
+						rootSum:  sum,
+					}
+				}
+				committed[proofType] = byKey
+			}
+
+			return nil
+		},
+	)
+	if dbErr != nil {
+		return nil, dbErr
+	}
+
+	// Page through all universe roots and collect those whose
+	// multiverse leaf doesn't commit to them.
+	var (
+		diverged []universe.Identifier
+		checked  int
+	)
+	params := sqlc.UniverseRootsParams{
+		SortDirection: sqlInt16(universe.SortAscending),
+		NumOffset:     0,
+		NumLimit:      universe.RequestPageSize,
+	}
+	for {
+		roots, err := b.queryRootNodes(ctx, params, false)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, root := range roots {
+			expected := multiverseLeafNode(root.ID, root.Node)
+			expectedHash := root.Node.NodeHash()
+
+			byKey := committed[root.ID.ProofType]
+			leaf, ok := byKey[root.ID.Bytes()]
+			if ok && bytes.Equal(leaf.rootHash, expectedHash[:]) &&
+				leaf.rootSum == expected.NodeSum() {
+
+				continue
+			}
+
+			diverged = append(diverged, root.ID)
+		}
+
+		checked += len(roots)
+		log.Debugf("Multiverse reconcile: checked %d universe "+
+			"roots, %d diverged so far", checked, len(diverged))
+
+		params.NumOffset += universe.RequestPageSize
+		if len(roots) < universe.RequestPageSize {
+			break
+		}
+	}
+
+	return diverged, nil
+}

--- a/tapdb/multiverse_reconcile.go
+++ b/tapdb/multiverse_reconcile.go
@@ -1,0 +1,218 @@
+package tapdb
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/lightninglabs/taproot-assets/mssmt"
+	"github.com/lightninglabs/taproot-assets/tapdb/sqlc"
+	"github.com/lightninglabs/taproot-assets/universe"
+)
+
+// defaultReconcileBatchSize bounds the number of universes repaired
+// per coalescer submission during startup reconciliation, so repairs
+// make durable forward progress in bounded steps.
+const defaultReconcileBatchSize = 512
+
+// ReconcileMultiverse verifies that the shared multiverse trees commit
+// to the current root of every universe, and repairs any entries that
+// diverged. The multiverse trees are fully derived from the universe
+// roots, so a daemon that stopped between a proof insert committing
+// and its multiverse update being flushed is always repairable here.
+// This is intended to run at startup, before the store serves
+// concurrent traffic; the given context bounds it, so a daemon
+// shutdown interrupts it.
+func (b *MultiverseStore) ReconcileMultiverse(ctx context.Context) error {
+	log.Infof("Checking multiverse trees for divergence")
+	start := time.Now()
+
+	diverged, err := b.multiverseDivergence(ctx)
+	if err != nil {
+		return fmt.Errorf("unable to check multiverse "+
+			"divergence: %w", err)
+	}
+
+	if len(diverged) == 0 {
+		log.Infof("Multiverse reconcile: no divergence found, took=%v",
+			time.Since(start))
+		return nil
+	}
+
+	log.Warnf("Repairing %d diverged multiverse entries", len(diverged))
+
+	// Repair in bounded chunks, each committing independently: a
+	// failure part-way through preserves the chunks already repaired,
+	// so a restart resumes with strictly less divergence rather than
+	// re-attempting one wholesale repair forever.
+	batchSize := b.reconcileBatchSize
+	for chunk := 0; chunk < len(diverged); chunk += batchSize {
+		end := min(chunk+batchSize, len(diverged))
+
+		err = b.rootCoalescer.updateRoots(ctx, diverged[chunk:end])
+		if err != nil {
+			return fmt.Errorf("unable to repair multiverse "+
+				"entries %d-%d of %d: %w", chunk, end-1,
+				len(diverged), err)
+		}
+
+		log.Infof("Multiverse reconcile: repaired %d/%d entries",
+			end, len(diverged))
+	}
+
+	log.Infof("Multiverse reconcile: repaired %d entries, took=%v",
+		len(diverged), time.Since(start))
+
+	return nil
+}
+
+// multiverseDivergence returns the identifier of every universe whose
+// current root is not committed to by its multiverse leaf, either
+// because the leaf is missing or because it holds a stale root.
+//
+// The scan pages through the universe roots by keyset on their table
+// id — each page costs the same, unlike offset pagination — and
+// resolves each page's multiverse leaves with point lookups inside the
+// same read transaction, so memory use is bounded by the page size no
+// matter how many universes the store holds.
+func (b *MultiverseStore) multiverseDivergence(
+	ctx context.Context) ([]universe.Identifier, error) {
+
+	var (
+		diverged []universe.Identifier
+		checked  int
+		afterID  int64
+		start    = time.Now()
+	)
+	for {
+		var (
+			numRows      int
+			pageDiverged = len(diverged)
+			pageAfter    = afterID
+		)
+		readTx := NewBaseMultiverseReadTx()
+		dbErr := b.db.ExecTx(
+			ctx, &readTx, func(db BaseMultiverseStore) error {
+				// The transaction may retry the closure
+				// wholesale, so reset the state a previous
+				// attempt of this page populated.
+				diverged = diverged[:pageDiverged]
+				afterID = pageAfter
+
+				rows, err := db.UniverseRootsAfterID(
+					ctx, sqlc.UniverseRootsAfterIDParams{
+						AfterID:  afterID,
+						NumLimit: b.reconcilePageSize,
+					},
+				)
+				if err != nil {
+					return err
+				}
+
+				numRows = len(rows)
+				for _, row := range rows {
+					afterID = row.ID
+
+					isDiverged, id, err := rootDiverged(
+						ctx, db, row,
+					)
+					if err != nil {
+						return err
+					}
+
+					if isDiverged {
+						diverged = append(diverged, id)
+					}
+				}
+
+				return nil
+			},
+		)
+		if dbErr != nil {
+			return nil, dbErr
+		}
+
+		checked += numRows
+		log.Debugf("Multiverse reconcile: checked %d universe "+
+			"roots, %d diverged so far", checked, len(diverged))
+
+		if numRows < int(b.reconcilePageSize) {
+			break
+		}
+	}
+
+	log.Debugf("Multiverse reconcile: divergence scan of %d roots "+
+		"took=%v", checked, time.Since(start))
+
+	return diverged, nil
+}
+
+// rootDiverged reports whether the given universe root row diverges
+// from its multiverse leaf, resolving the leaf with a point lookup in
+// the same transaction. Universe roots of proof types without a
+// multiverse tree — the supply-commitment sub-trees (mint supply,
+// burns, ignores), and any type added in the future — have no leaf to
+// reconcile against, and are never reported as diverged.
+func rootDiverged(ctx context.Context, db BaseMultiverseStore,
+	row sqlc.UniverseRootsAfterIDRow) (bool, universe.Identifier, error) {
+
+	var id universe.Identifier
+
+	proofType, err := universe.ParseStrProofType(row.ProofType.String)
+	if err != nil {
+		return false, id, err
+	}
+	id.ProofType = proofType
+
+	// The error only marks the proof type as having no multiverse
+	// tree; that is a skip, not a failure.
+	//nolint:nilerr
+	if _, err := namespaceForProof(id.ProofType); err != nil {
+		return false, id, nil
+	}
+
+	if row.AssetID != nil {
+		copy(id.AssetID[:], row.AssetID)
+	}
+	if row.GroupKey != nil {
+		id.GroupKey, err = schnorr.ParsePubKey(row.GroupKey)
+		if err != nil {
+			return false, id, err
+		}
+	}
+
+	var rootHash mssmt.NodeHash
+	copy(rootHash[:], row.RootHash)
+	rootNode := mssmt.NewComputedBranch(rootHash, uint64(row.RootSum))
+
+	expected := multiverseLeafNode(id, rootNode)
+
+	// Look up the universe's multiverse leaf directly, keyed the same
+	// way the insert path keys it: by group key when the universe is
+	// grouped, by asset ID otherwise.
+	query := QueryMultiverseLeaves{
+		ProofType: id.ProofType.String(),
+	}
+	if id.GroupKey != nil {
+		query.GroupKey = schnorr.SerializePubKey(id.GroupKey)
+	} else {
+		query.AssetID = id.AssetID[:]
+	}
+
+	leaves, err := db.QueryMultiverseLeaves(ctx, query)
+	if err != nil {
+		return false, id, err
+	}
+
+	for _, leaf := range leaves {
+		if bytes.Equal(leaf.UniverseRootHash, rootHash[:]) &&
+			uint64(leaf.UniverseRootSum) == expected.NodeSum() {
+
+			return false, id, nil
+		}
+	}
+
+	return true, id, nil
+}

--- a/tapdb/multiverse_reconcile_test.go
+++ b/tapdb/multiverse_reconcile_test.go
@@ -23,6 +23,11 @@ func tamperMultiverseLeaf(t require.TestingT, ctx context.Context,
 		bogusHash, uint64(test.RandInt[uint32]()),
 	)
 
+	// Take the multiverse write lock, as every multiverse writer
+	// must.
+	multiverse.multiverseWriteMu.Lock()
+	defer multiverse.multiverseWriteMu.Unlock()
+
 	var writeTx BaseMultiverseOptions
 	err := multiverse.db.ExecTx(
 		ctx, &writeTx, func(store BaseMultiverseStore) error {

--- a/tapdb/multiverse_reconcile_test.go
+++ b/tapdb/multiverse_reconcile_test.go
@@ -1,0 +1,203 @@
+package tapdb
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/lightninglabs/taproot-assets/internal/test"
+	"github.com/lightninglabs/taproot-assets/mssmt"
+	"github.com/lightninglabs/taproot-assets/universe"
+	"github.com/stretchr/testify/require"
+	"pgregory.net/rapid"
+)
+
+// tamperMultiverseLeaf overwrites a universe's multiverse leaf with a
+// bogus root, diverging it from the universe's actual root.
+func tamperMultiverseLeaf(t require.TestingT, ctx context.Context,
+	multiverse *MultiverseStore, id universe.Identifier) {
+
+	var bogusHash mssmt.NodeHash
+	copy(bogusHash[:], test.RandBytes(32))
+	bogusRoot := mssmt.NewComputedBranch(
+		bogusHash, uint64(test.RandInt[uint32]()),
+	)
+
+	var writeTx BaseMultiverseOptions
+	err := multiverse.db.ExecTx(
+		ctx, &writeTx, func(store BaseMultiverseStore) error {
+			return upsertMultiverseLeafEntry(
+				ctx, store, id, bogusRoot,
+			)
+		},
+	)
+	require.NoError(t, err)
+}
+
+// TestReconcileMultiverse asserts that startup reconciliation detects
+// and repairs both kinds of divergence between the universe trees and
+// the shared multiverse trees: a missing multiverse leaf (crash between
+// universe commit and multiverse write) and a stale one.
+func TestReconcileMultiverse(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	multiverse, _ := newTestMultiverse(t)
+
+	// A healthy store must show no divergence, including when empty.
+	updates, err := multiverse.multiverseDivergence(ctx)
+	require.NoError(t, err)
+	require.Empty(t, updates)
+
+	// Insert a few items through the normal path.
+	items := make([]*universe.Item, 3)
+	for i := range items {
+		items[i] = genRandomAsset(t)
+	}
+	require.NoError(t, multiverse.UpsertProofLeafBatch(ctx, items))
+
+	updates, err = multiverse.multiverseDivergence(ctx)
+	require.NoError(t, err)
+	require.Empty(t, updates)
+
+	// Orphan a new universe: leaf committed, multiverse never
+	// updated.
+	orphan := genRandomAsset(t)
+	_, err = insertUniverseLeafOnly(ctx, multiverse, orphan)
+	require.NoError(t, err)
+
+	// Tamper an existing universe's multiverse entry.
+	tamperMultiverseLeaf(t, ctx, multiverse, items[0].ID)
+
+	updates, err = multiverse.multiverseDivergence(ctx)
+	require.NoError(t, err)
+	require.Len(t, updates, 2)
+
+	// Reconciliation must repair both.
+	require.NoError(t, multiverse.ReconcileMultiverse(ctx))
+
+	updates, err = multiverse.multiverseDivergence(ctx)
+	require.NoError(t, err)
+	require.Empty(t, updates)
+
+	// Reconciling a healthy store must be a no-op.
+	require.NoError(t, multiverse.ReconcileMultiverse(ctx))
+}
+
+// TestReconcileMultiverseProps property-tests reconciliation: from any
+// mix of healthy universes, orphaned universes (universe leaf committed
+// but multiverse never updated) and tampered multiverse entries,
+// ReconcileMultiverse must restore a state with no divergence. The
+// store persists across property iterations, so repairs are also
+// checked against cumulative state.
+func TestReconcileMultiverseProps(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	multiverse, _ := newTestMultiverse(t)
+
+	rapid.Check(t, func(rt *rapid.T) {
+		// Draw a batch of new universes, each healthy, orphaned or
+		// with a tampered multiverse entry.
+		numUniverses := rapid.IntRange(1, 4).Draw(rt, "num_universes")
+
+		var expectDiverged int
+		for i := 0; i < numUniverses; i++ {
+			item := genRandomAsset(t)
+
+			kind := rapid.SampledFrom([]string{
+				"healthy", "orphaned", "tampered",
+			}).Draw(rt, "kind")
+
+			switch kind {
+			case "healthy":
+				_, err := multiverse.UpsertProofLeaf(
+					ctx, item.ID, item.Key, item.Leaf,
+					item.MetaReveal,
+				)
+				require.NoError(rt, err)
+
+			case "orphaned":
+				_, err := insertUniverseLeafOnly(
+					ctx, multiverse, item,
+				)
+				require.NoError(rt, err)
+				expectDiverged++
+
+			case "tampered":
+				_, err := multiverse.UpsertProofLeaf(
+					ctx, item.ID, item.Key, item.Leaf,
+					item.MetaReveal,
+				)
+				require.NoError(rt, err)
+
+				tamperMultiverseLeaf(
+					rt, ctx, multiverse, item.ID,
+				)
+				expectDiverged++
+			}
+		}
+
+		// Exactly the orphaned and tampered universes must show
+		// up as diverged: the previous iteration ended reconciled.
+		updates, err := multiverse.multiverseDivergence(ctx)
+		require.NoError(rt, err)
+		require.Len(rt, updates, expectDiverged)
+
+		require.NoError(rt, multiverse.ReconcileMultiverse(ctx))
+
+		updates, err = multiverse.multiverseDivergence(ctx)
+		require.NoError(rt, err)
+		require.Empty(rt, updates)
+	})
+}
+
+// TestReconcileMultiverseSyncerCache asserts that repairs made during
+// startup reconciliation do not seed a partial syncer cache: with the
+// cache enabled but not yet filled, the repair flushes install nothing,
+// and the first syncer query afterwards returns the complete root set
+// rather than just the repaired subset.
+func TestReconcileMultiverseSyncerCache(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	db := NewTestDB(t)
+	dbTxer := NewTransactionExecutor(
+		db, func(tx *sql.Tx) BaseMultiverseStore {
+			return db.WithTx(tx)
+		},
+	)
+	cfg := DefaultMultiverseStoreConfig()
+	cfg.Caches.SyncerCacheEnabled = true
+	multiverse, err := NewMultiverseStore(dbTxer, cfg)
+	require.NoError(t, err)
+
+	// A few healthy universes, plus one orphaned universe whose leaf
+	// committed without its multiverse update.
+	const numHealthy = 4
+	for i := 0; i < numHealthy; i++ {
+		item := genRandomAsset(t)
+		_, err := multiverse.UpsertProofLeaf(
+			ctx, item.ID, item.Key, item.Leaf, item.MetaReveal,
+		)
+		require.NoError(t, err)
+	}
+
+	orphan := genRandomAsset(t)
+	_, err = insertUniverseLeafOnly(ctx, multiverse, orphan)
+	require.NoError(t, err)
+
+	// Reconciliation repairs the orphan, which drives a flush
+	// callback into the still-unfilled syncer cache.
+	require.NoError(t, multiverse.ReconcileMultiverse(ctx))
+
+	// A syncer query must now return every universe, not just the
+	// repaired one.
+	roots, err := multiverse.RootNodes(ctx, universe.RootNodesQuery{
+		SortDirection: universe.SortAscending,
+		Limit:         universe.RequestPageSize,
+	})
+	require.NoError(t, err)
+	require.Len(t, roots, numHealthy+1)
+}

--- a/tapdb/multiverse_reconcile_test.go
+++ b/tapdb/multiverse_reconcile_test.go
@@ -27,6 +27,11 @@ func tamperMultiverseLeaf(t require.TestingT, ctx context.Context,
 		bogusHash, uint64(test.RandInt[uint32]()),
 	)
 
+	// Take the multiverse write lock, as every multiverse writer
+	// must.
+	multiverse.multiverseWriteMu.Lock()
+	defer multiverse.multiverseWriteMu.Unlock()
+
 	var writeTx BaseMultiverseOptions
 	err := multiverse.db.ExecTx(
 		ctx, &writeTx, func(store BaseMultiverseStore) error {
@@ -231,6 +236,7 @@ func TestReconcileMultiverseSupplyTrees(t *testing.T) {
 		multiverseTxer, DefaultMultiverseStoreConfig(),
 	)
 	require.NoError(t, err)
+	t.Cleanup(multiverse.Stop)
 
 	uniTxer := NewTransactionExecutor(
 		db, func(tx *sql.Tx) BaseUniverseStore {
@@ -363,6 +369,7 @@ func TestReconcileMultiverseSyncerCache(t *testing.T) {
 	cfg.Caches.SyncerCacheEnabled = true
 	multiverse, err := NewMultiverseStore(dbTxer, cfg)
 	require.NoError(t, err)
+	t.Cleanup(multiverse.Stop)
 
 	// A few healthy universes, plus one orphaned universe whose leaf
 	// committed without its multiverse update.

--- a/tapdb/multiverse_reconcile_test.go
+++ b/tapdb/multiverse_reconcile_test.go
@@ -1,0 +1,394 @@
+package tapdb
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/lightninglabs/taproot-assets/asset"
+	"github.com/lightninglabs/taproot-assets/fn"
+	"github.com/lightninglabs/taproot-assets/internal/test"
+	"github.com/lightninglabs/taproot-assets/mssmt"
+	"github.com/lightninglabs/taproot-assets/tapdb/sqlc"
+	"github.com/lightninglabs/taproot-assets/universe"
+	"github.com/lightninglabs/taproot-assets/universe/supplycommit"
+	"github.com/stretchr/testify/require"
+	"pgregory.net/rapid"
+)
+
+// tamperMultiverseLeaf overwrites a universe's multiverse leaf with a
+// bogus root, diverging it from the universe's actual root.
+func tamperMultiverseLeaf(t require.TestingT, ctx context.Context,
+	multiverse *MultiverseStore, id universe.Identifier) {
+
+	var bogusHash mssmt.NodeHash
+	copy(bogusHash[:], test.RandBytes(32))
+	bogusRoot := mssmt.NewComputedBranch(
+		bogusHash, uint64(test.RandInt[uint32]()),
+	)
+
+	var writeTx BaseMultiverseOptions
+	err := multiverse.db.ExecTx(
+		ctx, &writeTx, func(store BaseMultiverseStore) error {
+			return upsertMultiverseLeafEntry(
+				ctx, store, id, bogusRoot,
+			)
+		},
+	)
+	require.NoError(t, err)
+}
+
+// TestReconcileMultiverse asserts that startup reconciliation detects
+// and repairs both kinds of divergence between the universe trees and
+// the shared multiverse trees: a missing multiverse leaf (crash between
+// universe commit and multiverse write) and a stale one.
+func TestReconcileMultiverse(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	multiverse, _ := newTestMultiverse(t)
+
+	// A healthy store must show no divergence, including when empty.
+	updates, err := multiverse.multiverseDivergence(ctx)
+	require.NoError(t, err)
+	require.Empty(t, updates)
+
+	// Insert a few items through the normal path.
+	items := make([]*universe.Item, 3)
+	for i := range items {
+		items[i] = genRandomAsset(t)
+	}
+	require.NoError(t, multiverse.UpsertProofLeafBatch(ctx, items))
+
+	updates, err = multiverse.multiverseDivergence(ctx)
+	require.NoError(t, err)
+	require.Empty(t, updates)
+
+	// Orphan a new universe: leaf committed, multiverse never
+	// updated.
+	orphan := genRandomAsset(t)
+	_, err = insertUniverseLeafOnly(ctx, multiverse, orphan)
+	require.NoError(t, err)
+
+	// Tamper an existing universe's multiverse entry.
+	tamperMultiverseLeaf(t, ctx, multiverse, items[0].ID)
+
+	updates, err = multiverse.multiverseDivergence(ctx)
+	require.NoError(t, err)
+	require.Len(t, updates, 2)
+
+	// Reconciliation must repair both.
+	require.NoError(t, multiverse.ReconcileMultiverse(ctx))
+
+	updates, err = multiverse.multiverseDivergence(ctx)
+	require.NoError(t, err)
+	require.Empty(t, updates)
+
+	// Reconciling a healthy store must be a no-op.
+	require.NoError(t, multiverse.ReconcileMultiverse(ctx))
+}
+
+// TestReconcileMultiverseProps property-tests reconciliation: from any
+// mix of healthy universes, orphaned universes (universe leaf committed
+// but multiverse never updated) and tampered multiverse entries,
+// ReconcileMultiverse must restore a state with no divergence. The
+// store persists across property iterations, so repairs are also
+// checked against cumulative state.
+func TestReconcileMultiverseProps(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	multiverse, _ := newTestMultiverse(t)
+
+	rapid.Check(t, func(rt *rapid.T) {
+		// Draw a batch of new universes, each healthy, orphaned or
+		// with a tampered multiverse entry.
+		numUniverses := rapid.IntRange(1, 4).Draw(rt, "num_universes")
+
+		var expectDiverged int
+		for i := 0; i < numUniverses; i++ {
+			item := genRandomAsset(t)
+
+			kind := rapid.SampledFrom([]string{
+				"healthy", "orphaned", "tampered",
+			}).Draw(rt, "kind")
+
+			switch kind {
+			case "healthy":
+				_, err := multiverse.UpsertProofLeaf(
+					ctx, item.ID, item.Key, item.Leaf,
+					item.MetaReveal,
+				)
+				require.NoError(rt, err)
+
+			case "orphaned":
+				_, err := insertUniverseLeafOnly(
+					ctx, multiverse, item,
+				)
+				require.NoError(rt, err)
+				expectDiverged++
+
+			case "tampered":
+				_, err := multiverse.UpsertProofLeaf(
+					ctx, item.ID, item.Key, item.Leaf,
+					item.MetaReveal,
+				)
+				require.NoError(rt, err)
+
+				tamperMultiverseLeaf(
+					rt, ctx, multiverse, item.ID,
+				)
+				expectDiverged++
+			}
+		}
+
+		// Exactly the orphaned and tampered universes must show
+		// up as diverged: the previous iteration ended reconciled.
+		updates, err := multiverse.multiverseDivergence(ctx)
+		require.NoError(rt, err)
+		require.Len(rt, updates, expectDiverged)
+
+		require.NoError(rt, multiverse.ReconcileMultiverse(ctx))
+
+		updates, err = multiverse.multiverseDivergence(ctx)
+		require.NoError(rt, err)
+		require.Empty(rt, updates)
+	})
+}
+
+// TestReconcileMultiversePagination asserts that the divergence scan
+// finds divergence on every page of its keyset-paginated universe root
+// scan, not just the first, and that a canceled context interrupts
+// reconciliation.
+func TestReconcileMultiversePagination(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	multiverse, _ := newTestMultiverse(t)
+
+	// Force several pages with a handful of universes.
+	multiverse.reconcilePageSize = 2
+
+	const numUniverses = 7
+	var numOrphaned int
+	for i := 0; i < numUniverses; i++ {
+		item := genRandomAsset(t)
+
+		// Alternate healthy and orphaned universes, so divergence
+		// appears on every page of the scan.
+		if i%2 == 0 {
+			_, err := multiverse.UpsertProofLeaf(
+				ctx, item.ID, item.Key, item.Leaf,
+				item.MetaReveal,
+			)
+			require.NoError(t, err)
+			continue
+		}
+
+		_, err := insertUniverseLeafOnly(ctx, multiverse, item)
+		require.NoError(t, err)
+		numOrphaned++
+	}
+
+	diverged, err := multiverse.multiverseDivergence(ctx)
+	require.NoError(t, err)
+	require.Len(t, diverged, numOrphaned)
+
+	require.NoError(t, multiverse.ReconcileMultiverse(ctx))
+
+	diverged, err = multiverse.multiverseDivergence(ctx)
+	require.NoError(t, err)
+	require.Empty(t, diverged)
+
+	// A canceled context interrupts reconciliation rather than
+	// running it to completion.
+	canceledCtx, cancel := context.WithCancel(ctx)
+	cancel()
+	require.Error(t, multiverse.ReconcileMultiverse(canceledCtx))
+}
+
+// TestReconcileMultiverseSupplyTrees asserts that reconciliation
+// ignores universe roots of proof types without a multiverse tree: the
+// supply-commitment sub-trees (mint supply, burns, ignores) share the
+// universe_roots table but have no multiverse leaves, so they must
+// neither be reported as diverged nor be touched by a repair, while
+// ordinary issuance/transfer divergence alongside them is still
+// repaired.
+func TestReconcileMultiverseSupplyTrees(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	// A multiverse store and a supply tree store sharing one database,
+	// as in the daemon.
+	db := NewTestDB(t)
+	multiverseTxer := NewTransactionExecutor(
+		db, func(tx *sql.Tx) BaseMultiverseStore {
+			return db.WithTx(tx)
+		},
+	)
+	multiverse, err := NewMultiverseStore(
+		multiverseTxer, DefaultMultiverseStoreConfig(),
+	)
+	require.NoError(t, err)
+
+	uniTxer := NewTransactionExecutor(
+		db, func(tx *sql.Tx) BaseUniverseStore {
+			return db.WithTx(tx)
+		},
+	)
+	supplyStore := NewSupplyTreeStore(uniTxer)
+
+	// A grouped asset with its genesis and group key on record, as the
+	// supply tree paths require.
+	groupPrivKey := asset.PrivKeyGen.Example()
+	groupPub := groupPrivKey.PubKey()
+	groupKey := &asset.GroupKey{GroupPubKey: *groupPub}
+
+	baseGenesis := asset.GenesisGen.Example()
+	baseAssetID := baseGenesis.ID()
+	genesisPointID, err := upsertGenesisPoint(
+		ctx, uniTxer, baseGenesis.FirstPrevOut,
+	)
+	require.NoError(t, err)
+	genAssetID, err := upsertGenesis(
+		ctx, uniTxer, genesisPointID, baseGenesis,
+	)
+	require.NoError(t, err)
+	_, err = upsertGroupKey(
+		ctx, groupKey, uniTxer, genesisPointID, genAssetID,
+	)
+	require.NoError(t, err)
+
+	spec, err := asset.NewSpecifier(
+		&baseAssetID, &groupKey.GroupPubKey, nil, true,
+	)
+	require.NoError(t, err)
+
+	// Populate all three supply sub-trees through the production
+	// helper.
+	events := []supplycommit.SupplyUpdateEvent{
+		randMintEventGen(groupPub).Example(),
+		randBurnEventGen(baseGenesis, groupKey, uniTxer).Example(),
+		randIgnoreEventGen(baseAssetID, uniTxer).Example(),
+	}
+	_, err = supplyStore.ApplySupplyUpdates(ctx, spec, events)
+	require.NoError(t, err)
+
+	// The sub-trees must be visible to the universe root scan the
+	// divergence check pages through, or this test asserts nothing.
+	// Ignore roots carry no asset ID, so the scan's genesis join drops
+	// them before they could ever be misread as diverged; the mint
+	// supply and burn roots are the ones that reach the proof type
+	// check.
+	roots, err := multiverse.queryRootNodes(
+		ctx, sqlc.UniverseRootsParams{
+			SortDirection: sqlInt16(universe.SortAscending),
+			NumLimit:      universe.RequestPageSize,
+		}, false,
+	)
+	require.NoError(t, err)
+	seenProofTypes := fn.NewSet[universe.ProofType]()
+	for _, root := range roots {
+		seenProofTypes.Add(root.ID.ProofType)
+	}
+	require.True(t, seenProofTypes.Contains(universe.ProofTypeMintSupply))
+	require.True(t, seenProofTypes.Contains(universe.ProofTypeBurn))
+
+	subTreeRoots := func() map[supplycommit.SupplySubTree]mssmt.NodeHash {
+		trees, err := supplyStore.FetchSubTrees(
+			ctx, spec, fn.None[uint32](),
+		).Unpack()
+		require.NoError(t, err)
+
+		hashes := make(map[supplycommit.SupplySubTree]mssmt.NodeHash)
+		for treeType, tree := range trees {
+			root, err := tree.Root(ctx)
+			require.NoError(t, err)
+			hashes[treeType] = root.NodeHash()
+		}
+
+		return hashes
+	}
+	before := subTreeRoots()
+	require.Len(t, before, 3)
+
+	// The supply sub-trees have no multiverse leaves, and must not be
+	// reported as diverged.
+	diverged, err := multiverse.multiverseDivergence(ctx)
+	require.NoError(t, err)
+	require.Empty(t, diverged)
+
+	// Reconciling must succeed — this is the startup path of any node
+	// holding supply commitments — and must leave the sub-trees
+	// untouched.
+	require.NoError(t, multiverse.ReconcileMultiverse(ctx))
+	require.Equal(t, before, subTreeRoots())
+
+	// Ordinary divergence alongside the supply sub-trees must still be
+	// detected and repaired.
+	orphan := genRandomAsset(t)
+	_, err = insertUniverseLeafOnly(ctx, multiverse, orphan)
+	require.NoError(t, err)
+
+	diverged, err = multiverse.multiverseDivergence(ctx)
+	require.NoError(t, err)
+	require.Len(t, diverged, 1)
+
+	require.NoError(t, multiverse.ReconcileMultiverse(ctx))
+
+	diverged, err = multiverse.multiverseDivergence(ctx)
+	require.NoError(t, err)
+	require.Empty(t, diverged)
+	require.Equal(t, before, subTreeRoots())
+}
+
+// TestReconcileMultiverseSyncerCache asserts that repairs made during
+// startup reconciliation do not seed a partial syncer cache: with the
+// cache enabled but not yet filled, the repair flushes install nothing,
+// and the first syncer query afterwards returns the complete root set
+// rather than just the repaired subset.
+func TestReconcileMultiverseSyncerCache(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	db := NewTestDB(t)
+	dbTxer := NewTransactionExecutor(
+		db, func(tx *sql.Tx) BaseMultiverseStore {
+			return db.WithTx(tx)
+		},
+	)
+	cfg := DefaultMultiverseStoreConfig()
+	cfg.Caches.SyncerCacheEnabled = true
+	multiverse, err := NewMultiverseStore(dbTxer, cfg)
+	require.NoError(t, err)
+
+	// A few healthy universes, plus one orphaned universe whose leaf
+	// committed without its multiverse update.
+	const numHealthy = 4
+	for i := 0; i < numHealthy; i++ {
+		item := genRandomAsset(t)
+		_, err := multiverse.UpsertProofLeaf(
+			ctx, item.ID, item.Key, item.Leaf, item.MetaReveal,
+		)
+		require.NoError(t, err)
+	}
+
+	orphan := genRandomAsset(t)
+	_, err = insertUniverseLeafOnly(ctx, multiverse, orphan)
+	require.NoError(t, err)
+
+	// Reconciliation repairs the orphan, which drives a flush
+	// callback into the still-unfilled syncer cache.
+	require.NoError(t, multiverse.ReconcileMultiverse(ctx))
+
+	// A syncer query must now return every universe, not just the
+	// repaired one.
+	roots, err := multiverse.RootNodes(ctx, universe.RootNodesQuery{
+		SortDirection: universe.SortAscending,
+		Limit:         universe.RequestPageSize,
+	})
+	require.NoError(t, err)
+	require.Len(t, roots, numHealthy+1)
+}

--- a/tapdb/sqlc/querier.go
+++ b/tapdb/sqlc/querier.go
@@ -249,6 +249,7 @@ type Querier interface {
 	SupersedeConflictingTransfers(ctx context.Context, arg SupersedeConflictingTransfersParams) (int64, error)
 	UniverseLeaves(ctx context.Context) ([]UniverseLeafe, error)
 	UniverseRoots(ctx context.Context, arg UniverseRootsParams) ([]UniverseRootsRow, error)
+	UniverseRootsAfterID(ctx context.Context, arg UniverseRootsAfterIDParams) ([]UniverseRootsAfterIDRow, error)
 	UpdateBatchGenesisTx(ctx context.Context, arg UpdateBatchGenesisTxParams) error
 	UpdateMintingBatchState(ctx context.Context, arg UpdateMintingBatchStateParams) error
 	UpdateSupplyCommitTransitionCommitment(ctx context.Context, arg UpdateSupplyCommitTransitionCommitmentParams) error

--- a/tapdb/sqlc/queries/universe.sql
+++ b/tapdb/sqlc/queries/universe.sql
@@ -120,6 +120,21 @@ ORDER BY
     CASE WHEN sqlc.narg('sort_direction') = 1 THEN universe_roots.id END DESC
 LIMIT @num_limit OFFSET @num_offset;
 
+-- name: UniverseRootsAfterID :many
+SELECT universe_roots.id, universe_roots.asset_id, group_key, proof_type,
+       mssmt_roots.root_hash AS root_hash, mssmt_nodes.sum AS root_sum
+FROM universe_roots
+JOIN mssmt_roots
+    ON universe_roots.namespace_root = mssmt_roots.namespace
+JOIN mssmt_nodes
+    ON mssmt_nodes.hash_key = mssmt_roots.root_hash
+       AND mssmt_nodes.namespace = mssmt_roots.namespace
+JOIN genesis_assets
+    ON genesis_assets.asset_id = universe_roots.asset_id
+WHERE universe_roots.id > @after_id
+ORDER BY universe_roots.id ASC
+LIMIT @num_limit;
+
 -- name: InsertUniverseServer :exec
 INSERT INTO universe_servers(
     server_host, last_sync_time

--- a/tapdb/sqlc/universe.sql.go
+++ b/tapdb/sqlc/universe.sql.go
@@ -1173,6 +1173,66 @@ func (q *Queries) UniverseRoots(ctx context.Context, arg UniverseRootsParams) ([
 	return items, nil
 }
 
+const UniverseRootsAfterID = `-- name: UniverseRootsAfterID :many
+SELECT universe_roots.id, universe_roots.asset_id, group_key, proof_type,
+       mssmt_roots.root_hash AS root_hash, mssmt_nodes.sum AS root_sum
+FROM universe_roots
+JOIN mssmt_roots
+    ON universe_roots.namespace_root = mssmt_roots.namespace
+JOIN mssmt_nodes
+    ON mssmt_nodes.hash_key = mssmt_roots.root_hash
+       AND mssmt_nodes.namespace = mssmt_roots.namespace
+JOIN genesis_assets
+    ON genesis_assets.asset_id = universe_roots.asset_id
+WHERE universe_roots.id > $1
+ORDER BY universe_roots.id ASC
+LIMIT $2
+`
+
+type UniverseRootsAfterIDParams struct {
+	AfterID  int64
+	NumLimit int32
+}
+
+type UniverseRootsAfterIDRow struct {
+	ID        int64
+	AssetID   []byte
+	GroupKey  []byte
+	ProofType sql.NullString
+	RootHash  []byte
+	RootSum   int64
+}
+
+func (q *Queries) UniverseRootsAfterID(ctx context.Context, arg UniverseRootsAfterIDParams) ([]UniverseRootsAfterIDRow, error) {
+	rows, err := q.db.QueryContext(ctx, UniverseRootsAfterID, arg.AfterID, arg.NumLimit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []UniverseRootsAfterIDRow
+	for rows.Next() {
+		var i UniverseRootsAfterIDRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.AssetID,
+			&i.GroupKey,
+			&i.ProofType,
+			&i.RootHash,
+			&i.RootSum,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const UpsertFederationGlobalSyncConfig = `-- name: UpsertFederationGlobalSyncConfig :exec
 INSERT INTO federation_global_sync_config (
     proof_type, allow_sync_insert, allow_sync_export

--- a/tapdb/universe.go
+++ b/tapdb/universe.go
@@ -769,11 +769,19 @@ func (b *BaseUniverseTree) UpsertProofLeaf(ctx context.Context,
 			return fmt.Errorf("failed universe upsert: %w", err)
 		}
 
-		multiRoot, multiProof, err := upsertMultiverseLeafEntry(
+		err = upsertMultiverseLeafEntry(
 			ctx, dbTx, b.id, issuanceProof.UniverseRoot,
 		)
 		if err != nil {
 			return fmt.Errorf("failed multiverse upsert: %w", err)
+		}
+
+		multiRoot, multiProof, err := multiverseRootAndProof(
+			ctx, dbTx, b.id,
+		)
+		if err != nil {
+			return fmt.Errorf("failed multiverse root fetch: %w",
+				err)
 		}
 
 		issuanceProof.MultiverseRoot = multiRoot
@@ -791,18 +799,19 @@ func (b *BaseUniverseTree) UpsertProofLeaf(ctx context.Context,
 
 // upsertMultiverseLeafEntry inserts the universe root into the main multiverse
 // tree. This should be called *after* universeUpsertProofLeaf if the proof
-// needs to be added to the main issuance/transfer multiverse.
+// needs to be added to the main issuance/transfer multiverse. The resulting
+// multiverse root and inclusion proof can be fetched separately with
+// multiverseRootAndProof.
 //
 // NOTE: This function accepts a db transaction, as it's used when making
 // broader DB updates.
 func upsertMultiverseLeafEntry(ctx context.Context, dbTx BaseUniverseStore,
-	id universe.Identifier, universeRoot mssmt.Node) (
-	mssmt.Node, *mssmt.Proof, error) {
+	id universe.Identifier, universeRoot mssmt.Node) error {
 
 	// Determine the multiverse namespace based on the proof type.
 	multiverseNS, err := namespaceForProof(id.ProofType)
 	if err != nil {
-		return nil, nil, err
+		return err
 	}
 
 	// Retrieve a handle to the multiverse tree.
@@ -827,8 +836,7 @@ func upsertMultiverseLeafEntry(ctx context.Context, dbTx BaseUniverseStore,
 
 	_, err = multiverseTree.Insert(ctx, uniLeafNodeKey, uniLeafNode)
 	if err != nil {
-		return nil, nil, fmt.Errorf("multiverse tree insert "+
-			"failed: %w", err)
+		return fmt.Errorf("multiverse tree insert failed: %w", err)
 	}
 
 	// Ensure the corresponding multiverse roots and leaves DB entries
@@ -840,8 +848,7 @@ func upsertMultiverseLeafEntry(ctx context.Context, dbTx BaseUniverseStore,
 		},
 	)
 	if err != nil {
-		return nil, nil, fmt.Errorf("unable to upsert multiverse "+
-			"root: %w", err)
+		return fmt.Errorf("unable to upsert multiverse root: %w", err)
 	}
 
 	var assetIDBytes, groupKeyBytes []byte
@@ -859,26 +866,47 @@ func upsertMultiverseLeafEntry(ctx context.Context, dbTx BaseUniverseStore,
 		LeafNodeNamespace: multiverseNS,
 	})
 	if err != nil {
-		return nil, nil, fmt.Errorf("unable to upsert multiverse "+
-			"leaf: %w", err)
+		return fmt.Errorf("unable to upsert multiverse leaf: %w", err)
 	}
 
-	// Retrieve the multiverse root and inclusion proof.
-	finalMultiverseRoot, err := multiverseTree.Root(ctx)
+	return nil
+}
+
+// multiverseRootAndProof returns the current root of the multiverse tree for
+// the given universe's proof type, along with the inclusion proof for the
+// universe's leaf within it.
+//
+// NOTE: This function accepts a db transaction, as it's used when making
+// broader DB updates.
+func multiverseRootAndProof(ctx context.Context, dbTx BaseUniverseStore,
+	id universe.Identifier) (mssmt.Node, *mssmt.Proof, error) {
+
+	// Determine the multiverse namespace based on the proof type.
+	multiverseNS, err := namespaceForProof(id.ProofType)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Retrieve a handle to the multiverse tree.
+	multiverseTree := mssmt.NewCompactedTree(
+		newTreeStoreWrapperTx(dbTx, multiverseNS),
+	)
+
+	multiverseRoot, err := multiverseTree.Root(ctx)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get multiverse "+
 			"root: %w", err)
 	}
 
 	multiverseInclusionProof, err := multiverseTree.MerkleProof(
-		ctx, uniLeafNodeKey,
+		ctx, id.Bytes(),
 	)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get multiverse "+
 			"proof: %w", err)
 	}
 
-	return finalMultiverseRoot, multiverseInclusionProof, nil
+	return multiverseRoot, multiverseInclusionProof, nil
 }
 
 // universeRootStatus indicates whether upserting a proof leaf into a

--- a/tapdb/universe.go
+++ b/tapdb/universe.go
@@ -747,6 +747,11 @@ func maybeUpsertSupplyPreCommit(ctx context.Context, dbTx UpsertAssetStore,
 // UpsertProofLeaf inserts or updates a proof leaf within the universe tree,
 // stored at the base key. The metaReveal type is purely optional, and should be
 // specified if the genesis proof committed to a non-zero meta hash.
+//
+// NOTE: This method writes the shared multiverse namespaces inline, at
+// serializable isolation and without MultiverseStore's multiverse write
+// lock. No production write path uses it; it must not run concurrently
+// with a MultiverseStore writing to the same database.
 func (b *BaseUniverseTree) UpsertProofLeaf(ctx context.Context,
 	key universe.LeafKey, leaf *universe.Leaf,
 	metaReveal *proof.MetaReveal) (*universe.Proof, error) {
@@ -1585,6 +1590,10 @@ func deleteUniverseTree(ctx context.Context,
 }
 
 // DeleteUniverse deletes the entire universe tree.
+//
+// NOTE: This method writes the shared multiverse namespaces inline,
+// without MultiverseStore's multiverse write lock; the same caveat as
+// on UpsertProofLeaf applies.
 func (b *BaseUniverseTree) DeleteUniverse(ctx context.Context) (string, error) {
 	var writeTx BaseUniverseStoreOptions
 

--- a/tapdb/universe.go
+++ b/tapdb/universe.go
@@ -805,6 +805,23 @@ func (b *BaseUniverseTree) UpsertProofLeaf(ctx context.Context,
 //
 // NOTE: This function accepts a db transaction, as it's used when making
 // broader DB updates.
+// multiverseLeafNode builds the multiverse leaf that commits to the
+// given universe root. For issuance proofs, the sum in the multiverse
+// is always 1 (one asset or group). For transfers, it's the actual
+// amount.
+func multiverseLeafNode(id universe.Identifier,
+	universeRoot mssmt.Node) *mssmt.LeafNode {
+
+	universeRootHash := universeRoot.NodeHash()
+	assetGroupSum := universeRoot.NodeSum()
+
+	if id.ProofType == universe.ProofTypeIssuance {
+		assetGroupSum = 1
+	}
+
+	return mssmt.NewLeafNode(universeRootHash[:], assetGroupSum)
+}
+
 func upsertMultiverseLeafEntry(ctx context.Context, dbTx BaseUniverseStore,
 	id universe.Identifier, universeRoot mssmt.Node) error {
 
@@ -820,16 +837,7 @@ func upsertMultiverseLeafEntry(ctx context.Context, dbTx BaseUniverseStore,
 	)
 
 	// Construct a leaf node for insertion into the multiverse tree.
-	universeRootHash := universeRoot.NodeHash()
-	assetGroupSum := universeRoot.NodeSum()
-
-	// For issuance proofs, the sum in the multiverse is always 1 (one asset
-	// or group). For transfers, it's the actual amount.
-	if id.ProofType == universe.ProofTypeIssuance {
-		assetGroupSum = 1
-	}
-
-	uniLeafNode := mssmt.NewLeafNode(universeRootHash[:], assetGroupSum)
+	uniLeafNode := multiverseLeafNode(id, universeRoot)
 
 	// Use asset ID (or asset group hash) as the upper tree leaf node key.
 	uniLeafNodeKey := id.Bytes()

--- a/tapdb/universe.go
+++ b/tapdb/universe.go
@@ -797,18 +797,9 @@ func (b *BaseUniverseTree) UpsertProofLeaf(ctx context.Context,
 	return uniProof, nil
 }
 
-// upsertMultiverseLeafEntry inserts the universe root into the main multiverse
-// tree. This should be called *after* universeUpsertProofLeaf if the proof
-// needs to be added to the main issuance/transfer multiverse. The resulting
-// multiverse root and inclusion proof can be fetched separately with
-// multiverseRootAndProof.
-//
-// NOTE: This function accepts a db transaction, as it's used when making
-// broader DB updates.
-// multiverseLeafNode builds the multiverse leaf that commits to the
-// given universe root. For issuance proofs, the sum in the multiverse
-// is always 1 (one asset or group). For transfers, it's the actual
-// amount.
+// multiverseLeafNode builds the multiverse leaf committing to the given
+// universe root. For issuance proofs, the leaf sum is always 1 (one asset or
+// group). For transfers, it's the universe root's actual amount.
 func multiverseLeafNode(id universe.Identifier,
 	universeRoot mssmt.Node) *mssmt.LeafNode {
 
@@ -822,6 +813,14 @@ func multiverseLeafNode(id universe.Identifier,
 	return mssmt.NewLeafNode(universeRootHash[:], assetGroupSum)
 }
 
+// upsertMultiverseLeafEntry inserts the universe root into the main multiverse
+// tree. This should be called *after* universeUpsertProofLeaf if the proof
+// needs to be added to the main issuance/transfer multiverse. The resulting
+// multiverse root and inclusion proof can be fetched separately with
+// multiverseRootAndProof.
+//
+// NOTE: This function accepts a db transaction, as it's used when making
+// broader DB updates.
 func upsertMultiverseLeafEntry(ctx context.Context, dbTx BaseUniverseStore,
 	id universe.Identifier, universeRoot mssmt.Node) error {
 

--- a/tapdb/universe.go
+++ b/tapdb/universe.go
@@ -747,6 +747,12 @@ func maybeUpsertSupplyPreCommit(ctx context.Context, dbTx UpsertAssetStore,
 // UpsertProofLeaf inserts or updates a proof leaf within the universe tree,
 // stored at the base key. The metaReveal type is purely optional, and should be
 // specified if the genesis proof committed to a non-zero meta hash.
+//
+// NOTE: This method writes the shared multiverse namespaces inline,
+// bypassing MultiverseStore's root coalescer, multiverse write lock and
+// caches. No production write path uses it; run concurrently with a
+// MultiverseStore on the same database, the trees stay consistent under
+// serializable isolation, but that store's caches are left stale.
 func (b *BaseUniverseTree) UpsertProofLeaf(ctx context.Context,
 	key universe.LeafKey, leaf *universe.Leaf,
 	metaReveal *proof.MetaReveal) (*universe.Proof, error) {
@@ -1585,6 +1591,10 @@ func deleteUniverseTree(ctx context.Context,
 }
 
 // DeleteUniverse deletes the entire universe tree.
+//
+// NOTE: This method writes the shared multiverse namespaces inline,
+// without MultiverseStore's multiverse write lock; the same caveat as
+// on UpsertProofLeaf applies.
 func (b *BaseUniverseTree) DeleteUniverse(ctx context.Context) (string, error) {
 	var writeTx BaseUniverseStoreOptions
 

--- a/tapdb/universe.go
+++ b/tapdb/universe.go
@@ -885,6 +885,107 @@ func upsertMultiverseLeafEntry(ctx context.Context, dbTx BaseUniverseStore,
 	return nil
 }
 
+// multiverseLeafRefresh pairs a universe with the root its multiverse
+// leaf must commit to.
+type multiverseLeafRefresh struct {
+	id   universe.Identifier
+	root mssmt.Node
+}
+
+// upsertMultiverseLeafEntries refreshes the multiverse leaf of every
+// given universe. The tree writes are grouped by proof type — each
+// proof type is one multiverse tree — and applied through InsertMany,
+// so internal nodes shared by the batch are computed once per call
+// rather than once per universe; per-universe cost otherwise grows
+// superlinearly with the batch. The relational multiverse root and
+// leaf rows are upserted as in upsertMultiverseLeafEntry.
+//
+// NOTE: This function accepts a db transaction, as it's used when
+// making broader DB updates.
+func upsertMultiverseLeafEntries(ctx context.Context,
+	dbTx BaseUniverseStore, refreshes []multiverseLeafRefresh) error {
+
+	type proofTypeGroup struct {
+		ns      string
+		leaves  map[[32]byte]*mssmt.LeafNode
+		entries []multiverseLeafRefresh
+	}
+
+	groups := make(map[universe.ProofType]*proofTypeGroup, 2)
+	for _, refresh := range refreshes {
+		group, ok := groups[refresh.id.ProofType]
+		if !ok {
+			ns, err := namespaceForProof(refresh.id.ProofType)
+			if err != nil {
+				return err
+			}
+
+			group = &proofTypeGroup{
+				ns:     ns,
+				leaves: make(map[[32]byte]*mssmt.LeafNode),
+			}
+			groups[refresh.id.ProofType] = group
+		}
+
+		group.leaves[refresh.id.Bytes()] = multiverseLeafNode(
+			refresh.id, refresh.root,
+		)
+		group.entries = append(group.entries, refresh)
+	}
+
+	for proofType, group := range groups {
+		multiverseTree := mssmt.NewCompactedTree(
+			newTreeStoreWrapperTx(dbTx, group.ns),
+		)
+		_, err := multiverseTree.InsertMany(ctx, group.leaves)
+		if err != nil {
+			return fmt.Errorf("multiverse tree insert "+
+				"failed: %w", err)
+		}
+
+		// One multiverse root row covers every universe of the
+		// proof type.
+		multiverseRootID, err := dbTx.UpsertMultiverseRoot(
+			ctx, UpsertMultiverseRoot{
+				NamespaceRoot: group.ns,
+				ProofType:     proofType.String(),
+			},
+		)
+		if err != nil {
+			return fmt.Errorf("unable to upsert multiverse "+
+				"root: %w", err)
+		}
+
+		for _, entry := range group.entries {
+			var assetIDBytes, groupKeyBytes []byte
+			if entry.id.GroupKey == nil {
+				assetIDBytes = entry.id.AssetID[:]
+			} else {
+				groupKeyBytes = schnorr.SerializePubKey(
+					entry.id.GroupKey,
+				)
+			}
+
+			leafNodeKey := entry.id.Bytes()
+			_, err = dbTx.UpsertMultiverseLeaf(
+				ctx, UpsertMultiverseLeaf{
+					MultiverseRootID:  multiverseRootID,
+					AssetID:           assetIDBytes,
+					GroupKey:          groupKeyBytes,
+					LeafNodeKey:       leafNodeKey[:],
+					LeafNodeNamespace: group.ns,
+				},
+			)
+			if err != nil {
+				return fmt.Errorf("unable to upsert "+
+					"multiverse leaf: %w", err)
+			}
+		}
+	}
+
+	return nil
+}
+
 // multiverseRootAndProof returns the current root of the multiverse tree for
 // the given universe's proof type, along with the inclusion proof for the
 // universe's leaf within it.

--- a/tapdb/universe_test.go
+++ b/tapdb/universe_test.go
@@ -1895,3 +1895,94 @@ func TestProofCacheInvalidatesOnSiblingInsert(t *testing.T) {
 			"current universe root",
 	)
 }
+
+// TestUpsertProofLeafBatchMultiverseRoot asserts that the batch insert
+// path produces the same multiverse roots as inserting the same items
+// one at a time, including when a batch contains multiple items for the
+// same universe (in which case only the universe's final root must be
+// reflected in the multiverse tree).
+func TestUpsertProofLeafBatchMultiverseRoot(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	batchStore, _ := newTestMultiverse(t)
+	serialStore, _ := newTestMultiverse(t)
+
+	// Generate random items, then add a second leaf to each universe
+	// so the batch contains multiple items per universe. The first two
+	// items are pinned to one proof type each, so both multiverse
+	// trees deterministically exist for the assertions below.
+	const numAssets = 5
+	pinned := []universe.ProofType{
+		universe.ProofTypeIssuance, universe.ProofTypeTransfer,
+	}
+	var items []*universe.Item
+	for i := 0; i < numAssets; i++ {
+		item := genRandomAsset(t)
+		if i < len(pinned) {
+			for item.ID.ProofType != pinned[i] {
+				item = genRandomAsset(t)
+			}
+		}
+		items = append(items, item)
+
+		leaf := randMintingLeaf(
+			t, item.Leaf.Genesis, item.ID.GroupKey,
+		)
+		if item.ID.ProofType == universe.ProofTypeTransfer {
+			prevWitnesses := leaf.Asset.PrevWitnesses
+			prevWitnesses[0].TxWitness = [][]byte{
+				{1}, {1}, {1},
+			}
+			prevID := prevWitnesses[0].PrevID
+			prevID.OutPoint.Hash = [32]byte{1}
+		}
+
+		items = append(items, &universe.Item{
+			ID:   item.ID,
+			Key:  randLeafKey(t),
+			Leaf: &leaf,
+		})
+	}
+
+	err := batchStore.UpsertProofLeafBatch(ctx, items)
+	require.NoError(t, err)
+
+	for _, item := range items {
+		_, err := serialStore.UpsertProofLeaf(
+			ctx, item.ID, item.Key, item.Leaf, item.MetaReveal,
+		)
+		require.NoError(t, err)
+	}
+
+	proofTypes := []universe.ProofType{
+		universe.ProofTypeIssuance, universe.ProofTypeTransfer,
+	}
+	for _, proofType := range proofTypes {
+		batchRoot, err := batchStore.MultiverseRootNode(
+			ctx, proofType,
+		)
+		require.NoError(t, err)
+		serialRoot, err := serialStore.MultiverseRootNode(
+			ctx, proofType,
+		)
+		require.NoError(t, err)
+
+		require.Equal(
+			t, serialRoot.IsSome(), batchRoot.IsSome(),
+			"proof type %v", proofType,
+		)
+
+		serialRoot.WhenSome(func(sr universe.MultiverseRoot) {
+			batchRoot.WhenSome(func(br universe.MultiverseRoot) {
+				require.True(
+					t, mssmt.IsEqualNode(sr.Node, br.Node),
+					"proof type %v: serial root %v != "+
+						"batch root %v", proofType,
+					sr.Node, br.Node,
+				)
+			})
+		})
+	}
+}

--- a/tapdb/universe_test.go
+++ b/tapdb/universe_test.go
@@ -97,6 +97,7 @@ func newTestMultiverse(t testing.TB) (*MultiverseStore, sqlc.Querier) {
 		dbTxer, DefaultMultiverseStoreConfig(),
 	)
 	require.NoError(t, err)
+	t.Cleanup(multiverseStore.Stop)
 
 	return multiverseStore, db
 }
@@ -114,6 +115,7 @@ func newTestMultiverseWithDb(t *testing.T, db *BaseDB) (*MultiverseStore,
 		dbTxer, DefaultMultiverseStoreConfig(),
 	)
 	require.NoError(t, err)
+	t.Cleanup(multiverseStore.Stop)
 
 	return multiverseStore, db
 }

--- a/tapgarden/caretaker.go
+++ b/tapgarden/caretaker.go
@@ -1315,7 +1315,17 @@ func (b *BatchCaretaker) batchStreamUniverseItems(ctx context.Context,
 				numTotal)
 
 			err := uni.UpsertProofLeafBatch(ctx, batch)
-			if err != nil {
+			switch {
+			// The leaves are durably stored; only their
+			// multiverse entries are still outstanding, and the
+			// universe archive repairs those in the background.
+			// The batch must not be failed over writes that
+			// landed.
+			case errors.Is(err, universe.ErrMultiversePending):
+				log.Warnf("Batch minting proofs stored with "+
+					"multiverse updates pending: %v", err)
+
+			case err != nil:
 				return fmt.Errorf("unable to register "+
 					"proof leaf batch: %w", err)
 			}

--- a/universe/archive.go
+++ b/universe/archive.go
@@ -351,13 +351,16 @@ func (a *Archive) UpsertProofLeaf(ctx context.Context, id Identifier,
 	issuanceProof, err := a.cfg.Multiverse.UpsertProofLeaf(
 		ctx, id, key, leaf, assetSnapshot.MetaReveal,
 	)
-	if err != nil {
+	if err != nil && !errors.Is(err, ErrMultiversePending) {
 		return nil, fmt.Errorf("unable to register new "+
 			"issuance: %w", err)
 	}
+	upsertErr := err
 
 	// Log a sync event for the newly inserted leaf in the background as an
-	// async goroutine.
+	// async goroutine. This runs for the pending case too: the universe
+	// leaf is durably stored, only its multiverse entry is still
+	// outstanding.
 	go func() {
 		err := a.cfg.UniverseStats.LogNewProofEvent(
 			context.Background(), id, key,
@@ -367,6 +370,14 @@ func (a *Archive) UpsertProofLeaf(ctx context.Context, id Identifier,
 				id.StringForLog(), err)
 		}
 	}()
+
+	// With the proof stored but its multiverse update outstanding, no
+	// composing receipt exists to return; surface the typed error to
+	// the caller.
+	if upsertErr != nil {
+		return nil, fmt.Errorf("unable to register new "+
+			"issuance: %w", upsertErr)
+	}
 
 	return issuanceProof, nil
 }

--- a/universe/archive.go
+++ b/universe/archive.go
@@ -564,10 +564,22 @@ func (a *Archive) UpsertProofLeafBatch(ctx context.Context,
 		return err
 	}
 
+	// A pending error from either upsert means its leaves are durably
+	// stored with only their multiverse entries outstanding, which the
+	// archive repairs in the background. The rest of the batch must
+	// still be inserted and the proof events logged, so the error is
+	// carried to the end instead of returned where it occurs.
+	var upsertErr error
+
 	log.InfoS(ctx, "Inserting verified group anchor proofs into Universe",
 		"count", len(anchorItems))
 	err = a.cfg.Multiverse.UpsertProofLeafBatch(ctx, anchorItems)
-	if err != nil {
+	switch {
+	case errors.Is(err, ErrMultiversePending):
+		upsertErr = fmt.Errorf("upsert group anchor proof leaf "+
+			"batch (count=%d): %w", len(anchorItems), err)
+
+	case err != nil:
 		return fmt.Errorf("upsert group anchor proof leaf batch "+
 			"(count=%d): %w", len(anchorItems), err)
 	}
@@ -580,13 +592,20 @@ func (a *Archive) UpsertProofLeafBatch(ctx context.Context,
 	log.InfoS(ctx, "Inserting verified proofs into Universe",
 		"count", len(nonAnchorItems))
 	err = a.cfg.Multiverse.UpsertProofLeafBatch(ctx, nonAnchorItems)
-	if err != nil {
+	switch {
+	case errors.Is(err, ErrMultiversePending):
+		upsertErr = fmt.Errorf("upsert proof leaf batch "+
+			"(count=%d): %w", len(nonAnchorItems), err)
+
+	case err != nil:
 		return fmt.Errorf("upsert proof leaf batch (count=%d): %w",
 			len(nonAnchorItems), err)
 	}
 
 	// Log a sync event for the newly inserted leaf in the background as an
-	// async goroutine.
+	// async goroutine. This runs for the pending case too: the universe
+	// leaves are durably stored, only their multiverse entries are still
+	// outstanding.
 	ids := fn.Map(items, func(item *Item) Identifier {
 		return item.ID
 	})
@@ -599,7 +618,7 @@ func (a *Archive) UpsertProofLeafBatch(ctx context.Context,
 		}
 	}()
 
-	return nil
+	return upsertErr
 }
 
 // UniverseKey represents the key used to locate an item within a universe.

--- a/universe/federation.go
+++ b/universe/federation.go
@@ -2,6 +2,7 @@ package universe
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -546,17 +547,30 @@ func (f *FederationEnvoy) handlePushRequest(pushReq *FederationPushReq) error {
 	newProof, err := f.cfg.LocalRegistrar.UpsertProofLeaf(
 		ctx, pushReq.ID, pushReq.Key, pushReq.Leaf,
 	)
-	if err != nil {
+	switch {
+	// The proof leaf is durably stored; only its entry in the shared
+	// multiverse trees is still outstanding, and the archive repairs
+	// that in the background. The caller cannot receive a composing
+	// receipt, but the proof must not be stranded local-only, so the
+	// federation push below proceeds.
+	case errors.Is(err, ErrMultiversePending):
+		log.Warnf("Proof stored with multiverse update pending, "+
+			"proceeding with federation push (id=%v): %v",
+			pushReq.ID.StringForLog(), err)
+		pushReq.err <- err
+
+	case err != nil:
 		err = fmt.Errorf("unable to insert proof into local "+
 			"universe: %w", err)
 		pushReq.err <- err
 		return err
-	}
 
-	// Now that we know we were able to register the proof, we'll return
-	// back to the caller, and push the new proof out to the federation in
-	// the background.
-	pushReq.resp <- newProof
+	default:
+		// Now that we know we were able to register the proof, we'll
+		// return back to the caller, and push the new proof out to
+		// the federation in the background.
+		pushReq.resp <- newProof
+	}
 
 	// Fetch all universe servers in our federation.
 	fedServers, err := f.tryFetchServers()

--- a/universe/federation.go
+++ b/universe/federation.go
@@ -630,16 +630,28 @@ func (f *FederationEnvoy) handleBatchPushRequest(
 	// First, we'll attempt to registrar the proof leaf with the local
 	// registrar server.
 	err := f.cfg.LocalRegistrar.UpsertProofLeafBatch(ctx, pushReq.Batch)
-	if err != nil {
+	switch {
+	// The proof leaves are durably stored; only their entries in the
+	// shared multiverse trees are still outstanding, and the archive
+	// repairs that in the background. The proofs must not be stranded
+	// local-only, so the federation push below proceeds.
+	case errors.Is(err, ErrMultiversePending):
+		log.Warnf("Proof batch stored with multiverse updates "+
+			"pending, proceeding with federation push "+
+			"(num_leaves=%d): %v", len(pushReq.Batch), err)
+		pushReq.err <- err
+
+	case err != nil:
 		err = fmt.Errorf("unable to insert proof batch into local "+
 			"universe: %w", err)
 		pushReq.err <- err
 		return err
-	}
 
-	// Now that we know we were able to register the proof, we'll return
-	// back to the caller.
-	pushReq.resp <- struct{}{}
+	default:
+		// Now that we know we were able to register the proof, we'll
+		// return back to the caller.
+		pushReq.resp <- struct{}{}
+	}
 
 	// Fetch all universe servers in our federation.
 	fedServers, err := f.tryFetchServers()

--- a/universe/federation_test.go
+++ b/universe/federation_test.go
@@ -1,0 +1,216 @@
+package universe
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// errRegistrar is a BatchRegistrar whose upserts return the configured
+// error without storing anything.
+type errRegistrar struct {
+	err error
+}
+
+func (r *errRegistrar) UpsertProofLeaf(context.Context, Identifier,
+	LeafKey, *Leaf) (*Proof, error) {
+
+	return nil, r.err
+}
+
+func (r *errRegistrar) UpsertProofLeafBatch(context.Context,
+	[]*Item) error {
+
+	return r.err
+}
+
+func (r *errRegistrar) Close() error { return nil }
+
+// recordingRegistrar records every proof leaf pushed to it, standing
+// in for a remote federation server.
+type recordingRegistrar struct {
+	mu   sync.Mutex
+	keys []LeafKey
+}
+
+func (r *recordingRegistrar) UpsertProofLeaf(_ context.Context,
+	_ Identifier, key LeafKey, _ *Leaf) (*Proof, error) {
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.keys = append(r.keys, key)
+
+	return &Proof{}, nil
+}
+
+func (r *recordingRegistrar) Close() error { return nil }
+
+func (r *recordingRegistrar) numPushed() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return len(r.keys)
+}
+
+// staticServerDB serves a fixed federation server list; every other
+// FederationDB method panics via the embedded nil interface.
+type staticServerDB struct {
+	FederationDB
+
+	servers []ServerAddr
+}
+
+func (s *staticServerDB) UniverseServers(
+	context.Context) ([]ServerAddr, error) {
+
+	return s.servers, nil
+}
+
+// newTestEnvoy wires a federation envoy whose local registrar is the
+// given mock and whose single federation server records what is
+// pushed to it. The envoy is not started; tests drive the push
+// handlers directly.
+func newTestEnvoy(local BatchRegistrar,
+	remote *recordingRegistrar) *FederationEnvoy {
+
+	return NewFederationEnvoy(FederationConfig{
+		LocalRegistrar: local,
+		FederationDB: &staticServerDB{
+			servers: []ServerAddr{
+				NewServerAddr(1, "test-server:10029"),
+			},
+		},
+		NewRemoteRegistrar: func(ServerAddr) (Registrar, error) {
+			return remote, nil
+		},
+	})
+}
+
+// TestFederationPushPendingMultiverse asserts the push handlers honour
+// the weakened upsert contract: an error wrapping ErrMultiversePending
+// means the leaves are durably stored, so the federation push must
+// still run — skipping it would strand the proofs local-only — while
+// the caller receives the typed error. Any other upsert error must
+// abort the push.
+func TestFederationPushPendingMultiverse(t *testing.T) {
+	t.Parallel()
+
+	pendingErr := fmt.Errorf("upsert: %w", ErrMultiversePending)
+	hardErr := errors.New("database exploded")
+
+	newBatch := func(n int) []*Item {
+		items := make([]*Item, n)
+		for i := range items {
+			items[i] = &Item{
+				ID:   randIdentifier(),
+				Key:  BaseLeafKey{},
+				Leaf: &Leaf{},
+			}
+		}
+
+		return items
+	}
+
+	t.Run("single_pending_pushes", func(t *testing.T) {
+		t.Parallel()
+
+		remote := &recordingRegistrar{}
+		envoy := newTestEnvoy(&errRegistrar{err: pendingErr}, remote)
+
+		pushReq := &FederationPushReq{
+			ID:   randIdentifier(),
+			Key:  BaseLeafKey{},
+			Leaf: &Leaf{},
+			resp: make(chan *Proof, 1),
+			err:  make(chan error, 1),
+		}
+		require.NoError(t, envoy.handlePushRequest(pushReq))
+
+		// The caller must see the typed error, and the proof must
+		// have been pushed to the federation server regardless.
+		select {
+		case err := <-pushReq.err:
+			require.ErrorIs(t, err, ErrMultiversePending)
+		default:
+			t.Fatal("caller was not served the pending error")
+		}
+		require.Equal(t, 1, remote.numPushed())
+	})
+
+	t.Run("batch_pending_pushes", func(t *testing.T) {
+		t.Parallel()
+
+		remote := &recordingRegistrar{}
+		envoy := newTestEnvoy(&errRegistrar{err: pendingErr}, remote)
+
+		batch := newBatch(3)
+		pushReq := &FederationProofBatchPushReq{
+			Batch: batch,
+			resp:  make(chan struct{}, 1),
+			err:   make(chan error, 1),
+		}
+		require.NoError(t, envoy.handleBatchPushRequest(pushReq))
+
+		// The caller must see the typed error, and every leaf of
+		// the batch must have been pushed regardless.
+		select {
+		case err := <-pushReq.err:
+			require.ErrorIs(t, err, ErrMultiversePending)
+		default:
+			t.Fatal("caller was not served the pending error")
+		}
+		require.Equal(t, len(batch), remote.numPushed())
+	})
+
+	t.Run("single_hard_error_aborts", func(t *testing.T) {
+		t.Parallel()
+
+		remote := &recordingRegistrar{}
+		envoy := newTestEnvoy(&errRegistrar{err: hardErr}, remote)
+
+		pushReq := &FederationPushReq{
+			ID:   randIdentifier(),
+			Key:  BaseLeafKey{},
+			Leaf: &Leaf{},
+			resp: make(chan *Proof, 1),
+			err:  make(chan error, 1),
+		}
+		require.ErrorIs(t, envoy.handlePushRequest(pushReq), hardErr)
+
+		select {
+		case err := <-pushReq.err:
+			require.ErrorIs(t, err, hardErr)
+		default:
+			t.Fatal("caller was not served the upsert error")
+		}
+		require.Zero(t, remote.numPushed())
+	})
+
+	t.Run("batch_hard_error_aborts", func(t *testing.T) {
+		t.Parallel()
+
+		remote := &recordingRegistrar{}
+		envoy := newTestEnvoy(&errRegistrar{err: hardErr}, remote)
+
+		pushReq := &FederationProofBatchPushReq{
+			Batch: newBatch(3),
+			resp:  make(chan struct{}, 1),
+			err:   make(chan error, 1),
+		}
+		require.ErrorIs(
+			t, envoy.handleBatchPushRequest(pushReq), hardErr,
+		)
+
+		select {
+		case err := <-pushReq.err:
+			require.ErrorIs(t, err, hardErr)
+		default:
+			t.Fatal("caller was not served the upsert error")
+		}
+		require.Zero(t, remote.numPushed())
+	})
+}

--- a/universe/interface.go
+++ b/universe/interface.go
@@ -32,6 +32,16 @@ var (
 	// ErrNoUniverseProofFound is returned when a user attempts to look up
 	// a key in the universe that actually points to the empty leaf.
 	ErrNoUniverseProofFound = fmt.Errorf("no universe proof found")
+
+	// ErrMultiversePending is returned, wrapped, by multiverse upsert
+	// operations when the universe leaves committed durably but the
+	// update of the shared multiverse trees did not. The write is not
+	// lost: the archive retries the multiverse update in the
+	// background until the database recovers, and any update
+	// abandoned by a shutdown is repaired by reconciliation at the
+	// next startup. Callers should treat this as a transient,
+	// retryable condition, not as a failure to store the proof.
+	ErrMultiversePending = fmt.Errorf("multiverse update pending")
 )
 
 const (
@@ -561,12 +571,26 @@ type MultiverseArchive interface {
 
 	// UpsertProofLeaf upserts a proof leaf within the multiverse tree and
 	// the universe tree that corresponds to the given key.
+	//
+	// The universe leaf commits first, in its own transaction, and
+	// the shared multiverse trees are updated afterwards. An error
+	// wrapping ErrMultiversePending therefore means the leaf is
+	// durably stored while its multiverse update is still
+	// outstanding; the archive repairs the gap in the background, or
+	// at the next startup. On success the returned proof composes:
+	// its multiverse inclusion proof commits to its universe root.
 	UpsertProofLeaf(ctx context.Context, id Identifier, key LeafKey,
 		leaf *Leaf,
 		metaReveal *proof.MetaReveal) (*Proof, error)
 
 	// UpsertProofLeafBatch upserts a proof leaf batch within the multiverse
 	// tree and the universe tree that corresponds to the given key(s).
+	//
+	// As with UpsertProofLeaf, the universe leaves commit first: an
+	// error wrapping ErrMultiversePending means the leaves are
+	// durably stored while their multiverse updates are still
+	// outstanding, to be repaired in the background or at the next
+	// startup.
 	UpsertProofLeafBatch(ctx context.Context, items []*Item) error
 
 	// FetchProofLeaf returns a proof leaf for the target key. If the key

--- a/universe/interface.go
+++ b/universe/interface.go
@@ -34,9 +34,11 @@ var (
 	ErrNoUniverseProofFound = fmt.Errorf("no universe proof found")
 
 	// ErrMultiversePending is returned, wrapped, by multiverse upsert
-	// operations when the universe leaves committed durably but the
-	// update of the shared multiverse trees did not. The write is not
-	// lost: the archive retries the multiverse update in the
+	// operations that fail after the universe leaves committed
+	// durably: either the update of the shared multiverse trees is
+	// still outstanding, or it committed too and only a composing
+	// receipt could not be assembled. The write is not lost: the
+	// archive retries an outstanding multiverse update in the
 	// background until the database recovers, and any update
 	// abandoned by a shutdown is repaired by reconciliation at the
 	// next startup. Callers should treat this as a transient,

--- a/universe/syncer.go
+++ b/universe/syncer.go
@@ -659,7 +659,18 @@ func (s *SimpleSyncer) batchStreamNewItems(ctx context.Context,
 			err := s.cfg.LocalRegistrar.UpsertProofLeafBatch(
 				ctx, batch,
 			)
-			if err != nil {
+			switch {
+			// The leaves are durably stored; only their
+			// multiverse entries are still outstanding, and the
+			// archive repairs those in the background. The sync
+			// has done its job, so it must not be failed and
+			// re-attempted for a batch that landed.
+			case errors.Is(err, ErrMultiversePending):
+				log.Warnf("UniverseRoot(%v): proofs stored "+
+					"with multiverse updates pending: %v",
+					uniID.String(), err)
+
+			case err != nil:
 				return fmt.Errorf("unable to register "+
 					"proofs: %w", err)
 			}


### PR DESCRIPTION
(TLDR, disentangle the universe and multiverse writers. Postgres go brrrrrrrr. Fable's summary follows.)

Previously, every proof insert updated two trees inside one transaction: its own universe's tree, and the shared multiverse tree that summarizes all universe roots. Because the shared tree's root was rewritten by every insert, any two concurrent inserts — even into completely unrelated universes — collided on the same rows. Under Postgres's serializable isolation, a collision means abort-and-retry with backoff, so concurrent ingest was effectively single-writer, and in practice slower than serial: measured at 8 workers, 21.8 leaves/s concurrent vs 57.0 serial.

The fix is to decouple the two updates. An insert's transaction now touches only its own universe's state; the shared tree is maintained by a single coalescing writer that collects updates from all inserts and applies them in batches, one transaction per batch. Since only the latest root per universe matters, concurrent updates merge rather than queue, and callers still receive the post-flush multiverse root and inclusion proof, so RPC semantics are unchanged.

The multiverse tree is purely derived data, so a crash between universe commit and flush is healed by startup reconciliation — and its single-writer discipline lets the flush run at read committed on Postgres, taking it out of serialization-conflict detection entirely.

Result: 65.7 leaves/s concurrent vs 61.8 serial on the same benchmark, a 3x improvement with the inversion gone. Hooking #2188's batched-descent InsertMany into the flush should collapse each batch into a single descent per tree, which we expect to close much of the gap between the current ~65 leaves/s and the ~700 leaves/s ceiling measured for the universe transactions alone.