### PR TITLE
itest: wait on receive-event stream in AssertNonInteractiveRecvComplete

### DIFF
--- a/itest/assertions.go
+++ b/itest/assertions.go
@@ -1363,19 +1363,20 @@ func AssertNonInteractiveRecvComplete(t *testing.T,
 		return
 	}
 
-	var lastErr error
 	for {
 		event, err := stream.Recv()
 		if err != nil {
 			// Stream ended (deadline or error). Do one last
-			// authoritative check before failing.
-			if final := check(); final == nil {
+			// authoritative check before failing, and surface
+			// that snapshot as the failure reason.
+			final := check()
+			if final == nil {
 				return
 			}
 			require.Failf(t, "receive not complete",
 				"waiting for %d completed inbound "+
 					"transfers: %v",
-				totalInboundTransfers, lastErr)
+				totalInboundTransfers, final)
 			return
 		}
 
@@ -1384,10 +1385,8 @@ func AssertNonInteractiveRecvComplete(t *testing.T,
 			continue
 		}
 
-		if err := check(); err == nil {
+		if check() == nil {
 			return
-		} else {
-			lastErr = err
 		}
 	}
 }

--- a/itest/assertions.go
+++ b/itest/assertions.go
@@ -1309,22 +1309,39 @@ func AssertAssetOutboundTransferWithOutputs(t *testing.T,
 
 // AssertNonInteractiveRecvComplete makes sure the given receiver has the
 // correct number of completed non-interactive inbound asset transfers in their
-// list of events.
+// list of events. It subscribes to the receive-event stream first so status
+// transitions that happen after this point wake us immediately, avoiding a
+// polling race against the wait deadline.
 func AssertNonInteractiveRecvComplete(t *testing.T,
 	receiver taprpc.TaprootAssetsClient, totalInboundTransfers int) {
 
-	// And finally, they should be marked as completed with a proof
-	// available.
-	err := wait.NoError(func() error {
-		ctxb := context.Background()
-		ctxt, cancel := context.WithTimeout(ctxb, defaultWaitTimeout/2)
+	ctxb := context.Background()
+
+	ctxSub, cancelSub := context.WithTimeout(ctxb, defaultWaitTimeout)
+	defer cancelSub()
+
+	stream, err := receiver.SubscribeReceiveEvents(
+		ctxSub, &taprpc.SubscribeReceiveEventsRequest{},
+	)
+	require.NoError(t, err)
+
+	check := func() error {
+		ctxt, cancel := context.WithTimeout(
+			ctxb, defaultWaitTimeout/2,
+		)
 		defer cancel()
 
 		resp, err := receiver.AddrReceives(
 			ctxt, &taprpc.AddrReceivesRequest{},
 		)
-		require.NoError(t, err)
-		require.Len(t, resp.Events, totalInboundTransfers)
+		if err != nil {
+			return err
+		}
+
+		if len(resp.Events) != totalInboundTransfers {
+			return fmt.Errorf("want %d receive events, have %d",
+				totalInboundTransfers, len(resp.Events))
+		}
 
 		for _, event := range resp.Events {
 			if event.Status != statusCompleted {
@@ -1338,8 +1355,41 @@ func AssertNonInteractiveRecvComplete(t *testing.T,
 		}
 
 		return nil
-	}, defaultWaitTimeout)
-	require.NoError(t, err)
+	}
+
+	// The target may already be met before we subscribed; check once up
+	// front so we don't block on a stream that has nothing left to send.
+	if check() == nil {
+		return
+	}
+
+	var lastErr error
+	for {
+		event, err := stream.Recv()
+		if err != nil {
+			// Stream ended (deadline or error). Do one last
+			// authoritative check before failing.
+			if final := check(); final == nil {
+				return
+			}
+			require.Failf(t, "receive not complete",
+				"waiting for %d completed inbound "+
+					"transfers: %v",
+				totalInboundTransfers, lastErr)
+			return
+		}
+
+		// Only completed events can move the counter over the line.
+		if event.Status != statusCompleted {
+			continue
+		}
+
+		if err := check(); err == nil {
+			return
+		} else {
+			lastErr = err
+		}
+	}
 }
 
 // AssertAddr asserts that an address contains the correct information of an


### PR DESCRIPTION
Fixes a flake observed in [this CI job](https://github.com/lightninglabs/taproot-assets/actions/runs/29019317416/job/86122783108?pr=2195), and which I've seen pop up various times in the past (including in `fee_estimation`). Opus:

> The helper previously polled AddrReceives inside wait.NoError with a 30-second timeout. Under CI contention, proof-courier delivery to the receiver's tapd routinely exceeds that window; the poll then returns zero events for the full timeout and the test fails with "method did not return within the timeout". This is the failure mode observed in testReOrgSendV2Address, and the same helper is used by testFeeEstimation and many other transfer tests.
> 
> Subscribe to SubscribeReceiveEvents up front and drive the wait off the stream. AddrReceives is still queried on each completed event as the authoritative counter, so the semantics (N events, all completed, all with proofs) are unchanged. An initial pre-loop check preserves the fast path where the target is already met before we subscribed.