### PR TITLE
build: slim tooling docker images

### DIFF
--- a/taprpc/Dockerfile
+++ b/taprpc/Dockerfile
@@ -1,9 +1,8 @@
-FROM golang:1.26.3-bookworm
-
-RUN apt-get update && apt-get install -y \
-  git \
-  protobuf-compiler='3.21.12*' \
-  clang-format='1:14.0*'
+# Builder stage: compile the protoc plugins and fetch the lnd module.
+# Only the resulting binaries and the extracted lnd module are carried
+# over into the final image, so the Go toolchain and its caches are
+# discarded entirely.
+FROM golang:1.26.3-bookworm@sha256:386d475a660466863d9f8c766fec64d7fdad3edac2c6a05020c09534d71edb4b AS builder
 
 # We don't want any default values for these variables to make sure they're
 # explicitly provided by parsing the go.mod file. Otherwise we might forget to
@@ -14,21 +13,36 @@ ARG LND_VERSION
 
 ENV PROTOC_GEN_GO_GRPC_VERSION="v1.1.0"
 ENV FALAFEL_VERSION="v0.9.2"
-ENV GOCACHE=/tmp/build/.cache
 ENV GOMODCACHE=/tmp/build/.modcache
-ENV LND_VERSION=${LND_VERSION}
 
-RUN cd /tmp \
-  && mkdir -p /tmp/build/.cache \
-  && mkdir -p /tmp/build/.modcache \
-  && go install google.golang.org/protobuf/cmd/protoc-gen-go@${PROTOBUF_VERSION} \
+RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@${PROTOBUF_VERSION} \
   && go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@${PROTOC_GEN_GO_GRPC_VERSION} \
   && go install github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway@${GRPC_GATEWAY_VERSION} \
   && go install github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2@${GRPC_GATEWAY_VERSION} \
   && go install github.com/lightninglabs/falafel@${FALAFEL_VERSION} \
   && go install golang.org/x/tools/cmd/goimports@v0.1.7 \
-  && go mod download github.com/lightningnetwork/lnd@${LND_VERSION} \
-  && chmod -R 777 /tmp/build/
+  && go mod download github.com/lightningnetwork/lnd@${LND_VERSION}
+
+# Final stage: gen_protos.sh only needs protoc, clang-format, the plugin
+# binaries and the extracted lnd module (for proto includes) at runtime,
+# so a slim base without the Go toolchain suffices.
+FROM debian:bookworm-slim@sha256:60eac759739651111db372c07be67863818726f754804b8707c90979bda511df
+
+RUN apt-get update && apt-get install -y \
+  protobuf-compiler='3.21.12*' \
+  clang-format='1:14.0*' \
+  && rm -rf /var/lib/apt/lists/*
+
+ARG LND_VERSION
+
+ENV FALAFEL_VERSION="v0.9.2"
+ENV LND_VERSION=${LND_VERSION}
+ENV PATH="/go/bin:${PATH}"
+
+COPY --from=builder /go/bin /go/bin
+COPY --from=builder \
+  /tmp/build/.modcache/github.com/lightningnetwork/lnd@${LND_VERSION} \
+  /tmp/build/.modcache/github.com/lightningnetwork/lnd@${LND_VERSION}
 
 WORKDIR /build
 

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -1,16 +1,24 @@
-FROM golang:1.26.3-bookworm
+# The alpine variant suffices for linting: the repo is pure Go (all
+# builds set CGO_ENABLED=0 and no file imports "C"), so the C toolchain
+# and extra version control systems shipped by the bookworm variant are
+# dead weight. With no C compiler present, Go disables cgo on its own,
+# matching the release build configuration.
+FROM golang:1.26.3-alpine@sha256:91eda9776261207ea25fd06b5b7fed8d397dd2c0a283e77f2ab6e91bfa71079d
 
-RUN apt-get update && apt-get install -y git
+RUN apk add --no-cache git
 ENV GOCACHE=/tmp/build/.cache
 ENV GOMODCACHE=/tmp/build/.modcache
 
 COPY . /tmp/tools
 
-RUN cd /tmp \
-  && mkdir -p /tmp/build/.cache \
-  && mkdir -p /tmp/build/.modcache \
-  && cd /tmp/tools \
+# The build/module caches are wiped after the install because they are
+# shadowed at runtime anyway: the Makefile always mounts volumes (or CI
+# bind mounts) over GOCACHE/GOMODCACHE. Keeping them would only bloat
+# the image by roughly 800MB.
+RUN cd /tmp/tools \
   && go install -trimpath github.com/golangci/golangci-lint/v2/cmd/golangci-lint \
+  && go clean -cache -modcache \
+  && mkdir -p /tmp/build/.cache /tmp/build/.modcache \
   && chmod -R 777 /tmp/build/ \
   && git config --global --add safe.directory /build
 


### PR DESCRIPTION
Significantly slims the tooling images by pruning out unused or unnecessary cruft. The proto image could in principle easily be slimmed further (down to about 380 MB, IIRC), but the provenance story around clang-format gets sort of weird, so it doesn't feel worth it.

(I stumbled across this because my disk keeps filling up lately, and I noticed these images were probably a little bloated.)

Fable's summary:

> The lint and protobuf builder images carried far more than their runtime paths ever execute: Go build/module caches that the Makefile shadows with mounts, a C toolchain for a repo that builds with CGO_ENABLED=0, and a full Go toolchain in an image whose scripts only run protoc and clang-format.
> 
> Each image now contains exactly what its entrypoint uses. The lint image drops from 2.43GB to 450MB, the protobuf builder from 2.17GB to 726MB. Behavior is unchanged: lint results are identical, and proto generation and formatting reproduce the committed files byte for byte.