### PR TITLE
backup: restore LND key family indexes

### DIFF
--- a/backup/backup.go
+++ b/backup/backup.go
@@ -122,6 +122,11 @@ type WalletBackup struct {
 	// FederationURLs contains the universe federation server URLs used
 	// in v3 (optimistic) backups to fetch proofs on import.
 	FederationURLs []string
+
+	// KeyFamilyMarkers contains the last key derived in each local key
+	// family at the time the backup was created. Import uses these markers
+	// to restore LND's key-family counters after an aezeed recovery.
+	KeyFamilyMarkers []*KeyDescriptorBackup
 }
 
 // createAssetBackup creates a backup for a single asset by storing the

--- a/backup/backup_test.go
+++ b/backup/backup_test.go
@@ -2,6 +2,8 @@ package backup
 
 import (
 	"bytes"
+	"crypto/sha256"
+	"fmt"
 	"testing"
 
 	"github.com/btcsuite/btcd/btcec/v2"
@@ -356,6 +358,73 @@ func TestWalletBackupRoundtripV3(t *testing.T) {
 		require.Empty(t, decoded.Assets[i].StrippedProofFileBlob)
 		require.Empty(t, decoded.Assets[i].RehydrationHintsBlob)
 	}
+}
+
+// TestWalletBackupKeyFamilyMarkers tests that the optional key-family marker
+// extension round trips for every backup mode and that legacy payloads without
+// the extension remain decodable.
+func TestWalletBackupKeyFamilyMarkers(t *testing.T) {
+	t.Parallel()
+
+	versions := []uint32{
+		BackupVersionOriginal,
+		BackupVersionStripped,
+		BackupVersionOptimistic,
+	}
+
+	for _, version := range versions {
+		version := version
+		t.Run(fmt.Sprintf("version_%d", version), func(t *testing.T) {
+			t.Parallel()
+
+			marker := newTestKeyDescriptorBackup(t)
+			original := &WalletBackup{
+				Version: version,
+				KeyFamilyMarkers: []*KeyDescriptorBackup{
+					marker,
+				},
+			}
+			if version >= BackupVersionOptimistic {
+				original.FederationURLs = []string{
+					"universe.example.com:10029",
+				}
+			}
+
+			encoded, err := EncodeWalletBackup(original)
+			require.NoError(t, err)
+
+			decoded, err := DecodeWalletBackup(encoded)
+			require.NoError(t, err)
+			require.Len(t, decoded.KeyFamilyMarkers, 1)
+			require.True(t, marker.PubKey.IsEqual(
+				decoded.KeyFamilyMarkers[0].PubKey,
+			))
+			require.Equal(t, marker.KeyLocator,
+				decoded.KeyFamilyMarkers[0].KeyLocator)
+		})
+	}
+
+	// Simulate a backup produced before the trailing extension was added by
+	// removing the empty marker section and recomputing its checksum.
+	legacy := &WalletBackup{
+		Version: BackupVersionOriginal,
+	}
+	encoded, err := EncodeWalletBackup(legacy)
+	require.NoError(t, err)
+
+	payload := encoded[:len(encoded)-checksumSize]
+	require.True(t, bytes.HasSuffix(
+		payload, append([]byte(keyMarkerMagicBytes), 0),
+	))
+	legacyPayload := payload[:len(payload)-len(keyMarkerMagicBytes)-1]
+	checksum := sha256.Sum256(legacyPayload)
+	legacyEncoded := append(
+		append([]byte{}, legacyPayload...), checksum[:]...,
+	)
+
+	decoded, err := DecodeWalletBackup(legacyEncoded)
+	require.NoError(t, err)
+	require.Empty(t, decoded.KeyFamilyMarkers)
 }
 
 // TestFederationURLEncoding tests edge cases for federation URL encoding.

--- a/backup/encoding.go
+++ b/backup/encoding.go
@@ -11,6 +11,7 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 
@@ -61,6 +62,16 @@ const (
 	// maxFederationURLLen is the maximum length of a single federation
 	// URL in bytes.
 	maxFederationURLLen = 2048
+
+	// keyMarkerMagicBytes identifies the optional key-family marker section
+	// appended to the wallet backup payload. Keeping this as a trailing
+	// extension lets older readers continue to import newer backups while
+	// ignoring the marker data.
+	keyMarkerMagicBytes = "KEYI"
+
+	// maxKeyFamilyMarkers bounds the number of key-family markers decoded
+	// from an untrusted backup.
+	maxKeyFamilyMarkers = 100
 )
 
 // TLV type constants for AssetBackup fields.
@@ -198,6 +209,112 @@ func decodeFederationURLs(r io.Reader) ([]string, error) {
 	return urls, nil
 }
 
+// encodeKeyFamilyMarkers writes the optional key-family high-water markers.
+func encodeKeyFamilyMarkers(w io.Writer,
+	markers []*KeyDescriptorBackup) error {
+
+	if len(markers) > maxKeyFamilyMarkers {
+		return fmt.Errorf("key marker count %d exceeds maximum %d",
+			len(markers), maxKeyFamilyMarkers)
+	}
+
+	if _, err := w.Write([]byte(keyMarkerMagicBytes)); err != nil {
+		return fmt.Errorf("failed to write key marker magic: %w", err)
+	}
+
+	var scratch [8]byte
+	err := tlv.WriteVarInt(w, uint64(len(markers)), &scratch)
+	if err != nil {
+		return fmt.Errorf("failed to write key marker count: %w", err)
+	}
+
+	for i, marker := range markers {
+		if marker == nil || marker.PubKey == nil {
+			return fmt.Errorf("key marker %d is incomplete", i)
+		}
+
+		var markerBuf bytes.Buffer
+		if err := marker.Encode(&markerBuf); err != nil {
+			return fmt.Errorf("failed to encode key marker %d: %w",
+				i, err)
+		}
+
+		err = tlv.WriteVarInt(
+			w, uint64(markerBuf.Len()), &scratch,
+		)
+		if err != nil {
+			return fmt.Errorf("failed to write key marker %d "+
+				"length: %w", i, err)
+		}
+		if _, err := w.Write(markerBuf.Bytes()); err != nil {
+			return fmt.Errorf("failed to write key marker %d: %w",
+				i, err)
+		}
+	}
+
+	return nil
+}
+
+// decodeKeyFamilyMarkers reads an optional trailing key-family marker
+// section. An empty reader represents a legacy backup without the extension.
+func decodeKeyFamilyMarkers(r io.Reader) ([]*KeyDescriptorBackup, error) {
+	var magic [len(keyMarkerMagicBytes)]byte
+	n, err := io.ReadFull(r, magic[:])
+	switch {
+	case errors.Is(err, io.EOF) && n == 0:
+		return nil, nil
+	case err != nil:
+		return nil, fmt.Errorf("failed to read key marker magic: %w",
+			err)
+	case string(magic[:]) != keyMarkerMagicBytes:
+		return nil, fmt.Errorf("unknown wallet backup extension %x",
+			magic)
+	}
+
+	var scratch [8]byte
+	count, err := tlv.ReadVarInt(r, &scratch)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read key marker count: %w",
+			err)
+	}
+	if count > maxKeyFamilyMarkers {
+		return nil, fmt.Errorf("key marker count %d exceeds maximum %d",
+			count, maxKeyFamilyMarkers)
+	}
+
+	markers := make([]*KeyDescriptorBackup, count)
+	for i := uint64(0); i < count; i++ {
+		markerLen, err := tlv.ReadVarInt(r, &scratch)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read key marker %d "+
+				"length: %w", i, err)
+		}
+		if markerLen > maxTLVSize {
+			return nil, fmt.Errorf("key marker %d length %d "+
+				"exceeds maximum %d", i, markerLen, maxTLVSize)
+		}
+
+		markerBytes := make([]byte, markerLen)
+		if _, err := io.ReadFull(r, markerBytes); err != nil {
+			return nil, fmt.Errorf("failed to read key marker "+
+				"%d: %w", i, err)
+		}
+
+		marker := &KeyDescriptorBackup{}
+		markerReader := bytes.NewReader(markerBytes)
+		if err := marker.Decode(markerReader); err != nil {
+			return nil, fmt.Errorf("failed to decode key marker "+
+				"%d: %w", i, err)
+		}
+		if marker.PubKey == nil || marker.KeyLocator.IsEmpty() {
+			return nil, fmt.Errorf("key marker %d is incomplete", i)
+		}
+		markers[i] = marker
+	}
+
+	return markers, nil
+}
+
 // Encode serializes a WalletBackup to a writer.
 func (w *WalletBackup) Encode(writer io.Writer) error {
 	// Write magic bytes.
@@ -235,6 +352,16 @@ func (w *WalletBackup) Encode(writer io.Writer) error {
 			return fmt.Errorf("failed to encode "+
 				"asset %d: %w", i, err)
 		}
+	}
+
+	// Always write the extension, even when empty, so new backups have a
+	// canonical encoding. Older readers stop after the assets and therefore
+	// remain able to import this payload.
+	if err := encodeKeyFamilyMarkers(
+		writer, w.KeyFamilyMarkers,
+	); err != nil {
+		return fmt.Errorf("failed to encode key family markers: "+
+			"%w", err)
 	}
 
 	return nil
@@ -294,6 +421,14 @@ func (w *WalletBackup) Decode(reader io.Reader) error {
 				"asset %d: %w", i, err)
 		}
 		w.Assets[i] = ab
+	}
+
+	w.KeyFamilyMarkers, err = decodeKeyFamilyMarkers(
+		reader,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to decode key family markers: "+
+			"%w", err)
 	}
 
 	return nil

--- a/backup/export.go
+++ b/backup/export.go
@@ -16,7 +16,8 @@ import (
 func ExportBackup(ctx context.Context, mode ExportMode,
 	assets []*asset.ChainAsset, proofArchive proof.Archiver,
 	keyLookup KeyLocatorLookup,
-	federationURLs []string) ([]byte, error) {
+	federationURLs []string,
+	keyFamilyMarkers []*KeyDescriptorBackup) ([]byte, error) {
 
 	var (
 		assetBackups  []*AssetBackup
@@ -107,9 +108,10 @@ func ExportBackup(ctx context.Context, mode ExportMode,
 
 	// Create the wallet backup structure and encode it.
 	walletBackup := &WalletBackup{
-		Version:        backupVersion,
-		Assets:         assetBackups,
-		FederationURLs: federationURLs,
+		Version:          backupVersion,
+		Assets:           assetBackups,
+		FederationURLs:   federationURLs,
+		KeyFamilyMarkers: keyFamilyMarkers,
 	}
 
 	backupBytes, err := EncodeWalletBackup(walletBackup)

--- a/backup/import.go
+++ b/backup/import.go
@@ -57,8 +57,10 @@ type KeyRegistrar interface {
 // KeyRing derives and identifies keys controlled by LND. It is used to
 // restore monotonically increasing key-family indexes after seed recovery.
 type KeyRing interface {
-	// DeriveNextKey derives and persists the next key in a family.
-	DeriveNextKey(context.Context, keychain.KeyFamily) (
+	// DeriveAndStoreKey derives the key at the given locator and records it
+	// in the LND wallet, which advances the key family's derivation index
+	// past that key.
+	DeriveAndStoreKey(context.Context, keychain.KeyLocator) (
 		keychain.KeyDescriptor, error)
 
 	// IsLocalKey reports whether a descriptor belongs to the connected LND

--- a/backup/import.go
+++ b/backup/import.go
@@ -54,6 +54,18 @@ type KeyRegistrar interface {
 		keyType asset.ScriptKeyType) error
 }
 
+// KeyRing derives and identifies keys controlled by LND. It is used to
+// restore monotonically increasing key-family indexes after seed recovery.
+type KeyRing interface {
+	// DeriveNextKey derives and persists the next key in a family.
+	DeriveNextKey(context.Context, keychain.KeyFamily) (
+		keychain.KeyDescriptor, error)
+
+	// IsLocalKey reports whether a descriptor belongs to the connected LND
+	// wallet.
+	IsLocalKey(context.Context, keychain.KeyDescriptor) bool
+}
+
 // ImportConfig holds the dependencies needed to import a backup.
 type ImportConfig struct {
 	// SpendChecker is used to detect stale backup entries whose anchor
@@ -71,6 +83,10 @@ type ImportConfig struct {
 	// KeyRegistrar is used to register anchor internal keys and script
 	// keys so the wallet can sign for imported assets.
 	KeyRegistrar KeyRegistrar
+
+	// KeyRing is used to advance LND's key-family indexes beyond all keys
+	// represented by the backup. It may be nil for offline callers.
+	KeyRing KeyRing
 
 	// ProofVerifier provides the verification context for imported
 	// proofs.
@@ -561,6 +577,19 @@ func ImportBackup(ctx context.Context, backupBlob []byte,
 			idx, retryID[:])
 		numImported++
 		numSkipped--
+	}
+
+	// Advance LND only after all backup entries have been processed and
+	// verified. This prevents an invalid backup from changing wallet state.
+	// The operation is monotonic and idempotent, so retrying an import
+	// after an infrastructure error is safe.
+	if cfg.KeyRing != nil {
+		err = advanceKeyFamilyIndexes(ctx, walletBackup, cfg.KeyRing)
+		if err != nil {
+			return numImported, numSkipped, fmt.Errorf(
+				"failed to restore key family indexes: %w", err,
+			)
+		}
 	}
 
 	log.Infof("Imported %d assets from backup (%d skipped)",

--- a/backup/key_index.go
+++ b/backup/key_index.go
@@ -7,13 +7,6 @@ import (
 	"github.com/lightningnetwork/lnd/keychain"
 )
 
-const (
-	// maxKeyIndexAdvance bounds the number of DeriveNextKey RPCs an import
-	// can trigger for one family. This protects against resource exhaustion
-	// from a backup with a valid-looking but unreasonable marker.
-	maxKeyIndexAdvance = 10_000
-)
-
 // advanceKeyFamilyIndexes advances each local LND key family through the
 // highest locator represented in a wallet backup. Explicit markers cover all
 // keys consumed before export, including keys for assets that were later
@@ -79,41 +72,16 @@ func advanceKeyFamilyIndexes(ctx context.Context, wallet *WalletBackup,
 	}
 
 	for family, marker := range highest {
-		next, err := keyRing.DeriveNextKey(ctx, family)
+		// Storing a key records every key in the family that precedes
+		// it, so this single call advances LND's counter through the
+		// marker. LND keeps the operation monotonic, never rewinds a
+		// family, and bounds the number of keys it derives, so a marker
+		// that is already covered is a no-op and an unreasonable marker
+		// is rejected instead of causing excessive derivation.
+		_, err := keyRing.DeriveAndStoreKey(ctx, marker.KeyLocator)
 		if err != nil {
-			return fmt.Errorf("derive first key for family %d: %w",
-				family, err)
-		}
-		if next.Family != family {
-			return fmt.Errorf("derived unexpected key family %d, "+
-				"want %d", next.Family, family)
-		}
-		if next.Index >= marker.Index {
-			continue
-		}
-
-		gap := marker.Index - next.Index
-		if gap > maxKeyIndexAdvance {
-			return fmt.Errorf(
-				"key family %d requires advancing %d indexes, "+
-					"maximum is %d", family, gap,
-				maxKeyIndexAdvance,
-			)
-		}
-
-		for next.Index < marker.Index {
-			next, err = keyRing.DeriveNextKey(ctx, family)
-			if err != nil {
-				return fmt.Errorf("advance key family %d: %w",
-					family, err)
-			}
-			if next.Family != family {
-				return fmt.Errorf(
-					"derived unexpected key family %d, "+
-						"want "+
-						"%d", next.Family, family,
-				)
-			}
+			return fmt.Errorf("advance key family %d through "+
+				"index %d: %w", family, marker.Index, err)
 		}
 
 		log.Infof("Advanced LND key family %d through index %d",

--- a/backup/key_index.go
+++ b/backup/key_index.go
@@ -1,0 +1,134 @@
+package backup
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/lightningnetwork/lnd/keychain"
+)
+
+const (
+	// maxKeyIndexAdvance bounds the number of DeriveNextKey RPCs an import
+	// can trigger for one family. This protects against resource exhaustion
+	// from a backup with a valid-looking but unreasonable marker.
+	maxKeyIndexAdvance = 10_000
+)
+
+// advanceKeyFamilyIndexes advances each local LND key family through the
+// highest locator represented in a wallet backup. Explicit markers cover all
+// keys consumed before export, including keys for assets that were later
+// spent. Asset locators provide a backward-compatible fallback for backups
+// created before markers were added.
+func advanceKeyFamilyIndexes(ctx context.Context, wallet *WalletBackup,
+	keyRing KeyRing) error {
+
+	highest := make(map[keychain.KeyFamily]keychain.KeyDescriptor)
+
+	// Explicit markers only apply when the backup belongs to this LND seed.
+	// Backups can also be imported on watch-only or inspection nodes, so a
+	// marker from another seed is ignored instead of rejecting the assets.
+	for i, marker := range wallet.KeyFamilyMarkers {
+		if marker == nil || marker.PubKey == nil ||
+			marker.KeyLocator.IsEmpty() {
+
+			return fmt.Errorf("key family marker %d is "+
+				"incomplete", i)
+		}
+
+		desc := keychain.KeyDescriptor{
+			PubKey:     marker.PubKey,
+			KeyLocator: marker.KeyLocator,
+		}
+		if !keyRing.IsLocalKey(ctx, desc) {
+			log.Warnf("Ignoring key family marker %d "+
+				"(family=%d, index=%d): marker does not "+
+				"belong to the connected LND wallet", i,
+				desc.Family, desc.Index)
+			continue
+		}
+
+		addHighestKey(highest, desc)
+	}
+
+	// Older backups do not contain explicit markers. Their local active
+	// asset locators still let us advance through the highest known key.
+	for _, assetBackup := range wallet.Assets {
+		if assetBackup == nil {
+			continue
+		}
+
+		if info := assetBackup.ScriptKeyInfo; info != nil &&
+			info.RawKey.PubKey != nil &&
+			!info.RawKey.KeyLocator.IsEmpty() &&
+			keyRing.IsLocalKey(ctx, info.RawKey) {
+
+			addHighestKey(highest, info.RawKey)
+		}
+
+		if info := assetBackup.AnchorInternalKeyInfo; info != nil &&
+			info.PubKey != nil && !info.KeyLocator.IsEmpty() {
+
+			desc := keychain.KeyDescriptor{
+				PubKey:     info.PubKey,
+				KeyLocator: info.KeyLocator,
+			}
+			if keyRing.IsLocalKey(ctx, desc) {
+				addHighestKey(highest, desc)
+			}
+		}
+	}
+
+	for family, marker := range highest {
+		next, err := keyRing.DeriveNextKey(ctx, family)
+		if err != nil {
+			return fmt.Errorf("derive first key for family %d: %w",
+				family, err)
+		}
+		if next.Family != family {
+			return fmt.Errorf("derived unexpected key family %d, "+
+				"want %d", next.Family, family)
+		}
+		if next.Index >= marker.Index {
+			continue
+		}
+
+		gap := marker.Index - next.Index
+		if gap > maxKeyIndexAdvance {
+			return fmt.Errorf(
+				"key family %d requires advancing %d indexes, "+
+					"maximum is %d", family, gap,
+				maxKeyIndexAdvance,
+			)
+		}
+
+		for next.Index < marker.Index {
+			next, err = keyRing.DeriveNextKey(ctx, family)
+			if err != nil {
+				return fmt.Errorf("advance key family %d: %w",
+					family, err)
+			}
+			if next.Family != family {
+				return fmt.Errorf(
+					"derived unexpected key family %d, "+
+						"want "+
+						"%d", next.Family, family,
+				)
+			}
+		}
+
+		log.Infof("Advanced LND key family %d through index %d",
+			family, marker.Index)
+	}
+
+	return nil
+}
+
+// addHighestKey records the descriptor with the highest index per family.
+func addHighestKey(highest map[keychain.KeyFamily]keychain.KeyDescriptor,
+	desc keychain.KeyDescriptor) {
+
+	current, ok := highest[desc.Family]
+	if !ok || desc.Index > current.Index {
+		highest[desc.Family] = desc
+	}
+}

--- a/backup/key_index_test.go
+++ b/backup/key_index_test.go
@@ -41,14 +41,19 @@ func testKeyDesc(family keychain.KeyFamily,
 	}
 }
 
-func (t *testKeyRing) DeriveNextKey(_ context.Context,
-	family keychain.KeyFamily) (keychain.KeyDescriptor, error) {
+// DeriveAndStoreKey mirrors LND's behavior: recording a key implies recording
+// every key in the family that precedes it, so the family's next index moves
+// past the requested one, and an index the family already passed is a no-op.
+func (t *testKeyRing) DeriveAndStoreKey(_ context.Context,
+	keyLoc keychain.KeyLocator) (keychain.KeyDescriptor, error) {
 
-	index := t.next[family]
-	t.next[family]++
-	t.calls[family]++
+	t.calls[keyLoc.Family]++
 
-	return testKeyDesc(family, index), nil
+	if keyLoc.Index >= t.next[keyLoc.Family] {
+		t.next[keyLoc.Family] = keyLoc.Index + 1
+	}
+
+	return testKeyDesc(keyLoc.Family, keyLoc.Index), nil
 }
 
 func (t *testKeyRing) IsLocalKey(_ context.Context,
@@ -92,7 +97,9 @@ func TestAdvanceKeyFamilyIndexes(t *testing.T) {
 		)
 		require.NoError(t, err)
 		require.Equal(t, uint32(6), ring.next[family])
-		require.Equal(t, uint32(6), ring.calls[family])
+
+		// A single call is enough now, LND fills in the gap.
+		require.Equal(t, uint32(1), ring.calls[family])
 	})
 
 	t.Run("never rewinds", func(t *testing.T) {
@@ -108,7 +115,10 @@ func TestAdvanceKeyFamilyIndexes(t *testing.T) {
 			context.Background(), wallet, ring,
 		)
 		require.NoError(t, err)
-		require.Equal(t, uint32(9), ring.next[family])
+
+		// The marker is below where the family already is, so LND
+		// leaves the index alone.
+		require.Equal(t, uint32(8), ring.next[family])
 		require.Equal(t, uint32(1), ring.calls[family])
 	})
 
@@ -143,20 +153,5 @@ func TestAdvanceKeyFamilyIndexes(t *testing.T) {
 		)
 		require.NoError(t, err)
 		require.Zero(t, ring.calls[family])
-	})
-
-	t.Run("advance limit", func(t *testing.T) {
-		ring := newTestKeyRing()
-		wallet := &WalletBackup{
-			KeyFamilyMarkers: []*KeyDescriptorBackup{
-				keyMarker(family, maxKeyIndexAdvance+1),
-			},
-		}
-
-		err := advanceKeyFamilyIndexes(
-			context.Background(), wallet, ring,
-		)
-		require.ErrorContains(t, err, "requires advancing")
-		require.Equal(t, uint32(1), ring.calls[family])
 	})
 }

--- a/backup/key_index_test.go
+++ b/backup/key_index_test.go
@@ -1,0 +1,162 @@
+package backup
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/lightningnetwork/lnd/keychain"
+	"github.com/stretchr/testify/require"
+)
+
+type testKeyRing struct {
+	next  map[keychain.KeyFamily]uint32
+	calls map[keychain.KeyFamily]uint32
+}
+
+func newTestKeyRing() *testKeyRing {
+	return &testKeyRing{
+		next:  make(map[keychain.KeyFamily]uint32),
+		calls: make(map[keychain.KeyFamily]uint32),
+	}
+}
+
+func testKeyDesc(family keychain.KeyFamily,
+	index uint32) keychain.KeyDescriptor {
+
+	var keyMaterial [8]byte
+	binary.BigEndian.PutUint32(keyMaterial[:4], uint32(family))
+	binary.BigEndian.PutUint32(keyMaterial[4:], index)
+	digest := sha256.Sum256(keyMaterial[:])
+	_, pubKey := btcec.PrivKeyFromBytes(digest[:])
+
+	return keychain.KeyDescriptor{
+		PubKey: pubKey,
+		KeyLocator: keychain.KeyLocator{
+			Family: family,
+			Index:  index,
+		},
+	}
+}
+
+func (t *testKeyRing) DeriveNextKey(_ context.Context,
+	family keychain.KeyFamily) (keychain.KeyDescriptor, error) {
+
+	index := t.next[family]
+	t.next[family]++
+	t.calls[family]++
+
+	return testKeyDesc(family, index), nil
+}
+
+func (t *testKeyRing) IsLocalKey(_ context.Context,
+	desc keychain.KeyDescriptor) bool {
+
+	if desc.PubKey == nil {
+		return false
+	}
+
+	expected := testKeyDesc(desc.Family, desc.Index)
+	return expected.PubKey.IsEqual(desc.PubKey)
+}
+
+func keyMarker(family keychain.KeyFamily,
+	index uint32) *KeyDescriptorBackup {
+
+	desc := testKeyDesc(family, index)
+	return &KeyDescriptorBackup{
+		PubKey:     desc.PubKey,
+		KeyLocator: desc.KeyLocator,
+	}
+}
+
+// TestAdvanceKeyFamilyIndexes verifies marker restoration, monotonicity,
+// legacy locator fallback, seed validation, and the resource bound.
+func TestAdvanceKeyFamilyIndexes(t *testing.T) {
+	t.Parallel()
+
+	const family = keychain.KeyFamily(212)
+
+	t.Run("explicit marker", func(t *testing.T) {
+		ring := newTestKeyRing()
+		wallet := &WalletBackup{
+			KeyFamilyMarkers: []*KeyDescriptorBackup{
+				keyMarker(family, 5),
+			},
+		}
+
+		err := advanceKeyFamilyIndexes(
+			context.Background(), wallet, ring,
+		)
+		require.NoError(t, err)
+		require.Equal(t, uint32(6), ring.next[family])
+		require.Equal(t, uint32(6), ring.calls[family])
+	})
+
+	t.Run("never rewinds", func(t *testing.T) {
+		ring := newTestKeyRing()
+		ring.next[family] = 8
+		wallet := &WalletBackup{
+			KeyFamilyMarkers: []*KeyDescriptorBackup{
+				keyMarker(family, 5),
+			},
+		}
+
+		err := advanceKeyFamilyIndexes(
+			context.Background(), wallet, ring,
+		)
+		require.NoError(t, err)
+		require.Equal(t, uint32(9), ring.next[family])
+		require.Equal(t, uint32(1), ring.calls[family])
+	})
+
+	t.Run("legacy asset locator", func(t *testing.T) {
+		ring := newTestKeyRing()
+		desc := testKeyDesc(family, 4)
+		wallet := &WalletBackup{
+			Assets: []*AssetBackup{{
+				ScriptKeyInfo: &ScriptKeyBackup{
+					RawKey: desc,
+				},
+			}},
+		}
+
+		err := advanceKeyFamilyIndexes(
+			context.Background(), wallet, ring,
+		)
+		require.NoError(t, err)
+		require.Equal(t, uint32(5), ring.next[family])
+	})
+
+	t.Run("wrong seed", func(t *testing.T) {
+		ring := newTestKeyRing()
+		marker := keyMarker(family, 5)
+		marker.PubKey = randPubKey(t)
+		wallet := &WalletBackup{
+			KeyFamilyMarkers: []*KeyDescriptorBackup{marker},
+		}
+
+		err := advanceKeyFamilyIndexes(
+			context.Background(), wallet, ring,
+		)
+		require.NoError(t, err)
+		require.Zero(t, ring.calls[family])
+	})
+
+	t.Run("advance limit", func(t *testing.T) {
+		ring := newTestKeyRing()
+		wallet := &WalletBackup{
+			KeyFamilyMarkers: []*KeyDescriptorBackup{
+				keyMarker(family, maxKeyIndexAdvance+1),
+			},
+		}
+
+		err := advanceKeyFamilyIndexes(
+			context.Background(), wallet, ring,
+		)
+		require.ErrorContains(t, err, "requires advancing")
+		require.Equal(t, uint32(1), ring.calls[family])
+	})
+}

--- a/docs/release-notes/release-notes-0.9.0.md
+++ b/docs/release-notes/release-notes-0.9.0.md
@@ -25,6 +25,14 @@
   fixes a bug that could cause minted assets to commit to the wrong
   address.
 
+* [PR#2225](https://github.com/lightninglabs/taproot-assets/pull/2225) fixes
+  address key reuse after an `lnd` wallet is recovered from seed. Since `lnd`
+  has no record of the derivation indexes `tapd` consumed, newly created
+  Taproot Asset addresses could reuse historical script or internal keys.
+  Wallet backups now carry the key family's high-water marker, and importing a
+  backup restores `lnd`'s index from it. Exporting a backup no longer consumes
+  a key index itself.
+
 * [PR#2228](https://github.com/lightninglabs/taproot-assets/pull/2228)
   fixes `VerifyProof` failing the whole RPC for an invalid proof when
   decoding the last proof requires unknown asset metadata; it now

--- a/go.mod
+++ b/go.mod
@@ -232,3 +232,15 @@ replace github.com/prometheus/common => github.com/prometheus/common v0.66.1
 
 // Note this is a temporary replace and will be removed when taprpc is tagged.
 replace github.com/lightninglabs/taproot-assets/taprpc => ./taprpc
+
+// TEMPORARY: the key family index advance below calls an RPC that is not in
+// any released LND yet. These point at the branches of
+// lightningnetwork/lnd#11095 and lightninglabs/lndclient#288, and must both
+// be dropped in favor of normal version bumps before this can be merged.
+//
+// NOTE: The LND ref is the PR branch rebased onto the LND version this repo
+// already depends on, since LND master has since changed the itest harness
+// API that our own itests use.
+replace github.com/lightningnetwork/lnd => github.com/GeorgeTsagk/lnd v0.0.0-20260818092258-a7b9eb0643fd
+
+replace github.com/lightninglabs/lndclient => github.com/lightninglabs/lndclient v1.0.1-0.20260818101846-2c8ee79e1fdc

--- a/go.sum
+++ b/go.sum
@@ -603,6 +603,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/toml v1.4.0 h1:kuoIxZQy2WRRk1pttg9asf+WVv6tWQuBNVmK8+nqPr0=
 github.com/BurntSushi/toml v1.4.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/GeorgeTsagk/lnd v0.0.0-20260818092258-a7b9eb0643fd h1:QdCdIy+9IyLgDj7lyDHTzM/DG2bW+Rots+VgzAYwvXg=
+github.com/GeorgeTsagk/lnd v0.0.0-20260818092258-a7b9eb0643fd/go.mod h1:LWfQaNNXlZghUJqIIh+JsgfxiVtC+ecZkrIe5bm9o4U=
 github.com/JohnCGriffin/overflow v0.0.0-20211019200055-46fa312c352c/go.mod h1:X0CRv0ky0k6m906ixxpzmDRLvX58TFUKS2eePweuyxk=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
@@ -1070,8 +1072,8 @@ github.com/lightninglabs/lightning-node-connect/hashmailrpc v1.0.4-0.20250610182
 github.com/lightninglabs/lightning-node-connect/hashmailrpc v1.0.4-0.20250610182311-2f1d46ef18b7/go.mod h1:bDnEKRN1u13NFBuy/C+bFLhxA5bfd3clT25y76QY0AM=
 github.com/lightninglabs/lightning-node-connect/mailbox v1.0.2-0.20250610182311-2f1d46ef18b7 h1:EU/pEkszIbIJOHwOr67G9Gjmyy4CUXk6StRi9C26sUw=
 github.com/lightninglabs/lightning-node-connect/mailbox v1.0.2-0.20250610182311-2f1d46ef18b7/go.mod h1:cQA5pybYbERkMlE8j49LITZZozQZIXABbWJLIpMWnus=
-github.com/lightninglabs/lndclient v1.0.1-0.20260701212139-09c54915cfba h1:PbtOHmA9P41mjWt7HDZDDzYshv8fmyhIBPkdOf8wKws=
-github.com/lightninglabs/lndclient v1.0.1-0.20260701212139-09c54915cfba/go.mod h1:DtZg/wz7YFXVCwOwYOJyWKQBnUp1NFg4RQdax3MSYbc=
+github.com/lightninglabs/lndclient v1.0.1-0.20260818101846-2c8ee79e1fdc h1:sbGyJV+oZ6ZRz4OX/TgnwPajhTevXYn3NJNArjg3vhQ=
+github.com/lightninglabs/lndclient v1.0.1-0.20260818101846-2c8ee79e1fdc/go.mod h1:v6fWXFKVaox2yr/dmpfhOdWqrgCKEDt2ZFVnyw419SI=
 github.com/lightninglabs/migrate/v4 v4.18.2-9023d66a-fork-pr-2.0.20251211093704-71c1eef09789 h1:7kX7vUgHUazAHcCJ6uzBDa4/2MEGEbMEfa01GtfqmTQ=
 github.com/lightninglabs/migrate/v4 v4.18.2-9023d66a-fork-pr-2.0.20251211093704-71c1eef09789/go.mod h1:99BKpIi6ruaaXRM1A77eqZ+FWPQ3cfRa+ZVy5bmWMaY=
 github.com/lightninglabs/neutrino v0.18.0 h1:UsyeU3twkCSAXxUssVg8vGXcHkWKzHZ3xQCej57t5t0=
@@ -1082,8 +1084,6 @@ github.com/lightninglabs/protobuf-go-hex-display v1.34.2-hex-display h1:w7FM5LH9
 github.com/lightninglabs/protobuf-go-hex-display v1.34.2-hex-display/go.mod h1:qYOHts0dSfpeUzUFpOMr/WGzszTmLH+DiWniOlNbLDw=
 github.com/lightningnetwork/lightning-onion v1.4.0 h1:qWE1icOH4AKXRcq1KCzt6P/TesqptgBTP++V7wowTc0=
 github.com/lightningnetwork/lightning-onion v1.4.0/go.mod h1:YDPkvVTVQ6FBBE6Yj93tDd7zA3iTSrryi9xq46i7bKE=
-github.com/lightningnetwork/lnd v0.21.0-beta.rc2.0.20260630214209-40c64f9db30d h1:mDcB9mwuwJXRbDmxps6mBgGs318Iz5ZbOrt0ieEx0os=
-github.com/lightningnetwork/lnd v0.21.0-beta.rc2.0.20260630214209-40c64f9db30d/go.mod h1:LWfQaNNXlZghUJqIIh+JsgfxiVtC+ecZkrIe5bm9o4U=
 github.com/lightningnetwork/lnd/actor v0.0.6 h1:Ge8N2wivARG+27qJBwTlB0vwsypStZYZy8vk4Zl38sU=
 github.com/lightningnetwork/lnd/actor v0.0.6/go.mod h1:YAsoniSbY/cAM9HTVNfZLvt7RI6swDxy6wzPspTcMZg=
 github.com/lightningnetwork/lnd/cert v1.2.2 h1:71YK6hogeJtxSxw2teq3eGeuy4rHGKcFf0d0Uy4qBjI=

--- a/itest/backup_test.go
+++ b/itest/backup_test.go
@@ -208,9 +208,9 @@ func testBackupRestoreTransferred(t *harnessTest) {
 	)
 	require.NoError(t.t, err)
 
-	// Every backup mode must carry the key-family recovery marker. Each
-	// export derives the next marker, so their indexes should increase
-	// monotonically in export order.
+	// Every backup mode must carry the key-family recovery marker.
+	// Exporting a backup does not consume a key index, so all three
+	// exports must report the very same watermark.
 	var markerIndexes []uint32
 	for _, backupBlob := range [][]byte{
 		rawBackup.Backup,
@@ -225,8 +225,8 @@ func testBackupRestoreTransferred(t *harnessTest) {
 			decoded.KeyFamilyMarkers[0].KeyLocator.Index,
 		)
 	}
-	require.Less(t.t, markerIndexes[0], markerIndexes[1])
-	require.Less(t.t, markerIndexes[1], markerIndexes[2])
+	require.Equal(t.t, markerIndexes[0], markerIndexes[1])
+	require.Equal(t.t, markerIndexes[1], markerIndexes[2])
 
 	require.Less(t.t, len(compactBackup.Backup),
 		len(rawBackup.Backup),

--- a/itest/backup_test.go
+++ b/itest/backup_test.go
@@ -208,6 +208,26 @@ func testBackupRestoreTransferred(t *harnessTest) {
 	)
 	require.NoError(t.t, err)
 
+	// Every backup mode must carry the key-family recovery marker. Each
+	// export derives the next marker, so their indexes should increase
+	// monotonically in export order.
+	var markerIndexes []uint32
+	for _, backupBlob := range [][]byte{
+		rawBackup.Backup,
+		compactBackup.Backup,
+		optimisticBackup.Backup,
+	} {
+		decoded, err := backup.DecodeWalletBackup(backupBlob)
+		require.NoError(t.t, err)
+		require.Len(t.t, decoded.KeyFamilyMarkers, 1)
+		markerIndexes = append(
+			markerIndexes,
+			decoded.KeyFamilyMarkers[0].KeyLocator.Index,
+		)
+	}
+	require.Less(t.t, markerIndexes[0], markerIndexes[1])
+	require.Less(t.t, markerIndexes[1], markerIndexes[2])
+
 	require.Less(t.t, len(compactBackup.Backup),
 		len(rawBackup.Backup),
 		"compact backup should be smaller than raw")

--- a/itest/send_test.go
+++ b/itest/send_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/btcsuite/btcd/btcutil/v2"
 	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/lightninglabs/taproot-assets/backup"
 	"github.com/lightninglabs/taproot-assets/fn"
 	"github.com/lightninglabs/taproot-assets/internal/test"
 	"github.com/lightninglabs/taproot-assets/proof"
@@ -2140,9 +2141,17 @@ func testRestoreLndFromSeed(t *harnessTest) {
 
 	// We mint a batch of normal assets with enough units to allow us to
 	// send it around a few times.
+	seedRestoreAsset := &mintrpc.MintAssetRequest{
+		Asset: &mintrpc.MintAsset{
+			AssetType: taprpc.AssetType_NORMAL,
+			Name:      "seed-restore-key-index",
+			Amount:    5000,
+			AssetMeta: &taprpc.AssetMeta{},
+		},
+	}
 	rpcAssets := MintAssetsConfirmBatch(
 		t.t, t.lndHarness.Miner(), bob,
-		[]*mintrpc.MintAssetRequest{issuableAssets[0]},
+		[]*mintrpc.MintAssetRequest{seedRestoreAsset},
 	)
 
 	var (
@@ -2172,8 +2181,42 @@ func testRestoreLndFromSeed(t *harnessTest) {
 	AssertNonInteractiveRecvComplete(t.t, alice, 1)
 	AssertSendEventsComplete(t.t, aliceAddr.ScriptKey, sendEvents)
 
-	// We now restore Bob's lnd node from the seed.
-	require.NoError(t.t, bob.stop(false))
+	// Consume several address keys, then export a backup. The export also
+	// records LND's Taproot Assets key-family high-water marker.
+	historicalScriptKeys := make(map[string]struct{})
+	bobAssets, err := bob.ListAssets(ctxb, &taprpc.ListAssetRequest{
+		IncludeSpent: true,
+	})
+	require.NoError(t.t, err)
+	for _, bobAsset := range bobAssets.Assets {
+		historicalScriptKeys[hex.EncodeToString(bobAsset.ScriptKey)] =
+			struct{}{}
+	}
+	for range 3 {
+		bobAddr, err := bob.NewAddr(ctxb, &taprpc.NewAddrRequest{
+			AssetId: genInfo.AssetId,
+			Amt:     sendAmount,
+		})
+		require.NoError(t.t, err)
+		historicalScriptKeys[hex.EncodeToString(bobAddr.ScriptKey)] =
+			struct{}{}
+	}
+
+	backupResp, err := bob.ExportAssetWalletBackup(
+		ctxb, &wrpc.ExportAssetWalletBackupRequest{
+			Mode: wrpc.BackupMode_RAW,
+		},
+	)
+	require.NoError(t.t, err)
+
+	decodedBackup, err := backup.DecodeWalletBackup(backupResp.Backup)
+	require.NoError(t.t, err)
+	require.NotEmpty(t.t, decodedBackup.KeyFamilyMarkers)
+
+	// We now destroy both Bob's tapd state and LND wallet, then restore LND
+	// only from aezeed. This reproduces a full disaster recovery instead of
+	// a normal daemon restart.
+	require.NoError(t.t, bob.stop(true))
 	require.NoError(t.t, seedLnd.Shutdown())
 
 	// Starting the node again should restore it to the same state as
@@ -2187,6 +2230,27 @@ func testRestoreLndFromSeed(t *harnessTest) {
 	bob.updateLndNode(seedLnd)
 
 	require.NoError(t.t, bob.start(false))
+
+	importResp, err := bob.ImportAssetsFromBackup(
+		ctxb, &wrpc.ImportAssetsFromBackupRequest{
+			Backup: backupResp.Backup,
+		},
+	)
+	require.NoError(t.t, err)
+	require.NotZero(t.t, importResp.NumImported)
+
+	// The first address after restore must not reuse a key that was issued
+	// before the backup. Without restoring LND's family index, the address
+	// starts again at the first historical key.
+	restoredAddr, err := bob.NewAddr(ctxb, &taprpc.NewAddrRequest{
+		AssetId: genInfo.AssetId,
+		Amt:     sendAmount,
+	})
+	require.NoError(t.t, err)
+	restoredKey := hex.EncodeToString(restoredAddr.ScriptKey)
+	_, reused := historicalScriptKeys[restoredKey]
+	require.False(t.t, reused, "restored wallet reused script key %x",
+		restoredAddr.ScriptKey)
 
 	// Let's make sure we properly clean up the node at the end of the test.
 	defer func() {
@@ -2207,7 +2271,7 @@ func testRestoreLndFromSeed(t *harnessTest) {
 	ConfirmAndAssertOutboundTransfer(
 		t.t, t.lndHarness.Miner(), bob, sendResp,
 		genInfo.AssetId,
-		[]uint64{rpcAsset.Amount - sendAmount*2, sendAmount}, 1, 2,
+		[]uint64{rpcAsset.Amount - sendAmount*2, sendAmount}, 0, 1,
 	)
 	AssertNonInteractiveRecvComplete(t.t, alice, 2)
 	AssertSendEventsComplete(t.t, aliceAddr.ScriptKey, sendEvents)

--- a/itest/send_test.go
+++ b/itest/send_test.go
@@ -2227,9 +2227,12 @@ func testRestoreLndFromSeed(t *harnessTest) {
 		"lnd-seed-restored", lndDefaultArgs, password, mnemonic, "",
 		2500, nil,
 	)
-	bob.updateLndNode(seedLnd)
-
-	require.NoError(t.t, bob.start(false))
+	// We stand up a genuinely fresh tapd for the restored LND instead of
+	// restarting the previous harness. Stopping a harness only removes its
+	// base directory, which wipes the state of an sqlite backed node but
+	// leaves a postgres database untouched, so restarting would come back
+	// with all of Bob's assets still present.
+	bob = setupTapdHarness(t.t, t, seedLnd, t.universeServer)
 
 	importResp, err := bob.ImportAssetsFromBackup(
 		ctxb, &wrpc.ImportAssetsFromBackupRequest{

--- a/itest/send_test.go
+++ b/itest/send_test.go
@@ -5,11 +5,13 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/btcsuite/btcd/btcutil/v2"
 	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/lightninglabs/taproot-assets/asset"
 	"github.com/lightninglabs/taproot-assets/backup"
 	"github.com/lightninglabs/taproot-assets/fn"
 	"github.com/lightninglabs/taproot-assets/internal/test"
@@ -22,7 +24,10 @@ import (
 	"github.com/lightninglabs/taproot-assets/taprpc/tapdevrpc"
 	unirpc "github.com/lightninglabs/taproot-assets/taprpc/universerpc"
 	"github.com/lightninglabs/taproot-assets/tapsend"
+	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/lightningnetwork/lnd/lnrpc"
+	"github.com/lightningnetwork/lnd/lnrpc/walletrpc"
+	"github.com/lightningnetwork/lnd/lntest/node"
 	"github.com/lightningnetwork/lnd/lntest/wait"
 	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
 	"github.com/stretchr/testify/require"
@@ -2202,6 +2207,11 @@ func testRestoreLndFromSeed(t *harnessTest) {
 			struct{}{}
 	}
 
+	// Exporting a backup must not consume a key index itself, otherwise
+	// every export would permanently burn one.
+	keyCountBeforeExport := assetKeyFamilyIndex(t, seedLnd)
+	require.NotZero(t.t, keyCountBeforeExport)
+
 	backupResp, err := bob.ExportAssetWalletBackup(
 		ctxb, &wrpc.ExportAssetWalletBackupRequest{
 			Mode: wrpc.BackupMode_RAW,
@@ -2209,9 +2219,21 @@ func testRestoreLndFromSeed(t *harnessTest) {
 	)
 	require.NoError(t.t, err)
 
+	require.Equal(
+		t.t, keyCountBeforeExport, assetKeyFamilyIndex(t, seedLnd),
+		"exporting a backup consumed a key index",
+	)
+
 	decodedBackup, err := backup.DecodeWalletBackup(backupResp.Backup)
 	require.NoError(t.t, err)
 	require.NotEmpty(t.t, decodedBackup.KeyFamilyMarkers)
+
+	// The marker must record the last key we actually consumed, which is
+	// the index below the one the next key will get.
+	require.EqualValues(
+		t.t, keyCountBeforeExport-1,
+		decodedBackup.KeyFamilyMarkers[0].KeyLocator.Index,
+	)
 
 	// We now destroy both Bob's tapd state and LND wallet, then restore LND
 	// only from aezeed. This reproduces a full disaster recovery instead of
@@ -2241,6 +2263,13 @@ func testRestoreLndFromSeed(t *harnessTest) {
 	)
 	require.NoError(t.t, err)
 	require.NotZero(t.t, importResp.NumImported)
+
+	// The restored LND started out with an empty key family, so the import
+	// must have moved its index back past every key the backup covers.
+	require.GreaterOrEqual(
+		t.t, assetKeyFamilyIndex(t, seedLnd), keyCountBeforeExport,
+		"import did not restore the key family index",
+	)
 
 	// The first address after restore must not reuse a key that was issued
 	// before the backup. Without restoring LND's family index, the address
@@ -2278,6 +2307,27 @@ func testRestoreLndFromSeed(t *harnessTest) {
 	)
 	AssertNonInteractiveRecvComplete(t.t, alice, 2)
 	AssertSendEventsComplete(t.t, aliceAddr.ScriptKey, sendEvents)
+}
+
+// assetKeyFamilyIndex returns the index that the next key derived from the
+// given LND node's Taproot Assets key family will have.
+func assetKeyFamilyIndex(t *harnessTest, lnd *node.HarnessNode) uint32 {
+	accounts := lnd.RPC.ListAccounts(&walletrpc.ListAccountsRequest{})
+
+	purpose := fmt.Sprintf("/%d'/", keychain.BIP0043Purpose)
+	suffix := fmt.Sprintf("/%d'", asset.TaprootAssetsKeyFamily)
+	for _, account := range accounts.Accounts {
+		path := account.DerivationPath
+		if !strings.Contains(path, purpose) {
+			continue
+		}
+
+		if strings.HasSuffix(path, suffix) {
+			return account.ExternalKeyCount
+		}
+	}
+
+	return 0
 }
 
 // addProofTestVectorFromFile adds a proof test vector by extracting it from the

--- a/lndservices/key_ring.go
+++ b/lndservices/key_ring.go
@@ -43,6 +43,23 @@ func (l *LndRpcKeyRing) DeriveNextKey(ctx context.Context,
 	return *keyDesc, nil
 }
 
+// DeriveAndStoreKey derives the key at the given locator and records it in the
+// LND wallet, which advances the key family's derivation index past that key.
+func (l *LndRpcKeyRing) DeriveAndStoreKey(ctx context.Context,
+	keyLoc keychain.KeyLocator) (keychain.KeyDescriptor, error) {
+
+	log.Debugf("Deriving and storing key for fam_family=%v, index=%v",
+		keyLoc.Family, keyLoc.Index)
+
+	keyDesc, err := l.lnd.WalletKit.DeriveAndStoreKey(ctx, &keyLoc)
+	if err != nil {
+		return keychain.KeyDescriptor{}, fmt.Errorf("unable to derive "+
+			"and store key: %w", err)
+	}
+
+	return *keyDesc, nil
+}
+
 // DeriveNextTaprootAssetKey attempts to derive the *next* key within the
 // Taproot Asset key family.
 func (l *LndRpcKeyRing) DeriveNextTaprootAssetKey(

--- a/rpcserver/rpcserver.go
+++ b/rpcserver/rpcserver.go
@@ -37,6 +37,7 @@ import (
 	"github.com/lightninglabs/taproot-assets/backup"
 	"github.com/lightninglabs/taproot-assets/commitment"
 	"github.com/lightninglabs/taproot-assets/fn"
+	"github.com/lightninglabs/taproot-assets/lndservices"
 	"github.com/lightninglabs/taproot-assets/mssmt"
 	"github.com/lightninglabs/taproot-assets/mssmt/arith"
 	"github.com/lightninglabs/taproot-assets/proof"
@@ -12299,9 +12300,21 @@ func (r *RPCServer) ExportAssetWalletBackup(ctx context.Context,
 	}
 
 	// Delegate to the backup package.
+	keyMarker, err := r.cfg.Lnd.WalletKit.DeriveNextKey(
+		ctx, int32(asset.TaprootAssetsKeyFamily),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to derive backup key family "+
+			"marker: %w", err)
+	}
+
 	blob, err := backup.ExportBackup(
 		ctx, mode, confirmedAssets, r.cfg.ProofArchive,
 		r.cfg.TapAddrBook, fedURLs,
+		[]*backup.KeyDescriptorBackup{{
+			PubKey:     keyMarker.PubKey,
+			KeyLocator: keyMarker.KeyLocator,
+		}},
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to export backup: %w", err)
@@ -12323,6 +12336,7 @@ func (r *RPCServer) ImportAssetsFromBackup(ctx context.Context,
 		ChainQuerier:  r.cfg.ChainBridge,
 		ProofArchive:  r.cfg.ProofArchive,
 		KeyRegistrar:  r.cfg.TapAddrBook,
+		KeyRing:       lndservices.NewLndRpcKeyRing(r.cfg.Lnd),
 		ProofVerifier: r.ProofVerifierCtx(ctx),
 	}
 

--- a/rpcserver/rpcserver.go
+++ b/rpcserver/rpcserver.go
@@ -12281,6 +12281,68 @@ func (r *RPCServer) ProofVerifierCtx(ctx context.Context) proof.VerifierCtx {
 	}
 }
 
+// keyFamilyMarkers returns a marker for the last key index our key family has
+// consumed, which an import uses to restore LND's key family counter after the
+// LND wallet was recovered from seed.
+//
+// NOTE: This must not consume a key index itself, otherwise every export would
+// permanently burn one. The counter is read through ListAccounts, and the
+// marker's key is then derived read-only.
+func (r *RPCServer) keyFamilyMarkers(
+	ctx context.Context) ([]*backup.KeyDescriptorBackup, error) {
+
+	keyFam := keychain.KeyFamily(asset.TaprootAssetsKeyFamily)
+
+	accounts, err := r.cfg.Lnd.WalletKit.ListAccounts(
+		ctx, "", walletrpc.AddressType_UNKNOWN,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("unable to list wallet accounts: %w",
+			err)
+	}
+
+	// The account of a key family is the one under the BIP-0043 purpose LND
+	// derives its keys from, with the family as the last path element.
+	var (
+		purpose  = fmt.Sprintf("/%d'/", keychain.BIP0043Purpose)
+		suffix   = fmt.Sprintf("/%d'", keyFam)
+		keyCount uint32
+	)
+	for _, account := range accounts {
+		path := account.DerivationPath
+		if !strings.Contains(path, purpose) {
+			continue
+		}
+
+		if strings.HasSuffix(path, suffix) {
+			keyCount = account.ExternalKeyCount
+
+			break
+		}
+	}
+
+	// A key family that never handed out a key has no watermark to record.
+	if keyCount == 0 {
+		return nil, nil
+	}
+
+	// The key count is the index the *next* key will have, so the last key
+	// we consumed is the one below it.
+	marker, err := r.cfg.Lnd.WalletKit.DeriveKey(ctx, &keychain.KeyLocator{
+		Family: keyFam,
+		Index:  keyCount - 1,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("unable to derive key at index %d: %w",
+			keyCount-1, err)
+	}
+
+	return []*backup.KeyDescriptorBackup{{
+		PubKey:     marker.PubKey,
+		KeyLocator: marker.KeyLocator,
+	}}, nil
+}
+
 // ExportAssetWalletBackup exports a backup of all active assets in the wallet.
 // The backup includes all data necessary to restore the assets in case of
 // database or system failure.
@@ -12335,22 +12397,18 @@ func (r *RPCServer) ExportAssetWalletBackup(ctx context.Context,
 		}
 	}
 
-	// Delegate to the backup package.
-	keyMarker, err := r.cfg.Lnd.WalletKit.DeriveNextKey(
-		ctx, int32(asset.TaprootAssetsKeyFamily),
-	)
+	// Record the highest key index our key family has consumed so far, so
+	// that an import can restore LND's counter after a seed recovery.
+	keyMarkers, err := r.keyFamilyMarkers(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to derive backup key family "+
 			"marker: %w", err)
 	}
 
+	// Delegate to the backup package.
 	blob, err := backup.ExportBackup(
 		ctx, mode, confirmedAssets, r.cfg.ProofArchive,
-		r.cfg.TapAddrBook, fedURLs,
-		[]*backup.KeyDescriptorBackup{{
-			PubKey:     keyMarker.PubKey,
-			KeyLocator: keyMarker.KeyLocator,
-		}},
+		r.cfg.TapAddrBook, fedURLs, keyMarkers,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to export backup: %w", err)

--- a/rpcserver/rpcserver.go
+++ b/rpcserver/rpcserver.go
@@ -37,6 +37,7 @@ import (
 	"github.com/lightninglabs/taproot-assets/backup"
 	"github.com/lightninglabs/taproot-assets/commitment"
 	"github.com/lightninglabs/taproot-assets/fn"
+	"github.com/lightninglabs/taproot-assets/lndservices"
 	"github.com/lightninglabs/taproot-assets/mssmt"
 	"github.com/lightninglabs/taproot-assets/mssmt/arith"
 	"github.com/lightninglabs/taproot-assets/proof"
@@ -12335,9 +12336,21 @@ func (r *RPCServer) ExportAssetWalletBackup(ctx context.Context,
 	}
 
 	// Delegate to the backup package.
+	keyMarker, err := r.cfg.Lnd.WalletKit.DeriveNextKey(
+		ctx, int32(asset.TaprootAssetsKeyFamily),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to derive backup key family "+
+			"marker: %w", err)
+	}
+
 	blob, err := backup.ExportBackup(
 		ctx, mode, confirmedAssets, r.cfg.ProofArchive,
 		r.cfg.TapAddrBook, fedURLs,
+		[]*backup.KeyDescriptorBackup{{
+			PubKey:     keyMarker.PubKey,
+			KeyLocator: keyMarker.KeyLocator,
+		}},
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to export backup: %w", err)
@@ -12359,6 +12372,7 @@ func (r *RPCServer) ImportAssetsFromBackup(ctx context.Context,
 		ChainQuerier:  r.cfg.ChainBridge,
 		ProofArchive:  r.cfg.ProofArchive,
 		KeyRegistrar:  r.cfg.TapAddrBook,
+		KeyRing:       lndservices.NewLndRpcKeyRing(r.cfg.Lnd),
 		ProofVerifier: r.ProofVerifierCtx(ctx),
 	}
 


### PR DESCRIPTION
## Description


  After restoring LND from aezeed, LND has no record of the derivation indexes previously consumed by tapd’s key family. This can cause newly generated Taproot Asset addresses to reuse historical script or internal keys.

  This PR adds an optional key-family high-water marker to asset wallet backups. During backup import, tapd verifies that each marker belongs to the connected LND seed and advances LND’s key-family counter through the recorded index using `DeriveNextKey`.

  The marker is encoded as a trailing, checksummed extension, preserving compatibility:

  - New tapd versions can read backups with or without the marker.
  - Legacy backups fall back to the highest local key locator represented by their active assets.
  - Older readers continue to decode the existing backup payload.
  - Raw, compact, and optimistic backup modes use the same extension.

  Recovery is monotonic and never rewinds LND’s counter. Markers belonging to another seed are ignored, and advancement is bounded to prevent excessive derivation work.


## Tests 

  Tests cover:

  - Marker round trips for raw, compact, and optimistic backup versions.
  - Decoding legacy backups where the marker field is absent.
  - Legacy asset-locator fallback.
  - No counter rewind.
  - Wrong-seed markers.
  - Maximum advancement limits.
  - Full aezeed recovery, backup import, fresh address derivation, subsequent spending, and proof validation.
  - Marker export/import across all three backup modes.

### Other

Closes #2221