### PR TITLE
itest: tolerate skipped statuses in AssertReceiveEvents

### DIFF
--- a/itest/assertions.go
+++ b/itest/assertions.go
@@ -938,14 +938,21 @@ func AssertAddrEventByStatus(t *testing.T, client taprpc.TaprootAssetsClient,
 	require.NoError(t, err)
 }
 
-// AssertReceiveEvents makes sure all events with incremental status are sent
-// on the stream for the given address.
+// AssertReceiveEvents makes sure events with non-decreasing status are sent
+// on the stream for the given address, ending with the completed status.
+// Intermediate statuses may be skipped or repeated: the custodian only
+// publishes status transitions it actually observes, and a single
+// transition can jump multiple statuses. For example, on a send between
+// two addresses of the same node, the proof can arrive through the local
+// proof archive before lnd's confirmation notification is processed, in
+// which case the confirmed status is never published. Statuses can also
+// repeat, for example one proof received event per output of a V2 address.
 func AssertReceiveEvents(t *testing.T, addr *taprpc.Addr,
 	stream *EventSubscription[*taprpc.ReceiveEvent]) {
 
 	success := make(chan struct{})
 	timeout := time.After(defaultWaitTimeout)
-	startStatus := statusDetected
+	lastStatus := statusDetected
 
 	// To make sure we don't forever hang on receiving on the stream, we'll
 	// cancel it after the timeout.
@@ -963,7 +970,8 @@ func AssertReceiveEvents(t *testing.T, addr *taprpc.Addr,
 		require.NoError(t, err, "receiving address receive event")
 
 		require.True(t, proto.Equal(event.Address, addr))
-		require.Equal(t, startStatus, event.Status)
+		require.GreaterOrEqual(t, event.Status, lastStatus)
+		require.LessOrEqual(t, event.Status, statusCompleted)
 		require.Empty(t, event.Error)
 
 		if event.Status == statusCompleted {
@@ -973,7 +981,7 @@ func AssertReceiveEvents(t *testing.T, addr *taprpc.Addr,
 			return
 		}
 
-		startStatus++
+		lastStatus = event.Status
 	}
 }
 


### PR DESCRIPTION
(N.b., fixes the flake found in [this CI job](https://github.com/lightninglabs/taproot-assets/actions/runs/29019317416/job/86122783108), which I've also seen before.)

AssertReceiveEvents asserted that the receive event stream delivers every status in strict incremental order (detected, confirmed, proof received, completed). The custodian does not guarantee that: it only publishes the transitions it actually observes, and a transition can jump multiple statuses at once.

In particular, on a send between two addresses of the same node (as in the fee_estimation test), the proof is written to the local proof archive by the porter at confirmation time. The custodian's main event loop selects over both the proof notifier subscription and lnd's transaction notification stream. If the proof notification wins, mapProofToEvent publishes proof received and completed while the event is still at the detected status, and removes the event from the in-flight set. When lnd's confirmed transaction notification arrives afterwards, the event is already completed and is skipped, so the confirmed status is never published. The strict walk then fails with "expected: 2, actual: 3".

Relax the assertion to a monotonic walk: statuses must be non-decreasing, valid, and end with the completed status. Repeated statuses are also allowed, since V2 addresses publish one proof received event per output.