### PR TITLE
Add subscription RPCs for invoices and payments

### DIFF
--- a/docs/release-notes/release-notes-0.8.1.md
+++ b/docs/release-notes/release-notes-0.8.1.md
@@ -44,6 +44,13 @@
   the HTLCs' custom records. Results are filtered to records that involve
   a Taproot Asset; lnd's pagination offsets are passed through unchanged.
 
+- [PR#2195](https://github.com/lightninglabs/taproot-assets/pull/2195)
+  adds `SubscribeInvoices`, `SubscribePayments`, and `TrackPayment` RPCs to
+  the `TaprootAssetChannels` service. The new streaming RPCs wrap the
+  corresponding lnd invoice/payment streams, preserve lnd's request semantics
+  and index handling, and filter updates down to those involving Taproot
+  Assets while returning decoded `AssetAmount` summaries.
+
 ## tapcli Additions
 
 # Improvements

--- a/itest/custom_channels/helpers.go
+++ b/itest/custom_channels/helpers.go
@@ -2139,7 +2139,7 @@ func getPaymentResult(stream routerrpc.Router_SendPaymentV2Client,
 
 // sendKeySendPayment sends a BTC-only keysend payment (no assets).
 func sendKeySendPayment(t *testing.T, src, dst *itest.IntegratedNode,
-	amt btcutil.Amount, opts ...payOpt) {
+	amt btcutil.Amount, opts ...payOpt) lntypes.Hash {
 
 	cfg := defaultPayConfig()
 	for _, opt := range opts {
@@ -2182,6 +2182,8 @@ func sendKeySendPayment(t *testing.T, src, dst *itest.IntegratedNode,
 	result, err := getPaymentResult(stream, false)
 	require.NoError(t, err)
 	require.Equal(t, lnrpc.Payment_SUCCEEDED, result.Status)
+
+	return hash
 }
 
 // createNormalInvoice creates a non-asset LN invoice.

--- a/itest/custom_channels/list_asset_rpcs_test.go
+++ b/itest/custom_channels/list_asset_rpcs_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
+	"io"
 	"slices"
 	"testing"
 
@@ -17,6 +18,7 @@ import (
 	tchrpc "github.com/lightninglabs/taproot-assets/taprpc/tapchannelrpc"
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/lnrpc/invoicesrpc"
+	"github.com/lightningnetwork/lnd/lnrpc/routerrpc"
 	"github.com/lightningnetwork/lnd/lntest/node"
 	"github.com/lightningnetwork/lnd/lntest/port"
 	"github.com/lightningnetwork/lnd/lntest/wait"
@@ -110,17 +112,52 @@ func testCustomChannelsListInvoicesAndPayments(_ context.Context,
 	// so wait for it before proceeding.
 	assertPeerPolicyKnown(t.t, bob, alice, assetChanPoint)
 
+	subCtx, cancelSubscriptions := context.WithTimeout(
+		ctx, 2*wait.DefaultTimeout,
+	)
+	defer cancelSubscriptions()
+
+	bobInvoiceStream, err := asTapd(bob).SubscribeInvoices(
+		subCtx, &tchrpc.SubscribeInvoicesRequest{
+			Request: &lnrpc.InvoiceSubscription{},
+		},
+	)
+	require.NoError(t.t, err)
+
+	alicePaymentStream, err := asTapd(alice).SubscribePayments(
+		subCtx, &tchrpc.SubscribePaymentsRequest{
+			Request: &routerrpc.TrackPaymentsRequest{
+				NoInflightUpdates: true,
+			},
+		},
+	)
+	require.NoError(t.t, err)
+
+	btcPaymentHash := sendKeySendPayment(t.t, alice, bob, btcutil.Amount(10))
+	btcPaymentHashHex := hex.EncodeToString(btcPaymentHash[:])
+
 	// Create a plain BTC invoice on Alice. We never settle it, but we use
 	// it later to verify that tapd's ListInvoices filters out invoices
 	// that don't involve any asset.
 	btcInvoice := createNormalInvoice(t.t, alice, btcutil.Amount(1234))
 	require.NotEmpty(t.t, btcInvoice.RHash)
 
+	// Create a plain BTC invoice on Bob after subscribing. The subscription
+	// should filter it out and only forward later asset invoice updates.
+	bobBTCInvoice := createNormalInvoice(t.t, bob, btcutil.Amount(2345))
+	require.NotEmpty(t.t, bobBTCInvoice.RHash)
+
 	// Create and pay an asset invoice on Bob.
 	const assetInvoiceAmount = 1_500
 	invoiceResp := createAssetInvoice(
 		t.t, alice, bob, assetInvoiceAmount, assetID,
 	)
+	assetInvoiceAddUpdate := waitForAssetInvoiceUpdate(
+		t.t, bobInvoiceStream, invoiceResp.RHash, bobBTCInvoice.RHash,
+	)
+	require.Equal(t.t, lnrpc.Invoice_OPEN, assetInvoiceAddUpdate.Invoice.State)
+	require.Empty(t.t, assetInvoiceAddUpdate.AssetAmounts)
+
 	sentUnits, _ := payInvoiceWithAssets(
 		t.t, alice, bob, invoiceResp.PaymentRequest, assetID,
 	)
@@ -128,6 +165,65 @@ func testCustomChannelsListInvoicesAndPayments(_ context.Context,
 	t.Logf("Paid asset invoice: %d units sent", sentUnits)
 
 	waitForAssetChannelHtlcSettlement(t.t, alice, assetChanPoint)
+
+	assetInvoiceUpdate := waitForAssetInvoiceUpdate(
+		t.t, bobInvoiceStream, invoiceResp.RHash, bobBTCInvoice.RHash,
+	)
+	require.Len(t.t, assetInvoiceUpdate.AssetAmounts, 1)
+	require.Equal(t.t, assetID, assetInvoiceUpdate.AssetAmounts[0].AssetId)
+	require.Equal(t.t, sentUnits, assetInvoiceUpdate.AssetAmounts[0].Amount)
+	require.Equal(
+		t.t, expectedGroupKey, assetInvoiceUpdate.AssetAmounts[0].GroupKey,
+	)
+
+	assetPaymentUpdate := waitForAssetPaymentUpdate(
+		t.t, alicePaymentStream, hex.EncodeToString(invoiceResp.RHash),
+		btcPaymentHashHex,
+	)
+	require.Equal(t.t, lnrpc.Payment_SUCCEEDED, assetPaymentUpdate.Payment.Status)
+	require.Len(t.t, assetPaymentUpdate.AssetAmounts, 1)
+	require.Equal(t.t, assetID, assetPaymentUpdate.AssetAmounts[0].AssetId)
+	require.Equal(t.t, sentUnits, assetPaymentUpdate.AssetAmounts[0].Amount)
+
+	trackCtx, cancelTrackPayment := context.WithTimeout(
+		ctx, wait.DefaultTimeout,
+	)
+	defer cancelTrackPayment()
+
+	trackPaymentStream, err := asTapd(alice).TrackPayment(
+		trackCtx, &tchrpc.TrackPaymentRequest{
+			Request: &routerrpc.TrackPaymentRequest{
+				PaymentHash:       invoiceResp.RHash,
+				NoInflightUpdates: true,
+			},
+		},
+	)
+	require.NoError(t.t, err)
+
+	trackedPayment := waitForAssetPaymentUpdate(
+		t.t, trackPaymentStream, hex.EncodeToString(invoiceResp.RHash),
+		"",
+	)
+	require.Equal(t.t, lnrpc.Payment_SUCCEEDED, trackedPayment.Payment.Status)
+	require.Len(t.t, trackedPayment.AssetAmounts, 1)
+	require.Equal(t.t, assetID, trackedPayment.AssetAmounts[0].AssetId)
+	require.Equal(t.t, sentUnits, trackedPayment.AssetAmounts[0].Amount)
+
+	btcTrackCtx, cancelBTCTrack := context.WithTimeout(
+		ctx, wait.DefaultTimeout,
+	)
+	defer cancelBTCTrack()
+
+	btcTrackPaymentStream, err := asTapd(alice).TrackPayment(
+		btcTrackCtx, &tchrpc.TrackPaymentRequest{
+			Request: &routerrpc.TrackPaymentRequest{
+				PaymentHash:       btcPaymentHash[:],
+				NoInflightUpdates: true,
+			},
+		},
+	)
+	require.NoError(t.t, err)
+	assertNoAssetPaymentUpdate(t.t, btcTrackPaymentStream)
 
 	// Create an asset hodl invoice, send an HTLC to it, then cancel it.
 	// ListInvoices should still include the invoice as asset-related, but
@@ -149,6 +245,15 @@ func testCustomChannelsListInvoicesAndPayments(_ context.Context,
 	)
 	require.NoError(t.t, err)
 	assertNumHtlcsAll(t.t, 0, alice, bob)
+
+	canceledPaymentUpdate := waitForAssetPaymentUpdate(
+		t.t, alicePaymentStream, hex.EncodeToString(canceledHash[:]),
+		btcPaymentHashHex,
+	)
+	require.Equal(
+		t.t, lnrpc.Payment_FAILED, canceledPaymentUpdate.Payment.Status,
+	)
+	require.Empty(t.t, canceledPaymentUpdate.AssetAmounts)
 
 	// Create another asset hodl invoice and settle it explicitly. This
 	// exercises the same hodl invoice code path as the canceled case above,
@@ -238,7 +343,6 @@ func testCustomChannelsListInvoicesAndPayments(_ context.Context,
 			t.t, lnrpc.InvoiceHTLCState_CANCELED, htlc.State,
 		)
 	}
-
 	settledHodlInv := findAssetInvoice(
 		t.t, bobInvoices, settledHodlHash[:],
 	)
@@ -265,6 +369,30 @@ func testCustomChannelsListInvoicesAndPayments(_ context.Context,
 	)
 	require.Equal(
 		t.t, expectedGroupKey, assetInv.AssetAmounts[0].GroupKey,
+	)
+	require.NotZero(t.t, assetInv.Invoice.SettleIndex)
+
+	replaySettleCtx, cancelReplaySettle := context.WithTimeout(
+		ctx, wait.DefaultTimeout,
+	)
+	defer cancelReplaySettle()
+
+	replaySettleStream, err := asTapd(bob).SubscribeInvoices(
+		replaySettleCtx, &tchrpc.SubscribeInvoicesRequest{
+			Request: &lnrpc.InvoiceSubscription{
+				SettleIndex: assetInv.Invoice.SettleIndex - 1,
+			},
+		},
+	)
+	require.NoError(t.t, err)
+
+	replayedSettledInvoice := waitForAssetInvoiceUpdate(
+		t.t, replaySettleStream, invoiceResp.RHash, bobBTCInvoice.RHash,
+	)
+	require.Equal(t.t, lnrpc.Invoice_SETTLED, replayedSettledInvoice.Invoice.State)
+	require.Len(t.t, replayedSettledInvoice.AssetAmounts, 1)
+	require.Equal(
+		t.t, sentUnits, replayedSettledInvoice.AssetAmounts[0].Amount,
 	)
 
 	// Pagination offsets must come straight from lnd.
@@ -397,6 +525,73 @@ func testCustomChannelsListInvoicesAndPayments(_ context.Context,
 	)
 	require.NoError(t.t, err)
 	require.Empty(t.t, bobPayments.Payments)
+}
+
+type assetInvoiceStream interface {
+	Recv() (*tchrpc.AssetInvoice, error)
+}
+
+type assetPaymentStream interface {
+	Recv() (*tchrpc.AssetPayment, error)
+}
+
+// waitForAssetInvoiceUpdate reads asset invoice subscription updates until the
+// target invoice is found. If the explicitly forbidden invoice is seen, the
+// subscription failed to filter a non-asset invoice.
+func waitForAssetInvoiceUpdate(t *testing.T, stream assetInvoiceStream,
+	wantHash, forbiddenHash []byte) *tchrpc.AssetInvoice {
+
+	t.Helper()
+
+	for {
+		inv, err := stream.Recv()
+		require.NoError(t, err)
+		require.NotNil(t, inv)
+		require.NotNil(t, inv.Invoice)
+
+		require.Falsef(
+			t, bytes.Equal(inv.Invoice.RHash, forbiddenHash),
+			"non-asset invoice %x was forwarded", forbiddenHash,
+		)
+
+		if bytes.Equal(inv.Invoice.RHash, wantHash) {
+			return inv
+		}
+	}
+}
+
+// waitForAssetPaymentUpdate reads asset payment subscription updates until the
+// target payment is found.
+func waitForAssetPaymentUpdate(t *testing.T, stream assetPaymentStream,
+	wantHash, forbiddenHash string) *tchrpc.AssetPayment {
+
+	t.Helper()
+
+	for {
+		payment, err := stream.Recv()
+		require.NoError(t, err)
+		require.NotNil(t, payment)
+		require.NotNil(t, payment.Payment)
+
+		require.NotEqualf(
+			t, forbiddenHash, payment.Payment.PaymentHash,
+			"non-asset payment %s was forwarded", forbiddenHash,
+		)
+
+		if payment.Payment.PaymentHash == wantHash {
+			return payment
+		}
+	}
+}
+
+// assertNoAssetPaymentUpdate asserts that a payment stream closes without
+// forwarding any asset payment update.
+func assertNoAssetPaymentUpdate(t *testing.T, stream assetPaymentStream) {
+	t.Helper()
+
+	payment, err := stream.Recv()
+	require.ErrorIs(t, err, io.EOF)
+	require.Nil(t, payment)
 }
 
 // findAssetInvoiceOptional locates the asset invoice with the given r_hash in

--- a/rpcserver/rpcserver.go
+++ b/rpcserver/rpcserver.go
@@ -10791,7 +10791,9 @@ func (r *RPCServer) ListInvoices(ctx context.Context,
 
 	assetInvoices := make([]*tchrpc.AssetInvoice, 0, len(resp.Invoices))
 	for _, invoice := range resp.Invoices {
-		amounts, isAsset, err := assetAmountsFromInvoice(invoice)
+		assetInvoice, isAsset, err := marshalAssetInvoice(
+			invoice, lookup, r.cfg.AuxInvoiceManager,
+		)
 		if err != nil {
 			return nil, fmt.Errorf("error decoding asset "+
 				"amounts from invoice %x: %w",
@@ -10803,10 +10805,7 @@ func (r *RPCServer) ListInvoices(ctx context.Context,
 			continue
 		}
 
-		assetInvoices = append(assetInvoices, &tchrpc.AssetInvoice{
-			Invoice:      invoice,
-			AssetAmounts: marshalAssetAmounts(amounts, lookup),
-		})
+		assetInvoices = append(assetInvoices, assetInvoice)
 	}
 
 	return &tchrpc.ListInvoicesResponse{
@@ -10838,7 +10837,9 @@ func (r *RPCServer) ListPayments(ctx context.Context,
 
 	assetPayments := make([]*tchrpc.AssetPayment, 0, len(resp.Payments))
 	for _, payment := range resp.Payments {
-		amounts, isAsset, err := assetAmountsFromPayment(payment)
+		assetPayment, isAsset, err := marshalAssetPayment(
+			payment, lookup,
+		)
 		if err != nil {
 			return nil, fmt.Errorf("error decoding asset "+
 				"amounts from payment %s: %w",
@@ -10850,10 +10851,7 @@ func (r *RPCServer) ListPayments(ctx context.Context,
 			continue
 		}
 
-		assetPayments = append(assetPayments, &tchrpc.AssetPayment{
-			Payment:      payment,
-			AssetAmounts: marshalAssetAmounts(amounts, lookup),
-		})
+		assetPayments = append(assetPayments, assetPayment)
 	}
 
 	return &tchrpc.ListPaymentsResponse{
@@ -10861,6 +10859,187 @@ func (r *RPCServer) ListPayments(ctx context.Context,
 		FirstIndexOffset: resp.FirstIndexOffset,
 		LastIndexOffset:  resp.LastIndexOffset,
 	}, nil
+}
+
+// SubscribeInvoices is a wrapper around lnd's lnrpc.SubscribeInvoices method
+// that only streams invoices that involve at least one Taproot Asset. The full
+// lnd invoice is returned along with the decoded asset amounts that the
+// invoice's HTLCs carry.
+func (r *RPCServer) SubscribeInvoices(req *tchrpc.SubscribeInvoicesRequest,
+	stream tchrpc.TaprootAssetChannels_SubscribeInvoicesServer) error {
+
+	lndReq := req.GetRequest()
+	if lndReq == nil {
+		lndReq = &lnrpc.InvoiceSubscription{}
+	}
+
+	ctx := stream.Context()
+	rpcCtx, _, rawClient := r.cfg.Lnd.Client.RawClientWithMacAuth(ctx)
+	lndStream, err := rawClient.SubscribeInvoices(rpcCtx, lndReq)
+	if err != nil {
+		return fmt.Errorf("error subscribing to invoices: %w", err)
+	}
+
+	lookup := newAssetGroupLookup(ctx, r.cfg.AddrBook)
+
+	for {
+		invoice, err := lndStream.Recv()
+		if err != nil {
+			return streamRecvError(ctx, err)
+		}
+
+		assetInvoice, isAsset, err := marshalAssetInvoice(
+			invoice, lookup, r.cfg.AuxInvoiceManager,
+		)
+		if err != nil {
+			return fmt.Errorf("error decoding asset amounts from "+
+				"invoice %x: %w", invoice.GetRHash(), err)
+		}
+		if !isAsset {
+			continue
+		}
+
+		if err := stream.Send(assetInvoice); err != nil {
+			return err
+		}
+	}
+}
+
+// SubscribePayments is a wrapper around lnd's routerrpc.TrackPayments method
+// that only streams payments that involve at least one Taproot Asset. The full
+// lnd payment is returned along with the decoded asset amounts that the
+// payment's HTLCs carry.
+func (r *RPCServer) SubscribePayments(req *tchrpc.SubscribePaymentsRequest,
+	stream tchrpc.TaprootAssetChannels_SubscribePaymentsServer) error {
+
+	lndReq := req.GetRequest()
+	if lndReq == nil {
+		lndReq = &routerrpc.TrackPaymentsRequest{}
+	}
+
+	ctx := stream.Context()
+	rpcCtx, _, routerClient := r.cfg.Lnd.Router.RawClientWithMacAuth(ctx)
+	lndStream, err := routerClient.TrackPayments(rpcCtx, lndReq)
+	if err != nil {
+		return fmt.Errorf("error subscribing to payments: %w", err)
+	}
+
+	return r.forwardAssetPaymentUpdates(ctx, lndStream.Recv, stream.Send)
+}
+
+// TrackPayment is a wrapper around lnd's routerrpc.TrackPaymentV2 method that
+// only streams updates that involve at least one Taproot Asset. The full lnd
+// payment is returned along with the decoded asset amounts that the payment's
+// HTLCs carry.
+func (r *RPCServer) TrackPayment(req *tchrpc.TrackPaymentRequest,
+	stream tchrpc.TaprootAssetChannels_TrackPaymentServer) error {
+
+	lndReq := req.GetRequest()
+	if lndReq == nil {
+		lndReq = &routerrpc.TrackPaymentRequest{}
+	}
+
+	ctx := stream.Context()
+	rpcCtx, _, routerClient := r.cfg.Lnd.Router.RawClientWithMacAuth(ctx)
+	lndStream, err := routerClient.TrackPaymentV2(rpcCtx, lndReq)
+	if err != nil {
+		return fmt.Errorf("error tracking payment: %w", err)
+	}
+
+	return r.forwardAssetPaymentUpdates(ctx, lndStream.Recv, stream.Send)
+}
+
+// forwardAssetPaymentUpdates receives lnd payment updates, filters out
+// non-asset payments, and forwards asset payments to the caller.
+func (r *RPCServer) forwardAssetPaymentUpdates(ctx context.Context,
+	recv func() (*lnrpc.Payment, error),
+	send func(*tchrpc.AssetPayment) error) error {
+
+	lookup := newAssetGroupLookup(ctx, r.cfg.AddrBook)
+
+	for {
+		payment, err := recv()
+		if err != nil {
+			return streamRecvError(ctx, err)
+		}
+
+		assetPayment, isAsset, err := marshalAssetPayment(
+			payment, lookup,
+		)
+		if err != nil {
+			return fmt.Errorf("error decoding asset amounts from "+
+				"payment %s: %w", payment.GetPaymentHash(), err)
+		}
+		if !isAsset {
+			continue
+		}
+
+		if err := send(assetPayment); err != nil {
+			return err
+		}
+	}
+}
+
+// streamRecvError normalizes expected stream shutdown errors.
+func streamRecvError(ctx context.Context, err error) error {
+	if err == io.EOF {
+		return nil
+	}
+
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		if errors.Is(ctxErr, context.Canceled) {
+			return nil
+		}
+
+		return ctxErr
+	}
+
+	return err
+}
+
+// marshalAssetInvoice converts an lnd invoice into an asset invoice. The second
+// return value tells whether the invoice involves any asset at all.
+func marshalAssetInvoice(invoice *lnrpc.Invoice, lookup *assetGroupLookup,
+	rfqLookup tapchannel.RfqLookup) (*tchrpc.AssetInvoice, bool, error) {
+
+	amounts, isAsset, err := assetAmountsFromInvoice(invoice)
+	if err != nil {
+		return nil, false, err
+	}
+
+	// Freshly added asset invoices have RFQ route hints, but no HTLCs yet.
+	// Keep lnd's invoice add semantics by classifying those as asset
+	// invoices even though their settled asset amount is still empty.
+	if !isAsset && tapchannel.IsAssetInvoice(invoice, rfqLookup) {
+		isAsset = true
+	}
+	if !isAsset {
+		return nil, false, nil
+	}
+
+	return &tchrpc.AssetInvoice{
+		Invoice:      invoice,
+		AssetAmounts: marshalAssetAmounts(amounts, lookup),
+	}, true, nil
+}
+
+// marshalAssetPayment converts an lnd payment into an asset payment. The second
+// return value tells whether the payment involves any asset at all.
+func marshalAssetPayment(payment *lnrpc.Payment,
+	lookup *assetGroupLookup) (*tchrpc.AssetPayment, bool, error) {
+
+	amounts, isAsset, err := assetAmountsFromPayment(payment)
+	if err != nil {
+		return nil, false, err
+	}
+	if !isAsset {
+		return nil, false, nil
+	}
+
+	return &tchrpc.AssetPayment{
+		Payment:      payment,
+		AssetAmounts: marshalAssetAmounts(amounts, lookup),
+	}, true, nil
 }
 
 // assetAmountsFromInvoice extracts the per-asset amounts carried by an

--- a/taprpc/perms.go
+++ b/taprpc/perms.go
@@ -351,6 +351,18 @@ var (
 			Entity: "channels",
 			Action: "read",
 		}},
+		"/tapchannelrpc.TaprootAssetChannels/SubscribeInvoices": {{
+			Entity: "channels",
+			Action: "read",
+		}},
+		"/tapchannelrpc.TaprootAssetChannels/SubscribePayments": {{
+			Entity: "channels",
+			Action: "read",
+		}},
+		"/tapchannelrpc.TaprootAssetChannels/TrackPayment": {{
+			Entity: "channels",
+			Action: "read",
+		}},
 		"/tapchannelrpc.TaprootAssetChannels/EncodeCustomRecords": {
 			// This RPC is completely stateless and doesn't require
 			// any permissions to use.

--- a/taprpc/tapchannelrpc/tapchannel.pb.go
+++ b/taprpc/tapchannelrpc/tapchannel.pb.go
@@ -1179,6 +1179,57 @@ func (x *ListInvoicesRequest) GetRequest() *lnrpc.ListInvoiceRequest {
 	return nil
 }
 
+type SubscribeInvoicesRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The standard lnd invoice subscription request. All fields behave the same
+	// way as they do for lnd's lnrpc.SubscribeInvoices RPC method (see the API
+	// docs at
+	// https://lightning.engineering/api-docs/api/lnd/lightning/subscribe-invoices
+	// for more details). Invoice index replay is performed by lnd over all
+	// invoices; the returned stream is then filtered down to only those that
+	// involve assets.
+	Request       *lnrpc.InvoiceSubscription `protobuf:"bytes,1,opt,name=request,proto3" json:"request,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SubscribeInvoicesRequest) Reset() {
+	*x = SubscribeInvoicesRequest{}
+	mi := &file_tapchannelrpc_tapchannel_proto_msgTypes[15]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SubscribeInvoicesRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SubscribeInvoicesRequest) ProtoMessage() {}
+
+func (x *SubscribeInvoicesRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_tapchannelrpc_tapchannel_proto_msgTypes[15]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SubscribeInvoicesRequest.ProtoReflect.Descriptor instead.
+func (*SubscribeInvoicesRequest) Descriptor() ([]byte, []int) {
+	return file_tapchannelrpc_tapchannel_proto_rawDescGZIP(), []int{15}
+}
+
+func (x *SubscribeInvoicesRequest) GetRequest() *lnrpc.InvoiceSubscription {
+	if x != nil {
+		return x.Request
+	}
+	return nil
+}
+
 type AssetInvoice struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// The full lnd invoice, including any custom channel data on its HTLCs.
@@ -1193,7 +1244,7 @@ type AssetInvoice struct {
 
 func (x *AssetInvoice) Reset() {
 	*x = AssetInvoice{}
-	mi := &file_tapchannelrpc_tapchannel_proto_msgTypes[15]
+	mi := &file_tapchannelrpc_tapchannel_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1205,7 +1256,7 @@ func (x *AssetInvoice) String() string {
 func (*AssetInvoice) ProtoMessage() {}
 
 func (x *AssetInvoice) ProtoReflect() protoreflect.Message {
-	mi := &file_tapchannelrpc_tapchannel_proto_msgTypes[15]
+	mi := &file_tapchannelrpc_tapchannel_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1218,7 +1269,7 @@ func (x *AssetInvoice) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AssetInvoice.ProtoReflect.Descriptor instead.
 func (*AssetInvoice) Descriptor() ([]byte, []int) {
-	return file_tapchannelrpc_tapchannel_proto_rawDescGZIP(), []int{15}
+	return file_tapchannelrpc_tapchannel_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *AssetInvoice) GetInvoice() *lnrpc.Invoice {
@@ -1253,7 +1304,7 @@ type ListInvoicesResponse struct {
 
 func (x *ListInvoicesResponse) Reset() {
 	*x = ListInvoicesResponse{}
-	mi := &file_tapchannelrpc_tapchannel_proto_msgTypes[16]
+	mi := &file_tapchannelrpc_tapchannel_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1265,7 +1316,7 @@ func (x *ListInvoicesResponse) String() string {
 func (*ListInvoicesResponse) ProtoMessage() {}
 
 func (x *ListInvoicesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_tapchannelrpc_tapchannel_proto_msgTypes[16]
+	mi := &file_tapchannelrpc_tapchannel_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1278,7 +1329,7 @@ func (x *ListInvoicesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListInvoicesResponse.ProtoReflect.Descriptor instead.
 func (*ListInvoicesResponse) Descriptor() ([]byte, []int) {
-	return file_tapchannelrpc_tapchannel_proto_rawDescGZIP(), []int{16}
+	return file_tapchannelrpc_tapchannel_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *ListInvoicesResponse) GetInvoices() []*AssetInvoice {
@@ -1317,7 +1368,7 @@ type ListPaymentsRequest struct {
 
 func (x *ListPaymentsRequest) Reset() {
 	*x = ListPaymentsRequest{}
-	mi := &file_tapchannelrpc_tapchannel_proto_msgTypes[17]
+	mi := &file_tapchannelrpc_tapchannel_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1329,7 +1380,7 @@ func (x *ListPaymentsRequest) String() string {
 func (*ListPaymentsRequest) ProtoMessage() {}
 
 func (x *ListPaymentsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_tapchannelrpc_tapchannel_proto_msgTypes[17]
+	mi := &file_tapchannelrpc_tapchannel_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1342,10 +1393,111 @@ func (x *ListPaymentsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListPaymentsRequest.ProtoReflect.Descriptor instead.
 func (*ListPaymentsRequest) Descriptor() ([]byte, []int) {
-	return file_tapchannelrpc_tapchannel_proto_rawDescGZIP(), []int{17}
+	return file_tapchannelrpc_tapchannel_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *ListPaymentsRequest) GetRequest() *lnrpc.ListPaymentsRequest {
+	if x != nil {
+		return x.Request
+	}
+	return nil
+}
+
+type SubscribePaymentsRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The standard lnd payment tracking request. All fields behave the same way
+	// as they do for lnd's routerrpc.TrackPayments RPC method (see the API docs
+	// at https://lightning.engineering/api-docs/api/lnd/router/track-payments
+	// for more details). The payment update stream is produced by lnd over all
+	// active payments; the returned stream is then filtered down to only those
+	// that involve assets.
+	Request       *routerrpc.TrackPaymentsRequest `protobuf:"bytes,1,opt,name=request,proto3" json:"request,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SubscribePaymentsRequest) Reset() {
+	*x = SubscribePaymentsRequest{}
+	mi := &file_tapchannelrpc_tapchannel_proto_msgTypes[19]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SubscribePaymentsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SubscribePaymentsRequest) ProtoMessage() {}
+
+func (x *SubscribePaymentsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_tapchannelrpc_tapchannel_proto_msgTypes[19]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SubscribePaymentsRequest.ProtoReflect.Descriptor instead.
+func (*SubscribePaymentsRequest) Descriptor() ([]byte, []int) {
+	return file_tapchannelrpc_tapchannel_proto_rawDescGZIP(), []int{19}
+}
+
+func (x *SubscribePaymentsRequest) GetRequest() *routerrpc.TrackPaymentsRequest {
+	if x != nil {
+		return x.Request
+	}
+	return nil
+}
+
+type TrackPaymentRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The standard lnd payment tracking request. All fields behave the same way
+	// as they do for lnd's routerrpc.TrackPaymentV2 RPC method (see the API
+	// docs at
+	// https://lightning.engineering/api-docs/api/lnd/router/track-payment-v2
+	// for more details). The payment update stream is produced by lnd for the
+	// requested payment; the returned stream is then filtered down to only
+	// updates that involve assets.
+	Request       *routerrpc.TrackPaymentRequest `protobuf:"bytes,1,opt,name=request,proto3" json:"request,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *TrackPaymentRequest) Reset() {
+	*x = TrackPaymentRequest{}
+	mi := &file_tapchannelrpc_tapchannel_proto_msgTypes[20]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TrackPaymentRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TrackPaymentRequest) ProtoMessage() {}
+
+func (x *TrackPaymentRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_tapchannelrpc_tapchannel_proto_msgTypes[20]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TrackPaymentRequest.ProtoReflect.Descriptor instead.
+func (*TrackPaymentRequest) Descriptor() ([]byte, []int) {
+	return file_tapchannelrpc_tapchannel_proto_rawDescGZIP(), []int{20}
+}
+
+func (x *TrackPaymentRequest) GetRequest() *routerrpc.TrackPaymentRequest {
 	if x != nil {
 		return x.Request
 	}
@@ -1366,7 +1518,7 @@ type AssetPayment struct {
 
 func (x *AssetPayment) Reset() {
 	*x = AssetPayment{}
-	mi := &file_tapchannelrpc_tapchannel_proto_msgTypes[18]
+	mi := &file_tapchannelrpc_tapchannel_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1378,7 +1530,7 @@ func (x *AssetPayment) String() string {
 func (*AssetPayment) ProtoMessage() {}
 
 func (x *AssetPayment) ProtoReflect() protoreflect.Message {
-	mi := &file_tapchannelrpc_tapchannel_proto_msgTypes[18]
+	mi := &file_tapchannelrpc_tapchannel_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1391,7 +1543,7 @@ func (x *AssetPayment) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AssetPayment.ProtoReflect.Descriptor instead.
 func (*AssetPayment) Descriptor() ([]byte, []int) {
-	return file_tapchannelrpc_tapchannel_proto_rawDescGZIP(), []int{18}
+	return file_tapchannelrpc_tapchannel_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *AssetPayment) GetPayment() *lnrpc.Payment {
@@ -1426,7 +1578,7 @@ type ListPaymentsResponse struct {
 
 func (x *ListPaymentsResponse) Reset() {
 	*x = ListPaymentsResponse{}
-	mi := &file_tapchannelrpc_tapchannel_proto_msgTypes[19]
+	mi := &file_tapchannelrpc_tapchannel_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1438,7 +1590,7 @@ func (x *ListPaymentsResponse) String() string {
 func (*ListPaymentsResponse) ProtoMessage() {}
 
 func (x *ListPaymentsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_tapchannelrpc_tapchannel_proto_msgTypes[19]
+	mi := &file_tapchannelrpc_tapchannel_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1451,7 +1603,7 @@ func (x *ListPaymentsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListPaymentsResponse.ProtoReflect.Descriptor instead.
 func (*ListPaymentsResponse) Descriptor() ([]byte, []int) {
-	return file_tapchannelrpc_tapchannel_proto_rawDescGZIP(), []int{19}
+	return file_tapchannelrpc_tapchannel_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *ListPaymentsResponse) GetPayments() []*AssetPayment {
@@ -1558,7 +1710,9 @@ const file_tapchannelrpc_tapchannel_proto_rawDesc = "" +
 	"\x06amount\x18\x02 \x01(\x04R\x06amount\x12\x1b\n" +
 	"\tgroup_key\x18\x03 \x01(\fR\bgroupKey\"J\n" +
 	"\x13ListInvoicesRequest\x123\n" +
-	"\arequest\x18\x01 \x01(\v2\x19.lnrpc.ListInvoiceRequestR\arequest\"y\n" +
+	"\arequest\x18\x01 \x01(\v2\x19.lnrpc.ListInvoiceRequestR\arequest\"P\n" +
+	"\x18SubscribeInvoicesRequest\x124\n" +
+	"\arequest\x18\x01 \x01(\v2\x1a.lnrpc.InvoiceSubscriptionR\arequest\"y\n" +
 	"\fAssetInvoice\x12(\n" +
 	"\ainvoice\x18\x01 \x01(\v2\x0e.lnrpc.InvoiceR\ainvoice\x12?\n" +
 	"\rasset_amounts\x18\x02 \x03(\v2\x1a.tapchannelrpc.AssetAmountR\fassetAmounts\"\xa9\x01\n" +
@@ -1567,14 +1721,18 @@ const file_tapchannelrpc_tapchannel_proto_rawDesc = "" +
 	"\x11last_index_offset\x18\x02 \x01(\x04R\x0flastIndexOffset\x12,\n" +
 	"\x12first_index_offset\x18\x03 \x01(\x04R\x10firstIndexOffset\"K\n" +
 	"\x13ListPaymentsRequest\x124\n" +
-	"\arequest\x18\x01 \x01(\v2\x1a.lnrpc.ListPaymentsRequestR\arequest\"y\n" +
+	"\arequest\x18\x01 \x01(\v2\x1a.lnrpc.ListPaymentsRequestR\arequest\"U\n" +
+	"\x18SubscribePaymentsRequest\x129\n" +
+	"\arequest\x18\x01 \x01(\v2\x1f.routerrpc.TrackPaymentsRequestR\arequest\"O\n" +
+	"\x13TrackPaymentRequest\x128\n" +
+	"\arequest\x18\x01 \x01(\v2\x1e.routerrpc.TrackPaymentRequestR\arequest\"y\n" +
 	"\fAssetPayment\x12(\n" +
 	"\apayment\x18\x01 \x01(\v2\x0e.lnrpc.PaymentR\apayment\x12?\n" +
 	"\rasset_amounts\x18\x02 \x03(\v2\x1a.tapchannelrpc.AssetAmountR\fassetAmounts\"\xa9\x01\n" +
 	"\x14ListPaymentsResponse\x127\n" +
 	"\bpayments\x18\x01 \x03(\v2\x1b.tapchannelrpc.AssetPaymentR\bpayments\x12,\n" +
 	"\x12first_index_offset\x18\x02 \x01(\x04R\x10firstIndexOffset\x12*\n" +
-	"\x11last_index_offset\x18\x03 \x01(\x04R\x0flastIndexOffset2\x91\x05\n" +
+	"\x11last_index_offset\x18\x03 \x01(\x04R\x0flastIndexOffset2\x9e\a\n" +
 	"\x14TaprootAssetChannels\x12T\n" +
 	"\vFundChannel\x12!.tapchannelrpc.FundChannelRequest\x1a\".tapchannelrpc.FundChannelResponse\x12q\n" +
 	"\x13EncodeCustomRecords\x12).tapchannelrpc.EncodeCustomRecordsRequest\x1a*.tapchannelrpc.EncodeCustomRecordsResponse\"\x03\x88\x02\x01\x12V\n" +
@@ -1583,7 +1741,10 @@ const file_tapchannelrpc_tapchannel_proto_rawDesc = "" +
 	"AddInvoice\x12 .tapchannelrpc.AddInvoiceRequest\x1a!.tapchannelrpc.AddInvoiceResponse\x12S\n" +
 	"\x11DecodeAssetPayReq\x12\x1a.tapchannelrpc.AssetPayReq\x1a\".tapchannelrpc.AssetPayReqResponse\x12W\n" +
 	"\fListInvoices\x12\".tapchannelrpc.ListInvoicesRequest\x1a#.tapchannelrpc.ListInvoicesResponse\x12W\n" +
-	"\fListPayments\x12\".tapchannelrpc.ListPaymentsRequest\x1a#.tapchannelrpc.ListPaymentsResponseB>Z<github.com/lightninglabs/taproot-assets/taprpc/tapchannelrpcb\x06proto3"
+	"\fListPayments\x12\".tapchannelrpc.ListPaymentsRequest\x1a#.tapchannelrpc.ListPaymentsResponse\x12[\n" +
+	"\x11SubscribeInvoices\x12'.tapchannelrpc.SubscribeInvoicesRequest\x1a\x1b.tapchannelrpc.AssetInvoice0\x01\x12[\n" +
+	"\x11SubscribePayments\x12'.tapchannelrpc.SubscribePaymentsRequest\x1a\x1b.tapchannelrpc.AssetPayment0\x01\x12Q\n" +
+	"\fTrackPayment\x12\".tapchannelrpc.TrackPaymentRequest\x1a\x1b.tapchannelrpc.AssetPayment0\x01B>Z<github.com/lightninglabs/taproot-assets/taprpc/tapchannelrpcb\x06proto3"
 
 var (
 	file_tapchannelrpc_tapchannel_proto_rawDescOnce sync.Once
@@ -1597,91 +1758,106 @@ func file_tapchannelrpc_tapchannel_proto_rawDescGZIP() []byte {
 	return file_tapchannelrpc_tapchannel_proto_rawDescData
 }
 
-var file_tapchannelrpc_tapchannel_proto_msgTypes = make([]protoimpl.MessageInfo, 22)
+var file_tapchannelrpc_tapchannel_proto_msgTypes = make([]protoimpl.MessageInfo, 25)
 var file_tapchannelrpc_tapchannel_proto_goTypes = []any{
-	(*FundChannelRequest)(nil),           // 0: tapchannelrpc.FundChannelRequest
-	(*FundChannelResponse)(nil),          // 1: tapchannelrpc.FundChannelResponse
-	(*RouterSendPaymentData)(nil),        // 2: tapchannelrpc.RouterSendPaymentData
-	(*EncodeCustomRecordsRequest)(nil),   // 3: tapchannelrpc.EncodeCustomRecordsRequest
-	(*EncodeCustomRecordsResponse)(nil),  // 4: tapchannelrpc.EncodeCustomRecordsResponse
-	(*SendPaymentRequest)(nil),           // 5: tapchannelrpc.SendPaymentRequest
-	(*AcceptedSellQuotes)(nil),           // 6: tapchannelrpc.AcceptedSellQuotes
-	(*SendPaymentResponse)(nil),          // 7: tapchannelrpc.SendPaymentResponse
-	(*HodlInvoice)(nil),                  // 8: tapchannelrpc.HodlInvoice
-	(*AddInvoiceRequest)(nil),            // 9: tapchannelrpc.AddInvoiceRequest
-	(*AddInvoiceResponse)(nil),           // 10: tapchannelrpc.AddInvoiceResponse
-	(*AssetPayReq)(nil),                  // 11: tapchannelrpc.AssetPayReq
-	(*AssetPayReqResponse)(nil),          // 12: tapchannelrpc.AssetPayReqResponse
-	(*AssetAmount)(nil),                  // 13: tapchannelrpc.AssetAmount
-	(*ListInvoicesRequest)(nil),          // 14: tapchannelrpc.ListInvoicesRequest
-	(*AssetInvoice)(nil),                 // 15: tapchannelrpc.AssetInvoice
-	(*ListInvoicesResponse)(nil),         // 16: tapchannelrpc.ListInvoicesResponse
-	(*ListPaymentsRequest)(nil),          // 17: tapchannelrpc.ListPaymentsRequest
-	(*AssetPayment)(nil),                 // 18: tapchannelrpc.AssetPayment
-	(*ListPaymentsResponse)(nil),         // 19: tapchannelrpc.ListPaymentsResponse
-	nil,                                  // 20: tapchannelrpc.RouterSendPaymentData.AssetAmountsEntry
-	nil,                                  // 21: tapchannelrpc.EncodeCustomRecordsResponse.CustomRecordsEntry
-	(*routerrpc.SendPaymentRequest)(nil), // 22: routerrpc.SendPaymentRequest
-	(*rfqrpc.PeerAcceptedSellQuote)(nil), // 23: rfqrpc.PeerAcceptedSellQuote
-	(*lnrpc.Payment)(nil),                // 24: lnrpc.Payment
-	(*lnrpc.Invoice)(nil),                // 25: lnrpc.Invoice
-	(*rfqrpc.FixedPoint)(nil),            // 26: rfqrpc.FixedPoint
-	(rfqrpc.ExecutionPolicy)(0),          // 27: rfqrpc.ExecutionPolicy
-	(*rfqrpc.PeerAcceptedBuyQuote)(nil),  // 28: rfqrpc.PeerAcceptedBuyQuote
-	(*lnrpc.AddInvoiceResponse)(nil),     // 29: lnrpc.AddInvoiceResponse
-	(*taprpc.DecimalDisplay)(nil),        // 30: taprpc.DecimalDisplay
-	(*taprpc.AssetGroup)(nil),            // 31: taprpc.AssetGroup
-	(*taprpc.GenesisInfo)(nil),           // 32: taprpc.GenesisInfo
-	(*lnrpc.PayReq)(nil),                 // 33: lnrpc.PayReq
-	(*lnrpc.ListInvoiceRequest)(nil),     // 34: lnrpc.ListInvoiceRequest
-	(*lnrpc.ListPaymentsRequest)(nil),    // 35: lnrpc.ListPaymentsRequest
+	(*FundChannelRequest)(nil),             // 0: tapchannelrpc.FundChannelRequest
+	(*FundChannelResponse)(nil),            // 1: tapchannelrpc.FundChannelResponse
+	(*RouterSendPaymentData)(nil),          // 2: tapchannelrpc.RouterSendPaymentData
+	(*EncodeCustomRecordsRequest)(nil),     // 3: tapchannelrpc.EncodeCustomRecordsRequest
+	(*EncodeCustomRecordsResponse)(nil),    // 4: tapchannelrpc.EncodeCustomRecordsResponse
+	(*SendPaymentRequest)(nil),             // 5: tapchannelrpc.SendPaymentRequest
+	(*AcceptedSellQuotes)(nil),             // 6: tapchannelrpc.AcceptedSellQuotes
+	(*SendPaymentResponse)(nil),            // 7: tapchannelrpc.SendPaymentResponse
+	(*HodlInvoice)(nil),                    // 8: tapchannelrpc.HodlInvoice
+	(*AddInvoiceRequest)(nil),              // 9: tapchannelrpc.AddInvoiceRequest
+	(*AddInvoiceResponse)(nil),             // 10: tapchannelrpc.AddInvoiceResponse
+	(*AssetPayReq)(nil),                    // 11: tapchannelrpc.AssetPayReq
+	(*AssetPayReqResponse)(nil),            // 12: tapchannelrpc.AssetPayReqResponse
+	(*AssetAmount)(nil),                    // 13: tapchannelrpc.AssetAmount
+	(*ListInvoicesRequest)(nil),            // 14: tapchannelrpc.ListInvoicesRequest
+	(*SubscribeInvoicesRequest)(nil),       // 15: tapchannelrpc.SubscribeInvoicesRequest
+	(*AssetInvoice)(nil),                   // 16: tapchannelrpc.AssetInvoice
+	(*ListInvoicesResponse)(nil),           // 17: tapchannelrpc.ListInvoicesResponse
+	(*ListPaymentsRequest)(nil),            // 18: tapchannelrpc.ListPaymentsRequest
+	(*SubscribePaymentsRequest)(nil),       // 19: tapchannelrpc.SubscribePaymentsRequest
+	(*TrackPaymentRequest)(nil),            // 20: tapchannelrpc.TrackPaymentRequest
+	(*AssetPayment)(nil),                   // 21: tapchannelrpc.AssetPayment
+	(*ListPaymentsResponse)(nil),           // 22: tapchannelrpc.ListPaymentsResponse
+	nil,                                    // 23: tapchannelrpc.RouterSendPaymentData.AssetAmountsEntry
+	nil,                                    // 24: tapchannelrpc.EncodeCustomRecordsResponse.CustomRecordsEntry
+	(*routerrpc.SendPaymentRequest)(nil),   // 25: routerrpc.SendPaymentRequest
+	(*rfqrpc.PeerAcceptedSellQuote)(nil),   // 26: rfqrpc.PeerAcceptedSellQuote
+	(*lnrpc.Payment)(nil),                  // 27: lnrpc.Payment
+	(*lnrpc.Invoice)(nil),                  // 28: lnrpc.Invoice
+	(*rfqrpc.FixedPoint)(nil),              // 29: rfqrpc.FixedPoint
+	(rfqrpc.ExecutionPolicy)(0),            // 30: rfqrpc.ExecutionPolicy
+	(*rfqrpc.PeerAcceptedBuyQuote)(nil),    // 31: rfqrpc.PeerAcceptedBuyQuote
+	(*lnrpc.AddInvoiceResponse)(nil),       // 32: lnrpc.AddInvoiceResponse
+	(*taprpc.DecimalDisplay)(nil),          // 33: taprpc.DecimalDisplay
+	(*taprpc.AssetGroup)(nil),              // 34: taprpc.AssetGroup
+	(*taprpc.GenesisInfo)(nil),             // 35: taprpc.GenesisInfo
+	(*lnrpc.PayReq)(nil),                   // 36: lnrpc.PayReq
+	(*lnrpc.ListInvoiceRequest)(nil),       // 37: lnrpc.ListInvoiceRequest
+	(*lnrpc.InvoiceSubscription)(nil),      // 38: lnrpc.InvoiceSubscription
+	(*lnrpc.ListPaymentsRequest)(nil),      // 39: lnrpc.ListPaymentsRequest
+	(*routerrpc.TrackPaymentsRequest)(nil), // 40: routerrpc.TrackPaymentsRequest
+	(*routerrpc.TrackPaymentRequest)(nil),  // 41: routerrpc.TrackPaymentRequest
 }
 var file_tapchannelrpc_tapchannel_proto_depIdxs = []int32{
-	20, // 0: tapchannelrpc.RouterSendPaymentData.asset_amounts:type_name -> tapchannelrpc.RouterSendPaymentData.AssetAmountsEntry
+	23, // 0: tapchannelrpc.RouterSendPaymentData.asset_amounts:type_name -> tapchannelrpc.RouterSendPaymentData.AssetAmountsEntry
 	2,  // 1: tapchannelrpc.EncodeCustomRecordsRequest.router_send_payment:type_name -> tapchannelrpc.RouterSendPaymentData
-	21, // 2: tapchannelrpc.EncodeCustomRecordsResponse.custom_records:type_name -> tapchannelrpc.EncodeCustomRecordsResponse.CustomRecordsEntry
-	22, // 3: tapchannelrpc.SendPaymentRequest.payment_request:type_name -> routerrpc.SendPaymentRequest
-	23, // 4: tapchannelrpc.AcceptedSellQuotes.accepted_sell_orders:type_name -> rfqrpc.PeerAcceptedSellQuote
-	23, // 5: tapchannelrpc.SendPaymentResponse.accepted_sell_order:type_name -> rfqrpc.PeerAcceptedSellQuote
+	24, // 2: tapchannelrpc.EncodeCustomRecordsResponse.custom_records:type_name -> tapchannelrpc.EncodeCustomRecordsResponse.CustomRecordsEntry
+	25, // 3: tapchannelrpc.SendPaymentRequest.payment_request:type_name -> routerrpc.SendPaymentRequest
+	26, // 4: tapchannelrpc.AcceptedSellQuotes.accepted_sell_orders:type_name -> rfqrpc.PeerAcceptedSellQuote
+	26, // 5: tapchannelrpc.SendPaymentResponse.accepted_sell_order:type_name -> rfqrpc.PeerAcceptedSellQuote
 	6,  // 6: tapchannelrpc.SendPaymentResponse.accepted_sell_orders:type_name -> tapchannelrpc.AcceptedSellQuotes
-	24, // 7: tapchannelrpc.SendPaymentResponse.payment_result:type_name -> lnrpc.Payment
-	25, // 8: tapchannelrpc.AddInvoiceRequest.invoice_request:type_name -> lnrpc.Invoice
+	27, // 7: tapchannelrpc.SendPaymentResponse.payment_result:type_name -> lnrpc.Payment
+	28, // 8: tapchannelrpc.AddInvoiceRequest.invoice_request:type_name -> lnrpc.Invoice
 	8,  // 9: tapchannelrpc.AddInvoiceRequest.hodl_invoice:type_name -> tapchannelrpc.HodlInvoice
-	26, // 10: tapchannelrpc.AddInvoiceRequest.asset_rate_limit:type_name -> rfqrpc.FixedPoint
-	27, // 11: tapchannelrpc.AddInvoiceRequest.execution_policy:type_name -> rfqrpc.ExecutionPolicy
-	28, // 12: tapchannelrpc.AddInvoiceResponse.accepted_buy_quote:type_name -> rfqrpc.PeerAcceptedBuyQuote
-	29, // 13: tapchannelrpc.AddInvoiceResponse.invoice_result:type_name -> lnrpc.AddInvoiceResponse
-	30, // 14: tapchannelrpc.AssetPayReqResponse.decimal_display:type_name -> taprpc.DecimalDisplay
-	31, // 15: tapchannelrpc.AssetPayReqResponse.asset_group:type_name -> taprpc.AssetGroup
-	32, // 16: tapchannelrpc.AssetPayReqResponse.genesis_info:type_name -> taprpc.GenesisInfo
-	33, // 17: tapchannelrpc.AssetPayReqResponse.pay_req:type_name -> lnrpc.PayReq
-	34, // 18: tapchannelrpc.ListInvoicesRequest.request:type_name -> lnrpc.ListInvoiceRequest
-	25, // 19: tapchannelrpc.AssetInvoice.invoice:type_name -> lnrpc.Invoice
-	13, // 20: tapchannelrpc.AssetInvoice.asset_amounts:type_name -> tapchannelrpc.AssetAmount
-	15, // 21: tapchannelrpc.ListInvoicesResponse.invoices:type_name -> tapchannelrpc.AssetInvoice
-	35, // 22: tapchannelrpc.ListPaymentsRequest.request:type_name -> lnrpc.ListPaymentsRequest
-	24, // 23: tapchannelrpc.AssetPayment.payment:type_name -> lnrpc.Payment
-	13, // 24: tapchannelrpc.AssetPayment.asset_amounts:type_name -> tapchannelrpc.AssetAmount
-	18, // 25: tapchannelrpc.ListPaymentsResponse.payments:type_name -> tapchannelrpc.AssetPayment
-	0,  // 26: tapchannelrpc.TaprootAssetChannels.FundChannel:input_type -> tapchannelrpc.FundChannelRequest
-	3,  // 27: tapchannelrpc.TaprootAssetChannels.EncodeCustomRecords:input_type -> tapchannelrpc.EncodeCustomRecordsRequest
-	5,  // 28: tapchannelrpc.TaprootAssetChannels.SendPayment:input_type -> tapchannelrpc.SendPaymentRequest
-	9,  // 29: tapchannelrpc.TaprootAssetChannels.AddInvoice:input_type -> tapchannelrpc.AddInvoiceRequest
-	11, // 30: tapchannelrpc.TaprootAssetChannels.DecodeAssetPayReq:input_type -> tapchannelrpc.AssetPayReq
-	14, // 31: tapchannelrpc.TaprootAssetChannels.ListInvoices:input_type -> tapchannelrpc.ListInvoicesRequest
-	17, // 32: tapchannelrpc.TaprootAssetChannels.ListPayments:input_type -> tapchannelrpc.ListPaymentsRequest
-	1,  // 33: tapchannelrpc.TaprootAssetChannels.FundChannel:output_type -> tapchannelrpc.FundChannelResponse
-	4,  // 34: tapchannelrpc.TaprootAssetChannels.EncodeCustomRecords:output_type -> tapchannelrpc.EncodeCustomRecordsResponse
-	7,  // 35: tapchannelrpc.TaprootAssetChannels.SendPayment:output_type -> tapchannelrpc.SendPaymentResponse
-	10, // 36: tapchannelrpc.TaprootAssetChannels.AddInvoice:output_type -> tapchannelrpc.AddInvoiceResponse
-	12, // 37: tapchannelrpc.TaprootAssetChannels.DecodeAssetPayReq:output_type -> tapchannelrpc.AssetPayReqResponse
-	16, // 38: tapchannelrpc.TaprootAssetChannels.ListInvoices:output_type -> tapchannelrpc.ListInvoicesResponse
-	19, // 39: tapchannelrpc.TaprootAssetChannels.ListPayments:output_type -> tapchannelrpc.ListPaymentsResponse
-	33, // [33:40] is the sub-list for method output_type
-	26, // [26:33] is the sub-list for method input_type
-	26, // [26:26] is the sub-list for extension type_name
-	26, // [26:26] is the sub-list for extension extendee
-	0,  // [0:26] is the sub-list for field type_name
+	29, // 10: tapchannelrpc.AddInvoiceRequest.asset_rate_limit:type_name -> rfqrpc.FixedPoint
+	30, // 11: tapchannelrpc.AddInvoiceRequest.execution_policy:type_name -> rfqrpc.ExecutionPolicy
+	31, // 12: tapchannelrpc.AddInvoiceResponse.accepted_buy_quote:type_name -> rfqrpc.PeerAcceptedBuyQuote
+	32, // 13: tapchannelrpc.AddInvoiceResponse.invoice_result:type_name -> lnrpc.AddInvoiceResponse
+	33, // 14: tapchannelrpc.AssetPayReqResponse.decimal_display:type_name -> taprpc.DecimalDisplay
+	34, // 15: tapchannelrpc.AssetPayReqResponse.asset_group:type_name -> taprpc.AssetGroup
+	35, // 16: tapchannelrpc.AssetPayReqResponse.genesis_info:type_name -> taprpc.GenesisInfo
+	36, // 17: tapchannelrpc.AssetPayReqResponse.pay_req:type_name -> lnrpc.PayReq
+	37, // 18: tapchannelrpc.ListInvoicesRequest.request:type_name -> lnrpc.ListInvoiceRequest
+	38, // 19: tapchannelrpc.SubscribeInvoicesRequest.request:type_name -> lnrpc.InvoiceSubscription
+	28, // 20: tapchannelrpc.AssetInvoice.invoice:type_name -> lnrpc.Invoice
+	13, // 21: tapchannelrpc.AssetInvoice.asset_amounts:type_name -> tapchannelrpc.AssetAmount
+	16, // 22: tapchannelrpc.ListInvoicesResponse.invoices:type_name -> tapchannelrpc.AssetInvoice
+	39, // 23: tapchannelrpc.ListPaymentsRequest.request:type_name -> lnrpc.ListPaymentsRequest
+	40, // 24: tapchannelrpc.SubscribePaymentsRequest.request:type_name -> routerrpc.TrackPaymentsRequest
+	41, // 25: tapchannelrpc.TrackPaymentRequest.request:type_name -> routerrpc.TrackPaymentRequest
+	27, // 26: tapchannelrpc.AssetPayment.payment:type_name -> lnrpc.Payment
+	13, // 27: tapchannelrpc.AssetPayment.asset_amounts:type_name -> tapchannelrpc.AssetAmount
+	21, // 28: tapchannelrpc.ListPaymentsResponse.payments:type_name -> tapchannelrpc.AssetPayment
+	0,  // 29: tapchannelrpc.TaprootAssetChannels.FundChannel:input_type -> tapchannelrpc.FundChannelRequest
+	3,  // 30: tapchannelrpc.TaprootAssetChannels.EncodeCustomRecords:input_type -> tapchannelrpc.EncodeCustomRecordsRequest
+	5,  // 31: tapchannelrpc.TaprootAssetChannels.SendPayment:input_type -> tapchannelrpc.SendPaymentRequest
+	9,  // 32: tapchannelrpc.TaprootAssetChannels.AddInvoice:input_type -> tapchannelrpc.AddInvoiceRequest
+	11, // 33: tapchannelrpc.TaprootAssetChannels.DecodeAssetPayReq:input_type -> tapchannelrpc.AssetPayReq
+	14, // 34: tapchannelrpc.TaprootAssetChannels.ListInvoices:input_type -> tapchannelrpc.ListInvoicesRequest
+	18, // 35: tapchannelrpc.TaprootAssetChannels.ListPayments:input_type -> tapchannelrpc.ListPaymentsRequest
+	15, // 36: tapchannelrpc.TaprootAssetChannels.SubscribeInvoices:input_type -> tapchannelrpc.SubscribeInvoicesRequest
+	19, // 37: tapchannelrpc.TaprootAssetChannels.SubscribePayments:input_type -> tapchannelrpc.SubscribePaymentsRequest
+	20, // 38: tapchannelrpc.TaprootAssetChannels.TrackPayment:input_type -> tapchannelrpc.TrackPaymentRequest
+	1,  // 39: tapchannelrpc.TaprootAssetChannels.FundChannel:output_type -> tapchannelrpc.FundChannelResponse
+	4,  // 40: tapchannelrpc.TaprootAssetChannels.EncodeCustomRecords:output_type -> tapchannelrpc.EncodeCustomRecordsResponse
+	7,  // 41: tapchannelrpc.TaprootAssetChannels.SendPayment:output_type -> tapchannelrpc.SendPaymentResponse
+	10, // 42: tapchannelrpc.TaprootAssetChannels.AddInvoice:output_type -> tapchannelrpc.AddInvoiceResponse
+	12, // 43: tapchannelrpc.TaprootAssetChannels.DecodeAssetPayReq:output_type -> tapchannelrpc.AssetPayReqResponse
+	17, // 44: tapchannelrpc.TaprootAssetChannels.ListInvoices:output_type -> tapchannelrpc.ListInvoicesResponse
+	22, // 45: tapchannelrpc.TaprootAssetChannels.ListPayments:output_type -> tapchannelrpc.ListPaymentsResponse
+	16, // 46: tapchannelrpc.TaprootAssetChannels.SubscribeInvoices:output_type -> tapchannelrpc.AssetInvoice
+	21, // 47: tapchannelrpc.TaprootAssetChannels.SubscribePayments:output_type -> tapchannelrpc.AssetPayment
+	21, // 48: tapchannelrpc.TaprootAssetChannels.TrackPayment:output_type -> tapchannelrpc.AssetPayment
+	39, // [39:49] is the sub-list for method output_type
+	29, // [29:39] is the sub-list for method input_type
+	29, // [29:29] is the sub-list for extension type_name
+	29, // [29:29] is the sub-list for extension extendee
+	0,  // [0:29] is the sub-list for field type_name
 }
 
 func init() { file_tapchannelrpc_tapchannel_proto_init() }
@@ -1704,7 +1880,7 @@ func file_tapchannelrpc_tapchannel_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_tapchannelrpc_tapchannel_proto_rawDesc), len(file_tapchannelrpc_tapchannel_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   22,
+			NumMessages:   25,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/taprpc/tapchannelrpc/tapchannel.pb.gw.go
+++ b/taprpc/tapchannelrpc/tapchannel.pb.gw.go
@@ -208,6 +208,69 @@ func local_request_TaprootAssetChannels_ListPayments_0(ctx context.Context, mars
 
 }
 
+func request_TaprootAssetChannels_SubscribeInvoices_0(ctx context.Context, marshaler runtime.Marshaler, client TaprootAssetChannelsClient, req *http.Request, pathParams map[string]string) (TaprootAssetChannels_SubscribeInvoicesClient, runtime.ServerMetadata, error) {
+	var protoReq SubscribeInvoicesRequest
+	var metadata runtime.ServerMetadata
+
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	stream, err := client.SubscribeInvoices(ctx, &protoReq)
+	if err != nil {
+		return nil, metadata, err
+	}
+	header, err := stream.Header()
+	if err != nil {
+		return nil, metadata, err
+	}
+	metadata.HeaderMD = header
+	return stream, metadata, nil
+
+}
+
+func request_TaprootAssetChannels_SubscribePayments_0(ctx context.Context, marshaler runtime.Marshaler, client TaprootAssetChannelsClient, req *http.Request, pathParams map[string]string) (TaprootAssetChannels_SubscribePaymentsClient, runtime.ServerMetadata, error) {
+	var protoReq SubscribePaymentsRequest
+	var metadata runtime.ServerMetadata
+
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	stream, err := client.SubscribePayments(ctx, &protoReq)
+	if err != nil {
+		return nil, metadata, err
+	}
+	header, err := stream.Header()
+	if err != nil {
+		return nil, metadata, err
+	}
+	metadata.HeaderMD = header
+	return stream, metadata, nil
+
+}
+
+func request_TaprootAssetChannels_TrackPayment_0(ctx context.Context, marshaler runtime.Marshaler, client TaprootAssetChannelsClient, req *http.Request, pathParams map[string]string) (TaprootAssetChannels_TrackPaymentClient, runtime.ServerMetadata, error) {
+	var protoReq TrackPaymentRequest
+	var metadata runtime.ServerMetadata
+
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	stream, err := client.TrackPayment(ctx, &protoReq)
+	if err != nil {
+		return nil, metadata, err
+	}
+	header, err := stream.Header()
+	if err != nil {
+		return nil, metadata, err
+	}
+	metadata.HeaderMD = header
+	return stream, metadata, nil
+
+}
+
 // RegisterTaprootAssetChannelsHandlerServer registers the http handlers for service TaprootAssetChannels to "mux".
 // UnaryRPC     :call TaprootAssetChannelsServer directly.
 // StreamingRPC :currently unsupported pending https://github.com/grpc/grpc-go/issues/906.
@@ -369,6 +432,27 @@ func RegisterTaprootAssetChannelsHandlerServer(ctx context.Context, mux *runtime
 
 		forward_TaprootAssetChannels_ListPayments_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 
+	})
+
+	mux.Handle("POST", pattern_TaprootAssetChannels_SubscribeInvoices_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		err := status.Error(codes.Unimplemented, "streaming calls are not yet supported in the in-process transport")
+		_, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+		return
+	})
+
+	mux.Handle("POST", pattern_TaprootAssetChannels_SubscribePayments_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		err := status.Error(codes.Unimplemented, "streaming calls are not yet supported in the in-process transport")
+		_, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+		return
+	})
+
+	mux.Handle("POST", pattern_TaprootAssetChannels_TrackPayment_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		err := status.Error(codes.Unimplemented, "streaming calls are not yet supported in the in-process transport")
+		_, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+		return
 	})
 
 	return nil
@@ -566,6 +650,72 @@ func RegisterTaprootAssetChannelsHandlerClient(ctx context.Context, mux *runtime
 
 	})
 
+	mux.Handle("POST", pattern_TaprootAssetChannels_SubscribeInvoices_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		var err error
+		var annotatedContext context.Context
+		annotatedContext, err = runtime.AnnotateContext(ctx, mux, req, "/tapchannelrpc.TaprootAssetChannels/SubscribeInvoices", runtime.WithHTTPPathPattern("/v1/taproot-assets/channels/invoices/subscribe"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_TaprootAssetChannels_SubscribeInvoices_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_TaprootAssetChannels_SubscribeInvoices_0(annotatedContext, mux, outboundMarshaler, w, req, func() (proto.Message, error) { return resp.Recv() }, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("POST", pattern_TaprootAssetChannels_SubscribePayments_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		var err error
+		var annotatedContext context.Context
+		annotatedContext, err = runtime.AnnotateContext(ctx, mux, req, "/tapchannelrpc.TaprootAssetChannels/SubscribePayments", runtime.WithHTTPPathPattern("/v1/taproot-assets/channels/payments/subscribe"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_TaprootAssetChannels_SubscribePayments_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_TaprootAssetChannels_SubscribePayments_0(annotatedContext, mux, outboundMarshaler, w, req, func() (proto.Message, error) { return resp.Recv() }, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("POST", pattern_TaprootAssetChannels_TrackPayment_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		var err error
+		var annotatedContext context.Context
+		annotatedContext, err = runtime.AnnotateContext(ctx, mux, req, "/tapchannelrpc.TaprootAssetChannels/TrackPayment", runtime.WithHTTPPathPattern("/v1/taproot-assets/channels/payments/track"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_TaprootAssetChannels_TrackPayment_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_TaprootAssetChannels_TrackPayment_0(annotatedContext, mux, outboundMarshaler, w, req, func() (proto.Message, error) { return resp.Recv() }, mux.GetForwardResponseOptions()...)
+
+	})
+
 	return nil
 }
 
@@ -583,6 +733,12 @@ var (
 	pattern_TaprootAssetChannels_ListInvoices_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"v1", "taproot-assets", "channels", "invoices"}, ""))
 
 	pattern_TaprootAssetChannels_ListPayments_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"v1", "taproot-assets", "channels", "payments"}, ""))
+
+	pattern_TaprootAssetChannels_SubscribeInvoices_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3, 2, 4}, []string{"v1", "taproot-assets", "channels", "invoices", "subscribe"}, ""))
+
+	pattern_TaprootAssetChannels_SubscribePayments_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3, 2, 4}, []string{"v1", "taproot-assets", "channels", "payments", "subscribe"}, ""))
+
+	pattern_TaprootAssetChannels_TrackPayment_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3, 2, 4}, []string{"v1", "taproot-assets", "channels", "payments", "track"}, ""))
 )
 
 var (
@@ -599,4 +755,10 @@ var (
 	forward_TaprootAssetChannels_ListInvoices_0 = runtime.ForwardResponseMessage
 
 	forward_TaprootAssetChannels_ListPayments_0 = runtime.ForwardResponseMessage
+
+	forward_TaprootAssetChannels_SubscribeInvoices_0 = runtime.ForwardResponseStream
+
+	forward_TaprootAssetChannels_SubscribePayments_0 = runtime.ForwardResponseStream
+
+	forward_TaprootAssetChannels_TrackPayment_0 = runtime.ForwardResponseStream
 )

--- a/taprpc/tapchannelrpc/tapchannel.proto
+++ b/taprpc/tapchannelrpc/tapchannel.proto
@@ -72,6 +72,38 @@ service TaprootAssetChannels {
     lnrpc.ListPayments RPC method.
     */
     rpc ListPayments (ListPaymentsRequest) returns (ListPaymentsResponse);
+
+    /* litcli: `ln subscribeinvoices`
+    SubscribeInvoices is a wrapper around lnd's lnrpc.SubscribeInvoices method
+    that only streams invoices that involve at least one Taproot Asset. The full
+    lnd invoice is returned along with the decoded asset amounts that the
+    invoice's HTLCs carry, so that callers don't need to parse the custom
+    channel data themselves. All request fields behave the same way as they do
+    for lnd's lnrpc.SubscribeInvoices RPC method.
+    */
+    rpc SubscribeInvoices (SubscribeInvoicesRequest)
+        returns (stream AssetInvoice);
+
+    /* litcli: `ln subscribepayments`
+    SubscribePayments is a wrapper around lnd's routerrpc.TrackPayments method
+    that only streams payment updates that involve at least one Taproot Asset.
+    The full lnd payment is returned along with the decoded asset amounts that
+    the payment's HTLCs carry, so that callers don't need to parse the custom
+    channel data themselves. All request fields behave the same way as they do
+    for lnd's routerrpc.TrackPayments RPC method.
+    */
+    rpc SubscribePayments (SubscribePaymentsRequest)
+        returns (stream AssetPayment);
+
+    /* litcli: `ln trackpayment`
+    TrackPayment is a wrapper around lnd's routerrpc.TrackPaymentV2 method that
+    only streams payment updates that involve at least one Taproot Asset. The
+    full lnd payment is returned along with the decoded asset amounts that the
+    payment's HTLCs carry, so that callers don't need to parse the custom
+    channel data themselves. All request fields behave the same way as they do
+    for lnd's routerrpc.TrackPaymentV2 RPC method.
+    */
+    rpc TrackPayment (TrackPaymentRequest) returns (stream AssetPayment);
 }
 
 message FundChannelRequest {
@@ -365,6 +397,17 @@ message ListInvoicesRequest {
     lnrpc.ListInvoiceRequest request = 1;
 }
 
+message SubscribeInvoicesRequest {
+    // The standard lnd invoice subscription request. All fields behave the same
+    // way as they do for lnd's lnrpc.SubscribeInvoices RPC method (see the API
+    // docs at
+    // https://lightning.engineering/api-docs/api/lnd/lightning/subscribe-invoices
+    // for more details). Invoice index replay is performed by lnd over all
+    // invoices; the returned stream is then filtered down to only those that
+    // involve assets.
+    lnrpc.InvoiceSubscription request = 1;
+}
+
 message AssetInvoice {
     // The full lnd invoice, including any custom channel data on its HTLCs.
     lnrpc.Invoice invoice = 1;
@@ -398,6 +441,27 @@ message ListPaymentsRequest {
     // returned set is then filtered down to only those that involve assets, so
     // a page may contain fewer asset payments than the requested maximum.
     lnrpc.ListPaymentsRequest request = 1;
+}
+
+message SubscribePaymentsRequest {
+    // The standard lnd payment tracking request. All fields behave the same way
+    // as they do for lnd's routerrpc.TrackPayments RPC method (see the API docs
+    // at https://lightning.engineering/api-docs/api/lnd/router/track-payments
+    // for more details). The payment update stream is produced by lnd over all
+    // active payments; the returned stream is then filtered down to only those
+    // that involve assets.
+    routerrpc.TrackPaymentsRequest request = 1;
+}
+
+message TrackPaymentRequest {
+    // The standard lnd payment tracking request. All fields behave the same way
+    // as they do for lnd's routerrpc.TrackPaymentV2 RPC method (see the API
+    // docs at
+    // https://lightning.engineering/api-docs/api/lnd/router/track-payment-v2
+    // for more details). The payment update stream is produced by lnd for the
+    // requested payment; the returned stream is then filtered down to only
+    // updates that involve assets.
+    routerrpc.TrackPaymentRequest request = 1;
 }
 
 message AssetPayment {

--- a/taprpc/tapchannelrpc/tapchannel.swagger.json
+++ b/taprpc/tapchannelrpc/tapchannel.swagger.json
@@ -181,6 +181,48 @@
         ]
       }
     },
+    "/v1/taproot-assets/channels/invoices/subscribe": {
+      "post": {
+        "summary": "litcli: `ln subscribeinvoices`\nSubscribeInvoices is a wrapper around lnd's lnrpc.SubscribeInvoices method\nthat only streams invoices that involve at least one Taproot Asset. The full\nlnd invoice is returned along with the decoded asset amounts that the\ninvoice's HTLCs carry, so that callers don't need to parse the custom\nchannel data themselves. All request fields behave the same way as they do\nfor lnd's lnrpc.SubscribeInvoices RPC method.",
+        "operationId": "TaprootAssetChannels_SubscribeInvoices",
+        "responses": {
+          "200": {
+            "description": "A successful response.(streaming responses)",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "result": {
+                  "$ref": "#/definitions/tapchannelrpcAssetInvoice"
+                },
+                "error": {
+                  "$ref": "#/definitions/rpcStatus"
+                }
+              },
+              "title": "Stream result of tapchannelrpcAssetInvoice"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/tapchannelrpcSubscribeInvoicesRequest"
+            }
+          }
+        ],
+        "tags": [
+          "TaprootAssetChannels"
+        ]
+      }
+    },
     "/v1/taproot-assets/channels/payments": {
       "post": {
         "summary": "litcli: `ln listpayments`\nListPayments is a wrapper around lnd's lnrpc.ListPayments method that only\nreturns payments that involve at least one Taproot Asset. The full lnd\npayment is returned along with the decoded asset amounts that the payment's\nHTLCs carry, so that callers don't need to parse the custom channel data\nthemselves. All request fields behave the same way as they do for lnd's\nlnrpc.ListPayments RPC method.",
@@ -206,6 +248,90 @@
             "required": true,
             "schema": {
               "$ref": "#/definitions/tapchannelrpcListPaymentsRequest"
+            }
+          }
+        ],
+        "tags": [
+          "TaprootAssetChannels"
+        ]
+      }
+    },
+    "/v1/taproot-assets/channels/payments/subscribe": {
+      "post": {
+        "summary": "litcli: `ln subscribepayments`\nSubscribePayments is a wrapper around lnd's routerrpc.TrackPayments method\nthat only streams payment updates that involve at least one Taproot Asset.\nThe full lnd payment is returned along with the decoded asset amounts that\nthe payment's HTLCs carry, so that callers don't need to parse the custom\nchannel data themselves. All request fields behave the same way as they do\nfor lnd's routerrpc.TrackPayments RPC method.",
+        "operationId": "TaprootAssetChannels_SubscribePayments",
+        "responses": {
+          "200": {
+            "description": "A successful response.(streaming responses)",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "result": {
+                  "$ref": "#/definitions/tapchannelrpcAssetPayment"
+                },
+                "error": {
+                  "$ref": "#/definitions/rpcStatus"
+                }
+              },
+              "title": "Stream result of tapchannelrpcAssetPayment"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/tapchannelrpcSubscribePaymentsRequest"
+            }
+          }
+        ],
+        "tags": [
+          "TaprootAssetChannels"
+        ]
+      }
+    },
+    "/v1/taproot-assets/channels/payments/track": {
+      "post": {
+        "summary": "litcli: `ln trackpayment`\nTrackPayment is a wrapper around lnd's routerrpc.TrackPaymentV2 method that\nonly streams payment updates that involve at least one Taproot Asset. The\nfull lnd payment is returned along with the decoded asset amounts that the\npayment's HTLCs carry, so that callers don't need to parse the custom\nchannel data themselves. All request fields behave the same way as they do\nfor lnd's routerrpc.TrackPaymentV2 RPC method.",
+        "operationId": "TaprootAssetChannels_TrackPayment",
+        "responses": {
+          "200": {
+            "description": "A successful response.(streaming responses)",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "result": {
+                  "$ref": "#/definitions/tapchannelrpcAssetPayment"
+                },
+                "error": {
+                  "$ref": "#/definitions/rpcStatus"
+                }
+              },
+              "title": "Stream result of tapchannelrpcAssetPayment"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/tapchannelrpcTrackPaymentRequest"
             }
           }
         ],
@@ -1063,6 +1189,21 @@
       ],
       "default": "ACCEPTED"
     },
+    "lnrpcInvoiceSubscription": {
+      "type": "object",
+      "properties": {
+        "add_index": {
+          "type": "string",
+          "format": "uint64",
+          "description": "If specified (non-zero), then we'll first start by sending out\nnotifications for all added indexes with an add_index greater than this\nvalue. This allows callers to catch up on any events they missed while they\nweren't connected to the streaming RPC."
+        },
+        "settle_index": {
+          "type": "string",
+          "format": "uint64",
+          "description": "If specified (non-zero), then we'll first start by sending out\nnotifications for all settled indexes with an settle_index greater than\nthis value. This allows callers to catch up on any events they missed while\nthey weren't connected to the streaming RPC."
+        }
+      }
+    },
     "lnrpcListInvoiceRequest": {
       "type": "object",
       "properties": {
@@ -1661,6 +1802,29 @@
         }
       }
     },
+    "routerrpcTrackPaymentRequest": {
+      "type": "object",
+      "properties": {
+        "payment_hash": {
+          "type": "string",
+          "format": "byte",
+          "description": "The hash of the payment to look up."
+        },
+        "no_inflight_updates": {
+          "type": "boolean",
+          "description": "If set, only the final payment update is streamed back. Intermediate updates\nthat show which htlcs are still in flight are suppressed."
+        }
+      }
+    },
+    "routerrpcTrackPaymentsRequest": {
+      "type": "object",
+      "properties": {
+        "no_inflight_updates": {
+          "type": "boolean",
+          "description": "If set, only the final payment updates are streamed back. Intermediate\nupdates that show which htlcs are still in flight are suppressed."
+        }
+      }
+    },
     "rpcStatus": {
       "type": "object",
       "properties": {
@@ -2078,6 +2242,33 @@
         "payment_result": {
           "$ref": "#/definitions/lnrpcPayment",
           "description": "The payment result of a single payment attempt. Multiple attempts\nmay be returned per payment request until either the payment\nsucceeds or the payment times out."
+        }
+      }
+    },
+    "tapchannelrpcSubscribeInvoicesRequest": {
+      "type": "object",
+      "properties": {
+        "request": {
+          "$ref": "#/definitions/lnrpcInvoiceSubscription",
+          "description": "The standard lnd invoice subscription request. All fields behave the same\nway as they do for lnd's lnrpc.SubscribeInvoices RPC method (see the API\ndocs at\nhttps://lightning.engineering/api-docs/api/lnd/lightning/subscribe-invoices\nfor more details). Invoice index replay is performed by lnd over all\ninvoices; the returned stream is then filtered down to only those that\ninvolve assets."
+        }
+      }
+    },
+    "tapchannelrpcSubscribePaymentsRequest": {
+      "type": "object",
+      "properties": {
+        "request": {
+          "$ref": "#/definitions/routerrpcTrackPaymentsRequest",
+          "description": "The standard lnd payment tracking request. All fields behave the same way\nas they do for lnd's routerrpc.TrackPayments RPC method (see the API docs\nat https://lightning.engineering/api-docs/api/lnd/router/track-payments\nfor more details). The payment update stream is produced by lnd over all\nactive payments; the returned stream is then filtered down to only those\nthat involve assets."
+        }
+      }
+    },
+    "tapchannelrpcTrackPaymentRequest": {
+      "type": "object",
+      "properties": {
+        "request": {
+          "$ref": "#/definitions/routerrpcTrackPaymentRequest",
+          "description": "The standard lnd payment tracking request. All fields behave the same way\nas they do for lnd's routerrpc.TrackPaymentV2 RPC method (see the API\ndocs at\nhttps://lightning.engineering/api-docs/api/lnd/router/track-payment-v2\nfor more details). The payment update stream is produced by lnd for the\nrequested payment; the returned stream is then filtered down to only\nupdates that involve assets."
         }
       }
     },

--- a/taprpc/tapchannelrpc/tapchannel.yaml
+++ b/taprpc/tapchannelrpc/tapchannel.yaml
@@ -24,3 +24,12 @@ http:
     - selector: tapchannelrpc.TaprootAssetChannels.ListPayments
       post: "/v1/taproot-assets/channels/payments"
       body: "*"
+    - selector: tapchannelrpc.TaprootAssetChannels.SubscribeInvoices
+      post: "/v1/taproot-assets/channels/invoices/subscribe"
+      body: "*"
+    - selector: tapchannelrpc.TaprootAssetChannels.SubscribePayments
+      post: "/v1/taproot-assets/channels/payments/subscribe"
+      body: "*"
+    - selector: tapchannelrpc.TaprootAssetChannels.TrackPayment
+      post: "/v1/taproot-assets/channels/payments/track"
+      body: "*"

--- a/taprpc/tapchannelrpc/tapchannel_grpc.pb.go
+++ b/taprpc/tapchannelrpc/tapchannel_grpc.pb.go
@@ -65,6 +65,30 @@ type TaprootAssetChannelsClient interface {
 	// themselves. All request fields behave the same way as they do for lnd's
 	// lnrpc.ListPayments RPC method.
 	ListPayments(ctx context.Context, in *ListPaymentsRequest, opts ...grpc.CallOption) (*ListPaymentsResponse, error)
+	// litcli: `ln subscribeinvoices`
+	// SubscribeInvoices is a wrapper around lnd's lnrpc.SubscribeInvoices method
+	// that only streams invoices that involve at least one Taproot Asset. The full
+	// lnd invoice is returned along with the decoded asset amounts that the
+	// invoice's HTLCs carry, so that callers don't need to parse the custom
+	// channel data themselves. All request fields behave the same way as they do
+	// for lnd's lnrpc.SubscribeInvoices RPC method.
+	SubscribeInvoices(ctx context.Context, in *SubscribeInvoicesRequest, opts ...grpc.CallOption) (TaprootAssetChannels_SubscribeInvoicesClient, error)
+	// litcli: `ln subscribepayments`
+	// SubscribePayments is a wrapper around lnd's routerrpc.TrackPayments method
+	// that only streams payment updates that involve at least one Taproot Asset.
+	// The full lnd payment is returned along with the decoded asset amounts that
+	// the payment's HTLCs carry, so that callers don't need to parse the custom
+	// channel data themselves. All request fields behave the same way as they do
+	// for lnd's routerrpc.TrackPayments RPC method.
+	SubscribePayments(ctx context.Context, in *SubscribePaymentsRequest, opts ...grpc.CallOption) (TaprootAssetChannels_SubscribePaymentsClient, error)
+	// litcli: `ln trackpayment`
+	// TrackPayment is a wrapper around lnd's routerrpc.TrackPaymentV2 method that
+	// only streams payment updates that involve at least one Taproot Asset. The
+	// full lnd payment is returned along with the decoded asset amounts that the
+	// payment's HTLCs carry, so that callers don't need to parse the custom
+	// channel data themselves. All request fields behave the same way as they do
+	// for lnd's routerrpc.TrackPaymentV2 RPC method.
+	TrackPayment(ctx context.Context, in *TrackPaymentRequest, opts ...grpc.CallOption) (TaprootAssetChannels_TrackPaymentClient, error)
 }
 
 type taprootAssetChannelsClient struct {
@@ -162,6 +186,102 @@ func (c *taprootAssetChannelsClient) ListPayments(ctx context.Context, in *ListP
 	return out, nil
 }
 
+func (c *taprootAssetChannelsClient) SubscribeInvoices(ctx context.Context, in *SubscribeInvoicesRequest, opts ...grpc.CallOption) (TaprootAssetChannels_SubscribeInvoicesClient, error) {
+	stream, err := c.cc.NewStream(ctx, &TaprootAssetChannels_ServiceDesc.Streams[1], "/tapchannelrpc.TaprootAssetChannels/SubscribeInvoices", opts...)
+	if err != nil {
+		return nil, err
+	}
+	x := &taprootAssetChannelsSubscribeInvoicesClient{stream}
+	if err := x.ClientStream.SendMsg(in); err != nil {
+		return nil, err
+	}
+	if err := x.ClientStream.CloseSend(); err != nil {
+		return nil, err
+	}
+	return x, nil
+}
+
+type TaprootAssetChannels_SubscribeInvoicesClient interface {
+	Recv() (*AssetInvoice, error)
+	grpc.ClientStream
+}
+
+type taprootAssetChannelsSubscribeInvoicesClient struct {
+	grpc.ClientStream
+}
+
+func (x *taprootAssetChannelsSubscribeInvoicesClient) Recv() (*AssetInvoice, error) {
+	m := new(AssetInvoice)
+	if err := x.ClientStream.RecvMsg(m); err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
+func (c *taprootAssetChannelsClient) SubscribePayments(ctx context.Context, in *SubscribePaymentsRequest, opts ...grpc.CallOption) (TaprootAssetChannels_SubscribePaymentsClient, error) {
+	stream, err := c.cc.NewStream(ctx, &TaprootAssetChannels_ServiceDesc.Streams[2], "/tapchannelrpc.TaprootAssetChannels/SubscribePayments", opts...)
+	if err != nil {
+		return nil, err
+	}
+	x := &taprootAssetChannelsSubscribePaymentsClient{stream}
+	if err := x.ClientStream.SendMsg(in); err != nil {
+		return nil, err
+	}
+	if err := x.ClientStream.CloseSend(); err != nil {
+		return nil, err
+	}
+	return x, nil
+}
+
+type TaprootAssetChannels_SubscribePaymentsClient interface {
+	Recv() (*AssetPayment, error)
+	grpc.ClientStream
+}
+
+type taprootAssetChannelsSubscribePaymentsClient struct {
+	grpc.ClientStream
+}
+
+func (x *taprootAssetChannelsSubscribePaymentsClient) Recv() (*AssetPayment, error) {
+	m := new(AssetPayment)
+	if err := x.ClientStream.RecvMsg(m); err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
+func (c *taprootAssetChannelsClient) TrackPayment(ctx context.Context, in *TrackPaymentRequest, opts ...grpc.CallOption) (TaprootAssetChannels_TrackPaymentClient, error) {
+	stream, err := c.cc.NewStream(ctx, &TaprootAssetChannels_ServiceDesc.Streams[3], "/tapchannelrpc.TaprootAssetChannels/TrackPayment", opts...)
+	if err != nil {
+		return nil, err
+	}
+	x := &taprootAssetChannelsTrackPaymentClient{stream}
+	if err := x.ClientStream.SendMsg(in); err != nil {
+		return nil, err
+	}
+	if err := x.ClientStream.CloseSend(); err != nil {
+		return nil, err
+	}
+	return x, nil
+}
+
+type TaprootAssetChannels_TrackPaymentClient interface {
+	Recv() (*AssetPayment, error)
+	grpc.ClientStream
+}
+
+type taprootAssetChannelsTrackPaymentClient struct {
+	grpc.ClientStream
+}
+
+func (x *taprootAssetChannelsTrackPaymentClient) Recv() (*AssetPayment, error) {
+	m := new(AssetPayment)
+	if err := x.ClientStream.RecvMsg(m); err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
 // TaprootAssetChannelsServer is the server API for TaprootAssetChannels service.
 // All implementations must embed UnimplementedTaprootAssetChannelsServer
 // for forward compatibility
@@ -213,6 +333,30 @@ type TaprootAssetChannelsServer interface {
 	// themselves. All request fields behave the same way as they do for lnd's
 	// lnrpc.ListPayments RPC method.
 	ListPayments(context.Context, *ListPaymentsRequest) (*ListPaymentsResponse, error)
+	// litcli: `ln subscribeinvoices`
+	// SubscribeInvoices is a wrapper around lnd's lnrpc.SubscribeInvoices method
+	// that only streams invoices that involve at least one Taproot Asset. The full
+	// lnd invoice is returned along with the decoded asset amounts that the
+	// invoice's HTLCs carry, so that callers don't need to parse the custom
+	// channel data themselves. All request fields behave the same way as they do
+	// for lnd's lnrpc.SubscribeInvoices RPC method.
+	SubscribeInvoices(*SubscribeInvoicesRequest, TaprootAssetChannels_SubscribeInvoicesServer) error
+	// litcli: `ln subscribepayments`
+	// SubscribePayments is a wrapper around lnd's routerrpc.TrackPayments method
+	// that only streams payment updates that involve at least one Taproot Asset.
+	// The full lnd payment is returned along with the decoded asset amounts that
+	// the payment's HTLCs carry, so that callers don't need to parse the custom
+	// channel data themselves. All request fields behave the same way as they do
+	// for lnd's routerrpc.TrackPayments RPC method.
+	SubscribePayments(*SubscribePaymentsRequest, TaprootAssetChannels_SubscribePaymentsServer) error
+	// litcli: `ln trackpayment`
+	// TrackPayment is a wrapper around lnd's routerrpc.TrackPaymentV2 method that
+	// only streams payment updates that involve at least one Taproot Asset. The
+	// full lnd payment is returned along with the decoded asset amounts that the
+	// payment's HTLCs carry, so that callers don't need to parse the custom
+	// channel data themselves. All request fields behave the same way as they do
+	// for lnd's routerrpc.TrackPaymentV2 RPC method.
+	TrackPayment(*TrackPaymentRequest, TaprootAssetChannels_TrackPaymentServer) error
 	mustEmbedUnimplementedTaprootAssetChannelsServer()
 }
 
@@ -240,6 +384,15 @@ func (UnimplementedTaprootAssetChannelsServer) ListInvoices(context.Context, *Li
 }
 func (UnimplementedTaprootAssetChannelsServer) ListPayments(context.Context, *ListPaymentsRequest) (*ListPaymentsResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method ListPayments not implemented")
+}
+func (UnimplementedTaprootAssetChannelsServer) SubscribeInvoices(*SubscribeInvoicesRequest, TaprootAssetChannels_SubscribeInvoicesServer) error {
+	return status.Errorf(codes.Unimplemented, "method SubscribeInvoices not implemented")
+}
+func (UnimplementedTaprootAssetChannelsServer) SubscribePayments(*SubscribePaymentsRequest, TaprootAssetChannels_SubscribePaymentsServer) error {
+	return status.Errorf(codes.Unimplemented, "method SubscribePayments not implemented")
+}
+func (UnimplementedTaprootAssetChannelsServer) TrackPayment(*TrackPaymentRequest, TaprootAssetChannels_TrackPaymentServer) error {
+	return status.Errorf(codes.Unimplemented, "method TrackPayment not implemented")
 }
 func (UnimplementedTaprootAssetChannelsServer) mustEmbedUnimplementedTaprootAssetChannelsServer() {}
 
@@ -383,6 +536,69 @@ func _TaprootAssetChannels_ListPayments_Handler(srv interface{}, ctx context.Con
 	return interceptor(ctx, in, info, handler)
 }
 
+func _TaprootAssetChannels_SubscribeInvoices_Handler(srv interface{}, stream grpc.ServerStream) error {
+	m := new(SubscribeInvoicesRequest)
+	if err := stream.RecvMsg(m); err != nil {
+		return err
+	}
+	return srv.(TaprootAssetChannelsServer).SubscribeInvoices(m, &taprootAssetChannelsSubscribeInvoicesServer{stream})
+}
+
+type TaprootAssetChannels_SubscribeInvoicesServer interface {
+	Send(*AssetInvoice) error
+	grpc.ServerStream
+}
+
+type taprootAssetChannelsSubscribeInvoicesServer struct {
+	grpc.ServerStream
+}
+
+func (x *taprootAssetChannelsSubscribeInvoicesServer) Send(m *AssetInvoice) error {
+	return x.ServerStream.SendMsg(m)
+}
+
+func _TaprootAssetChannels_SubscribePayments_Handler(srv interface{}, stream grpc.ServerStream) error {
+	m := new(SubscribePaymentsRequest)
+	if err := stream.RecvMsg(m); err != nil {
+		return err
+	}
+	return srv.(TaprootAssetChannelsServer).SubscribePayments(m, &taprootAssetChannelsSubscribePaymentsServer{stream})
+}
+
+type TaprootAssetChannels_SubscribePaymentsServer interface {
+	Send(*AssetPayment) error
+	grpc.ServerStream
+}
+
+type taprootAssetChannelsSubscribePaymentsServer struct {
+	grpc.ServerStream
+}
+
+func (x *taprootAssetChannelsSubscribePaymentsServer) Send(m *AssetPayment) error {
+	return x.ServerStream.SendMsg(m)
+}
+
+func _TaprootAssetChannels_TrackPayment_Handler(srv interface{}, stream grpc.ServerStream) error {
+	m := new(TrackPaymentRequest)
+	if err := stream.RecvMsg(m); err != nil {
+		return err
+	}
+	return srv.(TaprootAssetChannelsServer).TrackPayment(m, &taprootAssetChannelsTrackPaymentServer{stream})
+}
+
+type TaprootAssetChannels_TrackPaymentServer interface {
+	Send(*AssetPayment) error
+	grpc.ServerStream
+}
+
+type taprootAssetChannelsTrackPaymentServer struct {
+	grpc.ServerStream
+}
+
+func (x *taprootAssetChannelsTrackPaymentServer) Send(m *AssetPayment) error {
+	return x.ServerStream.SendMsg(m)
+}
+
 // TaprootAssetChannels_ServiceDesc is the grpc.ServiceDesc for TaprootAssetChannels service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -419,6 +635,21 @@ var TaprootAssetChannels_ServiceDesc = grpc.ServiceDesc{
 		{
 			StreamName:    "SendPayment",
 			Handler:       _TaprootAssetChannels_SendPayment_Handler,
+			ServerStreams: true,
+		},
+		{
+			StreamName:    "SubscribeInvoices",
+			Handler:       _TaprootAssetChannels_SubscribeInvoices_Handler,
+			ServerStreams: true,
+		},
+		{
+			StreamName:    "SubscribePayments",
+			Handler:       _TaprootAssetChannels_SubscribePayments_Handler,
+			ServerStreams: true,
+		},
+		{
+			StreamName:    "TrackPayment",
+			Handler:       _TaprootAssetChannels_TrackPayment_Handler,
 			ServerStreams: true,
 		},
 	},

--- a/taprpc/tapchannelrpc/taprootassetchannels.pb.json.go
+++ b/taprpc/tapchannelrpc/taprootassetchannels.pb.json.go
@@ -212,4 +212,130 @@ func RegisterTaprootAssetChannelsJSONCallbacks(registry map[string]func(ctx cont
 		}
 		callback(string(respBytes), nil)
 	}
+
+	registry["tapchannelrpc.TaprootAssetChannels.SubscribeInvoices"] = func(ctx context.Context,
+		conn *grpc.ClientConn, reqJSON string, callback func(string, error)) {
+
+		req := &SubscribeInvoicesRequest{}
+		err := marshaler.Unmarshal([]byte(reqJSON), req)
+		if err != nil {
+			callback("", err)
+			return
+		}
+
+		client := NewTaprootAssetChannelsClient(conn)
+		stream, err := client.SubscribeInvoices(ctx, req)
+		if err != nil {
+			callback("", err)
+			return
+		}
+
+		go func() {
+			for {
+				select {
+				case <-stream.Context().Done():
+					callback("", stream.Context().Err())
+					return
+				default:
+				}
+
+				resp, err := stream.Recv()
+				if err != nil {
+					callback("", err)
+					return
+				}
+
+				respBytes, err := marshaler.Marshal(resp)
+				if err != nil {
+					callback("", err)
+					return
+				}
+				callback(string(respBytes), nil)
+			}
+		}()
+	}
+
+	registry["tapchannelrpc.TaprootAssetChannels.SubscribePayments"] = func(ctx context.Context,
+		conn *grpc.ClientConn, reqJSON string, callback func(string, error)) {
+
+		req := &SubscribePaymentsRequest{}
+		err := marshaler.Unmarshal([]byte(reqJSON), req)
+		if err != nil {
+			callback("", err)
+			return
+		}
+
+		client := NewTaprootAssetChannelsClient(conn)
+		stream, err := client.SubscribePayments(ctx, req)
+		if err != nil {
+			callback("", err)
+			return
+		}
+
+		go func() {
+			for {
+				select {
+				case <-stream.Context().Done():
+					callback("", stream.Context().Err())
+					return
+				default:
+				}
+
+				resp, err := stream.Recv()
+				if err != nil {
+					callback("", err)
+					return
+				}
+
+				respBytes, err := marshaler.Marshal(resp)
+				if err != nil {
+					callback("", err)
+					return
+				}
+				callback(string(respBytes), nil)
+			}
+		}()
+	}
+
+	registry["tapchannelrpc.TaprootAssetChannels.TrackPayment"] = func(ctx context.Context,
+		conn *grpc.ClientConn, reqJSON string, callback func(string, error)) {
+
+		req := &TrackPaymentRequest{}
+		err := marshaler.Unmarshal([]byte(reqJSON), req)
+		if err != nil {
+			callback("", err)
+			return
+		}
+
+		client := NewTaprootAssetChannelsClient(conn)
+		stream, err := client.TrackPayment(ctx, req)
+		if err != nil {
+			callback("", err)
+			return
+		}
+
+		go func() {
+			for {
+				select {
+				case <-stream.Context().Done():
+					callback("", stream.Context().Err())
+					return
+				default:
+				}
+
+				resp, err := stream.Recv()
+				if err != nil {
+					callback("", err)
+					return
+				}
+
+				respBytes, err := marshaler.Marshal(resp)
+				if err != nil {
+					callback("", err)
+					return
+				}
+				callback(string(respBytes), nil)
+			}
+		}()
+	}
 }


### PR DESCRIPTION
## Description 

This PR adds asset-aware streaming RPCs to the TaprootAssetChannels service: `SubscribeInvoices`, `SubscribePayments`, and `TrackPayment`.

These wrap the corresponding lnd invoice/payment streams while preserving lnd’s request semantics, then filter updates down to asset related invoices/payments and return decoded AssetAmount summaries alongside the original lnd objects.

Closes https://github.com/lightninglabs/taproot-assets/issues/2171