### PR TITLE
tapgarden: hardening phase two (batch invariants)

### DIFF
--- a/cmd/tapd/main.go
+++ b/cmd/tapd/main.go
@@ -35,6 +35,20 @@ func main() {
 		os.Exit(0)
 	}
 
+	// If the operator has invoked tapd in one-shot repair mode, run
+	// the requested repair against the database and exit before
+	// constructing the full server. The repair tool opens the DB
+	// with migrations skipped, so it can recover a legacy DB whose
+	// state would otherwise block a migration from applying.
+	if cfg.Repair != nil && cfg.Repair.CancelDuplicateBatches {
+		err := tapcfg.RunRepairTool(cfg, cfgLogger, shutdownInterceptor)
+		if err != nil {
+			_, _ = fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		os.Exit(0)
+	}
+
 	// Enable http profiling server if requested.
 	if cfg.Profile != "" {
 		go func() {

--- a/cmd/tapd/main.go
+++ b/cmd/tapd/main.go
@@ -5,12 +5,27 @@ import (
 	"net/http"
 	"os"
 	"runtime/pprof"
+	"strings"
 
 	"github.com/jessevdk/go-flags"
 	"github.com/lightninglabs/taproot-assets/fn"
 	"github.com/lightninglabs/taproot-assets/tapcfg"
 	"github.com/lightningnetwork/lnd/signal"
 )
+
+// repairFlagOnCommandLine reports whether the one-shot repair flag
+// was passed on the command line itself, as opposed to being read
+// from a config file.
+func repairFlagOnCommandLine() bool {
+	const flag = "--repair.cancel-duplicate-batches"
+	for _, arg := range os.Args[1:] {
+		if arg == flag || strings.HasPrefix(arg, flag+"=") {
+			return true
+		}
+	}
+
+	return false
+}
 
 func main() {
 	// Hook interceptor for os signals.
@@ -33,6 +48,34 @@ func main() {
 
 		// Help was requested, exit normally.
 		os.Exit(0)
+	}
+
+	// If the operator has invoked tapd in one-shot repair mode, run
+	// the requested repair against the database and exit before
+	// constructing the full server. The repair tool opens the DB
+	// with migrations skipped, so it can recover a legacy DB whose
+	// state would otherwise block a migration from applying.
+	//
+	// The flag is only honored when given on the command line
+	// itself. Repair mode exits after running, so a value left
+	// behind in tapd.conf would otherwise turn every subsequent
+	// start into a no-op exit with a success code, silently taking
+	// a supervised node out of service.
+	if cfg.Repair != nil && cfg.Repair.CancelDuplicateBatches {
+		if repairFlagOnCommandLine() {
+			err := tapcfg.RunRepairTool(
+				cfg, cfgLogger, shutdownInterceptor,
+			)
+			if err != nil {
+				_, _ = fmt.Fprintln(os.Stderr, err)
+				os.Exit(1)
+			}
+			os.Exit(0)
+		}
+
+		cfgLogger.Warnf("Ignoring repair.cancel-duplicate-batches " +
+			"from the config file: repair mode exits after " +
+			"running and must be requested on the command line")
 	}
 
 	// Enable http profiling server if requested.

--- a/docs/release-notes/release-notes-0.9.0.md
+++ b/docs/release-notes/release-notes-0.9.0.md
@@ -25,6 +25,10 @@
   fixes a bug that could cause minted assets to commit to the wrong
   address.
 
+* [PR#2203](https://github.com/lightninglabs/taproot-assets/pull/2203)
+  fixes a bug that could leave invalid minting batch state on disk after
+  failure.
+
 # New Features
 
 ## Functional Enhancements

--- a/docs/release-notes/release-notes-0.9.0.md
+++ b/docs/release-notes/release-notes-0.9.0.md
@@ -25,6 +25,15 @@
   fixes a bug that could cause minted assets to commit to the wrong
   address.
 
+* [PR#2203](https://github.com/lightninglabs/taproot-assets/pull/2203)
+  fixes a bug that could leave invalid minting batch state on disk after
+  failure. A database migration now enforces that at most one minting
+  batch is in a pre-broadcast (pending or frozen) state; on upgrade, if
+  a legacy database holds several such batches, all but the most
+  recently created one are automatically cancelled. A new
+  `--repair.cancel-duplicate-batches` startup flag applies the same
+  repair on demand.
+
 * [PR#2228](https://github.com/lightninglabs/taproot-assets/pull/2228)
   fixes `VerifyProof` failing the whole RPC for an invalid proof when
   decoding the last proof requires unknown asset metadata; it now

--- a/rpcserver/rpcserver.go
+++ b/rpcserver/rpcserver.go
@@ -5744,7 +5744,7 @@ func (r *RPCServer) SubscribeMintEvents(req *mintrpc.SubscribeMintEventsRequest,
 			return nil, fmt.Errorf("invalid event type: %T", event)
 		}
 
-		rpcState, err := marshalBatchState(e.BatchState)
+		rpcState, err := marshalBatchState(e.Batch.State())
 		if err != nil {
 			return nil, fmt.Errorf("error marshaling batch state: "+
 				"%w", err)

--- a/rpcserver/rpcserver.go
+++ b/rpcserver/rpcserver.go
@@ -5783,7 +5783,7 @@ func (r *RPCServer) SubscribeMintEvents(req *mintrpc.SubscribeMintEventsRequest,
 			return nil, fmt.Errorf("invalid event type: %T", event)
 		}
 
-		rpcState, err := marshalBatchState(e.BatchState)
+		rpcState, err := marshalBatchState(e.Batch.State())
 		if err != nil {
 			return nil, fmt.Errorf("error marshaling batch state: "+
 				"%w", err)

--- a/sample-tapd.conf
+++ b/sample-tapd.conf
@@ -544,3 +544,12 @@
 ; The amount of time we should wait between certificate expiration health checks.
 ; This value must be >= 1m.
 ; healthcheck.tls.interval=1m
+
+[repair]
+
+; If set, tapd cancels all but the most recent minting batch in
+; BatchStatePending or BatchStateFrozen and then exits. Used to recover
+; from a database that violates the singleton pre-broadcast batch
+; invariant added in migration 000061 (e.g. a legacy DB with duplicate
+; pending batches that blocks the migration).
+; repair.cancel-duplicate-batches=false

--- a/tapcfg/config.go
+++ b/tapcfg/config.go
@@ -368,6 +368,15 @@ type ExperimentalConfig struct {
 	Rfq rfq.CliConfig `group:"rfq" namespace:"rfq"`
 }
 
+// RepairConfig houses one-shot recovery flags that, when set, cause
+// tapd to perform a targeted repair action against the database and
+// exit before constructing the full server. These flags are intended
+// for operator use after a constraint or invariant failure has
+// prevented normal startup.
+type RepairConfig struct {
+	CancelDuplicateBatches bool `long:"cancel-duplicate-batches" description:"If set, tapd cancels all but the most recent minting batch in BatchStatePending or BatchStateFrozen and then exits. Used to recover from a database that violates the singleton pre-broadcast batch invariant added in migration 000061 (e.g. a legacy DB with duplicate pending batches that blocks the migration)."`
+}
+
 // CleanAndValidate performs final processing on the ExperimentalConfig,
 // returning an error if the configuration is invalid.
 func (c *ExperimentalConfig) CleanAndValidate() error {
@@ -427,6 +436,8 @@ type Config struct {
 	Prometheus monitoring.PrometheusConfig `group:"prometheus" namespace:"prometheus"`
 
 	Experimental *ExperimentalConfig `group:"experimental" namespace:"experimental"`
+
+	Repair *RepairConfig `group:"repair" namespace:"repair"`
 
 	HealthChecks *HealthCheckConfig `group:"healthcheck" namespace:"healthcheck"`
 
@@ -548,6 +559,7 @@ func DefaultConfig() Config {
 				AcceptPriceDeviationPpm: rfq.DefaultAcceptPriceDeviationPpm,
 			},
 		},
+		Repair: &RepairConfig{},
 		HealthChecks: &HealthCheckConfig{
 			TLSCheck: &CheckConfig{
 				Interval: defaultTLSInterval,

--- a/tapcfg/repair.go
+++ b/tapcfg/repair.go
@@ -1,0 +1,151 @@
+package tapcfg
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/btcsuite/btclog/v2"
+	"github.com/lightninglabs/taproot-assets/tapdb"
+	"github.com/lightninglabs/taproot-assets/tapgarden"
+	"github.com/lightningnetwork/lnd/signal"
+)
+
+// RunRepairTool inspects the configured database for batches that
+// violate the singleton "≤ 1 in {Pending, Frozen}" invariant added
+// in migration 000060, and cancels all but the most recent. The
+// preserved batch is the one with the latest CreationTime; cancelled
+// batches transition to BatchStateSeedlingCancelled, leaving their
+// row and seedlings on disk for later inspection.
+//
+// The function opens the database with migrations skipped, so it can
+// run against a legacy database whose state would otherwise fail the
+// migration.
+//
+// NOTE: With migration 000061's self-heal in place, restarting tapd
+// normally will cancel the duplicates as part of applying the
+// migration. This tool is retained as a diagnostic that surfaces the
+// same repair outside the migration stream (e.g. after operator
+// intervention that re-introduces duplicates).
+func RunRepairTool(cfg *Config, cfgLogger btclog.Logger,
+	shutdownInterceptor signal.Interceptor) error {
+
+	// Derive a cancellable context that trips on shutdown. Without
+	// this, a Ctrl+C mid-repair would leave partial state behind
+	// (some batches cancelled, others not).
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		select {
+		case <-shutdownInterceptor.ShutdownChannel():
+			cancel()
+		case <-ctx.Done():
+		}
+	}()
+
+	// Open the database with migrations skipped. We want to inspect
+	// and repair a database whose state would otherwise prevent
+	// migration 000060 from applying; running migrations as part of
+	// opening the DB would defeat the purpose.
+	var (
+		db  tapdb.DatabaseBackend
+		err error
+	)
+	switch cfg.DatabaseBackend {
+	case DatabaseBackendSqlite:
+		sqliteCfg := *cfg.Sqlite
+		sqliteCfg.SkipMigrations = true
+		cfgLogger.Infof("repair: opening sqlite3 database at %v "+
+			"(migrations skipped)",
+			sqliteCfg.DatabaseFileName)
+		db, err = tapdb.NewSqliteStore(&sqliteCfg)
+
+	case DatabaseBackendPostgres:
+		pgCfg := *cfg.Postgres
+		pgCfg.SkipMigrations = true
+		cfgLogger.Infof("repair: opening postgres database " +
+			"(migrations skipped)")
+		db, err = tapdb.NewPostgresStore(&pgCfg)
+
+	default:
+		return fmt.Errorf("unknown database backend: %s",
+			cfg.DatabaseBackend)
+	}
+	if err != nil {
+		return fmt.Errorf("repair: unable to open database: %w", err)
+	}
+
+	mintingExec := tapdb.NewTransactionExecutor(
+		db, func(tx *sql.Tx) tapdb.PendingAssetStore {
+			return db.WithTx(tx)
+		},
+	)
+	store := tapdb.NewAssetMintingStore(mintingExec)
+
+	nonFinal, err := store.FetchNonFinalBatches(ctx)
+	if err != nil {
+		return fmt.Errorf("repair: unable to fetch non-final "+
+			"batches: %w", err)
+	}
+
+	var preBroadcast []*tapgarden.MintingBatch
+	for _, batch := range nonFinal {
+		switch batch.State() {
+		case tapgarden.BatchStatePending,
+			tapgarden.BatchStateFrozen:
+
+			preBroadcast = append(preBroadcast, batch)
+
+		default:
+			// Only pre-broadcast states are constrained by
+			// the singleton index; ignore everything else.
+		}
+	}
+
+	if len(preBroadcast) <= 1 {
+		cfgLogger.Infof("repair: nothing to do; found %d batches "+
+			"in pre-broadcast state", len(preBroadcast))
+		return nil
+	}
+
+	// Sort newest-first by CreationTime; preserve [0], cancel the
+	// rest. SliceStable gives a deterministic winner when two
+	// batches share a timestamp -- the input order (from
+	// FetchNonFinalBatches) then acts as the tiebreak.
+	sort.SliceStable(preBroadcast, func(i, j int) bool {
+		return preBroadcast[i].CreationTime.After(
+			preBroadcast[j].CreationTime,
+		)
+	})
+
+	preserved := preBroadcast[0]
+	cfgLogger.Infof("repair: preserving most recent pre-broadcast "+
+		"batch %x (state=%v, created=%s)",
+		preserved.BatchKey.PubKey.SerializeCompressed(),
+		preserved.State(),
+		preserved.CreationTime.Format(time.RFC3339))
+
+	for _, batch := range preBroadcast[1:] {
+		cfgLogger.Warnf("repair: cancelling pre-broadcast batch "+
+			"%x (state=%v, created=%s)",
+			batch.BatchKey.PubKey.SerializeCompressed(),
+			batch.State(),
+			batch.CreationTime.Format(time.RFC3339))
+
+		err := store.UpdateBatchState(
+			ctx, batch, tapgarden.BatchStateSeedlingCancelled,
+		)
+		if err != nil {
+			return fmt.Errorf("repair: unable to cancel batch "+
+				"%x: %w",
+				batch.BatchKey.PubKey.SerializeCompressed(),
+				err)
+		}
+	}
+
+	cfgLogger.Infof("repair: complete; cancelled %d duplicate "+
+		"batches, preserved 1.", len(preBroadcast)-1)
+	return nil
+}

--- a/tapcfg/repair.go
+++ b/tapcfg/repair.go
@@ -1,0 +1,171 @@
+package tapcfg
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"fmt"
+	"io"
+	"sort"
+	"time"
+
+	"github.com/btcsuite/btclog/v2"
+	"github.com/lightninglabs/taproot-assets/tapdb"
+	"github.com/lightninglabs/taproot-assets/tapgarden"
+	"github.com/lightningnetwork/lnd/signal"
+)
+
+// RunRepairTool inspects the configured database for batches that
+// violate the singleton "≤ 1 in {Pending, Frozen}" invariant added
+// in migration 000061, and cancels all but the most recent. The
+// preserved batch is the one with the latest CreationTime; cancelled
+// batches transition to BatchStateSeedlingCancelled, leaving their
+// row and seedlings on disk for later inspection.
+//
+// The function opens the database with migrations skipped, so it can
+// run against a legacy database whose state would otherwise fail the
+// migration.
+//
+// NOTE: With migration 000061's self-heal in place, restarting tapd
+// normally will cancel the duplicates as part of applying the
+// migration. This tool is retained as a diagnostic that surfaces the
+// same repair outside the migration stream (e.g. after operator
+// intervention that re-introduces duplicates).
+func RunRepairTool(cfg *Config, cfgLogger btclog.Logger,
+	shutdownInterceptor signal.Interceptor) error {
+
+	// Derive a cancellable context that trips on shutdown. Without
+	// this, a Ctrl+C mid-repair would leave partial state behind
+	// (some batches cancelled, others not).
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		select {
+		case <-shutdownInterceptor.ShutdownChannel():
+			cancel()
+		case <-ctx.Done():
+		}
+	}()
+
+	// Open the database with migrations skipped. We want to inspect
+	// and repair a database whose state would otherwise prevent
+	// migration 000061 from applying; running migrations as part of
+	// opening the DB would defeat the purpose.
+	var (
+		db  tapdb.DatabaseBackend
+		err error
+	)
+	switch cfg.DatabaseBackend {
+	case DatabaseBackendSqlite:
+		sqliteCfg := *cfg.Sqlite
+		sqliteCfg.SkipMigrations = true
+		cfgLogger.Infof("repair: opening sqlite3 database at %v "+
+			"(migrations skipped)",
+			sqliteCfg.DatabaseFileName)
+		db, err = tapdb.NewSqliteStore(&sqliteCfg)
+
+	case DatabaseBackendPostgres:
+		pgCfg := *cfg.Postgres
+		pgCfg.SkipMigrations = true
+		cfgLogger.Infof("repair: opening postgres database " +
+			"(migrations skipped)")
+		db, err = tapdb.NewPostgresStore(&pgCfg)
+
+	default:
+		return fmt.Errorf("unknown database backend: %s",
+			cfg.DatabaseBackend)
+	}
+	if err != nil {
+		return fmt.Errorf("repair: unable to open database: %w", err)
+	}
+
+	// Both backend stores embed the underlying *sql.DB; release it
+	// on the way out.
+	if closer, ok := db.(io.Closer); ok {
+		defer func() {
+			if err := closer.Close(); err != nil {
+				cfgLogger.Warnf("repair: error closing "+
+					"database: %v", err)
+			}
+		}()
+	}
+
+	mintingExec := tapdb.NewTransactionExecutor(
+		db, func(tx *sql.Tx) tapdb.PendingAssetStore {
+			return db.WithTx(tx)
+		},
+	)
+	store := tapdb.NewAssetMintingStore(mintingExec)
+
+	nonFinal, err := store.FetchNonFinalBatches(ctx)
+	if err != nil {
+		return fmt.Errorf("repair: unable to fetch non-final "+
+			"batches: %w", err)
+	}
+
+	var preBroadcast []*tapgarden.MintingBatch
+	for _, batch := range nonFinal {
+		switch batch.State() {
+		case tapgarden.BatchStatePending,
+			tapgarden.BatchStateFrozen:
+
+			preBroadcast = append(preBroadcast, batch)
+
+		default:
+			// Only pre-broadcast states are constrained by
+			// the singleton index; ignore everything else.
+		}
+	}
+
+	if len(preBroadcast) <= 1 {
+		cfgLogger.Infof("repair: nothing to do; found %d batches "+
+			"in pre-broadcast state", len(preBroadcast))
+		return nil
+	}
+
+	// Sort newest-first by CreationTime; preserve [0], cancel the
+	// rest. The full stored timestamp precision is compared
+	// (sub-second parts included), and ties are broken by the raw
+	// batch key, matching the ORDER BY used by migration 000061's
+	// self-heal so both paths preserve the same batch.
+	sort.Slice(preBroadcast, func(i, j int) bool {
+		ti := preBroadcast[i].CreationTime
+		tj := preBroadcast[j].CreationTime
+		if !ti.Equal(tj) {
+			return ti.After(tj)
+		}
+
+		ki := preBroadcast[i].BatchKey.PubKey.SerializeCompressed()
+		kj := preBroadcast[j].BatchKey.PubKey.SerializeCompressed()
+		return bytes.Compare(ki, kj) > 0
+	})
+
+	preserved := preBroadcast[0]
+	cfgLogger.Infof("repair: preserving most recent pre-broadcast "+
+		"batch %x (state=%v, created=%s)",
+		preserved.BatchKey.PubKey.SerializeCompressed(),
+		preserved.State(),
+		preserved.CreationTime.Format(time.RFC3339))
+
+	for _, batch := range preBroadcast[1:] {
+		cfgLogger.Warnf("repair: cancelling pre-broadcast batch "+
+			"%x (state=%v, created=%s)",
+			batch.BatchKey.PubKey.SerializeCompressed(),
+			batch.State(),
+			batch.CreationTime.Format(time.RFC3339))
+
+		err := store.UpdateBatchState(
+			ctx, batch, tapgarden.BatchStateSeedlingCancelled,
+		)
+		if err != nil {
+			return fmt.Errorf("repair: unable to cancel batch "+
+				"%x: %w",
+				batch.BatchKey.PubKey.SerializeCompressed(),
+				err)
+		}
+	}
+
+	cfgLogger.Infof("repair: complete; cancelled %d duplicate "+
+		"batches, preserved 1.", len(preBroadcast)-1)
+	return nil
+}

--- a/tapdb/asset_minting.go
+++ b/tapdb/asset_minting.go
@@ -1319,7 +1319,7 @@ func marshalMintingBatch(ctx context.Context, q PendingAssetStore,
 		return nil, err
 	}
 
-	batch.UpdateState(batchState)
+	batch.SetStateOnDBSuccess(batchState)
 
 	if len(dbBatch.TapscriptSibling) != 0 {
 		batchSibling, err := chainhash.NewHash(dbBatch.TapscriptSibling)
@@ -1472,15 +1472,22 @@ func marshalMintingBatch(ctx context.Context, q PendingAssetStore,
 
 // UpdateBatchState updates the state of a batch based on the batch key.
 func (a *AssetMintingStore) UpdateBatchState(ctx context.Context,
-	batchKey *btcec.PublicKey, newState tapgarden.BatchState) error {
+	batch *tapgarden.MintingBatch, newState tapgarden.BatchState) error {
 
+	batchKey := batch.BatchKey.PubKey
 	var writeTxOpts AssetStoreTxOptions
-	return a.db.ExecTx(ctx, &writeTxOpts, func(q PendingAssetStore) error {
+	err := a.db.ExecTx(ctx, &writeTxOpts, func(q PendingAssetStore) error {
 		return q.UpdateMintingBatchState(ctx, BatchStateUpdate{
 			RawKey:     batchKey.SerializeCompressed(),
 			BatchState: int16(newState),
 		})
 	})
+	if err != nil {
+		return err
+	}
+
+	batch.SetStateOnDBSuccess(newState)
+	return nil
 }
 
 // encodeOutpoint encodes the outpoint point in Bitcoin wire format, returning
@@ -1793,7 +1800,7 @@ func fetchSeedlingGroups(ctx context.Context, q PendingAssetStore,
 // binds the genesis transaction (which will create the set of assets in the
 // batch) to the batch itself.
 func (a *AssetMintingStore) AddSproutsToBatch(ctx context.Context,
-	batchKey *btcec.PublicKey,
+	batch *tapgarden.MintingBatch,
 	genesisPacket *tapgarden.FundedMintAnchorPsbt,
 	assetRoot *commitment.TapCommitment) error {
 
@@ -1824,10 +1831,11 @@ func (a *AssetMintingStore) AddSproutsToBatch(ctx context.Context,
 		return err
 	}
 
+	batchKey := batch.BatchKey.PubKey
 	rawBatchKey := batchKey.SerializeCompressed()
 
 	var writeTxOpts AssetStoreTxOptions
-	return a.db.ExecTx(ctx, &writeTxOpts, func(q PendingAssetStore) error {
+	err = a.db.ExecTx(ctx, &writeTxOpts, func(q PendingAssetStore) error {
 		// Upsert the assets with genesis.
 		_, _, err := upsertAssetsWithGenesis(
 			ctx, q, genesisOutpoint, sortedAssets, nil,
@@ -1852,6 +1860,12 @@ func (a *AssetMintingStore) AddSproutsToBatch(ctx context.Context,
 			BatchState: int16(tapgarden.BatchStateCommitted),
 		})
 	})
+	if err != nil {
+		return err
+	}
+
+	batch.SetStateOnDBSuccess(tapgarden.BatchStateCommitted)
+	return nil
 }
 
 // CommitSignedGenesisTx binds a fully signed genesis transaction to a pending
@@ -1863,9 +1877,11 @@ func (a *AssetMintingStore) AddSproutsToBatch(ctx context.Context,
 // TODO(roasbeef): or could just re-read assets from disk and set the script
 // root manually?
 func (a *AssetMintingStore) CommitSignedGenesisTx(ctx context.Context,
-	batchKey *btcec.PublicKey, genesisPkt *tapsend.FundedPsbt,
+	batch *tapgarden.MintingBatch, genesisPkt *tapsend.FundedPsbt,
 	anchorOutputIndex uint32, merkleRoot, tapTreeRoot []byte,
 	tapSibling []byte) error {
+
+	batchKey := batch.BatchKey.PubKey
 
 	// The managed UTXO we'll insert only contains the raw tx of the
 	// genesis packet, so we'll extract that now.
@@ -1902,7 +1918,7 @@ func (a *AssetMintingStore) CommitSignedGenesisTx(ctx context.Context,
 	}
 
 	var writeTxOpts AssetStoreTxOptions
-	return a.db.ExecTx(ctx, &writeTxOpts, func(q PendingAssetStore) error {
+	err = a.db.ExecTx(ctx, &writeTxOpts, func(q PendingAssetStore) error {
 		// First, we'll update the genesis packet stored as part of the
 		// batch, as this packet is now fully signed.
 		pktBytes, err := fn.Serialize(genesisPkt.Pkt)
@@ -1977,19 +1993,26 @@ func (a *AssetMintingStore) CommitSignedGenesisTx(ctx context.Context,
 			BatchState: int16(tapgarden.BatchStateBroadcast),
 		})
 	})
+	if err != nil {
+		return err
+	}
+
+	batch.SetStateOnDBSuccess(tapgarden.BatchStateBroadcast)
+	return nil
 }
 
 // MarkBatchConfirmed stores final confirmation information for a batch on
 // disk.
 func (a *AssetMintingStore) MarkBatchConfirmed(ctx context.Context,
-	batchKey *btcec.PublicKey, blockHash *chainhash.Hash,
+	batch *tapgarden.MintingBatch, blockHash *chainhash.Hash,
 	blockHeight uint32, txIndex uint32,
 	mintingProofs proof.AssetBlobs) error {
 
+	batchKey := batch.BatchKey.PubKey
 	rawBatchKey := batchKey.SerializeCompressed()
 
 	var writeTxOpts AssetStoreTxOptions
-	return a.db.ExecTx(ctx, &writeTxOpts, func(q PendingAssetStore) error {
+	err := a.db.ExecTx(ctx, &writeTxOpts, func(q PendingAssetStore) error {
 		// First, we'll update the state of the target batch to reflect
 		// that the batch is fully finalized.
 		err := q.UpdateMintingBatchState(ctx, BatchStateUpdate{
@@ -2044,6 +2067,12 @@ func (a *AssetMintingStore) MarkBatchConfirmed(ctx context.Context,
 		}
 		return nil
 	})
+	if err != nil {
+		return err
+	}
+
+	batch.SetStateOnDBSuccess(tapgarden.BatchStateConfirmed)
+	return nil
 }
 
 // FetchGroupByGenesis fetches the asset group created by the genesis referenced

--- a/tapdb/asset_minting.go
+++ b/tapdb/asset_minting.go
@@ -476,6 +476,19 @@ func (a *AssetMintingStore) CommitMintingBatch(ctx context.Context,
 
 	rawBatchKey := newBatch.BatchKey.PubKey.SerializeCompressed()
 
+	// Set when the batch insert itself fails on a unique constraint
+	// violation, which means the partial unique index from migration
+	// 000061 rejected a second pre-broadcast batch. The transaction
+	// executor re-maps errors returned from the closure, so the
+	// classification cannot ride along on the error itself.
+	//
+	// This attributes any unique violation on the insert to the
+	// singleton index. The only other unique constraint reachable
+	// from it is the batch_id primary key, which would require two
+	// batches sharing a batch key; keys are freshly derived per
+	// batch, so that case is not distinguished here.
+	var singletonViolation bool
+
 	var writeTxOpts AssetStoreTxOptions
 	err := a.db.ExecTx(ctx, &writeTxOpts, func(q PendingAssetStore) error {
 		// First, we'll need to insert a new internal key which'll act
@@ -497,6 +510,11 @@ func (a *AssetMintingStore) CommitMintingBatch(ctx context.Context,
 			CreationTimeUnix:    newBatch.CreationTime.UTC(),
 			UniverseCommitments: newBatch.SupplyCommitments,
 		}); err != nil {
+			var uniqueErr *ErrSqlUniqueConstraintViolation
+			if errors.As(MapSQLError(err), &uniqueErr) {
+				singletonViolation = true
+			}
+
 			return fmt.Errorf("unable to insert minting "+
 				"batch: %w", err)
 		}
@@ -617,6 +635,12 @@ func (a *AssetMintingStore) CommitMintingBatch(ctx context.Context,
 
 		return nil
 	})
+	if err != nil && singletonViolation {
+		// Surface the singleton violation as a domain error
+		// instead of the raw SQL constraint error.
+		return fmt.Errorf("%w: %w",
+			tapgarden.ErrDuplicatePreBroadcastBatch, err)
+	}
 
 	return err
 }

--- a/tapdb/asset_minting_test.go
+++ b/tapdb/asset_minting_test.go
@@ -550,8 +550,9 @@ func TestCommitMintingBatchSeedlings(t *testing.T) {
 	// Finally update the state of the batch, and asset that when we read
 	// it from disk again, it has transitioned to being frozen.
 	require.NoError(t, assetStore.UpdateBatchState(
-		ctx, batchKey, tapgarden.BatchStateFrozen,
+		ctx, mintingBatch, tapgarden.BatchStateFrozen,
 	))
+	require.Equal(t, tapgarden.BatchStateFrozen, mintingBatch.State())
 
 	mintingBatches = noError1(t, assetStore.FetchNonFinalBatches, ctx)
 	assertSeedlingBatchLen(t, mintingBatches, 1, numSeedlings*2)
@@ -560,7 +561,7 @@ func TestCommitMintingBatchSeedlings(t *testing.T) {
 	// If we finalize the batch, then the next query to
 	// FetchNonFinalBatches should return zero batches.
 	require.NoError(t, assetStore.UpdateBatchState(
-		ctx, batchKey, tapgarden.BatchStateFinalized,
+		ctx, mintingBatch, tapgarden.BatchStateFinalized,
 	))
 	mintingBatches = noError1(t, assetStore.FetchNonFinalBatches, ctx)
 	assertSeedlingBatchLen(t, mintingBatches, 0, 0)
@@ -584,10 +585,13 @@ func TestCommitMintingBatchSeedlings(t *testing.T) {
 	// Adding sprouts updates the batch state to committed, so we'll set it
 	// back to finalized.
 	require.NoError(t, assetStore.AddSproutsToBatch(
-		ctx, batchKey, genesisPacket, assetRoot,
+		ctx, mintingBatch, genesisPacket, assetRoot,
 	))
+	require.Equal(
+		t, tapgarden.BatchStateCommitted, mintingBatch.State(),
+	)
 	require.NoError(t, assetStore.UpdateBatchState(
-		ctx, batchKey, tapgarden.BatchStateFinalized,
+		ctx, mintingBatch, tapgarden.BatchStateFinalized,
 	))
 
 	// We should still be able to fetch the finalized batch from disk.
@@ -874,8 +878,6 @@ func TestAddSproutsToBatch(t *testing.T) {
 	// First, we'll create a new batch, then add some sample seedlings.
 	require.NoError(t, assetStore.CommitMintingBatch(ctx, mintingBatch))
 
-	batchKey := mintingBatch.BatchKey.PubKey
-
 	// Now that the batch is on disk, we'll map those seedlings to an
 	// actual asset commitment, then insert them into the DB as sprouts.
 	genesisPacket := mintingBatch.GenesisPacket
@@ -899,8 +901,11 @@ func TestAddSproutsToBatch(t *testing.T) {
 	genesisPacket.Pkt.UnsignedTx.TxOut[anchorOutputIndex].PkScript = script
 
 	require.NoError(t, assetStore.AddSproutsToBatch(
-		ctx, batchKey, genesisPacket, assetRoot,
+		ctx, mintingBatch, genesisPacket, assetRoot,
 	))
+	require.Equal(
+		t, tapgarden.BatchStateCommitted, mintingBatch.State(),
+	)
 
 	// Now we'll query for that same batch, and assert that the set of
 	// assets we just inserted into the database matches up.
@@ -940,7 +945,6 @@ func TestAddSproutsToBatch(t *testing.T) {
 }
 
 type randAssetCtx struct {
-	batchKey        *btcec.PublicKey
 	groupKey        *btcec.PublicKey
 	groupGenAmt     uint64
 	genesisPkt      *tapsend.FundedPsbt
@@ -963,7 +967,6 @@ func addRandAssets(t *testing.T, ctx context.Context,
 		t, assetStore, ctx, mintingBatch.Seedlings,
 	)
 	randSibling, randSiblingHash := addRandSiblingToBatch(t, mintingBatch)
-	batchKey := mintingBatch.BatchKey.PubKey
 	require.NoError(t, assetStore.CommitMintingBatch(ctx, mintingBatch))
 
 	genesisPacket := mintingBatch.GenesisPacket
@@ -990,8 +993,11 @@ func addRandAssets(t *testing.T, ctx context.Context,
 	genesisPacket.Pkt.UnsignedTx.TxOut[anchorOutputIndex].PkScript = script
 
 	require.NoError(t, assetStore.AddSproutsToBatch(
-		ctx, batchKey, genesisPacket, assetRoot,
+		ctx, mintingBatch, genesisPacket, assetRoot,
 	))
+	require.Equal(
+		t, tapgarden.BatchStateCommitted, mintingBatch.State(),
+	)
 
 	merkleRoot := assetRoot.TapscriptRoot(&randSiblingHash)
 	scriptRoot := assetRoot.TapscriptRoot(nil)
@@ -1001,7 +1007,6 @@ func addRandAssets(t *testing.T, ctx context.Context,
 	require.NoError(t, err)
 
 	return randAssetCtx{
-		batchKey:        batchKey,
 		groupKey:        &group.GroupKey.GroupPubKey,
 		groupGenAmt:     genAmt,
 		genesisPkt:      &genesisPacket.FundedPsbt,
@@ -1042,10 +1047,14 @@ func TestCommitBatchChainActions(t *testing.T) {
 	// to disk, along with the Taproot Asset script root that's stored
 	// alongside any managed UTXOs.
 	require.NoError(t, assetStore.CommitSignedGenesisTx(
-		ctx, randAssetCtx.batchKey, randAssetCtx.genesisPkt, 0,
+		ctx, randAssetCtx.mintingBatch, randAssetCtx.genesisPkt, 0,
 		randAssetCtx.merkleRoot, randAssetCtx.scriptRoot,
 		randAssetCtx.tapSiblingBytes,
 	))
+	require.Equal(
+		t, tapgarden.BatchStateBroadcast,
+		randAssetCtx.mintingBatch.State(),
+	)
 
 	// The batch updated above should be found, with the batch state
 	// updated, and also the genesis transaction updated to match what we
@@ -1118,9 +1127,13 @@ func TestCommitBatchChainActions(t *testing.T) {
 	blockHeight := uint32(20)
 	txIndex := uint32(5)
 	require.NoError(t, assetStore.MarkBatchConfirmed(
-		ctx, randAssetCtx.batchKey, &fakeBlockHash, blockHeight,
+		ctx, randAssetCtx.mintingBatch, &fakeBlockHash, blockHeight,
 		txIndex, assetProofs,
 	))
+	require.Equal(
+		t, tapgarden.BatchStateConfirmed,
+		randAssetCtx.mintingBatch.State(),
+	)
 
 	// We'll now fetch the chain transaction again, to confirm that all the
 	// field have been properly updated.
@@ -1557,8 +1570,11 @@ func TestGroupAnchors(t *testing.T) {
 	genesisPacket.Pkt.UnsignedTx.TxOut[anchorOutputIndex].PkScript = script
 
 	require.NoError(t, assetStore.AddSproutsToBatch(
-		ctx, batchKey, genesisPacket, assetRoot,
+		ctx, mintingBatch, genesisPacket, assetRoot,
 	))
+	require.Equal(
+		t, tapgarden.BatchStateCommitted, mintingBatch.State(),
+	)
 
 	// Now we'll query for that same batch, and assert that the set of
 	// assets we just inserted into the database matches up.
@@ -2071,6 +2087,48 @@ func TestUpsertMintSupplyPreCommit(t *testing.T) {
 	assertMintSupplyPreCommit(
 		t, *assetStore, batchKey, preCommitOut.OutIdx, internalKey2,
 		groupPubKey2Bytes, preCommitOutpoint,
+	)
+}
+
+// TestUpdateBatchStateMemoryCoherence pins the invariant that the
+// in-memory batch state never advances unless the on-disk write
+// succeeds. When the DB call fails (here, via a pre-cancelled
+// context), batch.State() must remain at its prior value and a fresh
+// read from disk must agree.
+func TestUpdateBatchStateMemoryCoherence(t *testing.T) {
+	t.Parallel()
+
+	assetStore, _, _ := newAssetStore(t)
+	ctx := context.Background()
+
+	mintingBatch := tapgarden.RandMintingBatch(t)
+	require.NoError(t, assetStore.CommitMintingBatch(ctx, mintingBatch))
+	require.Equal(
+		t, tapgarden.BatchStatePending, mintingBatch.State(),
+	)
+
+	// A pre-cancelled context forces ExecTx to fail before touching
+	// the row, exercising the failure path of UpdateBatchState.
+	cancelledCtx, cancel := context.WithCancel(ctx)
+	cancel()
+
+	err := assetStore.UpdateBatchState(
+		cancelledCtx, mintingBatch, tapgarden.BatchStateFrozen,
+	)
+	require.Error(t, err)
+
+	// In-memory state must not have moved.
+	require.Equal(
+		t, tapgarden.BatchStatePending, mintingBatch.State(),
+	)
+
+	// On-disk state must not have moved either.
+	fetched, err := assetStore.FetchMintingBatch(
+		ctx, mintingBatch.BatchKey.PubKey,
+	)
+	require.NoError(t, err)
+	require.Equal(
+		t, tapgarden.BatchStatePending, fetched.State(),
 	)
 }
 

--- a/tapdb/asset_minting_test.go
+++ b/tapdb/asset_minting_test.go
@@ -2132,6 +2132,58 @@ func TestUpdateBatchStateMemoryCoherence(t *testing.T) {
 	)
 }
 
+// TestSingletonPreBroadcastBatchConstraint exercises the partial
+// unique index added in migration 000061. At most one
+// asset_minting_batches row may be in BatchStatePending or
+// BatchStateFrozen at any time; the second insert into that set
+// must fail with a constraint error, and a row in
+// BatchStateCommitted (or later) must not count against the
+// constraint.
+func TestSingletonPreBroadcastBatchConstraint(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	assetStore, _, _ := newAssetStore(t)
+
+	// A first Pending batch is fine.
+	first := tapgarden.RandMintingBatch(t)
+	require.NoError(t, assetStore.CommitMintingBatch(ctx, first))
+
+	// A second Pending batch must be rejected: two rows in
+	// BatchStatePending violate the partial unique index.
+	secondPending := tapgarden.RandMintingBatch(t)
+	err := assetStore.CommitMintingBatch(ctx, secondPending)
+	require.Error(t, err)
+
+	// Move the first batch to Frozen; it is still in the
+	// pre-broadcast set, so a new Pending batch must still be
+	// rejected (Pending ∪ Frozen, not just Pending).
+	require.NoError(t, assetStore.UpdateBatchState(
+		ctx, first, tapgarden.BatchStateFrozen,
+	))
+
+	pendingWhileFrozen := tapgarden.RandMintingBatch(t)
+	err = assetStore.CommitMintingBatch(ctx, pendingWhileFrozen)
+	require.Error(t, err)
+
+	// Move the first batch out of the pre-broadcast set into
+	// Committed; the constraint no longer applies to it. A new
+	// Pending batch must now succeed.
+	require.NoError(t, assetStore.UpdateBatchState(
+		ctx, first, tapgarden.BatchStateCommitted,
+	))
+
+	third := tapgarden.RandMintingBatch(t)
+	require.NoError(t, assetStore.CommitMintingBatch(ctx, third))
+
+	// And finally: two batches both in Committed must be
+	// permitted -- the constraint targets only the pre-broadcast
+	// set.
+	require.NoError(t, assetStore.UpdateBatchState(
+		ctx, third, tapgarden.BatchStateCommitted,
+	))
+}
+
 func init() {
 	rand.Seed(time.Now().Unix())
 

--- a/tapdb/asset_minting_test.go
+++ b/tapdb/asset_minting_test.go
@@ -2132,6 +2132,60 @@ func TestUpdateBatchStateMemoryCoherence(t *testing.T) {
 	)
 }
 
+// TestSingletonPreBroadcastBatchConstraint exercises the partial
+// unique index added in migration 000061. At most one
+// asset_minting_batches row may be in BatchStatePending or
+// BatchStateFrozen at any time; the second insert into that set
+// must fail with a constraint error, and a row in
+// BatchStateCommitted (or later) must not count against the
+// constraint.
+func TestSingletonPreBroadcastBatchConstraint(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	assetStore, _, _ := newAssetStore(t)
+
+	// A first Pending batch is fine.
+	first := tapgarden.RandMintingBatch(t)
+	require.NoError(t, assetStore.CommitMintingBatch(ctx, first))
+
+	// A second Pending batch must be rejected: two rows in
+	// BatchStatePending violate the partial unique index. The
+	// violation must surface as the domain error, not as a raw
+	// SQL constraint error.
+	secondPending := tapgarden.RandMintingBatch(t)
+	err := assetStore.CommitMintingBatch(ctx, secondPending)
+	require.ErrorIs(t, err, tapgarden.ErrDuplicatePreBroadcastBatch)
+
+	// Move the first batch to Frozen; it is still in the
+	// pre-broadcast set, so a new Pending batch must still be
+	// rejected (Pending ∪ Frozen, not just Pending).
+	require.NoError(t, assetStore.UpdateBatchState(
+		ctx, first, tapgarden.BatchStateFrozen,
+	))
+
+	pendingWhileFrozen := tapgarden.RandMintingBatch(t)
+	err = assetStore.CommitMintingBatch(ctx, pendingWhileFrozen)
+	require.ErrorIs(t, err, tapgarden.ErrDuplicatePreBroadcastBatch)
+
+	// Move the first batch out of the pre-broadcast set into
+	// Committed; the constraint no longer applies to it. A new
+	// Pending batch must now succeed.
+	require.NoError(t, assetStore.UpdateBatchState(
+		ctx, first, tapgarden.BatchStateCommitted,
+	))
+
+	third := tapgarden.RandMintingBatch(t)
+	require.NoError(t, assetStore.CommitMintingBatch(ctx, third))
+
+	// And finally: two batches both in Committed must be
+	// permitted -- the constraint targets only the pre-broadcast
+	// set.
+	require.NoError(t, assetStore.UpdateBatchState(
+		ctx, third, tapgarden.BatchStateCommitted,
+	))
+}
+
 func init() {
 	rand.Seed(time.Now().Unix())
 

--- a/tapdb/migrations.go
+++ b/tapdb/migrations.go
@@ -24,7 +24,7 @@ const (
 	// daemon.
 	//
 	// NOTE: This MUST be updated when a new migration is added.
-	LatestMigrationVersion = 60
+	LatestMigrationVersion = 61
 )
 
 // DatabaseBackend is an interface that contains all methods our different

--- a/tapdb/migrations_test.go
+++ b/tapdb/migrations_test.go
@@ -12,6 +12,7 @@ import (
 	"sort"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/btcsuite/btcd/wire/v2"
 	"github.com/lightninglabs/taproot-assets/asset"
@@ -1398,4 +1399,137 @@ func TestSequenceConsistency(t *testing.T) {
 			lastValue, s.column, maxID,
 		)
 	}
+}
+
+// TestMigration61CancelsDuplicatePreBroadcastBatches verifies that the
+// legacy-DB self-heal step in migration 61 preserves the most recent
+// pre-broadcast batch and cancels the rest before the partial unique
+// index is applied. Without the self-heal, a database that already
+// held duplicate rows in {Pending, Frozen} would fail the migration
+// with a raw unique-index error and force a manual repair step. Two
+// of the seeded rows share the most recent creation time, so the
+// survivor is decided by the raw-batch-key tie-break in the
+// migration's ORDER BY.
+func TestMigration61CancelsDuplicatePreBroadcastBatches(t *testing.T) {
+	ctx := context.Background()
+
+	// Start at version 60: the singleton index does not yet exist,
+	// so we can seed the DB with several pre-broadcast rows to
+	// simulate the legacy failure mode.
+	db := NewTestDBWithVersion(t, 60)
+
+	// Seed four internal_keys and four asset_minting_batches rows:
+	// two Pending (state=0) with distinct creation times and two
+	// Frozen (state=1) sharing the most recent creation time. Of
+	// the latter pair, the one with the greater raw batch key must
+	// be the preserved row after migration 61 runs, per the
+	// tie-break.
+	type seed struct {
+		batchID     int
+		keyBytes    string
+		state       int
+		createdUnix int64
+	}
+	seeds := []seed{
+		{
+			batchID:  1,
+			keyBytes: "02" + strings.Repeat("01", 32),
+			state:    0, // BatchStatePending
+			// oldest
+			createdUnix: 1_000_000_000,
+		},
+		{
+			batchID:  2,
+			keyBytes: "02" + strings.Repeat("02", 32),
+			state:    0, // BatchStatePending
+			// middle
+			createdUnix: 1_000_000_050,
+		},
+		{
+			batchID:  3,
+			keyBytes: "02" + strings.Repeat("03", 32),
+			state:    1, // BatchStateFrozen
+			// most recent, but loses the tie-break: its
+			// raw key is below batch 4's
+			createdUnix: 1_000_000_100,
+		},
+		{
+			batchID:  4,
+			keyBytes: "03" + strings.Repeat("03", 32),
+			state:    1, // BatchStateFrozen
+			// most recent, wins the tie-break on raw key
+			// -- must be preserved
+			createdUnix: 1_000_000_100,
+		},
+	}
+
+	insertBatch := `
+		INSERT INTO asset_minting_batches (
+			batch_id, batch_state, height_hint,
+			creation_time_unix
+		) VALUES ($1, $2, 0, $3)
+	`
+	if db.Backend() == sqlc.BackendTypeSqlite {
+		insertBatch = `
+		INSERT INTO asset_minting_batches (
+			batch_id, batch_state, height_hint,
+			creation_time_unix
+		) VALUES (?, ?, 0, ?)
+		`
+	}
+
+	for _, s := range seeds {
+		_, err := db.ExecContext(ctx, transformByteLiterals(
+			t, db.BaseDB, fmt.Sprintf(`
+			INSERT INTO internal_keys (
+				key_id, raw_key, key_family, key_index
+			) VALUES (%d, X'%s', 0, %d)
+			`, s.batchID, s.keyBytes, s.batchID),
+		))
+		require.NoError(t, err)
+
+		_, err = db.ExecContext(
+			ctx, insertBatch, s.batchID, s.state,
+			time.Unix(s.createdUnix, 0).UTC(),
+		)
+		require.NoError(t, err)
+	}
+
+	// Migrate to latest -- the self-heal in 61 runs before the
+	// index creation, so the migration must succeed.
+	err := db.ExecuteMigrations(TargetLatest, WithProgrammaticMigrations(
+		makeProgrammaticMigrations(db, programmaticMigrations, true),
+	))
+	require.NoError(t, err)
+
+	// The single remaining pre-broadcast row must be batch_id=4
+	// (Frozen, most recent, greater raw key), and it must retain
+	// its original batch_state so the planter can resume it.
+	var (
+		preCount    int
+		survivingID int
+		survivingSt int
+	)
+	require.NoError(t, db.QueryRowContext(ctx, `
+		SELECT COUNT(*) FROM asset_minting_batches
+		WHERE batch_state IN (0, 1)
+	`).Scan(&preCount))
+	require.Equal(t, 1, preCount)
+
+	require.NoError(t, db.QueryRowContext(ctx, `
+		SELECT batch_id, batch_state
+		FROM asset_minting_batches
+		WHERE batch_state IN (0, 1)
+	`).Scan(&survivingID, &survivingSt))
+	require.Equal(t, 4, survivingID)
+	require.Equal(t, 1, survivingSt)
+
+	// The three other rows must have moved to
+	// BatchStateSeedlingCancelled = 6.
+	var cancelledCount int
+	require.NoError(t, db.QueryRowContext(ctx, `
+		SELECT COUNT(*) FROM asset_minting_batches
+		WHERE batch_state = 6
+	`).Scan(&cancelledCount))
+	require.Equal(t, 3, cancelledCount)
 }

--- a/tapdb/sqlc/migrations/000061_unique_pending_or_frozen_batch.down.sql
+++ b/tapdb/sqlc/migrations/000061_unique_pending_or_frozen_batch.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS asset_minting_batches_unique_pending_or_frozen;

--- a/tapdb/sqlc/migrations/000061_unique_pending_or_frozen_batch.up.sql
+++ b/tapdb/sqlc/migrations/000061_unique_pending_or_frozen_batch.up.sql
@@ -1,0 +1,21 @@
+-- Enforce that at most one minting batch is in a pre-broadcast state
+-- (BatchStatePending = 0 or BatchStateFrozen = 1) at any time. This
+-- matches the planter's in-memory model, which assumes a single
+-- "current" pre-broadcast batch in flight. Older versions of the
+-- planter could in some failure scenarios desync the in-memory slot
+-- from disk and leave two pre-broadcast rows behind; this index
+-- makes that state unrepresentable going forward.
+--
+-- The unique index targets the constant expression `(1)`, which
+-- means "at most one row total" among rows matching the WHERE
+-- filter. The syntax is dialect-agnostic across SQLite and
+-- Postgres.
+--
+-- This is a deliberate design choice rather than a fundamental
+-- limit. If multi-batch support is ever added to the planter,
+-- drop this index and revisit the planter API and recovery loop
+-- alongside that change.
+CREATE UNIQUE INDEX IF NOT EXISTS
+    asset_minting_batches_unique_pending_or_frozen
+    ON asset_minting_batches ((1))
+    WHERE batch_state IN (0, 1);

--- a/tapdb/sqlc/migrations/000061_unique_pending_or_frozen_batch.up.sql
+++ b/tapdb/sqlc/migrations/000061_unique_pending_or_frozen_batch.up.sql
@@ -1,0 +1,44 @@
+-- Enforce that at most one minting batch is in a pre-broadcast state
+-- (BatchStatePending = 0 or BatchStateFrozen = 1) at any time. This
+-- matches the planter's in-memory model, which assumes a single
+-- "current" pre-broadcast batch in flight. Older versions of the
+-- planter could in some failure scenarios desync the in-memory slot
+-- from disk and leave two pre-broadcast rows behind; this migration
+-- makes that state unrepresentable going forward.
+--
+-- Legacy databases may already violate the invariant. Rather than
+-- fail here with an opaque unique-index error and force the operator
+-- into a manual repair step, cancel all but the most recent
+-- pre-broadcast batch first. The preserved row is the one with the
+-- latest creation_time_unix, tie-broken by the raw batch key, so the
+-- outcome is deterministic on identical timestamps and matches the
+-- ordering used by the tapd repair tool
+-- (--repair.cancel-duplicate-batches), which cannot see batch_id.
+-- Cancelled rows move to BatchStateSeedlingCancelled = 6, which
+-- leaves them and their seedlings on disk for later inspection.
+UPDATE asset_minting_batches
+SET batch_state = 6
+WHERE batch_state IN (0, 1)
+  AND batch_id NOT IN (
+      SELECT b.batch_id
+      FROM asset_minting_batches b
+      JOIN internal_keys k
+          ON k.key_id = b.batch_id
+      WHERE b.batch_state IN (0, 1)
+      ORDER BY b.creation_time_unix DESC, k.raw_key DESC
+      LIMIT 1
+  );
+
+-- The unique index targets the constant expression `(1)`, which
+-- means "at most one row total" among rows matching the WHERE
+-- filter. The syntax is dialect-agnostic across SQLite and
+-- Postgres.
+--
+-- This is a deliberate design choice rather than a fundamental
+-- limit. If multi-batch support is ever added to the planter,
+-- drop this index and revisit the planter API and recovery loop
+-- alongside that change.
+CREATE UNIQUE INDEX IF NOT EXISTS
+    asset_minting_batches_unique_pending_or_frozen
+    ON asset_minting_batches ((1))
+    WHERE batch_state IN (0, 1);

--- a/tapdb/supply_commit_test.go
+++ b/tapdb/supply_commit_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/lightninglabs/taproot-assets/mssmt"
 	"github.com/lightninglabs/taproot-assets/proof"
 	"github.com/lightninglabs/taproot-assets/tapdb/sqlc"
+	"github.com/lightninglabs/taproot-assets/tapgarden"
 	"github.com/lightninglabs/taproot-assets/universe"
 	"github.com/lightninglabs/taproot-assets/universe/supplycommit"
 	"github.com/lightninglabs/taproot-assets/universe/supplyverifier"
@@ -145,6 +146,23 @@ func (h *supplyCommitTestHarness) addTestMintingBatch() ([]byte, int64,
 		HeightHint:       100,
 		CreationTimeUnix: time.Now(),
 	})
+	require.NoError(h.t, err)
+
+	// NewMintingBatch hardcodes state=BatchStatePending. These
+	// supply-commit tests need to create multiple batches as
+	// fixtures, which would violate the singleton invariant added
+	// in migration 000061 (≤ 1 batch in {Pending, Frozen}).
+	// Immediately advance to a terminal state so each fixture is
+	// outside the constrained set; the tests do not exercise the
+	// planter state machine, only the supply-commit logic, so the
+	// specific state does not matter as long as it is not
+	// Pending or Frozen.
+	err = db.UpdateMintingBatchState(
+		ctx, sqlc.UpdateMintingBatchStateParams{
+			RawKey:     batchKeyBytes,
+			BatchState: int16(tapgarden.BatchStateFinalized),
+		},
+	)
 	require.NoError(h.t, err)
 
 	_, err = db.BindMintingBatchWithTx(

--- a/tapgarden/batch.go
+++ b/tapgarden/batch.go
@@ -107,7 +107,7 @@ func (m *MintingBatch) Copy() *MintingBatch {
 		SupplyCommitments:   m.SupplyCommitments,
 		tapSibling:          m.tapSibling,
 	}
-	batchCopy.UpdateState(m.State())
+	batchCopy.setState(m.State())
 
 	if m.Seedlings != nil {
 		batchCopy.Seedlings = make(
@@ -280,10 +280,27 @@ func (m *MintingBatch) State() BatchState {
 	return batchStateCopy
 }
 
-// UpdateState updates the state of a batch to a value that has been verified to
-// be a valid batch state.
-func (m *MintingBatch) UpdateState(state BatchState) {
+// setState updates the in-memory batch state. This is unexported because
+// every authoritative state mutation must flow through a MintingStore call
+// that writes to disk first and only then mutates memory. Use this only for
+// package-internal cases that are not the result of a DB transition
+// (currently: initial Pending state during batch construction and copying
+// a batch via Copy()).
+func (m *MintingBatch) setState(state BatchState) {
 	m.batchState.Store(uint32(state))
+}
+
+// SetStateOnDBSuccess mutates the in-memory batch state. It is intended to
+// be called exclusively by MintingStore implementations after a successful
+// DB write has committed the same state to disk; this is what guarantees
+// that the in-memory mirror cannot get ahead of the on-disk truth.
+//
+// NOTE: Ordinary callers (planter, caretaker, RPC layer, tests) must never
+// invoke this method directly. Use the MintingStore interface, whose
+// state-mutating methods take *MintingBatch and update memory only on DB
+// success.
+func (m *MintingBatch) SetStateOnDBSuccess(state BatchState) {
+	m.setState(state)
 }
 
 // TapSibling returns the optional tapscript sibling for the batch, which is a
@@ -499,38 +516,70 @@ func (m *MintingBatch) validateUniCommitment(newSeedling Seedling) error {
 	return nil
 }
 
-// AddSeedling adds a new seedling to the batch.
-func (m *MintingBatch) AddSeedling(newSeedling Seedling) error {
-	// Ensure that the seedling adheres to the universe commitment feature
-	// restrictions in relation to the current batch state.
-	err := m.validateUniCommitment(newSeedling)
-	if err != nil {
+// validateSeedling checks that a candidate seedling is admissible into
+// the batch given the batch's current state. It does not mutate the
+// batch; this is the read-only half of AddSeedling.
+//
+// Callers that need a persistence boundary between validation and
+// mutation (e.g. "validate, write to disk, then update in memory")
+// should pair this with commitSeedling so an in-memory mutation
+// cannot precede the persistence that justifies it.
+func (m *MintingBatch) validateSeedling(newSeedling Seedling) error {
+	// Ensure that the seedling adheres to the universe commitment
+	// feature restrictions in relation to the current batch state.
+	if err := m.validateUniCommitment(newSeedling); err != nil {
 		return fmt.Errorf("seedling does not comply with universe "+
 			"commitment feature: %w", err)
 	}
 
-	// At this stage, the seedling has been confirmed to comply with the
-	// universe commitment feature restrictions. If this is the first
-	// seedling being added to the batch, the batch universe commitment flag
-	// can be set to match the seedling's flag state.
+	// Ensure that the delegation key is valid for the seedling being
+	// considered for inclusion in the batch. validateDelegationKey
+	// reads newSeedling.SupplyCommitments (not m.SupplyCommitments),
+	// so it is order-independent with respect to the
+	// SupplyCommitments mutation that commitSeedling performs.
+	if err := m.validateDelegationKey(newSeedling); err != nil {
+		return fmt.Errorf("delegation key validation failed: %w", err)
+	}
+
+	return nil
+}
+
+// commitSeedling applies the in-memory mutation that adds newSeedling
+// to the batch. It assumes the seedling has already been validated by
+// validateSeedling; calling it on an invalid seedling is a
+// programming error.
+//
+// The SupplyCommitments mutation must happen before the seedling is
+// inserted into the map, because the gate is m.HasSeedlings() which
+// flips once the insertion has happened.
+func (m *MintingBatch) commitSeedling(newSeedling Seedling) {
 	if !m.HasSeedlings() {
 		m.SupplyCommitments = newSeedling.SupplyCommitments
 	}
 
-	// Ensure that the delegation key is valid for the seedling being
-	// considered for inclusion in the batch.
-	err = m.validateDelegationKey(newSeedling)
-	if err != nil {
-		return fmt.Errorf("delegation key validation failed: %w", err)
-	}
-
-	// Add the seedling to the batch.
 	if m.Seedlings == nil {
 		m.Seedlings = make(map[string]*Seedling)
 	}
 
 	m.Seedlings[newSeedling.AssetName] = &newSeedling
+}
 
+// AddSeedling validates the seedling against the batch and, if valid,
+// adds it. This is the convenience wrapper for callers that do not
+// need a persistence boundary between validation and the in-memory
+// mutation (e.g. constructing a fresh batch in memory that will be
+// persisted whole, or test helpers building random batches).
+//
+// Callers that *do* need a persistence boundary -- e.g. adding a
+// seedling to an existing on-disk batch where the in-memory mirror
+// must not advance unless the DB write succeeds -- should use
+// validateSeedling and commitSeedling explicitly around the
+// persistence call.
+func (m *MintingBatch) AddSeedling(newSeedling Seedling) error {
+	if err := m.validateSeedling(newSeedling); err != nil {
+		return err
+	}
+	m.commitSeedling(newSeedling)
 	return nil
 }
 

--- a/tapgarden/batch.go
+++ b/tapgarden/batch.go
@@ -516,6 +516,43 @@ func (m *MintingBatch) validateUniCommitment(newSeedling Seedling) error {
 	return nil
 }
 
+// uniqueAnchorSeedling returns the single group anchor seedling in
+// the batch -- the seedling whose GroupAnchor is nil and that other
+// seedlings may reference by name. If the batch contains zero or
+// more than one such seedling, an error is returned.
+//
+// This invariant ("exactly one anchor per batch") is required by
+// callers that derive batch-wide properties (the delegation key,
+// the pre-commitment group key) from the anchor seedling: with no
+// anchor there is no answer, and with multiple anchors the answer
+// is ambiguous. The function computes the answer deterministically
+// rather than relying on non-deterministic map iteration to land
+// on the unique anchor by luck.
+func (m *MintingBatch) uniqueAnchorSeedling() (*Seedling, error) {
+	var (
+		anchor *Seedling
+		count  int
+	)
+	for _, seedling := range m.Seedlings {
+		if seedling.GroupAnchor != nil {
+			continue
+		}
+
+		anchor = seedling
+		count++
+	}
+
+	switch count {
+	case 0:
+		return nil, fmt.Errorf("no group anchor seedling in batch")
+	case 1:
+		return anchor, nil
+	default:
+		return nil, fmt.Errorf("batch has %d group anchor "+
+			"seedlings, expected exactly 1", count)
+	}
+}
+
 // validateSeedling checks that a candidate seedling is admissible into
 // the batch given the batch's current state. It does not mutate the
 // batch; this is the read-only half of AddSeedling.

--- a/tapgarden/batch.go
+++ b/tapgarden/batch.go
@@ -516,6 +516,51 @@ func (m *MintingBatch) validateUniCommitment(newSeedling Seedling) error {
 	return nil
 }
 
+// uniqueAnchorSeedling returns the single group anchor seedling in
+// the batch -- the seedling whose GroupAnchor is nil and that other
+// seedlings may reference by name. If the batch contains zero or
+// more than one such seedling, an error is returned.
+//
+// This invariant ("exactly one anchor per batch") is required by
+// callers that derive batch-wide properties (the delegation key,
+// the pre-commitment group key) from the anchor seedling: with no
+// anchor there is no answer, and with multiple anchors the answer
+// is ambiguous. The function computes the answer deterministically
+// rather than relying on non-deterministic map iteration to land
+// on the unique anchor by luck.
+//
+// For batches with universe commitments enabled -- the context in
+// which both callers run -- admission checks keep the invariant:
+// once such a batch is non-empty, validateUniCommitment rejects any
+// candidate seedling that does not reference a group anchor already
+// in the batch, so a second anchor seedling can never be admitted.
+// This helper still asserts the invariant at the point of use
+// rather than trusting admission alone.
+func (m *MintingBatch) uniqueAnchorSeedling() (*Seedling, error) {
+	var (
+		anchor *Seedling
+		count  int
+	)
+	for _, seedling := range m.Seedlings {
+		if seedling.GroupAnchor != nil {
+			continue
+		}
+
+		anchor = seedling
+		count++
+	}
+
+	switch count {
+	case 0:
+		return nil, fmt.Errorf("no group anchor seedling in batch")
+	case 1:
+		return anchor, nil
+	default:
+		return nil, fmt.Errorf("batch has %d group anchor "+
+			"seedlings, expected exactly 1", count)
+	}
+}
+
 // validateSeedling checks that a candidate seedling is admissible into
 // the batch given the batch's current state. It does not mutate the
 // batch; this is the read-only half of AddSeedling.

--- a/tapgarden/batch_test.go
+++ b/tapgarden/batch_test.go
@@ -361,6 +361,102 @@ func TestMintingOutputKeyPureInSibling(t *testing.T) {
 	)
 }
 
+// TestUniqueAnchorSeedling pins the contract of
+// MintingBatch.uniqueAnchorSeedling: it deterministically returns
+// the batch's single group anchor seedling (the one with GroupAnchor
+// == nil) and errors loudly when that invariant doesn't hold. The
+// callers (fetchDelegationKey, fetchPreCommitGroupKey) used to scan
+// non-deterministically and pick whichever seedling Go's map
+// iteration handed them first; this test exists to keep them from
+// regressing back to that pattern.
+func TestUniqueAnchorSeedling(t *testing.T) {
+	t.Parallel()
+
+	mkAnchor := func(name string) *Seedling {
+		return &Seedling{
+			AssetName:      name,
+			AssetType:      asset.Normal,
+			Amount:         1,
+			EnableEmission: true,
+		}
+	}
+
+	mkChild := func(name, anchorName string) *Seedling {
+		s := &Seedling{
+			AssetName: name,
+			AssetType: asset.Normal,
+			Amount:    1,
+		}
+		s.GroupAnchor = &anchorName
+		return s
+	}
+
+	t.Run("anchor only", func(t *testing.T) {
+		batch := &MintingBatch{
+			Seedlings: map[string]*Seedling{
+				"a": mkAnchor("a"),
+			},
+		}
+
+		got, err := batch.uniqueAnchorSeedling()
+		require.NoError(t, err)
+		require.Equal(t, "a", got.AssetName)
+	})
+
+	t.Run("anchor plus children", func(t *testing.T) {
+		batch := &MintingBatch{
+			Seedlings: map[string]*Seedling{
+				"a":     mkAnchor("a"),
+				"child": mkChild("child", "a"),
+				"other": mkChild("other", "a"),
+			},
+		}
+
+		// Run many times to defeat any incidental ordering: the
+		// returned anchor must be "a" regardless of how Go
+		// iterates the map.
+		for i := 0; i < 32; i++ {
+			got, err := batch.uniqueAnchorSeedling()
+			require.NoError(t, err)
+			require.Equal(t, "a", got.AssetName)
+		}
+	})
+
+	t.Run("multiple anchors errors", func(t *testing.T) {
+		batch := &MintingBatch{
+			Seedlings: map[string]*Seedling{
+				"a": mkAnchor("a"),
+				"b": mkAnchor("b"),
+			},
+		}
+
+		_, err := batch.uniqueAnchorSeedling()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "expected exactly 1")
+	})
+
+	t.Run("no anchor errors", func(t *testing.T) {
+		batch := &MintingBatch{
+			Seedlings: map[string]*Seedling{
+				"child1": mkChild("child1", "missing"),
+				"child2": mkChild("child2", "missing"),
+			},
+		}
+
+		_, err := batch.uniqueAnchorSeedling()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "no group anchor")
+	})
+
+	t.Run("empty batch errors", func(t *testing.T) {
+		batch := &MintingBatch{}
+
+		_, err := batch.uniqueAnchorSeedling()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "no group anchor")
+	})
+}
+
 // TestSeedlingValidateCommitSplit pins the invariant that
 // validateSeedling never mutates the batch -- it is the read-only
 // half of AddSeedling, used by callers that need to persist a

--- a/tapgarden/batch_test.go
+++ b/tapgarden/batch_test.go
@@ -1,6 +1,7 @@
 package tapgarden
 
 import (
+	"encoding/hex"
 	"testing"
 
 	"github.com/btcsuite/btcd/txscript/v2"
@@ -280,6 +281,93 @@ func TestMintingBatchCopy(t *testing.T) {
 		batch.Seedlings["new"] = &Seedling{AssetName: "new"}
 		require.Empty(t, emptyCopy.Seedlings)
 	})
+}
+
+// TestCheckSingletonInvariant pins the contract of
+// checkSingletonInvariant: it returns nil for any slice of batches
+// containing at most one batch in {Pending, Frozen}, and returns a
+// descriptive error otherwise. Counts both states together
+// (Pending ∪ Frozen), not separately, and ignores batches in any
+// other state.
+func TestCheckSingletonInvariant(t *testing.T) {
+	t.Parallel()
+
+	mkBatch := func(state BatchState) *MintingBatch {
+		batchKey, _ := test.RandKeyDesc(t)
+		b := &MintingBatch{BatchKey: batchKey}
+		b.setState(state)
+		return b
+	}
+
+	t.Run("empty slice is ok", func(t *testing.T) {
+		require.NoError(t, checkSingletonInvariant(nil))
+	})
+
+	t.Run("single Pending is ok", func(t *testing.T) {
+		err := checkSingletonInvariant([]*MintingBatch{
+			mkBatch(BatchStatePending),
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("single Frozen is ok", func(t *testing.T) {
+		err := checkSingletonInvariant([]*MintingBatch{
+			mkBatch(BatchStateFrozen),
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("Pending plus Committed is ok", func(t *testing.T) {
+		err := checkSingletonInvariant([]*MintingBatch{
+			mkBatch(BatchStatePending),
+			mkBatch(BatchStateCommitted),
+			mkBatch(BatchStateBroadcast),
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("two Pending errors", func(t *testing.T) {
+		err := checkSingletonInvariant([]*MintingBatch{
+			mkBatch(BatchStatePending),
+			mkBatch(BatchStatePending),
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "singleton")
+		require.Contains(t, err.Error(), "found 2 batches")
+	})
+
+	t.Run("Pending plus Frozen errors", func(t *testing.T) {
+		err := checkSingletonInvariant([]*MintingBatch{
+			mkBatch(BatchStatePending),
+			mkBatch(BatchStateFrozen),
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "singleton")
+	})
+
+	t.Run("error names offending keys and repair tool",
+		func(t *testing.T) {
+			a := mkBatch(BatchStatePending)
+			b := mkBatch(BatchStateFrozen)
+
+			err := checkSingletonInvariant(
+				[]*MintingBatch{a, b},
+			)
+			require.Error(t, err)
+			require.Contains(t, err.Error(),
+				"--repair.cancel-duplicate-batches")
+			// Both batch keys should appear in the error.
+			require.Contains(t, err.Error(),
+				hex.EncodeToString(
+					a.BatchKey.PubKey.
+						SerializeCompressed(),
+				))
+			require.Contains(t, err.Error(),
+				hex.EncodeToString(
+					b.BatchKey.PubKey.
+						SerializeCompressed(),
+				))
+		})
 }
 
 // TestMintingOutputKeyPureInSibling pins the contract that

--- a/tapgarden/batch_test.go
+++ b/tapgarden/batch_test.go
@@ -360,3 +360,100 @@ func TestMintingOutputKeyPureInSibling(t *testing.T) {
 			"as MintingOutputKey(siblingA)",
 	)
 }
+
+// TestSeedlingValidateCommitSplit pins the invariant that
+// validateSeedling never mutates the batch -- it is the read-only
+// half of AddSeedling, used by callers that need to persist a
+// seedling before mirroring it into the in-memory batch. A regression
+// here would silently revive the §X bug shape in prepAssetSeedling:
+// an in-memory mutation that precedes the DB write that justifies it.
+func TestSeedlingValidateCommitSplit(t *testing.T) {
+	t.Parallel()
+
+	mkCandidate := func(name string, supplyCommitments bool) Seedling {
+		return Seedling{
+			AssetName:         name,
+			AssetType:         asset.Normal,
+			Amount:            1,
+			SupplyCommitments: supplyCommitments,
+			DelegationKey:     fn.None[keychain.KeyDescriptor](),
+		}
+	}
+
+	t.Run("validate on populated batch leaves it unchanged",
+		func(t *testing.T) {
+			batch := RandMintingBatch(
+				t, WithTotalSeedlings(3),
+			)
+			seedlingsBefore := len(batch.Seedlings)
+			supplyBefore := batch.SupplyCommitments
+
+			candidate := mkCandidate(
+				"validate-only-candidate", supplyBefore,
+			)
+
+			err := batch.validateSeedling(candidate)
+			require.NoError(t, err)
+
+			require.Equal(t, seedlingsBefore, len(batch.Seedlings))
+			require.Equal(
+				t, supplyBefore, batch.SupplyCommitments,
+			)
+			require.NotContains(
+				t, batch.Seedlings, candidate.AssetName,
+			)
+		})
+
+	t.Run("validate failure also leaves batch unchanged",
+		func(t *testing.T) {
+			batch := RandMintingBatch(
+				t, WithTotalSeedlings(3),
+			)
+			seedlingsBefore := len(batch.Seedlings)
+			supplyBefore := batch.SupplyCommitments
+
+			// Force a SupplyCommitments mismatch so
+			// validateUniCommitment rejects the seedling.
+			candidate := mkCandidate(
+				"validate-fail-candidate", !supplyBefore,
+			)
+
+			err := batch.validateSeedling(candidate)
+			require.Error(t, err)
+
+			require.Equal(t, seedlingsBefore, len(batch.Seedlings))
+			require.Equal(
+				t, supplyBefore, batch.SupplyCommitments,
+			)
+			require.NotContains(
+				t, batch.Seedlings, candidate.AssetName,
+			)
+		})
+
+	t.Run("commit on empty batch adopts SupplyCommitments",
+		func(t *testing.T) {
+			batch := &MintingBatch{}
+
+			candidate := mkCandidate("first-seedling", false)
+
+			require.NoError(t, batch.validateSeedling(candidate))
+
+			// validateSeedling must not have set
+			// SupplyCommitments even though this would be
+			// "the first seedling" -- only commitSeedling may
+			// do that.
+			require.False(t, batch.SupplyCommitments)
+			require.Empty(t, batch.Seedlings)
+
+			batch.commitSeedling(candidate)
+
+			require.Equal(t, 1, len(batch.Seedlings))
+			require.Contains(
+				t, batch.Seedlings, candidate.AssetName,
+			)
+			require.Equal(
+				t, candidate.SupplyCommitments,
+				batch.SupplyCommitments,
+			)
+		})
+}

--- a/tapgarden/caretaker.go
+++ b/tapgarden/caretaker.go
@@ -198,7 +198,7 @@ func (b *BatchCaretaker) Cancel() error {
 	// In the pending state, the batch seedlings have not sprouted yet.
 	case BatchStatePending, BatchStateFrozen:
 		err := b.cfg.Log.UpdateBatchState(
-			ctx, b.cfg.Batch.BatchKey.PubKey,
+			ctx, b.cfg.Batch,
 			BatchStateSeedlingCancelled,
 		)
 		if err != nil {
@@ -219,7 +219,7 @@ func (b *BatchCaretaker) Cancel() error {
 
 	case BatchStateCommitted:
 		err := b.cfg.Log.UpdateBatchState(
-			ctx, b.cfg.Batch.BatchKey.PubKey,
+			ctx, b.cfg.Batch,
 			BatchStateSproutCancelled,
 		)
 		if err != nil {
@@ -320,7 +320,12 @@ func (b *BatchCaretaker) advanceStateUntil(currentState,
 
 		currentState = nextState
 
-		b.cfg.Batch.UpdateState(currentState)
+		// We do not mirror currentState into the in-memory batch
+		// here. Each branch of stateStep that transitions state does
+		// so via a MintingStore call, which advances the in-memory
+		// mirror only after the DB write succeeds. Writing the local
+		// currentState here would re-introduce the two-truth split
+		// that the store calls exist to prevent.
 	}
 
 	return currentState, nil
@@ -387,12 +392,17 @@ func (b *BatchCaretaker) assetCultivator() {
 				confInfo.BlockHash, confInfo.BlockHeight)
 
 			b.confInfo = confInfo
-			b.cfg.Batch.UpdateState(BatchStateConfirmed)
-			currentBatchState = b.cfg.Batch.State()
 
+			// Hand BatchStateConfirmed to advanceStateUntil
+			// directly rather than mutating the in-memory state
+			// here: the Confirmed branch of stateStep calls
+			// MarkBatchConfirmed, which advances both the on-disk
+			// row and the in-memory mirror as one step. Setting
+			// memory here would re-create the two-truth window.
+			//
 			// TODO(roasbeef): use a "trigger" here instead?
 			_, err = b.advanceStateUntil(
-				currentBatchState, BatchStateFinalized,
+				BatchStateConfirmed, BatchStateFinalized,
 			)
 			if err != nil {
 				log.Error(err)
@@ -667,7 +677,7 @@ func (b *BatchCaretaker) stateStep(currentState BatchState) (BatchState, error) 
 		// replacing the existing seedlings we had created for each of
 		// these assets.
 		err = b.cfg.Log.AddSproutsToBatch(
-			ctx, b.cfg.Batch.BatchKey.PubKey,
+			ctx, b.cfg.Batch,
 			&fundedGenesisPsbt, b.cfg.Batch.RootAssetCommitment,
 		)
 		if err != nil {
@@ -793,7 +803,7 @@ func (b *BatchCaretaker) stateStep(currentState BatchState) (BatchState, error) 
 			TapscriptRoot(nil)
 
 		err = b.cfg.Log.CommitSignedGenesisTx(
-			ctx, b.cfg.Batch.BatchKey.PubKey,
+			ctx, b.cfg.Batch,
 			&b.cfg.Batch.GenesisPacket.FundedPsbt,
 			b.anchorOutputIndex, merkleRoot, tapCommitmentRoot[:],
 			siblingBytes,
@@ -1159,7 +1169,7 @@ func (b *BatchCaretaker) stateStep(currentState BatchState) (BatchState, error) 
 		}
 
 		err = b.cfg.Log.MarkBatchConfirmed(
-			ctx, b.cfg.Batch.BatchKey.PubKey, confInfo.BlockHash,
+			ctx, b.cfg.Batch, confInfo.BlockHash,
 			confInfo.BlockHeight, confInfo.TxIndex,
 			mintingProofBlobs,
 		)
@@ -1190,7 +1200,7 @@ func (b *BatchCaretaker) stateStep(currentState BatchState) (BatchState, error) 
 		ctx, cancel := b.WithCtxQuit()
 		defer cancel()
 		err := b.cfg.Log.UpdateBatchState(
-			ctx, b.cfg.Batch.BatchKey.PubKey, BatchStateFinalized,
+			ctx, b.cfg.Batch, BatchStateFinalized,
 		)
 		return BatchStateFinalized, err
 
@@ -1335,23 +1345,19 @@ func (b *BatchCaretaker) batchStreamUniverseItems(ctx context.Context,
 }
 
 // AssetMintEvent is an event which is sent to the BatchCaretaker's event
-// subscribers after a state was executed successfully.
+// subscribers after a state was executed successfully. The just-executed
+// state is read from Batch.State(); the event's constructors mirror the
+// state into the copied batch so it cannot lag the executed step.
 type AssetMintEvent struct {
 	// timestamp is the time the event was created.
 	timestamp time.Time
 
-	// BatchState is the last state that was executed before the event is
-	// received. This field takes precedence over Batch.State() as that
-	// might not always be updated when the event is created. In case Error
-	// below is set, the BatchState is the state that was executed that lead
-	// to the error.
-	BatchState BatchState
-
 	// Error is an optional error, indicating that something went wrong
-	// during the execution of the BatchState above.
+	// during the execution of Batch.State().
 	Error error
 
-	// Batch is the batch that is being minted.
+	// Batch is the batch that is being minted. Batch.State() reports the
+	// last state that was executed before the event was emitted.
 	Batch *MintingBatch
 }
 
@@ -1360,12 +1366,15 @@ func (e *AssetMintEvent) Timestamp() time.Time {
 	return e.timestamp
 }
 
-// newAssetMintEvent creates a new AssetMintEvent from the given batch.
+// newAssetMintEvent creates a new AssetMintEvent from the given batch. The
+// copied batch's state is set to the just-executed state so consumers can
+// trust Batch.State() to reflect the step that produced the event.
 func newAssetMintEvent(state BatchState, b *MintingBatch) *AssetMintEvent {
+	batchCopy := b.Copy()
+	batchCopy.setState(state)
 	return &AssetMintEvent{
-		timestamp:  time.Now().UTC(),
-		BatchState: state,
-		Batch:      b.Copy(),
+		timestamp: time.Now().UTC(),
+		Batch:     batchCopy,
 	}
 }
 
@@ -1374,11 +1383,12 @@ func newAssetMintEvent(state BatchState, b *MintingBatch) *AssetMintEvent {
 func newAssetMintErrorEvent(err error, state BatchState,
 	b *MintingBatch) *AssetMintEvent {
 
+	batchCopy := b.Copy()
+	batchCopy.setState(state)
 	return &AssetMintEvent{
-		timestamp:  time.Now().UTC(),
-		BatchState: state,
-		Error:      err,
-		Batch:      b.Copy(),
+		timestamp: time.Now().UTC(),
+		Error:     err,
+		Batch:     batchCopy,
 	}
 }
 

--- a/tapgarden/caretaker.go
+++ b/tapgarden/caretaker.go
@@ -198,7 +198,7 @@ func (b *BatchCaretaker) Cancel() error {
 	// In the pending state, the batch seedlings have not sprouted yet.
 	case BatchStatePending, BatchStateFrozen:
 		err := b.cfg.Log.UpdateBatchState(
-			ctx, b.cfg.Batch.BatchKey.PubKey,
+			ctx, b.cfg.Batch,
 			BatchStateSeedlingCancelled,
 		)
 		if err != nil {
@@ -219,7 +219,7 @@ func (b *BatchCaretaker) Cancel() error {
 
 	case BatchStateCommitted:
 		err := b.cfg.Log.UpdateBatchState(
-			ctx, b.cfg.Batch.BatchKey.PubKey,
+			ctx, b.cfg.Batch,
 			BatchStateSproutCancelled,
 		)
 		if err != nil {
@@ -320,7 +320,12 @@ func (b *BatchCaretaker) advanceStateUntil(currentState,
 
 		currentState = nextState
 
-		b.cfg.Batch.UpdateState(currentState)
+		// We do not mirror currentState into the in-memory batch
+		// here. Each branch of stateStep that transitions state does
+		// so via a MintingStore call, which advances the in-memory
+		// mirror only after the DB write succeeds. Writing the local
+		// currentState here would re-introduce the two-truth split
+		// that the store calls exist to prevent.
 	}
 
 	return currentState, nil
@@ -387,12 +392,17 @@ func (b *BatchCaretaker) assetCultivator() {
 				confInfo.BlockHash, confInfo.BlockHeight)
 
 			b.confInfo = confInfo
-			b.cfg.Batch.UpdateState(BatchStateConfirmed)
-			currentBatchState = b.cfg.Batch.State()
 
+			// Hand BatchStateConfirmed to advanceStateUntil
+			// directly rather than mutating the in-memory state
+			// here: the Confirmed branch of stateStep calls
+			// MarkBatchConfirmed, which advances both the on-disk
+			// row and the in-memory mirror as one step. Setting
+			// memory here would re-create the two-truth window.
+			//
 			// TODO(roasbeef): use a "trigger" here instead?
 			_, err = b.advanceStateUntil(
-				currentBatchState, BatchStateFinalized,
+				BatchStateConfirmed, BatchStateFinalized,
 			)
 			if err != nil {
 				log.Error(err)
@@ -667,7 +677,7 @@ func (b *BatchCaretaker) stateStep(currentState BatchState) (BatchState, error) 
 		// replacing the existing seedlings we had created for each of
 		// these assets.
 		err = b.cfg.Log.AddSproutsToBatch(
-			ctx, b.cfg.Batch.BatchKey.PubKey,
+			ctx, b.cfg.Batch,
 			&fundedGenesisPsbt, b.cfg.Batch.RootAssetCommitment,
 		)
 		if err != nil {
@@ -793,7 +803,7 @@ func (b *BatchCaretaker) stateStep(currentState BatchState) (BatchState, error) 
 			TapscriptRoot(nil)
 
 		err = b.cfg.Log.CommitSignedGenesisTx(
-			ctx, b.cfg.Batch.BatchKey.PubKey,
+			ctx, b.cfg.Batch,
 			&b.cfg.Batch.GenesisPacket.FundedPsbt,
 			b.anchorOutputIndex, merkleRoot, tapCommitmentRoot[:],
 			siblingBytes,
@@ -1159,7 +1169,7 @@ func (b *BatchCaretaker) stateStep(currentState BatchState) (BatchState, error) 
 		}
 
 		err = b.cfg.Log.MarkBatchConfirmed(
-			ctx, b.cfg.Batch.BatchKey.PubKey, confInfo.BlockHash,
+			ctx, b.cfg.Batch, confInfo.BlockHash,
 			confInfo.BlockHeight, confInfo.TxIndex,
 			mintingProofBlobs,
 		)
@@ -1190,7 +1200,7 @@ func (b *BatchCaretaker) stateStep(currentState BatchState) (BatchState, error) 
 		ctx, cancel := b.WithCtxQuit()
 		defer cancel()
 		err := b.cfg.Log.UpdateBatchState(
-			ctx, b.cfg.Batch.BatchKey.PubKey, BatchStateFinalized,
+			ctx, b.cfg.Batch, BatchStateFinalized,
 		)
 		return BatchStateFinalized, err
 
@@ -1345,23 +1355,19 @@ func (b *BatchCaretaker) batchStreamUniverseItems(ctx context.Context,
 }
 
 // AssetMintEvent is an event which is sent to the BatchCaretaker's event
-// subscribers after a state was executed successfully.
+// subscribers after a state was executed successfully. The just-executed
+// state is read from Batch.State(); the event's constructors mirror the
+// state into the copied batch so it cannot lag the executed step.
 type AssetMintEvent struct {
 	// timestamp is the time the event was created.
 	timestamp time.Time
 
-	// BatchState is the last state that was executed before the event is
-	// received. This field takes precedence over Batch.State() as that
-	// might not always be updated when the event is created. In case Error
-	// below is set, the BatchState is the state that was executed that lead
-	// to the error.
-	BatchState BatchState
-
 	// Error is an optional error, indicating that something went wrong
-	// during the execution of the BatchState above.
+	// during the execution of Batch.State().
 	Error error
 
-	// Batch is the batch that is being minted.
+	// Batch is the batch that is being minted. Batch.State() reports the
+	// last state that was executed before the event was emitted.
 	Batch *MintingBatch
 }
 
@@ -1370,12 +1376,15 @@ func (e *AssetMintEvent) Timestamp() time.Time {
 	return e.timestamp
 }
 
-// newAssetMintEvent creates a new AssetMintEvent from the given batch.
+// newAssetMintEvent creates a new AssetMintEvent from the given batch. The
+// copied batch's state is set to the just-executed state so consumers can
+// trust Batch.State() to reflect the step that produced the event.
 func newAssetMintEvent(state BatchState, b *MintingBatch) *AssetMintEvent {
+	batchCopy := b.Copy()
+	batchCopy.setState(state)
 	return &AssetMintEvent{
-		timestamp:  time.Now().UTC(),
-		BatchState: state,
-		Batch:      b.Copy(),
+		timestamp: time.Now().UTC(),
+		Batch:     batchCopy,
 	}
 }
 
@@ -1384,11 +1393,12 @@ func newAssetMintEvent(state BatchState, b *MintingBatch) *AssetMintEvent {
 func newAssetMintErrorEvent(err error, state BatchState,
 	b *MintingBatch) *AssetMintEvent {
 
+	batchCopy := b.Copy()
+	batchCopy.setState(state)
 	return &AssetMintEvent{
-		timestamp:  time.Now().UTC(),
-		BatchState: state,
-		Error:      err,
-		Batch:      b.Copy(),
+		timestamp: time.Now().UTC(),
+		Error:     err,
+		Batch:     batchCopy,
 	}
 }
 

--- a/tapgarden/interface.go
+++ b/tapgarden/interface.go
@@ -202,7 +202,12 @@ type MintingStore interface {
 	// AddSeedlingsToBatch adds a new seedling to an existing batch. Once
 	// added this batch should remain in the BatchStatePending state.
 	//
-	// TODO(roasbeef): assumption that only one pending batch at a time?
+	// The "exactly one batch in BatchStatePending or BatchStateFrozen
+	// at a time" invariant the planter relies on is enforced at the
+	// DB layer by migration 000060 (a partial unique index on
+	// asset_minting_batches). Callers may assume that any successful
+	// CommitMintingBatch left the singleton slot occupied by exactly
+	// the batch they just committed.
 	AddSeedlingsToBatch(ctx context.Context, batchKey *btcec.PublicKey,
 		seedlings ...*Seedling) error
 

--- a/tapgarden/interface.go
+++ b/tapgarden/interface.go
@@ -191,9 +191,12 @@ type MintingStore interface {
 	// by its batch key.
 	CommitMintingBatch(ctx context.Context, newBatch *MintingBatch) error
 
-	// UpdateBatchState updates the batch state on disk identified by the
-	// batch key.
-	UpdateBatchState(ctx context.Context, batchKey *btcec.PublicKey,
+	// UpdateBatchState writes the new batch state to disk and, on
+	// success, mirrors it into the in-memory batch. Either both writes
+	// succeed and the in-memory state advances, or both stay at the
+	// prior value. Callers must never mutate batch state by any other
+	// route.
+	UpdateBatchState(ctx context.Context, batch *MintingBatch,
 		newState BatchState) error
 
 	// AddSeedlingsToBatch adds a new seedling to an existing batch. Once
@@ -230,9 +233,10 @@ type MintingStore interface {
 	// a GenesisPacket, that once signed and broadcast with create the
 	// set of assets on chain.
 	//
-	// NOTE: The BatchState should transition to BatchStateCommitted upon a
-	// successful call.
-	AddSproutsToBatch(ctx context.Context, batchKey *btcec.PublicKey,
+	// NOTE: On success the batch transitions to BatchStateCommitted on
+	// disk and the in-memory state of the supplied batch is advanced to
+	// match. On failure neither moves.
+	AddSproutsToBatch(ctx context.Context, batch *MintingBatch,
 		genesisPacket *FundedMintAnchorPsbt,
 		assets *commitment.TapCommitment) error
 
@@ -241,9 +245,10 @@ type MintingStore interface {
 	// left/right sibling for the Taproot Asset tapscript commitment in the
 	// transaction.
 	//
-	// NOTE: The BatchState should transition to the BatchStateBroadcast
-	// state upon a successful call.
-	CommitSignedGenesisTx(ctx context.Context, batchKey *btcec.PublicKey,
+	// NOTE: On success the batch transitions to BatchStateBroadcast on
+	// disk and the in-memory state of the supplied batch is advanced to
+	// match. On failure neither moves.
+	CommitSignedGenesisTx(ctx context.Context, batch *MintingBatch,
 		genesisTx *tapsend.FundedPsbt, anchorOutputIndex uint32,
 		merkleRoot, tapTreeRoot, tapSibling []byte) error
 
@@ -251,9 +256,10 @@ type MintingStore interface {
 	// block location information determines where exactly in the chain the
 	// batch was confirmed.
 	//
-	// NOTE: The BatchState should transition to the BatchStateConfirmed
-	// state upon a successful call.
-	MarkBatchConfirmed(ctx context.Context, batchKey *btcec.PublicKey,
+	// NOTE: On success the batch transitions to BatchStateConfirmed on
+	// disk and the in-memory state of the supplied batch is advanced to
+	// match. On failure neither moves.
+	MarkBatchConfirmed(ctx context.Context, batch *MintingBatch,
 		blockHash *chainhash.Hash, blockHeight uint32,
 		txIndex uint32, mintingProofs proof.AssetBlobs) error
 

--- a/tapgarden/interface.go
+++ b/tapgarden/interface.go
@@ -202,7 +202,12 @@ type MintingStore interface {
 	// AddSeedlingsToBatch adds a new seedling to an existing batch. Once
 	// added this batch should remain in the BatchStatePending state.
 	//
-	// TODO(roasbeef): assumption that only one pending batch at a time?
+	// The "exactly one batch in BatchStatePending or BatchStateFrozen
+	// at a time" invariant the planter relies on is enforced at the
+	// DB layer by migration 000061 (a partial unique index on
+	// asset_minting_batches). Callers may assume that any successful
+	// CommitMintingBatch left the singleton slot occupied by exactly
+	// the batch they just committed.
 	AddSeedlingsToBatch(ctx context.Context, batchKey *btcec.PublicKey,
 		seedlings ...*Seedling) error
 

--- a/tapgarden/planter.go
+++ b/tapgarden/planter.go
@@ -538,7 +538,7 @@ func (c *ChainPlanter) Start() error {
 				log.Warnf("Marking batch as cancelled (%x)",
 					batchKey)
 				err := c.cfg.Log.UpdateBatchState(
-					ctx, batch.BatchKey.PubKey,
+					ctx, batch,
 					BatchStateSeedlingCancelled,
 				)
 
@@ -609,12 +609,12 @@ func (c *ChainPlanter) Start() error {
 
 				// Any pending batch that was funded and sealed
 				// can now be set as frozen. We are already not
-				// able to add new seedlings to the batch.
-				batch.UpdateState(BatchStateFrozen)
-
+				// able to add new seedlings to the batch. The
+				// store call below moves both the on-disk row
+				// and the in-memory mirror atomically; if it
+				// fails, neither has moved.
 				err := c.cfg.Log.UpdateBatchState(
-					ctx, batch.BatchKey.PubKey,
-					BatchStateFrozen,
+					ctx, batch, BatchStateFrozen,
 				)
 				if err != nil {
 					log.Warnf("Failed to update batch "+
@@ -710,7 +710,11 @@ func (c *ChainPlanter) newBatch() (*MintingBatch, error) {
 		Seedlings:    make(map[string]*Seedling),
 		AssetMetas:   make(AssetMetas),
 	}
-	newBatch.UpdateState(BatchStatePending)
+	// The batch is private to this caller until CommitMintingBatch
+	// succeeds, so setting the in-memory state directly here does not
+	// open a two-truth window: the next DB call is the first to publish
+	// the row, with state=Pending.
+	newBatch.setState(BatchStatePending)
 	return newBatch, nil
 }
 
@@ -1430,7 +1434,7 @@ func freezeMintingBatch(ctx context.Context, batchStore MintingStore,
 	//
 	// TODO(roasbeef): assert not in some other state first?
 	return batchStore.UpdateBatchState(
-		ctx, batchKey, BatchStateFrozen,
+		ctx, batch, BatchStateFrozen,
 	)
 }
 
@@ -1852,10 +1856,12 @@ func (c *ChainPlanter) cancelMintingBatch(ctx context.Context,
 	log.Infof("Cancelling MintingBatch(key=%x, num_assets=%v)",
 		batchKeySerialized, len(c.pendingBatch.Seedlings))
 
-	// If the target batch was not assigned a caretaker, we only need to
-	// update the batch state on disk to cancel it.
+	// If the target batch was not assigned a caretaker, the only
+	// non-cancelled batch in play is c.pendingBatch (canCancelBatch
+	// guarantees this). Update the batch state on disk and in memory in
+	// a single atomic call.
 	err := c.cfg.Log.UpdateBatchState(
-		ctx, batchKey, BatchStateSeedlingCancelled,
+		ctx, c.pendingBatch, BatchStateSeedlingCancelled,
 	)
 	if err != nil {
 		return fmt.Errorf("unable to cancel minting batch: %w", err)
@@ -1919,7 +1925,6 @@ func (c *ChainPlanter) gardener() {
 			}
 			req.updates <- SeedlingUpdate{
 				PendingBatch: batchCopy,
-				NewState:     MintingStateSeed,
 			}
 
 		// A caretaker has finished processing their batch to full
@@ -2709,12 +2714,13 @@ func (c *ChainPlanter) finalizeBatch(params FinalizeParams) (*BatchCaretaker,
 
 	// Now that funding and sealing have succeeded, freeze the
 	// batch on disk and in memory. This means no further
-	// seedlings can be added to this batch.
+	// seedlings can be added to this batch. freezeMintingBatch
+	// updates both the on-disk row and the in-memory state in a
+	// single atomic step via the MintingStore.
 	err = freezeMintingBatch(ctx, c.cfg.Log, c.pendingBatch)
 	if err != nil {
 		return nil, err
 	}
-	c.pendingBatch.UpdateState(BatchStateFrozen)
 	caretaker := c.newCaretakerForBatch(c.pendingBatch, feeRate)
 	if err := caretaker.Start(); err != nil {
 		return nil, fmt.Errorf("unable to start new caretaker: %w", err)
@@ -3043,12 +3049,15 @@ func (c *ChainPlanter) prepAssetSeedling(ctx context.Context,
 			return err
 		}
 
-		c.pendingBatch = newBatch
-
 		log.Infof("Attempting to add a seedling to a new batch "+
 			"(seedling=%v)", req)
 
-		err = c.pendingBatch.AddSeedling(*req)
+		// Stage the seedling on the local newBatch and persist
+		// the whole batch atomically via CommitMintingBatch. The
+		// planter's pendingBatch is assigned only after the DB
+		// write succeeds; on any failure newBatch is discarded
+		// and the planter state is unchanged.
+		err = newBatch.AddSeedling(*req)
 		if err != nil {
 			return fmt.Errorf("failed to add seedling to batch: %w",
 				err)
@@ -3056,10 +3065,12 @@ func (c *ChainPlanter) prepAssetSeedling(ctx context.Context,
 
 		ctx, cancel := c.WithCtxQuit()
 		defer cancel()
-		err = c.cfg.Log.CommitMintingBatch(ctx, c.pendingBatch)
+		err = c.cfg.Log.CommitMintingBatch(ctx, newBatch)
 		if err != nil {
 			return err
 		}
+
+		c.pendingBatch = newBatch
 
 	// A batch already exists, so we'll add this seedling to the batch,
 	// committing it to disk fully before we move on.
@@ -3067,13 +3078,18 @@ func (c *ChainPlanter) prepAssetSeedling(ctx context.Context,
 		log.Infof("Attempting to add a seedling to batch (seedling=%v)",
 			req)
 
-		err := c.pendingBatch.AddSeedling(*req)
+		// Validate first without mutating the in-memory batch,
+		// then persist, then mirror the seedling into memory.
+		// This ordering ensures the in-memory batch never
+		// advances unless the DB write succeeded: a failed
+		// AddSeedlingsToBatch leaves both disk and memory at
+		// their prior state.
+		err := c.pendingBatch.validateSeedling(*req)
 		if err != nil {
 			return fmt.Errorf("failed to add seedling to batch: %w",
 				err)
 		}
 
-		// Now that we know the seedling is ok, we'll write it to disk.
 		ctx, cancel := c.WithCtxQuit()
 		defer cancel()
 		err = c.cfg.Log.AddSeedlingsToBatch(
@@ -3082,6 +3098,8 @@ func (c *ChainPlanter) prepAssetSeedling(ctx context.Context,
 		if err != nil {
 			return err
 		}
+
+		c.pendingBatch.commitSeedling(*req)
 	}
 
 	// Now that we have the batch committed to disk, we'll return back to

--- a/tapgarden/planter.go
+++ b/tapgarden/planter.go
@@ -850,6 +850,9 @@ func anchorTxOutputIndexes(fundedPsbt tapsend.FundedPsbt,
 type DelegationKey = keychain.KeyDescriptor
 
 // fetchDelegationKey retrieves the delegation key from the given batch.
+// The key is read from the batch's unique group anchor seedling; an
+// error is returned if the anchor cannot be identified
+// deterministically.
 func fetchDelegationKey(pendingBatch *MintingBatch) (fn.Option[DelegationKey],
 	error) {
 
@@ -867,26 +870,13 @@ func fetchDelegationKey(pendingBatch *MintingBatch) (fn.Option[DelegationKey],
 			"delegation key: no seedlings in batch")
 	}
 
-	// Retrieve batch anchor seedling.
-	var groupAnchorSeedling fn.Option[Seedling]
-	for _, seedling := range pendingBatch.Seedlings {
-		if seedling.GroupAnchor == nil {
-			groupAnchorSeedling = fn.Some(*seedling)
-			break
-		}
-
-		groupAnchorSeedling =
-			fn.Some(*pendingBatch.Seedlings[*seedling.GroupAnchor])
-		break
+	anchor, err := pendingBatch.uniqueAnchorSeedling()
+	if err != nil {
+		return zero, fmt.Errorf("unable to identify group anchor "+
+			"seedling: %w", err)
 	}
 
-	delegationKeyDesc := fn.MapOptionZ(groupAnchorSeedling,
-		func(s Seedling) fn.Option[keychain.KeyDescriptor] {
-			return s.DelegationKey
-		},
-	)
-
-	return delegationKeyDesc, nil
+	return anchor.DelegationKey, nil
 }
 
 // fetchPreCommitGroupKey retrieves the group key associated with the
@@ -914,28 +904,19 @@ func fetchPreCommitGroupKey(
 		return zero, nil
 	}
 
-	// Retrieve batch anchor seedling.
-	var groupAnchorSeedling Seedling
-	for _, seedling := range pendingBatch.Seedlings {
-		// If the seedling has no group anchor, we can use it as the
-		// group anchor seedling.
-		if seedling.GroupAnchor == nil {
-			groupAnchorSeedling = *seedling
-			break
-		}
-
-		groupAnchorSeedling =
-			*pendingBatch.Seedlings[*seedling.GroupAnchor]
-		break
+	anchor, err := pendingBatch.uniqueAnchorSeedling()
+	if err != nil {
+		return zero, fmt.Errorf("unable to identify group anchor "+
+			"seedling: %w", err)
 	}
 
 	// If the group info is unset, then there is no pre-commitment group pub
 	// key defined in the batch.
-	if groupAnchorSeedling.GroupInfo == nil {
+	if anchor.GroupInfo == nil {
 		return zero, nil
 	}
 
-	return fn.Some(groupAnchorSeedling.GroupInfo.GroupPubKey), nil
+	return fn.Some(anchor.GroupInfo.GroupPubKey), nil
 }
 
 // anchorTxFeeRate computes the fee rate for the anchor transaction. If a fee

--- a/tapgarden/planter.go
+++ b/tapgarden/planter.go
@@ -569,7 +569,7 @@ func (c *ChainPlanter) Start() error {
 				if !batch.IsFunded() {
 					log.Infof("Funding non-finalized "+
 						"batch from DB (%x)", batchKey)
-					fundErr = c.fundBatch(
+					fundErr = c.applyFundingToBatch(
 						ctx, FundParams{}, batch,
 					)
 				}
@@ -2005,8 +2005,8 @@ func (c *ChainPlanter) gardener() {
 				}
 
 				ctx, cancel := c.WithCtxQuit()
-				err = c.fundBatch(
-					ctx, *fundReqParams, c.pendingBatch,
+				err = c.fundPendingBatch(
+					ctx, *fundReqParams,
 				)
 				cancel()
 				if err != nil {
@@ -2155,36 +2155,47 @@ func (c *ChainPlanter) gardener() {
 	}
 }
 
-// fundBatch attempts to fund a minting batch and create a funded genesis PSBT.
-// This PSBT is a template that the caretaker will modify when finalizing the
-// batch. If a feerate or tapscript sibling are provided, those will be used
-// when funding the batch. If no pending batch exists, a batch will be created
-// with the funded genesis PSBT. After funding, the pending batch will be
-// saved to disk and updated in memory.
-func (c *ChainPlanter) fundBatch(ctx context.Context, params FundParams,
-	workingBatch *MintingBatch) error {
+// fundingPrep stores a tapscript-sibling root hash (already persisted
+// to the tree store) and a closure that computes a funded mint anchor
+// PSBT for a given batch without mutating it. Both fields are
+// populated by prepareFunding and consumed by createFundedBatch /
+// applyFundingToBatch.
+type fundingPrep struct {
+	// rootHash is the persisted root hash of the optional tapscript
+	// sibling supplied via FundParams. nil if no sibling was given.
+	rootHash *chainhash.Hash
+
+	// computeFunding builds the funded genesis PSBT for a batch
+	// without mutating it. Callers must apply the result only after
+	// all persistence has succeeded, so a failure leaves the batch
+	// unchanged.
+	computeFunding func(batch *MintingBatch) (*FundedMintAnchorPsbt,
+		error)
+}
+
+// prepareFunding stores the optional tapscript sibling and constructs
+// the funding-computation closure shared by createFundedBatch and
+// applyFundingToBatch.
+func (c *ChainPlanter) prepareFunding(ctx context.Context,
+	params FundParams) (fundingPrep, error) {
 
 	var (
+		zero     fundingPrep
 		rootHash *chainhash.Hash
 		err      error
 	)
 
-	// If a tapscript tree was specified for this batch, we'll store it on
-	// disk. The caretaker we start for this batch will use it when deriving
-	// the final Taproot output key.
+	// If a tapscript tree was specified for this batch, we'll store
+	// it on disk. The caretaker we start for this batch will use it
+	// when deriving the final Taproot output key.
 	params.SiblingTapTree.WhenSome(func(tn asset.TapscriptTreeNodes) {
 		rootHash, err = c.cfg.TreeStore.StoreTapscriptTree(ctx, tn)
 	})
-
 	if err != nil {
-		return fmt.Errorf("unable to store tapscript tree for minting "+
-			"batch: %w", err)
+		return zero, fmt.Errorf("unable to store tapscript tree "+
+			"for minting batch: %w", err)
 	}
 
-	// computeFunding builds the funded genesis PSBT for a batch
-	// without mutating it. The caller is responsible for applying
-	// the result to the batch only after all persistence has
-	// succeeded, so a failure leaves the batch unchanged.
 	computeFunding := func(batch *MintingBatch) (
 		*FundedMintAnchorPsbt, error) {
 
@@ -2196,8 +2207,8 @@ func (c *ChainPlanter) fundBatch(ctx context.Context, params FundParams,
 
 		batchKey := asset.ToSerialized(batch.BatchKey.PubKey)
 
-		// walletFundPsbt is a closure that will be used to fund the
-		// batch with the specified fee rate.
+		// walletFundPsbt is a closure that will be used to fund
+		// the batch with the specified fee rate.
 		walletFundPsbt := func(ctx context.Context,
 			anchorPkt psbt.Packet) (tapsend.FundedPsbt, error) {
 
@@ -2226,39 +2237,78 @@ func (c *ChainPlanter) fundBatch(ctx context.Context, params FundParams,
 		return &mintAnchorTx, nil
 	}
 
-	// If we don't have a batch, we'll create an empty batch before funding
-	// and writing to disk.
-	if workingBatch == nil {
-		newBatch, err := c.newBatch()
-		if err != nil {
-			return fmt.Errorf("unable to create new batch: %w", err)
-		}
+	return fundingPrep{
+		rootHash:       rootHash,
+		computeFunding: computeFunding,
+	}, nil
+}
 
-		mintAnchorTx, err := computeFunding(newBatch)
-		if err != nil {
-			return err
-		}
+// createFundedBatch derives a fresh minting batch, computes its
+// funding, and persists the funded batch to disk as a single new row.
+// On any failure no new batch is committed and no in-memory state is
+// touched; the caller may try again. The returned batch is ready to
+// be installed as c.pendingBatch by the caller.
+//
+// NOTE: This is the create half of what used to be a single fundBatch
+// function with two purposes. The split exists so that "create a new
+// funded batch" cannot be silently dispatched into "update an
+// existing batch's funding" (or vice-versa) by callers passing a
+// stale or wrong reference -- the bug shape behind #2136.
+func (c *ChainPlanter) createFundedBatch(ctx context.Context,
+	params FundParams) (*MintingBatch, error) {
 
-		// Apply the funding to the local batch and commit. If the
-		// commit fails, newBatch is discarded and the planter's
-		// pendingBatch is never assigned.
-		newBatch.GenesisPacket = mintAnchorTx
-		if rootHash != nil {
-			newBatch.tapSibling = rootHash
-		}
-
-		err = c.cfg.Log.CommitMintingBatch(ctx, newBatch)
-		if err != nil {
-			return err
-		}
-
-		c.pendingBatch = newBatch
-		return nil
+	prep, err := c.prepareFunding(ctx, params)
+	if err != nil {
+		return nil, err
 	}
 
-	// Compute the funded genesis packet for the existing batch
-	// without mutating it yet.
-	mintAnchorTx, err := computeFunding(workingBatch)
+	newBatch, err := c.newBatch()
+	if err != nil {
+		return nil, fmt.Errorf("unable to create new batch: %w", err)
+	}
+
+	mintAnchorTx, err := prep.computeFunding(newBatch)
+	if err != nil {
+		return nil, err
+	}
+
+	// Apply the funding to the local batch and commit. If the
+	// commit fails, newBatch is discarded and the caller's planter
+	// state is never assigned.
+	newBatch.GenesisPacket = mintAnchorTx
+	if prep.rootHash != nil {
+		newBatch.tapSibling = prep.rootHash
+	}
+
+	if err := c.cfg.Log.CommitMintingBatch(ctx, newBatch); err != nil {
+		return nil, err
+	}
+
+	return newBatch, nil
+}
+
+// applyFundingToBatch computes funding for an existing on-disk batch,
+// persists the funding atomically (sibling + genesis TX in one DB
+// transaction), and only then mirrors the funding into the in-memory
+// batch. On any failure neither disk nor memory is mutated.
+//
+// NOTE: This is the update half of the former fundBatch. It must
+// never be called with a batch that has not yet been written to disk
+// -- use createFundedBatch for that case.
+func (c *ChainPlanter) applyFundingToBatch(ctx context.Context,
+	params FundParams, batch *MintingBatch) error {
+
+	if batch == nil {
+		return fmt.Errorf("applyFundingToBatch requires non-nil " +
+			"batch; use createFundedBatch to create a new one")
+	}
+
+	prep, err := c.prepareFunding(ctx, params)
+	if err != nil {
+		return err
+	}
+
+	mintAnchorTx, err := prep.computeFunding(batch)
 	if err != nil {
 		return err
 	}
@@ -2268,19 +2318,42 @@ func (c *ChainPlanter) fundBatch(ctx context.Context, params FundParams,
 	// failure cannot leave the batch with one persisted and the
 	// other absent.
 	err = c.cfg.Log.CommitBatchFunding(
-		ctx, workingBatch.BatchKey.PubKey, rootHash, *mintAnchorTx,
+		ctx, batch.BatchKey.PubKey, prep.rootHash, *mintAnchorTx,
 	)
 	if err != nil {
 		return fmt.Errorf("unable to commit batch funding: %w", err)
 	}
 
-	// All persistence succeeded; commit the funding to memory.
-	workingBatch.GenesisPacket = mintAnchorTx
-	if rootHash != nil {
-		workingBatch.tapSibling = rootHash
+	// All persistence succeeded; mirror the funding into memory.
+	batch.GenesisPacket = mintAnchorTx
+	if prep.rootHash != nil {
+		batch.tapSibling = prep.rootHash
 	}
 
 	return nil
+}
+
+// fundPendingBatch funds c.pendingBatch, creating it first if it does
+// not yet exist. This is the convenience wrapper used by the
+// gardener's fund-batch request handler and by finalizeBatch; both
+// have the same "I want the pending batch funded, regardless of
+// whether it exists yet" semantics. c.pendingBatch is updated only on
+// success of the create path; the update path mutates the existing
+// batch in place via applyFundingToBatch.
+func (c *ChainPlanter) fundPendingBatch(ctx context.Context,
+	params FundParams) error {
+
+	if c.pendingBatch == nil {
+		newBatch, err := c.createFundedBatch(ctx, params)
+		if err != nil {
+			return err
+		}
+
+		c.pendingBatch = newBatch
+		return nil
+	}
+
+	return c.applyFundingToBatch(ctx, params, c.pendingBatch)
 }
 
 // matchPsbtToGroupReq attempts to match a signed group virtual PSBT to a
@@ -2684,10 +2757,15 @@ func (c *ChainPlanter) finalizeBatch(params FinalizeParams) (*BatchCaretaker,
 	}
 	// Fund the batch if it hasn't been funded yet. If funding
 	// fails, the batch stays pending so the user can retry.
+	//
+	// finalizeBatch is only reached when c.pendingBatch is
+	// non-nil (the gardener short-circuits with an error
+	// otherwise), so the "create" path of fundPendingBatch is
+	// not exercised here; calling fundPendingBatch keeps the
+	// dispatch in one place rather than re-checking pending-ness
+	// here.
 	if !c.pendingBatch.IsFunded() {
-		err = c.fundBatch(
-			ctx, FundParams(params), c.pendingBatch,
-		)
+		err = c.fundPendingBatch(ctx, FundParams(params))
 		if err != nil {
 			return nil, err
 		}

--- a/tapgarden/planter.go
+++ b/tapgarden/planter.go
@@ -3,6 +3,7 @@ package tapgarden
 import (
 	"bytes"
 	"context"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"slices"
@@ -509,6 +510,19 @@ func (c *ChainPlanter) Start() error {
 
 		log.Infof("Retrieved %v non-finalized batches from DB",
 			len(nonFinalBatches))
+
+		// Enforce the singleton invariant: at most one batch may
+		// be in BatchStatePending or BatchStateFrozen at a time.
+		// The DB constraint added in migration 000060 should
+		// already make this impossible, but a legacy DB that was
+		// migrated post-population, or a manually-modified row,
+		// could still violate it. Surfacing the error here gives
+		// the operator a human-readable diagnostic instead of an
+		// opaque SQL one later.
+		if err := checkSingletonInvariant(nonFinalBatches); err != nil {
+			startErr = err
+			return
+		}
 
 		// Now for each of these non-final batches, we'll make a new
 		// caretaker which'll handle progressing each batch to
@@ -1419,6 +1433,49 @@ func freezeMintingBatch(ctx context.Context, batchStore MintingStore,
 	)
 }
 
+// checkSingletonInvariant verifies that at most one batch in the
+// supplied slice is in a pre-broadcast state (BatchStatePending or
+// BatchStateFrozen). The invariant is enforced at the DB layer by
+// the partial unique index added in migration 000060; this Go-level
+// check exists as defense in depth and to produce a human-readable
+// diagnostic naming the offending batch keys, since a raw SQL
+// constraint error from a downstream insert is harder to act on.
+//
+// The check is called from ChainPlanter.Start() after
+// FetchNonFinalBatches. If it fails, startup is aborted so the
+// operator can investigate rather than letting the daemon run with
+// ambiguous "which batch is current?" semantics.
+func checkSingletonInvariant(batches []*MintingBatch) error {
+	var preBroadcastKeys []string
+	for _, batch := range batches {
+		switch batch.State() {
+		case BatchStatePending, BatchStateFrozen:
+			preBroadcastKeys = append(
+				preBroadcastKeys,
+				hex.EncodeToString(
+					batch.BatchKey.PubKey.
+						SerializeCompressed(),
+				),
+			)
+
+		default:
+			// Only pre-broadcast states are constrained by
+			// the singleton index; ignore everything else.
+		}
+	}
+
+	if len(preBroadcastKeys) <= 1 {
+		return nil
+	}
+
+	return fmt.Errorf("singleton pre-broadcast batch invariant "+
+		"violated: found %d batches in BatchStatePending or "+
+		"BatchStateFrozen (keys: %v); at most one is permitted. "+
+		"Resolve by running `tapd --repair.cancel-duplicate-batches` "+
+		"to cancel all but the most recent, then restart",
+		len(preBroadcastKeys), preBroadcastKeys)
+}
+
 // filterFinalizedBatches separates a set of batches into two sets based on
 // their batch state.
 func filterFinalizedBatches(batches []*MintingBatch) ([]*MintingBatch,
@@ -1778,11 +1835,20 @@ func (c *ChainPlanter) canCancelBatch() (*btcec.PublicKey, error) {
 
 		return c.pendingBatch.BatchKey.PubKey, nil
 	case 1:
-		// TODO(jhb): Update once we support multiple batches.
-		// If there is exactly one caretaker, our pending batch should
-		// be empty. Otherwise, the batch to cancel is ambiguous.
+		// If there is exactly one caretaker, our pending batch
+		// must be empty for the cancel target to be
+		// unambiguous. Both can coexist legitimately: the
+		// caretaker may be handling a post-broadcast batch
+		// (Committed/Broadcast/Confirmed) while a fresh
+		// Pending/Frozen batch has begun in c.pendingBatch. The
+		// singleton constraint added in migration 000060 only
+		// applies to {Pending, Frozen}, so this case is real,
+		// not unreachable.
 		if c.pendingBatch != nil {
-			return nil, fmt.Errorf("multiple batches not supported")
+			return nil, fmt.Errorf("cancellation ambiguous: " +
+				"pending batch and an active caretaker " +
+				"coexist; cancel-by-batch-key not " +
+				"implemented")
 		}
 
 		batchKeys := maps.Keys(c.caretakers)
@@ -1795,8 +1861,13 @@ func (c *ChainPlanter) canCancelBatch() (*btcec.PublicKey, error) {
 	default:
 	}
 
-	// TODO(jhb): Update once we support multiple batches.
-	return nil, fmt.Errorf("multiple caretakers not supported")
+	// Multiple caretakers can coexist when several post-broadcast
+	// batches are awaiting confirmation in parallel. The singleton
+	// constraint added in migration 000060 does not forbid this; it
+	// only constrains {Pending, Frozen}.
+	return nil, fmt.Errorf("cancellation ambiguous: %d active "+
+		"caretakers; cancel-by-batch-key not implemented",
+		caretakerCount)
 }
 
 // cancelMintingBatch attempts to cancel a target minting batch. This can fail
@@ -2101,6 +2172,36 @@ func (c *ChainPlanter) gardener() {
 					}
 
 					delete(c.caretakers, batchKeySerial)
+
+					// Cancel the failed batch on disk so it
+					// isn't left wedged in a pre-broadcast
+					// state, which the migration 000061
+					// singleton index forbids. Same rule as
+					// caretaker.Cancel: Pending/Frozen ->
+					// SeedlingCancelled (no sprouts yet),
+					// else SproutCancelled.
+					cancelState :=
+						BatchStateSeedlingCancelled
+					if c.pendingBatch.State() ==
+						BatchStateCommitted {
+
+						cancelState =
+							BatchStateSproutCancelled //nolint:lll
+					}
+
+					cancelCtx, cancelCtxCancel :=
+						c.WithCtxQuit()
+					cancelErr := c.cfg.Log.UpdateBatchState(
+						cancelCtx, c.pendingBatch,
+						cancelState,
+					)
+					cancelCtxCancel()
+					if cancelErr != nil {
+						log.Warnf("Unable to cancel "+
+							"failed batch (%x): %v",
+							batchKeySerial[:],
+							cancelErr)
+					}
 
 				case <-c.Quit:
 					return

--- a/tapgarden/planter.go
+++ b/tapgarden/planter.go
@@ -3,6 +3,7 @@ package tapgarden
 import (
 	"bytes"
 	"context"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"slices"
@@ -510,6 +511,19 @@ func (c *ChainPlanter) Start() error {
 		log.Infof("Retrieved %v non-finalized batches from DB",
 			len(nonFinalBatches))
 
+		// Enforce the singleton invariant: at most one batch may
+		// be in BatchStatePending or BatchStateFrozen at a time.
+		// The DB constraint added in migration 000061 should
+		// already make this impossible, but a legacy DB that was
+		// migrated post-population, or a manually-modified row,
+		// could still violate it. Surfacing the error here gives
+		// the operator a human-readable diagnostic instead of an
+		// opaque SQL one later.
+		if err := checkSingletonInvariant(nonFinalBatches); err != nil {
+			startErr = err
+			return
+		}
+
 		// Now for each of these non-final batches, we'll make a new
 		// caretaker which'll handle progressing each batch to
 		// completion. We'll skip batches that were cancelled.
@@ -630,6 +644,22 @@ func (c *ChainPlanter) Start() error {
 			if err := caretaker.Start(); err != nil {
 				startErr = err
 				return
+			}
+
+			// The caretaker advances the batch in the background,
+			// and nothing else reads its broadcast channels on
+			// this path: BroadcastErrChan is otherwise only
+			// consumed by the interactive finalize handler. Watch
+			// for a pre-broadcast failure so a failed resume
+			// cannot leave the batch occupying the singleton slot
+			// enforced by the migration 000061 index, which would
+			// block all further minting. A batch resumed at
+			// BatchStateConfirmed skips the broadcast phase
+			// entirely and reports through the completion signal,
+			// so there is nothing to watch.
+			if batch.State() != BatchStateConfirmed {
+				c.Wg.Add(1)
+				go c.watchResumedCaretaker(caretaker)
 			}
 		}
 
@@ -1419,6 +1449,59 @@ func freezeMintingBatch(ctx context.Context, batchStore MintingStore,
 	)
 }
 
+// ErrDuplicatePreBroadcastBatch is returned when a new minting batch
+// cannot be persisted because another batch already occupies the
+// pre-broadcast singleton slot (BatchStatePending or
+// BatchStateFrozen) enforced by the partial unique index added in
+// migration 000061. This can happen transiently right after a
+// restart, while a resumed batch is still working towards broadcast.
+var ErrDuplicatePreBroadcastBatch = errors.New("another minting batch " +
+	"is already awaiting broadcast; wait for it to be broadcast or " +
+	"cancel it before creating a new batch")
+
+// checkSingletonInvariant verifies that at most one batch in the
+// supplied slice is in a pre-broadcast state (BatchStatePending or
+// BatchStateFrozen). The invariant is enforced at the DB layer by
+// the partial unique index added in migration 000061; this Go-level
+// check exists as defense in depth and to produce a human-readable
+// diagnostic naming the offending batch keys, since a raw SQL
+// constraint error from a downstream insert is harder to act on.
+//
+// The check is called from ChainPlanter.Start() after
+// FetchNonFinalBatches. If it fails, startup is aborted so the
+// operator can investigate rather than letting the daemon run with
+// ambiguous "which batch is current?" semantics.
+func checkSingletonInvariant(batches []*MintingBatch) error {
+	var preBroadcastKeys []string
+	for _, batch := range batches {
+		switch batch.State() {
+		case BatchStatePending, BatchStateFrozen:
+			preBroadcastKeys = append(
+				preBroadcastKeys,
+				hex.EncodeToString(
+					batch.BatchKey.PubKey.
+						SerializeCompressed(),
+				),
+			)
+
+		default:
+			// Only pre-broadcast states are constrained by
+			// the singleton index; ignore everything else.
+		}
+	}
+
+	if len(preBroadcastKeys) <= 1 {
+		return nil
+	}
+
+	return fmt.Errorf("singleton pre-broadcast batch invariant "+
+		"violated: found %d batches in BatchStatePending or "+
+		"BatchStateFrozen (keys: %v); at most one is permitted. "+
+		"Resolve by running `tapd --repair.cancel-duplicate-batches` "+
+		"to cancel all but the most recent, then restart",
+		len(preBroadcastKeys), preBroadcastKeys)
+}
+
 // filterFinalizedBatches separates a set of batches into two sets based on
 // their batch state.
 func filterFinalizedBatches(batches []*MintingBatch) ([]*MintingBatch,
@@ -1778,11 +1861,20 @@ func (c *ChainPlanter) canCancelBatch() (*btcec.PublicKey, error) {
 
 		return c.pendingBatch.BatchKey.PubKey, nil
 	case 1:
-		// TODO(jhb): Update once we support multiple batches.
-		// If there is exactly one caretaker, our pending batch should
-		// be empty. Otherwise, the batch to cancel is ambiguous.
+		// If there is exactly one caretaker, our pending batch
+		// must be empty for the cancel target to be
+		// unambiguous. Both can coexist legitimately: the
+		// caretaker may be handling a post-broadcast batch
+		// (Committed/Broadcast/Confirmed) while a fresh
+		// Pending/Frozen batch has begun in c.pendingBatch. The
+		// singleton constraint added in migration 000061 only
+		// applies to {Pending, Frozen}, so this case is real,
+		// not unreachable.
 		if c.pendingBatch != nil {
-			return nil, fmt.Errorf("multiple batches not supported")
+			return nil, fmt.Errorf("cancellation ambiguous: " +
+				"pending batch and an active caretaker " +
+				"coexist; cancel-by-batch-key not " +
+				"implemented")
 		}
 
 		batchKeys := maps.Keys(c.caretakers)
@@ -1795,8 +1887,13 @@ func (c *ChainPlanter) canCancelBatch() (*btcec.PublicKey, error) {
 	default:
 	}
 
-	// TODO(jhb): Update once we support multiple batches.
-	return nil, fmt.Errorf("multiple caretakers not supported")
+	// Multiple caretakers can coexist when several post-broadcast
+	// batches are awaiting confirmation in parallel. The singleton
+	// constraint added in migration 000061 does not forbid this; it
+	// only constrains {Pending, Frozen}.
+	return nil, fmt.Errorf("cancellation ambiguous: %d active "+
+		"caretakers; cancel-by-batch-key not implemented",
+		caretakerCount)
 }
 
 // cancelMintingBatch attempts to cancel a target minting batch. This can fail
@@ -1849,6 +1946,88 @@ func (c *ChainPlanter) cancelMintingBatch(ctx context.Context,
 	}
 
 	return nil
+}
+
+// cancelFailedBatch cancels a batch whose caretaker reported a
+// broadcast-path error, so the batch isn't left occupying the
+// pre-broadcast singleton slot enforced by the migration 000061
+// index. Only Pending and Frozen batches are cancelled: those are
+// the states the index constrains, and no sprouts exist yet, so
+// SeedlingCancelled applies. Batches at Committed or beyond are
+// left untouched. They don't occupy the singleton slot, and the
+// restart path resumes and retries them, so cancelling here would
+// turn a transient failure (say, a brief signer outage) into a
+// permanent one that forces a re-mint with new asset IDs.
+//
+// The returned error is non-nil only when the batch occupied the
+// singleton slot and the on-disk cancellation failed, i.e. exactly
+// when the slot is still occupied and the batch still needs an
+// owner.
+func (c *ChainPlanter) cancelFailedBatch(batch *MintingBatch) error {
+	batchKeySerial := asset.ToSerialized(batch.BatchKey.PubKey)
+
+	batchState := batch.State()
+	if batchState != BatchStatePending && batchState != BatchStateFrozen {
+		log.Infof("Leaving failed batch (%x) at state %v; restart "+
+			"will resume it", batchKeySerial[:], batchState)
+		return nil
+	}
+
+	ctx, cancel := c.WithCtxQuit()
+	defer cancel()
+	err := c.cfg.Log.UpdateBatchState(
+		ctx, batch, BatchStateSeedlingCancelled,
+	)
+	if err != nil {
+		return fmt.Errorf("unable to cancel failed batch (%x): %w",
+			batchKeySerial[:], err)
+	}
+
+	return nil
+}
+
+// watchResumedCaretaker waits for a caretaker launched for a resumed
+// batch to either broadcast its batch or fail beforehand. On a
+// pre-broadcast failure it cancels the batch, freeing the singleton
+// slot enforced by the migration 000061 index, and hands the dead
+// caretaker to the gardener via the completion signal so it is
+// stopped and removed from the caretaker set (the gardener owns that
+// set, so removal must happen there). The interactive finalize
+// handler performs the equivalent duties for caretakers launched via
+// FinalizeBatch.
+func (c *ChainPlanter) watchResumedCaretaker(caretaker *BatchCaretaker) {
+	defer c.Wg.Done()
+
+	batchKey := asset.ToSerialized(caretaker.cfg.Batch.BatchKey.PubKey)
+
+	select {
+	case <-caretaker.cfg.BroadcastCompleteChan:
+		// The batch reached broadcast; from here on the caretaker
+		// reports completion through the completion signal on its
+		// own.
+
+	case err := <-caretaker.cfg.BroadcastErrChan:
+		log.Errorf("Resumed batch (%x) failed before broadcast: %v",
+			batchKey[:], err)
+
+		// On the resume path there is no in-memory owner to
+		// preserve, so a failed cancellation can only be
+		// logged; restarting tapd retries the resume.
+		cancelErr := c.cancelFailedBatch(caretaker.cfg.Batch)
+		if cancelErr != nil {
+			log.Errorf("%v; the pre-broadcast singleton slot is "+
+				"still occupied on disk, so new batches will "+
+				"be rejected until tapd is restarted",
+				cancelErr)
+		}
+
+		select {
+		case c.completionSignals <- batchKey:
+		case <-c.Quit:
+		}
+
+	case <-c.Quit:
+	}
 }
 
 // gardener is responsible for collecting new potential taproot asset
@@ -2088,6 +2267,10 @@ func (c *ChainPlanter) gardener() {
 				case <-caretaker.cfg.BroadcastCompleteChan:
 					req.Resolve(caretaker.cfg.Batch)
 
+					// The batch has been broadcast, so we
+					// can remove the pending batch.
+					c.pendingBatch = nil
+
 				case err := <-caretaker.cfg.BroadcastErrChan:
 					req.Error(err)
 					// Unrecoverable error, stop caretaker
@@ -2102,14 +2285,32 @@ func (c *ChainPlanter) gardener() {
 
 					delete(c.caretakers, batchKeySerial)
 
+					// Cancel the failed batch on disk if
+					// it is still pre-broadcast, so it
+					// isn't left wedged in a state the
+					// migration 000061 singleton index
+					// forbids. Only drop the in-memory
+					// reference if the batch no longer
+					// occupies the singleton slot;
+					// otherwise keep it so a retried
+					// cancel request can still find and
+					// cancel the batch.
+					cancelErr := c.cancelFailedBatch(
+						caretaker.cfg.Batch,
+					)
+					if cancelErr != nil {
+						log.Errorf("%v; retry "+
+							"cancelling the "+
+							"batch, or restart "+
+							"tapd", cancelErr)
+						break
+					}
+
+					c.pendingBatch = nil
+
 				case <-c.Quit:
 					return
 				}
-
-				// Now that we have a caretaker launched for
-				// this batch and broadcast its minting
-				// transaction, we can remove the pending batch.
-				c.pendingBatch = nil
 
 			case reqTypeCancelBatch:
 				batchKey, err := c.canCancelBatch()
@@ -2123,7 +2324,16 @@ func (c *ChainPlanter) gardener() {
 				ctx, cancel := c.WithCtxQuit()
 				err = c.cancelMintingBatch(ctx, batchKey)
 				cancel()
-				c.pendingBatch = nil
+
+				// Only drop the in-memory reference if the
+				// on-disk cancellation went through. If it
+				// failed, the row still occupies the
+				// pre-broadcast singleton slot, and orphaning
+				// it here would wedge new batch creation
+				// until restart.
+				if err == nil {
+					c.pendingBatch = nil
+				}
 
 				// Always return the key of the batch we tried
 				// to cancel.

--- a/tapgarden/planter_test.go
+++ b/tapgarden/planter_test.go
@@ -222,53 +222,6 @@ func (t *mintingTestHarness) assertBatchResumedBackground(wg *sync.WaitGroup,
 	}()
 }
 
-// createExternalBatch creates a new pending batch outside the planter, which
-// can then be stored on disk.
-func (t *mintingTestHarness) createExternalBatch(
-	numSeedlings int) *tapgarden.MintingBatch {
-
-	t.Helper()
-
-	seedlings := t.newRandSeedlings(numSeedlings)
-	seedlingsWithKeys := make(map[string]*tapgarden.Seedling)
-	for _, seedling := range seedlings {
-		scriptKeyInternalDesc, _ := test.RandKeyDesc(t)
-		scriptKey := asset.NewScriptKeyBip86(scriptKeyInternalDesc)
-		seedling.ScriptKey = scriptKey
-
-		// The group internal key should be from the key ring since we
-		// expect the caretaker to sign with it later.
-		if seedling.EnableEmission {
-			groupKey, err := t.keyRing.DeriveNextKey(
-				context.Background(),
-				asset.TaprootAssetsKeyFamily,
-			)
-			require.NoError(t, err)
-
-			seedling.GroupInternalKey = &groupKey
-		}
-
-		seedlingsWithKeys[seedling.AssetName] = seedling
-	}
-
-	batchInternalKey, err := t.keyRing.DeriveNextKey(
-		context.Background(), asset.TaprootAssetsKeyFamily,
-	)
-	require.NoError(t, err)
-
-	newBatch := &tapgarden.MintingBatch{
-		CreationTime: time.Now(),
-		HeightHint:   0,
-		BatchKey:     batchInternalKey,
-		Seedlings:    seedlingsWithKeys,
-		AssetMetas:   make(tapgarden.AssetMetas),
-	}
-
-	// The zero value of MintingBatch.batchState is BatchStatePending,
-	// so no explicit state setter is needed here.
-
-	return newBatch
-}
 
 // queueSeedlingsInBatch adds the series of seedlings to the batch, an error is
 // raised if any of the seedlings aren't accepted.
@@ -1676,9 +1629,14 @@ func testFinalizeWithTapscriptTree(t *mintingTestHarness) {
 	batchCount++
 
 	// The caretaker should fail when computing the Taproot output key.
+	// The gardener cancels the failed batch on disk so it does not
+	// block subsequent pending batches via the singleton invariant
+	// added in migration 000060.
 	_ = t.assertGenesisTxFunded(nil)
 	t.assertFinalizeBatch(&wg, respChan, "failed to load tapscript tree")
-	t.assertLastBatchState(batchCount, tapgarden.BatchStateFrozen)
+	t.assertLastBatchState(
+		batchCount, tapgarden.BatchStateSeedlingCancelled,
+	)
 	t.assertNoPendingBatch()
 
 	// Reset the tapscript tree store to not force load or store failures.
@@ -2207,46 +2165,14 @@ func testFundSealOnRestart(t *mintingTestHarness) {
 	t.assertNumCaretakersActive(0)
 	t.assertLastBatchState(batchCount, tapgarden.BatchStateFinalized)
 
-	// Submit another batch, which we'll leave as pending.
-	secondSeedlings := t.newRandSeedlings(numSeedlings)
-	t.queueSeedlingsInBatch(false, secondSeedlings...)
-	batchCount++
-
-	t.assertLastBatchState(batchCount, tapgarden.BatchStatePending)
-	require.NoError(t, t.planter.Stop())
-	t.planter = nil
-
-	// We should also be able to resume one batch even when resuming another
-	// batch fails. Since we can only queue one batch at a time, we'll
-	// insert another pending batch on disk while the planter is shut down.
-	dbBatch := t.createExternalBatch(numSeedlings)
-	batchCount++
-	err := t.store.CommitMintingBatch(context.Background(), dbBatch)
-	require.NoError(t, err)
-
-	// With two pending batches on disk, we want resume for the first batch
-	// to fail. Resume for the second batch should succeed.
-	t.chain.FailFeeEstimatesOnce()
-	failedBatchCount++
-
-	t.assertBatchResumedBackground(&wg, true, false)
-	t.assertBatchResumedBackground(&wg, true, true)
-	t.refreshChainPlanter()
-	wg.Wait()
-
-	t.assertNumCaretakersActive(1)
-	t.assertNoPendingBatch()
-
-	sendConfNtfn = t.progressCaretaker(true, nil, nil)
-	t.assertLastBatchState(batchCount, tapgarden.BatchStateBroadcast)
-
-	sendConfNtfn()
-	t.assertNoError()
-	t.assertNumCaretakersActive(0)
-	t.assertNumBatchesWithState(
-		failedBatchCount, tapgarden.BatchStateSeedlingCancelled,
-	)
-	t.assertLastBatchState(batchCount, tapgarden.BatchStateFinalized)
+	// The original test continued by inserting a second Pending
+	// batch directly on disk to exercise recovery when multiple
+	// pending batches were present. That scenario is now forbidden
+	// by the singleton invariant added in migration 000060, so the
+	// section has been removed. The single-pending-batch recovery
+	// paths exercised above are the surviving useful coverage; the
+	// "multiple pre-broadcast batches" case is covered by
+	// TestSingletonPreBroadcastBatchConstraint in tapdb.
 }
 
 // mintingStoreTestCase is used to programmatically run a series of test cases

--- a/tapgarden/planter_test.go
+++ b/tapgarden/planter_test.go
@@ -263,7 +263,9 @@ func (t *mintingTestHarness) createExternalBatch(
 		Seedlings:    seedlingsWithKeys,
 		AssetMetas:   make(tapgarden.AssetMetas),
 	}
-	newBatch.UpdateState(tapgarden.BatchStatePending)
+
+	// The zero value of MintingBatch.batchState is BatchStatePending,
+	// so no explicit state setter is needed here.
 
 	return newBatch
 }
@@ -310,9 +312,6 @@ func (t *mintingTestHarness) queueSeedlingsInBatch(isFunded bool,
 
 		// Make sure the seedling was planted without error.
 		require.NoError(t, update.Error)
-
-		// The received update should be a state of MintingStateSeed.
-		require.Equal(t, tapgarden.MintingStateSeed, update.NewState)
 
 		err = wait.NoError(func() error {
 			// Assert that the key ring method DeriveNextKey was

--- a/tapgarden/planter_test.go
+++ b/tapgarden/planter_test.go
@@ -222,54 +222,6 @@ func (t *mintingTestHarness) assertBatchResumedBackground(wg *sync.WaitGroup,
 	}()
 }
 
-// createExternalBatch creates a new pending batch outside the planter, which
-// can then be stored on disk.
-func (t *mintingTestHarness) createExternalBatch(
-	numSeedlings int) *tapgarden.MintingBatch {
-
-	t.Helper()
-
-	seedlings := t.newRandSeedlings(numSeedlings)
-	seedlingsWithKeys := make(map[string]*tapgarden.Seedling)
-	for _, seedling := range seedlings {
-		scriptKeyInternalDesc, _ := test.RandKeyDesc(t)
-		scriptKey := asset.NewScriptKeyBip86(scriptKeyInternalDesc)
-		seedling.ScriptKey = scriptKey
-
-		// The group internal key should be from the key ring since we
-		// expect the caretaker to sign with it later.
-		if seedling.EnableEmission {
-			groupKey, err := t.keyRing.DeriveNextKey(
-				context.Background(),
-				asset.TaprootAssetsKeyFamily,
-			)
-			require.NoError(t, err)
-
-			seedling.GroupInternalKey = &groupKey
-		}
-
-		seedlingsWithKeys[seedling.AssetName] = seedling
-	}
-
-	batchInternalKey, err := t.keyRing.DeriveNextKey(
-		context.Background(), asset.TaprootAssetsKeyFamily,
-	)
-	require.NoError(t, err)
-
-	newBatch := &tapgarden.MintingBatch{
-		CreationTime: time.Now(),
-		HeightHint:   0,
-		BatchKey:     batchInternalKey,
-		Seedlings:    seedlingsWithKeys,
-		AssetMetas:   make(tapgarden.AssetMetas),
-	}
-
-	// The zero value of MintingBatch.batchState is BatchStatePending,
-	// so no explicit state setter is needed here.
-
-	return newBatch
-}
-
 // queueSeedlingsInBatch adds the series of seedlings to the batch, an error is
 // raised if any of the seedlings aren't accepted.
 func (t *mintingTestHarness) queueSeedlingsInBatch(isFunded bool,
@@ -1676,9 +1628,14 @@ func testFinalizeWithTapscriptTree(t *mintingTestHarness) {
 	batchCount++
 
 	// The caretaker should fail when computing the Taproot output key.
+	// The gardener cancels the failed batch on disk so it does not
+	// block subsequent pending batches via the singleton invariant
+	// added in migration 000061.
 	_ = t.assertGenesisTxFunded(nil)
 	t.assertFinalizeBatch(&wg, respChan, "failed to load tapscript tree")
-	t.assertLastBatchState(batchCount, tapgarden.BatchStateFrozen)
+	t.assertLastBatchState(
+		batchCount, tapgarden.BatchStateSeedlingCancelled,
+	)
 	t.assertNoPendingBatch()
 
 	// Reset the tapscript tree store to not force load or store failures.
@@ -2207,46 +2164,139 @@ func testFundSealOnRestart(t *mintingTestHarness) {
 	t.assertNumCaretakersActive(0)
 	t.assertLastBatchState(batchCount, tapgarden.BatchStateFinalized)
 
-	// Submit another batch, which we'll leave as pending.
-	secondSeedlings := t.newRandSeedlings(numSeedlings)
-	t.queueSeedlingsInBatch(false, secondSeedlings...)
-	batchCount++
+	// The original test continued by inserting a second Pending
+	// batch directly on disk to exercise recovery when multiple
+	// pending batches were present. That scenario is now forbidden
+	// by the singleton invariant added in migration 000061, so the
+	// section has been removed. The single-pending-batch recovery
+	// paths exercised above are the surviving useful coverage; the
+	// "multiple pre-broadcast batches" case is covered by
+	// TestSingletonPreBroadcastBatchConstraint in tapdb.
+}
 
-	t.assertLastBatchState(batchCount, tapgarden.BatchStatePending)
-	require.NoError(t, t.planter.Stop())
-	t.planter = nil
+// testCaretakerResumeFailure tests that a batch whose caretaker fails
+// before broadcast while being resumed on restart is cancelled in the
+// background. The cancelled batch must free the pre-broadcast
+// singleton slot enforced by the migration 000061 index, so that new
+// batches can be created without another restart.
+func testCaretakerResumeFailure(t *mintingTestHarness) {
+	t.refreshChainPlanter()
 
-	// We should also be able to resume one batch even when resuming another
-	// batch fails. Since we can only queue one batch at a time, we'll
-	// insert another pending batch on disk while the planter is shut down.
-	dbBatch := t.createExternalBatch(numSeedlings)
-	batchCount++
-	err := t.store.CommitMintingBatch(context.Background(), dbBatch)
+	// Create a batch and fund it with a tapscript sibling, so the
+	// resumed caretaker must load the tapscript tree before it can
+	// commit the batch.
+	const numSeedlings = 5
+	seedlings := t.newRandSeedlings(numSeedlings)
+	t.queueSeedlingsInBatch(false, seedlings...)
+
+	sigLockKey := test.RandPubKey(t)
+	hashLockWitness := []byte("foobar")
+	hashLockLeaf := test.ScriptHashLock(t.T, hashLockWitness)
+	sigLeaf := test.ScriptSchnorrSig(t.T, sigLockKey)
+	tapTreePreimage, err := asset.TapTreeNodesFromLeaves(
+		[]txscript.TapLeaf{hashLockLeaf, sigLeaf},
+	)
 	require.NoError(t, err)
 
-	// With two pending batches on disk, we want resume for the first batch
-	// to fail. Resume for the second batch should succeed.
-	t.chain.FailFeeEstimatesOnce()
-	failedBatchCount++
+	var (
+		wg       sync.WaitGroup
+		respChan = make(chan *FundBatchResp, 1)
+	)
 
-	t.assertBatchResumedBackground(&wg, true, false)
-	t.assertBatchResumedBackground(&wg, true, true)
+	fundReq := tapgarden.FundParams{
+		SiblingTapTree: fn.Some(*tapTreePreimage),
+	}
+	t.fundBatch(&wg, respChan, &fundReq)
+	_ = t.assertGenesisTxFunded(nil)
+	t.assertFundBatch(&wg, respChan, "")
+
+	// Force tapscript tree loading to fail, then restart the
+	// planter. The resume path will fund (no-op), seal, and freeze
+	// the batch, and hand it to a caretaker; the caretaker then
+	// fails to load the tapscript tree before the batch can be
+	// committed.
+	t.treeStore.FailLoad = true
 	t.refreshChainPlanter()
-	wg.Wait()
 
-	t.assertNumCaretakersActive(1)
+	// The planter must notice the background failure and cancel
+	// the batch, freeing the singleton slot.
+	err = wait.NoError(func() error {
+		batches, err := t.store.FetchAllBatches(
+			context.Background(),
+		)
+		if err != nil {
+			return err
+		}
+		if len(batches) != 1 {
+			return fmt.Errorf("expected 1 batch, found %d",
+				len(batches))
+		}
+
+		batchState := batches[0].State()
+		if batchState != tapgarden.BatchStateSeedlingCancelled {
+			return fmt.Errorf("batch not cancelled, state %v",
+				batchState)
+		}
+
+		return nil
+	}, defaultTimeout)
+	require.NoError(t, err)
+
+	t.assertNumCaretakersActive(0)
 	t.assertNoPendingBatch()
 
-	sendConfNtfn = t.progressCaretaker(true, nil, nil)
-	t.assertLastBatchState(batchCount, tapgarden.BatchStateBroadcast)
+	// With the slot free, a new batch can be created without
+	// restarting the planter.
+	t.treeStore.FailLoad = false
+	newSeedlings := t.newRandSeedlings(numSeedlings)
+	t.queueSeedlingsInBatch(false, newSeedlings...)
+	t.assertPendingBatchExists(newSeedlings)
+	t.assertNumBatchesWithState(
+		1, tapgarden.BatchStateSeedlingCancelled,
+	)
+}
+
+// testFinalizeSignFailure tests that a transient failure on the
+// broadcast path after the batch has been committed does not cancel
+// the batch: a committed batch does not occupy the pre-broadcast
+// singleton slot, and a restart must be able to resume and retry it
+// with the same asset IDs.
+func testFinalizeSignFailure(t *mintingTestHarness) {
+	t.refreshChainPlanter()
+
+	const numSeedlings = 5
+	_ = t.queueInitialBatch(numSeedlings)
+
+	var (
+		wg       sync.WaitGroup
+		respChan = make(chan *FinalizeBatchResp, 1)
+	)
+
+	// Arm the wallet so signing the genesis TX fails after the
+	// batch has been committed.
+	t.wallet.FailSignPsbtOnce()
+	t.finalizeBatch(&wg, respChan, nil)
+
+	_ = t.assertGenesisTxFunded(nil)
+	t.assertFinalizeBatch(&wg, respChan, "unable to sign psbt")
+
+	// The batch must stay committed rather than being cancelled,
+	// with no caretaker and no pending batch.
+	t.assertNumCaretakersActive(0)
+	t.assertNoPendingBatch()
+	t.assertLastBatchState(1, tapgarden.BatchStateCommitted)
+
+	// On restart, the committed batch is resumed and completes
+	// with the signing failure cleared.
+	t.refreshChainPlanter()
+
+	sendConfNtfn := t.progressCaretaker(true, nil, nil)
+	t.assertLastBatchState(1, tapgarden.BatchStateBroadcast)
 
 	sendConfNtfn()
 	t.assertNoError()
 	t.assertNumCaretakersActive(0)
-	t.assertNumBatchesWithState(
-		failedBatchCount, tapgarden.BatchStateSeedlingCancelled,
-	)
-	t.assertLastBatchState(batchCount, tapgarden.BatchStateFinalized)
+	t.assertLastBatchState(1, tapgarden.BatchStateFinalized)
 }
 
 // mintingStoreTestCase is used to programmatically run a series of test cases
@@ -2293,6 +2343,14 @@ var testCases = []mintingStoreTestCase{
 	{
 		name:     "fund_seal_on_restart",
 		testFunc: testFundSealOnRestart,
+	},
+	{
+		name:     "caretaker_resume_failure",
+		testFunc: testCaretakerResumeFailure,
+	},
+	{
+		name:     "finalize_sign_failure",
+		testFunc: testFinalizeSignFailure,
 	},
 }
 

--- a/tapgarden/seedling.go
+++ b/tapgarden/seedling.go
@@ -23,36 +23,9 @@ var (
 	ErrInvalidAssetAmt = fmt.Errorf("asset amt cannot be zero")
 )
 
-// MintingState is an enum that tracks an asset through the various minting
-// stages.
-type MintingState uint8
-
-const (
-	// MintingStateNone is the default state, no actions have been taken.
-	MintingStateNone MintingState = iota
-
-	// MintingStateSeed denotes the seedling as been added to a batch.
-	MintingStateSeed
-
-	// MintingStateSeedling denotes that a seedling has been finalized in a
-	// batch and now has a corresponding asset associated with it.
-	MintingStateSeedling
-
-	// MintingStateSprout denotes that a seedling has been paired with a
-	// genesis transaction and broadcast for confirmation.
-	MintingStateSprout
-
-	// MintingStateAdult denotes that a seedling has been confirmed on
-	// chain and reached full adulthood.
-	MintingStateAdult
-)
-
 // SeedlingUpdate is a struct used to send notifications w.r.t the state of a
 // seedling back to the caller.
 type SeedlingUpdate struct {
-	// NewState is the new state a seedling has transitioned to.
-	NewState MintingState
-
 	// PendingBatch is the current pending batch that the seedling has been
 	// added to.
 	PendingBatch *MintingBatch

--- a/tapnode/tapnodemock/wallet_anchor.go
+++ b/tapnode/tapnodemock/wallet_anchor.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"sync/atomic"
 	"testing"
 
 	btcaddr "github.com/btcsuite/btcd/address/v2"
@@ -37,6 +38,14 @@ type WalletAnchor struct {
 
 	Transactions  []lndclient.Transaction
 	ImportedUtxos []*lnwallet.Utxo
+
+	failSignPsbt atomic.Bool
+}
+
+// FailSignPsbtOnce arms the next call to SignAndFinalizePsbt to return
+// an error. The failing call does not send on SignPsbtSignal.
+func (m *WalletAnchor) FailSignPsbtOnce() {
+	m.failSignPsbt.Store(true)
 }
 
 // NewWalletAnchor returns a freshly-initialised mock WalletAnchor.
@@ -149,6 +158,10 @@ func (m *WalletAnchor) SignAndFinalizePsbt(ctx context.Context,
 	case <-ctx.Done():
 		return nil, fmt.Errorf("shutting down")
 	default:
+	}
+
+	if m.failSignPsbt.Swap(false) {
+		return nil, fmt.Errorf("failed to sign psbt")
 	}
 
 	// We'll modify the packet by attaching a "signature" so the PSBT


### PR DESCRIPTION
This is the next chunk of the large-scale tapgarden hardening work originally contained in #2153 (following #2190). It handles the following bullets from the original PR description:

> **Persistence atomicity**. Previously it was possible for an in-memory batch state to advance while the corresponding database write failed, leaving memory and disk disagreeing about what state the batch was in; now, because every state mutation flows through a store method that touches memory only after the database commit succeeds, the two views cannot drift.
> 
> **Funding overload**. Previously it was possible for a fund-batch call to silently create a new batch when the caller meant to attach funding to an existing one (the bug behind #2136); now, because "create" and "attach" are separate functions with non-overlapping signatures, the wrong intent will not type-check.
> 
> **Singleton invariant**. Previously it was possible for two unbroadcast minting batches to coexist on disk and block all subsequent minting; now, because the schema itself forbids more than one row in the pre-broadcast subset, that state cannot exist.
> 
> **Determinism**. Previously it was possible for the planter to pick a different "anchor seedling" on different runs of the same input because the choice depended on Go map iteration order; now, because the lookup scans deterministically and refuses to return when the singleton invariant fails, the choice is fixed.

It contains the following changes (summary ctsy Opus):

**Two-truth collapse.** `MintingBatch.batchState` (in-memory) and the `asset_minting_batches.state` column (on-disk) were maintained by separate code paths and could diverge under failure -- store methods sometimes updated the DB while the in-memory mirror was patched up later, or in places got ahead of the DB entirely. Every state mutation now flows through a `MintingStore` method that advances the in-memory field only after the DB write commits; the two views can no longer drift.

**FundBatch split.** `fundBatch` was overloaded: same call either attached funding to a pending batch or silently minted a new one, depending on hidden state. It splits into a `create` half and an `apply` half with disjoint signatures, so the caller's intent is carried by the function chosen rather than by an implicit side condition.

**Deterministic anchor lookup.** Two call sites that fetched the "anchor seedling" iterated `pendingBatch.Seedlings` and took the first match, relying on Go map iteration order and an unenforced <=1-anchor invariant validated elsewhere. Replaced with a deterministic scan that returns the unique seedling with `GroupAnchor == nil` and errors loudly on zero or multiple matches -- the invariant is now asserted at the point it's depended on.

Singleton invariant, enforced. The planter has always treated the pre-broadcast batch as a singleton in memory, but the schema admitted plurality; older planter versions could desync the in-memory slot from disk under certain failure paths and leave two pre-broadcast rows behind. Migration 000061 adds a partial unique index on asset_minting_batches forbidding more than one row in Pending or Frozen at a time. Legacy databases already holding duplicates are healed as part of applying the migration: all but the most recent pre-broadcast batch (latest creation time, ties broken by the raw batch key) move to SeedlingCancelled, leaving the rows and their seedlings on disk for inspection. A one-shot repair tool (tapd --repair.cancel-duplicate-batches, honored from the command line only) performs the same repair outside the migration stream as a diagnostic.
