### PR TITLE
proof: support versioned custom-anchor transition proofs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+.git
+.github
+
+# Locally built daemon and integration-test binaries are not required by the
+# development image. Excluding them keeps the Docker build context small and
+# stable while another test build may be updating those files.
+tapcli-debug
+tapd-debug
+itest/*-itest
+itest/chantools/chantools
+
+# Runtime and editor artifacts never belong in a source build context.
+*.log
+.DS_Store
+test-artifacts

--- a/docs/release-notes/release-notes-0.9.0.md
+++ b/docs/release-notes/release-notes-0.9.0.md
@@ -39,6 +39,10 @@
 
 ## RPC Updates
 
+* [PR#2226](https://github.com/lightninglabs/taproot-assets/pull/2226)
+  lets `CommitVirtualPsbts` select the transition proof version and adds
+  BIP-371 tapscript sibling exclusion proofs for version 1 proofs.
+
 ## tapcli Updates
 
 ## Config Changes

--- a/itest/multisig.go
+++ b/itest/multisig.go
@@ -385,10 +385,21 @@ func DeriveKeys(t *testing.T, tapd commands.RpcClientsBundle) (asset.ScriptKey,
 	return *scriptKey, internalKeyLnd
 }
 
+type commitVirtualPsbtsOption func(*wrpc.CommitVirtualPsbtsRequest)
+
+func withTransitionProofVersion(
+	version wrpc.TransitionProofVersion) commitVirtualPsbtsOption {
+
+	return func(request *wrpc.CommitVirtualPsbtsRequest) {
+		request.TransitionProofVersion = version
+	}
+}
+
 func CommitVirtualPsbts(t *testing.T, funder commands.RpcClientsBundle,
 	packet *psbt.Packet, activePackets []*tappsbt.VPacket,
 	passivePackets []*tappsbt.VPacket,
-	changeOutputIndex int32) (*psbt.Packet, []*tappsbt.VPacket,
+	changeOutputIndex int32,
+	opts ...commitVirtualPsbtsOption) (*psbt.Packet, []*tappsbt.VPacket,
 	[]*tappsbt.VPacket, *wrpc.CommitVirtualPsbtsResponse) {
 
 	ctx := context.Background()
@@ -403,6 +414,9 @@ func CommitVirtualPsbts(t *testing.T, funder commands.RpcClientsBundle,
 		Fees: &wrpc.CommitVirtualPsbtsRequest_SatPerVbyte{
 			SatPerVbyte: uint64(feeRateSatPerKVByte / 1000),
 		},
+	}
+	for _, opt := range opts {
+		opt(request)
 	}
 
 	type existingIndex = wrpc.CommitVirtualPsbtsRequest_ExistingOutputIndex

--- a/itest/psbt_test.go
+++ b/itest/psbt_test.go
@@ -2861,7 +2861,22 @@ func testPsbtExternalCommit(t *harnessTest) {
 	var commitResp *wrpc.CommitVirtualPsbtsResponse
 	btcPacket, activeAssets, passiveAssets, commitResp = CommitVirtualPsbts(
 		t.t, aliceTapd, btcPacket, activeAssets, passiveAssets, -1,
+		withTransitionProofVersion(
+			wrpc.TransitionProofVersion_TRANSITION_PROOF_VERSION_V1,
+		),
 	)
+
+	allPackets = append([]*tappsbt.VPacket{}, activeAssets...)
+	allPackets = append(allPackets, passiveAssets...)
+	for _, packet := range allPackets {
+		for _, output := range packet.Outputs {
+			require.NotNil(t.t, output.ProofSuffix)
+			require.Equal(
+				t.t, proof.TransitionV1,
+				output.ProofSuffix.Version,
+			)
+		}
+	}
 
 	t.Logf("Committed transaction: %v", toJSON(t.t, commitResp))
 

--- a/proof/taproot.go
+++ b/proof/taproot.go
@@ -1,6 +1,7 @@
 package proof
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"io"
@@ -634,6 +635,16 @@ func (p TaprootProof) DeriveByTapscriptProof() (*btcec.PublicKey, error) {
 func AddExclusionProofs(baseProof *BaseProofParams, finalTx *wire.MsgTx,
 	finalTxPacketOutputs []psbt.POutput, isAnchor func(uint32) bool) error {
 
+	if finalTx == nil {
+		return fmt.Errorf("cannot add exclusion proofs without a " +
+			"final transaction")
+	}
+	if len(finalTx.TxOut) != len(finalTxPacketOutputs) {
+		return fmt.Errorf("cannot add exclusion proofs, "+
+			"transaction has %d outputs but PSBT has %d",
+			len(finalTx.TxOut), len(finalTxPacketOutputs))
+	}
+
 	for outIdx := range finalTxPacketOutputs {
 		txOut := finalTx.TxOut[outIdx]
 
@@ -664,28 +675,266 @@ func AddExclusionProofs(baseProof *BaseProofParams, finalTx *wire.MsgTx,
 				"invalid: %w", outIdx, err)
 		}
 
-		// Make sure this is a BIP-0086 key spend as that is the only
-		// method we currently support here.
-		if len(out.TaprootTapTree) > 0 {
-			return fmt.Errorf("cannot add exclusion proof, output "+
-				"%d uses a tap tree which is currently not "+
-				"supported", outIdx)
+		var (
+			tapTree        txscript.TapNode
+			tapscriptProof *TapscriptProof
+		)
+		if len(out.TaprootTapTree) == 0 {
+			// An output without a declared tap tree is a BIP-0086
+			// key spend.
+			tapscriptProof = &TapscriptProof{
+				Bip86: true,
+			}
+		} else {
+			tapTree, err = parseBIP371TapTree(out.TaprootTapTree)
+			if err != nil {
+				return fmt.Errorf("cannot add exclusion "+
+					"proof, output %d has an invalid "+
+					"PSBT tap tree: %w", outIdx, err)
+			}
+
+			tapscriptProof, err = createTapscriptProofFromRoot(
+				tapTree,
+			)
+			if err != nil {
+				return fmt.Errorf("cannot add exclusion "+
+					"proof, output %d has an invalid "+
+					"tapscript tree: %w", outIdx, err)
+			}
 		}
 
-		// Okay, we now know this is a normal BIP-0086 key spend and can
-		// add the exclusion proof accordingly.
+		// The PSBT metadata is supplied by the creator of the output.
+		// Make sure it actually opens the P2TR output before using it
+		// to create an exclusion proof.
+		var tapscriptRoot []byte
+		if tapTree != nil {
+			rootHash := tapTree.TapHash()
+			tapscriptRoot = rootHash[:]
+		}
+		outputKey := txscript.ComputeTaprootOutputKey(
+			internalKey, tapscriptRoot,
+		)
+		expectedPkScript, err := txscript.PayToTaprootScript(outputKey)
+		if err != nil {
+			return fmt.Errorf("cannot add exclusion proof, output "+
+				"%d has an invalid taproot key: %w", outIdx,
+				err)
+		}
+		if !bytes.Equal(expectedPkScript, txOut.PkScript) {
+			return fmt.Errorf("cannot add exclusion proof, output "+
+				"%d PSBT taproot metadata does not match the "+
+				"transaction output", outIdx)
+		}
+
 		baseProof.ExclusionProofs = append(
 			baseProof.ExclusionProofs, TaprootProof{
-				OutputIndex: uint32(outIdx),
-				InternalKey: internalKey,
-				TapscriptProof: &TapscriptProof{
-					Bip86: true,
-				},
+				OutputIndex:    uint32(outIdx),
+				InternalKey:    internalKey,
+				TapscriptProof: tapscriptProof,
 			},
 		)
 	}
 
 	return nil
+}
+
+// bip371TapLeaf is a single PSBT_OUT_TAP_TREE depth-first tuple.
+type bip371TapLeaf struct {
+	depth uint8
+	leaf  txscript.TapLeaf
+}
+
+// bip371TapTreeParser reconstructs the exact tree shape committed to by the
+// depth-first PSBT_OUT_TAP_TREE tuples.
+type bip371TapTreeParser struct {
+	leaves []bip371TapLeaf
+	next   int
+}
+
+// parseNode parses either a leaf at expectedDepth or the two children of a
+// branch at expectedDepth. A complete binary tree has exactly one root and two
+// children for every branch, so a depth-first leaf stream is unambiguous.
+func (p *bip371TapTreeParser) parseNode(expectedDepth uint8) (
+	txscript.TapNode, error) {
+
+	if p.next >= len(p.leaves) {
+		return nil, fmt.Errorf(
+			"missing node at depth %d", expectedDepth,
+		)
+	}
+
+	nextLeaf := p.leaves[p.next]
+	if nextLeaf.depth < expectedDepth {
+		return nil, fmt.Errorf(
+			"leaf %d at depth %d cannot fill node at depth %d",
+			p.next, nextLeaf.depth, expectedDepth,
+		)
+	}
+	if nextLeaf.depth == expectedDepth {
+		p.next++
+		return nextLeaf.leaf, nil
+	}
+	if expectedDepth >= txscript.ControlBlockMaxNodeCount {
+		return nil, fmt.Errorf("tree exceeds maximum depth %d",
+			txscript.ControlBlockMaxNodeCount)
+	}
+
+	left, err := p.parseNode(expectedDepth + 1)
+	if err != nil {
+		return nil, fmt.Errorf("invalid left subtree at depth %d: %w",
+			expectedDepth, err)
+	}
+	right, err := p.parseNode(expectedDepth + 1)
+	if err != nil {
+		return nil, fmt.Errorf("invalid right subtree at depth %d: %w",
+			expectedDepth, err)
+	}
+
+	return txscript.NewTapBranch(left, right), nil
+}
+
+// parseBIP371TapTree decodes PSBT_OUT_TAP_TREE and reconstructs its exact
+// binary tree. BIP-371 encodes leaves as depth-first tuples:
+//
+//	<depth><leaf version><compact size script><script>
+//
+// The depth stream is validated as a complete binary tree rather than flattened
+// and reassembled, since a different tree shape can produce a different root.
+func parseBIP371TapTree(encoded []byte) (txscript.TapNode, error) {
+	if len(encoded) == 0 {
+		return nil, fmt.Errorf("tap tree is empty")
+	}
+
+	reader := bytes.NewReader(encoded)
+	leaves := make([]bip371TapLeaf, 0)
+	for reader.Len() > 0 {
+		leafIndex := len(leaves)
+
+		depth, err := reader.ReadByte()
+		if err != nil {
+			return nil, fmt.Errorf("read leaf %d depth: %w",
+				leafIndex, err)
+		}
+		if int(depth) > txscript.ControlBlockMaxNodeCount {
+			return nil, fmt.Errorf("leaf %d depth %d exceeds "+
+				"maximum %d", leafIndex, depth,
+				txscript.ControlBlockMaxNodeCount)
+		}
+
+		leafVersion, err := reader.ReadByte()
+		if err != nil {
+			return nil, fmt.Errorf("read leaf %d version: %w",
+				leafIndex, err)
+		}
+		if leafVersion&1 != 0 {
+			return nil, fmt.Errorf(
+				"leaf %d has odd leaf version %d", leafIndex,
+				leafVersion,
+			)
+		}
+
+		scriptLen, err := wire.ReadVarInt(reader, 0)
+		if err != nil {
+			return nil, fmt.Errorf("read leaf %d script length: %w",
+				leafIndex, err)
+		}
+		if scriptLen > uint64(reader.Len()) {
+			return nil, fmt.Errorf(
+				"leaf %d script length %d exceeds "+
+					"remaining tap tree bytes %d",
+				leafIndex, scriptLen, reader.Len(),
+			)
+		}
+
+		script := make([]byte, int(scriptLen))
+		if _, err := io.ReadFull(reader, script); err != nil {
+			return nil, fmt.Errorf("read leaf %d script: %w",
+				leafIndex, err)
+		}
+		leaves = append(leaves, bip371TapLeaf{
+			depth: depth,
+			leaf: txscript.NewTapLeaf(
+				txscript.TapscriptLeafVersion(leafVersion),
+				script,
+			),
+		})
+	}
+
+	parser := &bip371TapTreeParser{
+		leaves: leaves,
+	}
+	root, err := parser.parseNode(0)
+	if err != nil {
+		return nil, fmt.Errorf("invalid depth-first tree: %w", err)
+	}
+	if parser.next != len(leaves) {
+		return nil, fmt.Errorf("invalid depth-first tree: %d trailing "+
+			"leaf tuples after root", len(leaves)-parser.next)
+	}
+
+	return root, nil
+}
+
+// createTapscriptProofFromRoot creates a tapscript exclusion proof from the
+// actual root children reconstructed from PSBT_OUT_TAP_TREE.
+func createTapscriptProofFromRoot(root txscript.TapNode) (
+	*TapscriptProof, error) {
+
+	switch node := root.(type) {
+	case txscript.TapLeaf:
+		preimage, err := commitment.NewPreimageFromLeaf(node)
+		if err != nil {
+			return nil, err
+		}
+
+		return &TapscriptProof{
+			TapPreimage1: preimage,
+		}, nil
+
+	case txscript.TapBranch:
+		first, err := tapscriptPreimage(node.Left())
+		if err != nil {
+			return nil, err
+		}
+		second, err := tapscriptPreimage(node.Right())
+		if err != nil {
+			return nil, err
+		}
+
+		// TapscriptProof's mixed-node encoding requires the leaf to be
+		// the first preimage. TapBranch hashing itself is commutative.
+		if first.Type() == commitment.BranchPreimage &&
+			second.Type() == commitment.LeafPreimage {
+
+			first, second = second, first
+		}
+
+		return &TapscriptProof{
+			TapPreimage1: first,
+			TapPreimage2: second,
+		}, nil
+
+	default:
+		return nil, fmt.Errorf("unknown tap tree root type %T", root)
+	}
+}
+
+// tapscriptPreimage returns the leaf or branch preimage required to open one
+// child of a tapscript root.
+func tapscriptPreimage(node txscript.TapNode) (
+	*commitment.TapscriptPreimage, error) {
+
+	switch node := node.(type) {
+	case txscript.TapLeaf:
+		return commitment.NewPreimageFromLeaf(node)
+
+	case txscript.TapBranch:
+		preimage := commitment.NewPreimageFromBranch(node)
+		return &preimage, nil
+
+	default:
+		return nil, fmt.Errorf("unknown tap tree node type %T", node)
+	}
 }
 
 // CreateTapscriptProof creates a TapscriptProof from a list of tapscript leaves

--- a/proof/taproot_test.go
+++ b/proof/taproot_test.go
@@ -4,9 +4,13 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/btcsuite/btcd/psbt/v2"
 	"github.com/btcsuite/btcd/txscript/v2"
+	"github.com/btcsuite/btcd/wire/v2"
 	"github.com/lightninglabs/taproot-assets/asset"
+	"github.com/lightninglabs/taproot-assets/commitment"
 	"github.com/lightninglabs/taproot-assets/fn"
 	"github.com/lightninglabs/taproot-assets/internal/test"
 	"github.com/lightningnetwork/lnd/tlv"
@@ -101,6 +105,417 @@ func TestCreateTapscriptProof(t *testing.T) {
 			require.Equal(t, expectedKey, proofKey)
 		})
 	}
+}
+
+// TestAddExclusionProofsTapTrees verifies that Bitcoin-only P2TR outputs can
+// be proven from either BIP-0086 metadata or the exact tree shape encoded in
+// PSBT_OUT_TAP_TREE.
+func TestAddExclusionProofsTapTrees(t *testing.T) {
+	t.Parallel()
+
+	internalKey := test.RandPubKey(t)
+	leaves := testTapLeaves(8)
+
+	twoLeafRoot := txscript.NewTapBranch(leaves[0], leaves[1])
+	manyLeafRoot := txscript.NewTapBranch(
+		txscript.NewTapBranch(
+			txscript.NewTapBranch(leaves[0], leaves[1]),
+			txscript.NewTapBranch(leaves[2], leaves[3]),
+		),
+		txscript.NewTapBranch(
+			txscript.NewTapBranch(leaves[4], leaves[5]),
+			txscript.NewTapBranch(leaves[6], leaves[7]),
+		),
+	)
+
+	// This is the split-at-n/2 shape used by Wavelength for five leaves:
+	//
+	//	           root
+	//	          /    \
+	//	       (0,1)  (2,(3,4))
+	//
+	// It differs from txscript.AssembleTaprootScriptTree's pair-then-merge
+	// shape for a non-power-of-two leaf count.
+	nonPowerOfTwoRoot := txscript.NewTapBranch(
+		txscript.NewTapBranch(leaves[0], leaves[1]),
+		txscript.NewTapBranch(
+			leaves[2],
+			txscript.NewTapBranch(leaves[3], leaves[4]),
+		),
+	)
+	flatTree := txscript.AssembleTaprootScriptTree(leaves[:5]...)
+	require.NotEqual(
+		t, nonPowerOfTwoRoot.TapHash(), flatTree.RootNode.TapHash(),
+	)
+
+	testCases := []struct {
+		name    string
+		depths  []uint8
+		leaves  []txscript.TapLeaf
+		root    txscript.TapNode
+		isBip86 bool
+	}{
+		{
+			name:    "bip86",
+			isBip86: true,
+		},
+		{
+			name:   "one leaf",
+			depths: []uint8{0},
+			leaves: leaves[:1],
+			root:   leaves[0],
+		},
+		{
+			name:   "two leaves",
+			depths: []uint8{1, 1},
+			leaves: leaves[:2],
+			root:   twoLeafRoot,
+		},
+		{
+			name: "many leaves",
+			depths: []uint8{
+				3, 3, 3, 3, 3, 3, 3, 3,
+			},
+			leaves: leaves,
+			root:   manyLeafRoot,
+		},
+		{
+			name:   "non power of two exact shape",
+			depths: []uint8{2, 2, 2, 3, 3},
+			leaves: leaves[:5],
+			root:   nonPowerOfTwoRoot,
+		},
+	}
+
+	for _, testCase := range testCases {
+		tc := testCase
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var tapTree []byte
+			if !tc.isBip86 {
+				tapTree = encodeBIP371TapTree(
+					t, tc.depths, tc.leaves,
+				)
+			}
+
+			pkScript := testTaprootPkScript(
+				t, internalKey, tc.root,
+			)
+			finalTx := wire.NewMsgTx(2)
+			finalTx.AddTxOut(&wire.TxOut{
+				Value:    1_000,
+				PkScript: pkScript,
+			})
+			packetOutputs := []psbt.POutput{{
+				TaprootInternalKey: schnorr.SerializePubKey(
+					internalKey,
+				),
+				TaprootTapTree: tapTree,
+			}}
+
+			baseProof := &BaseProofParams{}
+			err := AddExclusionProofs(
+				baseProof, finalTx, packetOutputs,
+				func(uint32) bool {
+					return false
+				},
+			)
+			require.NoError(t, err)
+			require.Len(t, baseProof.ExclusionProofs, 1)
+
+			exclusionProof := baseProof.ExclusionProofs[0]
+			require.Zero(t, exclusionProof.OutputIndex)
+			require.True(t, exclusionProof.InternalKey.IsEqual(
+				internalKey,
+			))
+			require.Equal(
+				t, tc.isBip86,
+				exclusionProof.TapscriptProof.Bip86,
+			)
+
+			proofKey, err := exclusionProof.TapscriptProof.
+				DeriveTaprootKeys(internalKey)
+			require.NoError(t, err)
+			outputKey, err := schnorr.ParsePubKey(pkScript[2:])
+			require.NoError(t, err)
+			require.True(t, proofKey.IsEqual(outputKey))
+
+			if tc.name == "non power of two exact shape" {
+				require.Equal(
+					t, commitment.BranchPreimage,
+					exclusionProof.TapscriptProof.
+						TapPreimage1.Type(),
+				)
+				require.Equal(
+					t, commitment.BranchPreimage,
+					exclusionProof.TapscriptProof.
+						TapPreimage2.Type(),
+				)
+			}
+		})
+	}
+}
+
+// TestParseBIP371TapTreeRejectsMalformedEncoding verifies both tuple-level
+// canonical encoding and complete depth-first binary tree structure.
+func TestParseBIP371TapTreeRejectsMalformedEncoding(t *testing.T) {
+	t.Parallel()
+
+	leaf := testTapLeaves(1)[0]
+	rootLeaf := encodeBIP371TapTree(
+		t, []uint8{0}, []txscript.TapLeaf{leaf},
+	)
+	depthOneLeaf := encodeBIP371TapTree(
+		t, []uint8{1}, []txscript.TapLeaf{leaf},
+	)
+
+	testCases := []struct {
+		name        string
+		encoded     []byte
+		errContains string
+	}{
+		{
+			name:        "empty",
+			errContains: "tap tree is empty",
+		},
+		{
+			name:        "truncated after depth",
+			encoded:     []byte{0},
+			errContains: "read leaf 0 version",
+		},
+		{
+			name: "truncated compact size",
+			encoded: []byte{
+				0, byte(txscript.BaseLeafVersion), 0xfd, 0x01,
+			},
+			errContains: "read leaf 0 script length",
+		},
+		{
+			name: "non canonical compact size",
+			encoded: []byte{
+				0, byte(txscript.BaseLeafVersion), 0xfd, 0x01,
+				0x00, txscript.OP_TRUE,
+			},
+			errContains: "non-canonical",
+		},
+		{
+			name: "truncated script",
+			encoded: []byte{
+				0, byte(txscript.BaseLeafVersion), 2,
+				txscript.OP_TRUE,
+			},
+			errContains: "exceeds remaining tap tree bytes",
+		},
+		{
+			name: "odd leaf version",
+			encoded: []byte{
+				0, byte(txscript.BaseLeafVersion) | 1, 1,
+				txscript.OP_TRUE,
+			},
+			errContains: "odd leaf version",
+		},
+		{
+			name: "depth exceeds control block maximum",
+			encoded: []byte{
+				txscript.ControlBlockMaxNodeCount + 1,
+				byte(txscript.BaseLeafVersion), 1,
+				txscript.OP_TRUE,
+			},
+			errContains: "exceeds maximum",
+		},
+		{
+			name:        "incomplete branch",
+			encoded:     depthOneLeaf,
+			errContains: "missing node at depth 1",
+		},
+		{
+			name: "trailing root",
+			encoded: append(
+				append([]byte(nil), rootLeaf...), rootLeaf...,
+			),
+			errContains: "trailing leaf tuples after root",
+		},
+		{
+			name: "invalid depth first closure",
+			encoded: encodeBIP371TapTree(
+				t, []uint8{2, 1, 2},
+				[]txscript.TapLeaf{leaf, leaf, leaf},
+			),
+			errContains: "cannot fill node at depth 2",
+		},
+	}
+
+	for _, testCase := range testCases {
+		tc := testCase
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := parseBIP371TapTree(tc.encoded)
+			require.ErrorContains(t, err, tc.errContains)
+		})
+	}
+}
+
+// TestAddExclusionProofsRejectsMismatchedTaprootMetadata verifies that neither
+// BIP-0086 nor tapscript output metadata can claim a different P2TR output.
+func TestAddExclusionProofsRejectsMismatchedTaprootMetadata(t *testing.T) {
+	t.Parallel()
+
+	internalKey := test.RandPubKey(t)
+	otherKey := test.RandPubKey(t)
+	leaves := testTapLeaves(2)
+	leaf := leaves[0]
+	tapTree := encodeBIP371TapTree(
+		t, []uint8{0}, []txscript.TapLeaf{leaf},
+	)
+
+	testCases := []struct {
+		name              string
+		tapTree           []byte
+		outputInternalKey *btcec.PublicKey
+		outputRoot        txscript.TapNode
+	}{
+		{
+			name:              "bip86 internal key mismatch",
+			outputInternalKey: otherKey,
+		},
+		{
+			name:              "tapscript internal key mismatch",
+			tapTree:           tapTree,
+			outputInternalKey: otherKey,
+			outputRoot:        leaf,
+		},
+		{
+			name:              "tapscript tree mismatch",
+			tapTree:           tapTree,
+			outputInternalKey: internalKey,
+			outputRoot:        leaves[1],
+		},
+	}
+
+	for _, testCase := range testCases {
+		tc := testCase
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			finalTx := wire.NewMsgTx(2)
+			finalTx.AddTxOut(&wire.TxOut{
+				Value: 1_000,
+				PkScript: testTaprootPkScript(
+					t, tc.outputInternalKey, tc.outputRoot,
+				),
+			})
+			packetOutputs := []psbt.POutput{{
+				TaprootInternalKey: schnorr.SerializePubKey(
+					internalKey,
+				),
+				TaprootTapTree: tc.tapTree,
+			}}
+
+			err := AddExclusionProofs(
+				&BaseProofParams{}, finalTx, packetOutputs,
+				func(uint32) bool {
+					return false
+				},
+			)
+			require.ErrorContains(
+				t, err, "PSBT taproot metadata does not match "+
+					"the transaction output",
+			)
+		})
+	}
+}
+
+// TestAddExclusionProofsRejectsUnsupportedTapTreeLeaf verifies structurally
+// valid BIP-371 metadata still needs to be representable by the Taproot Assets
+// tapscript exclusion proof format.
+func TestAddExclusionProofsRejectsUnsupportedTapTreeLeaf(t *testing.T) {
+	t.Parallel()
+
+	internalKey := test.RandPubKey(t)
+	leaf := txscript.NewTapLeaf(
+		txscript.TapscriptLeafVersion(
+			byte(txscript.BaseLeafVersion)+2,
+		),
+		[]byte{txscript.OP_TRUE},
+	)
+	tapTree := encodeBIP371TapTree(
+		t, []uint8{0}, []txscript.TapLeaf{leaf},
+	)
+	finalTx := wire.NewMsgTx(2)
+	finalTx.AddTxOut(&wire.TxOut{
+		Value: 1_000,
+		PkScript: testTaprootPkScript(
+			t, internalKey, leaf,
+		),
+	})
+
+	err := AddExclusionProofs(
+		&BaseProofParams{}, finalTx, []psbt.POutput{{
+			TaprootInternalKey: schnorr.SerializePubKey(
+				internalKey,
+			),
+			TaprootTapTree: tapTree,
+		}}, func(uint32) bool {
+			return false
+		},
+	)
+	require.ErrorContains(t, err, "tapleaf version")
+	require.ErrorContains(t, err, "not supported")
+}
+
+func testTapLeaves(count int) []txscript.TapLeaf {
+	leaves := make([]txscript.TapLeaf, count)
+	for idx := range leaves {
+		leaves[idx] = txscript.NewBaseTapLeaf([]byte{
+			byte(txscript.OP_1 + idx),
+		})
+	}
+
+	return leaves
+}
+
+func encodeBIP371TapTree(t *testing.T, depths []uint8,
+	leaves []txscript.TapLeaf) []byte {
+
+	t.Helper()
+	require.Len(t, leaves, len(depths))
+
+	var encoded bytes.Buffer
+	for idx := range leaves {
+		require.NoError(t, encoded.WriteByte(depths[idx]))
+		require.NoError(
+			t, encoded.WriteByte(byte(leaves[idx].LeafVersion)),
+		)
+		require.NoError(
+			t, wire.WriteVarBytes(&encoded, 0, leaves[idx].Script),
+		)
+	}
+
+	return encoded.Bytes()
+}
+
+func testTaprootPkScript(t *testing.T, internalKey *btcec.PublicKey,
+	root txscript.TapNode) []byte {
+
+	t.Helper()
+
+	var tapscriptRoot []byte
+	if root != nil {
+		rootHash := root.TapHash()
+		tapscriptRoot = rootHash[:]
+	}
+	outputKey := txscript.ComputeTaprootOutputKey(
+		internalKey, tapscriptRoot,
+	)
+	pkScript, err := txscript.PayToTaprootScript(outputKey)
+	require.NoError(t, err)
+
+	return pkScript
 }
 
 // TestTaprootProofUnknownOddType tests that an unknown odd type is allowed in a

--- a/rpcserver/rpcserver.go
+++ b/rpcserver/rpcserver.go
@@ -3015,6 +3015,24 @@ func (r *RPCServer) AnchorVirtualPsbts(ctx context.Context,
 	}, nil
 }
 
+func transitionProofOption(
+	version wrpc.TransitionProofVersion) (proof.GenOption, error) {
+
+	switch version {
+	case wrpc.TransitionProofVersion_TRANSITION_PROOF_VERSION_V0:
+		return proof.WithVersion(proof.TransitionV0), nil
+
+	case wrpc.TransitionProofVersion_TRANSITION_PROOF_VERSION_V1:
+		return proof.WithVersion(proof.TransitionV1), nil
+
+	default:
+		return nil, status.Errorf(
+			codes.InvalidArgument,
+			"unsupported transition proof version: %v", version,
+		)
+	}
+}
+
 // CommitVirtualPsbts creates the output commitments and proofs for the given
 // virtual transactions by committing them to the BTC level anchor transaction.
 // In addition, the BTC level anchor transaction is funded and prepared up to
@@ -3022,6 +3040,11 @@ func (r *RPCServer) AnchorVirtualPsbts(ctx context.Context,
 func (r *RPCServer) CommitVirtualPsbts(ctx context.Context,
 	req *wrpc.CommitVirtualPsbtsRequest) (*wrpc.CommitVirtualPsbtsResponse,
 	error) {
+
+	proofOption, err := transitionProofOption(req.TransitionProofVersion)
+	if err != nil {
+		return nil, err
+	}
 
 	if len(req.VirtualPsbts) == 0 {
 		return nil, fmt.Errorf("no virtual PSBTs specified")
@@ -3185,6 +3208,7 @@ func (r *RPCServer) CommitVirtualPsbts(ctx context.Context,
 			proofSuffix, err := tapsend.CreateProofSuffix(
 				fundedPacket.UnsignedTx, fundedPacket.Outputs,
 				vPkt, outputCommitments, vOutIdx, allPackets,
+				proofOption,
 			)
 			if err != nil {
 				return nil, fmt.Errorf("unable to create "+

--- a/rpcserver/validation_test.go
+++ b/rpcserver/validation_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/lightninglabs/taproot-assets/proof"
 	"github.com/lightninglabs/taproot-assets/tapconfig"
 	"github.com/lightninglabs/taproot-assets/taprpc"
+	wrpc "github.com/lightninglabs/taproot-assets/taprpc/assetwalletrpc"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -40,6 +41,70 @@ func newTestServer() *RPCServer {
 			ChainParams: address.MainNetTap,
 		},
 	}
+}
+
+// TestTransitionProofOption tests the mapping from RPC proof versions to
+// internal proof generation options.
+func TestTransitionProofOption(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		rpcVersion  wrpc.TransitionProofVersion
+		wantVersion proof.TransitionVersion
+		wantErr     bool
+	}{
+		{
+			name:        "default v0",
+			rpcVersion:  wrpc.TransitionProofVersion(0),
+			wantVersion: proof.TransitionV0,
+		},
+		{
+			name:        "v1",
+			rpcVersion:  wrpc.TransitionProofVersion(1),
+			wantVersion: proof.TransitionV1,
+		},
+		{
+			name:       "unsupported",
+			rpcVersion: wrpc.TransitionProofVersion(2),
+			wantErr:    true,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			option, err := transitionProofOption(tc.rpcVersion)
+			if tc.wantErr {
+				assertCode(t, err, codes.InvalidArgument)
+				return
+			}
+
+			require.NoError(t, err)
+
+			cfg := proof.DefaultGenConfig()
+			option(&cfg)
+			require.Equal(t, tc.wantVersion, cfg.TransitionVersion)
+		})
+	}
+}
+
+// TestCommitVirtualPsbtsProofVersionValidation tests that unsupported proof
+// versions are rejected before the request is decoded or any funding is
+// attempted.
+func TestCommitVirtualPsbtsProofVersionValidation(t *testing.T) {
+	t.Parallel()
+
+	server := newTestServer()
+	_, err := server.CommitVirtualPsbts(
+		context.Background(), &wrpc.CommitVirtualPsbtsRequest{
+			VirtualPsbts:           [][]byte{{0x01}},
+			TransitionProofVersion: wrpc.TransitionProofVersion(2),
+		},
+	)
+	assertCode(t, err, codes.InvalidArgument)
 }
 
 // TestDecodeAddrValidation tests that DecodeAddr returns InvalidArgument

--- a/taprpc/assetwalletrpc/assetwallet.pb.go
+++ b/taprpc/assetwalletrpc/assetwallet.pb.go
@@ -77,6 +77,56 @@ func (CoinSelectType) EnumDescriptor() ([]byte, []int) {
 	return file_assetwalletrpc_assetwallet_proto_rawDescGZIP(), []int{0}
 }
 
+type TransitionProofVersion int32
+
+const (
+	// The first version of the state transition proof. This is the default for
+	// backward compatibility.
+	TransitionProofVersion_TRANSITION_PROOF_VERSION_V0 TransitionProofVersion = 0
+	// The second version of the state transition proof. This version adds spent
+	// transaction output (STXO) inclusion and exclusion proofs.
+	TransitionProofVersion_TRANSITION_PROOF_VERSION_V1 TransitionProofVersion = 1
+)
+
+// Enum value maps for TransitionProofVersion.
+var (
+	TransitionProofVersion_name = map[int32]string{
+		0: "TRANSITION_PROOF_VERSION_V0",
+		1: "TRANSITION_PROOF_VERSION_V1",
+	}
+	TransitionProofVersion_value = map[string]int32{
+		"TRANSITION_PROOF_VERSION_V0": 0,
+		"TRANSITION_PROOF_VERSION_V1": 1,
+	}
+)
+
+func (x TransitionProofVersion) Enum() *TransitionProofVersion {
+	p := new(TransitionProofVersion)
+	*p = x
+	return p
+}
+
+func (x TransitionProofVersion) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (TransitionProofVersion) Descriptor() protoreflect.EnumDescriptor {
+	return file_assetwalletrpc_assetwallet_proto_enumTypes[1].Descriptor()
+}
+
+func (TransitionProofVersion) Type() protoreflect.EnumType {
+	return &file_assetwalletrpc_assetwallet_proto_enumTypes[1]
+}
+
+func (x TransitionProofVersion) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use TransitionProofVersion.Descriptor instead.
+func (TransitionProofVersion) EnumDescriptor() ([]byte, []int) {
+	return file_assetwalletrpc_assetwallet_proto_rawDescGZIP(), []int{1}
+}
+
 // BackupMode specifies the backup format to use when exporting.
 type BackupMode int32
 
@@ -118,11 +168,11 @@ func (x BackupMode) String() string {
 }
 
 func (BackupMode) Descriptor() protoreflect.EnumDescriptor {
-	return file_assetwalletrpc_assetwallet_proto_enumTypes[1].Descriptor()
+	return file_assetwalletrpc_assetwallet_proto_enumTypes[2].Descriptor()
 }
 
 func (BackupMode) Type() protoreflect.EnumType {
-	return &file_assetwalletrpc_assetwallet_proto_enumTypes[1]
+	return &file_assetwalletrpc_assetwallet_proto_enumTypes[2]
 }
 
 func (x BackupMode) Number() protoreflect.EnumNumber {
@@ -131,7 +181,7 @@ func (x BackupMode) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use BackupMode.Descriptor instead.
 func (BackupMode) EnumDescriptor() ([]byte, []int) {
-	return file_assetwalletrpc_assetwallet_proto_rawDescGZIP(), []int{1}
+	return file_assetwalletrpc_assetwallet_proto_rawDescGZIP(), []int{2}
 }
 
 type FundVirtualPsbtRequest struct {
@@ -634,9 +684,12 @@ type CommitVirtualPsbtsRequest struct {
 	LockExpirationSeconds uint64 `protobuf:"varint,9,opt,name=lock_expiration_seconds,json=lockExpirationSeconds,proto3" json:"lock_expiration_seconds,omitempty"`
 	// If set, the psbt funding step will be skipped. This is useful if the intent
 	// is to create a zero-fee transaction.
-	SkipFunding   bool `protobuf:"varint,10,opt,name=skip_funding,json=skipFunding,proto3" json:"skip_funding,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	SkipFunding bool `protobuf:"varint,10,opt,name=skip_funding,json=skipFunding,proto3" json:"skip_funding,omitempty"`
+	// The version to use when generating the state transition proof suffixes.
+	// This defaults to TRANSITION_PROOF_VERSION_V0 for backward compatibility.
+	TransitionProofVersion TransitionProofVersion `protobuf:"varint,11,opt,name=transition_proof_version,json=transitionProofVersion,proto3,enum=assetwalletrpc.TransitionProofVersion" json:"transition_proof_version,omitempty"`
+	unknownFields          protoimpl.UnknownFields
+	sizeCache              protoimpl.SizeCache
 }
 
 func (x *CommitVirtualPsbtsRequest) Reset() {
@@ -759,6 +812,13 @@ func (x *CommitVirtualPsbtsRequest) GetSkipFunding() bool {
 		return x.SkipFunding
 	}
 	return false
+}
+
+func (x *CommitVirtualPsbtsRequest) GetTransitionProofVersion() TransitionProofVersion {
+	if x != nil {
+		return x.TransitionProofVersion
+	}
+	return TransitionProofVersion_TRANSITION_PROOF_VERSION_V0
 }
 
 type isCommitVirtualPsbtsRequest_AnchorChangeOutput interface {
@@ -2045,7 +2105,7 @@ const file_assetwalletrpc_assetwallet_proto_rawDesc = "" +
 	"signedPsbt\x12#\n" +
 	"\rsigned_inputs\x18\x02 \x03(\rR\fsignedInputs\"@\n" +
 	"\x19AnchorVirtualPsbtsRequest\x12#\n" +
-	"\rvirtual_psbts\x18\x01 \x03(\fR\fvirtualPsbts\"\xc5\x03\n" +
+	"\rvirtual_psbts\x18\x01 \x03(\fR\fvirtualPsbts\"\xa7\x04\n" +
 	"\x19CommitVirtualPsbtsRequest\x12#\n" +
 	"\rvirtual_psbts\x18\x01 \x03(\fR\fvirtualPsbts\x12.\n" +
 	"\x13passive_asset_psbts\x18\x02 \x03(\fR\x11passiveAssetPsbts\x12\x1f\n" +
@@ -2059,7 +2119,8 @@ const file_assetwalletrpc_assetwallet_proto_rawDesc = "" +
 	"\x0ecustom_lock_id\x18\b \x01(\fR\fcustomLockId\x126\n" +
 	"\x17lock_expiration_seconds\x18\t \x01(\x04R\x15lockExpirationSeconds\x12!\n" +
 	"\fskip_funding\x18\n" +
-	" \x01(\bR\vskipFundingB\x16\n" +
+	" \x01(\bR\vskipFunding\x12`\n" +
+	"\x18transition_proof_version\x18\v \x01(\x0e2&.assetwalletrpc.TransitionProofVersionR\x16transitionProofVersionB\x16\n" +
 	"\x14anchor_change_outputB\x06\n" +
 	"\x04fees\"\xfe\x01\n" +
 	"\x1aCommitVirtualPsbtsResponse\x12\x1f\n" +
@@ -2140,7 +2201,10 @@ const file_assetwalletrpc_assetwallet_proto_rawDesc = "" +
 	"\x0eCoinSelectType\x12\x17\n" +
 	"\x13COIN_SELECT_DEFAULT\x10\x00\x12\x1a\n" +
 	"\x16COIN_SELECT_BIP86_ONLY\x10\x01\x12$\n" +
-	" COIN_SELECT_SCRIPT_TREES_ALLOWED\x10\x02*2\n" +
+	" COIN_SELECT_SCRIPT_TREES_ALLOWED\x10\x02*Z\n" +
+	"\x16TransitionProofVersion\x12\x1f\n" +
+	"\x1bTRANSITION_PROOF_VERSION_V0\x10\x00\x12\x1f\n" +
+	"\x1bTRANSITION_PROOF_VERSION_V1\x10\x01*2\n" +
 	"\n" +
 	"BackupMode\x12\a\n" +
 	"\x03RAW\x10\x00\x12\v\n" +
@@ -2176,102 +2240,104 @@ func file_assetwalletrpc_assetwallet_proto_rawDescGZIP() []byte {
 	return file_assetwalletrpc_assetwallet_proto_rawDescData
 }
 
-var file_assetwalletrpc_assetwallet_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
+var file_assetwalletrpc_assetwallet_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
 var file_assetwalletrpc_assetwallet_proto_msgTypes = make([]protoimpl.MessageInfo, 31)
 var file_assetwalletrpc_assetwallet_proto_goTypes = []any{
 	(CoinSelectType)(0),                     // 0: assetwalletrpc.CoinSelectType
-	(BackupMode)(0),                         // 1: assetwalletrpc.BackupMode
-	(*FundVirtualPsbtRequest)(nil),          // 2: assetwalletrpc.FundVirtualPsbtRequest
-	(*FundVirtualPsbtResponse)(nil),         // 3: assetwalletrpc.FundVirtualPsbtResponse
-	(*TxTemplate)(nil),                      // 4: assetwalletrpc.TxTemplate
-	(*PrevId)(nil),                          // 5: assetwalletrpc.PrevId
-	(*SignVirtualPsbtRequest)(nil),          // 6: assetwalletrpc.SignVirtualPsbtRequest
-	(*SignVirtualPsbtResponse)(nil),         // 7: assetwalletrpc.SignVirtualPsbtResponse
-	(*AnchorVirtualPsbtsRequest)(nil),       // 8: assetwalletrpc.AnchorVirtualPsbtsRequest
-	(*CommitVirtualPsbtsRequest)(nil),       // 9: assetwalletrpc.CommitVirtualPsbtsRequest
-	(*CommitVirtualPsbtsResponse)(nil),      // 10: assetwalletrpc.CommitVirtualPsbtsResponse
-	(*PublishAndLogRequest)(nil),            // 11: assetwalletrpc.PublishAndLogRequest
-	(*NextInternalKeyRequest)(nil),          // 12: assetwalletrpc.NextInternalKeyRequest
-	(*NextInternalKeyResponse)(nil),         // 13: assetwalletrpc.NextInternalKeyResponse
-	(*NextScriptKeyRequest)(nil),            // 14: assetwalletrpc.NextScriptKeyRequest
-	(*NextScriptKeyResponse)(nil),           // 15: assetwalletrpc.NextScriptKeyResponse
-	(*QueryInternalKeyRequest)(nil),         // 16: assetwalletrpc.QueryInternalKeyRequest
-	(*QueryInternalKeyResponse)(nil),        // 17: assetwalletrpc.QueryInternalKeyResponse
-	(*QueryScriptKeyRequest)(nil),           // 18: assetwalletrpc.QueryScriptKeyRequest
-	(*QueryScriptKeyResponse)(nil),          // 19: assetwalletrpc.QueryScriptKeyResponse
-	(*ProveAssetOwnershipRequest)(nil),      // 20: assetwalletrpc.ProveAssetOwnershipRequest
-	(*ProveAssetOwnershipResponse)(nil),     // 21: assetwalletrpc.ProveAssetOwnershipResponse
-	(*VerifyAssetOwnershipRequest)(nil),     // 22: assetwalletrpc.VerifyAssetOwnershipRequest
-	(*VerifyAssetOwnershipResponse)(nil),    // 23: assetwalletrpc.VerifyAssetOwnershipResponse
-	(*RemoveUTXOLeaseRequest)(nil),          // 24: assetwalletrpc.RemoveUTXOLeaseRequest
-	(*RemoveUTXOLeaseResponse)(nil),         // 25: assetwalletrpc.RemoveUTXOLeaseResponse
-	(*DeclareScriptKeyRequest)(nil),         // 26: assetwalletrpc.DeclareScriptKeyRequest
-	(*DeclareScriptKeyResponse)(nil),        // 27: assetwalletrpc.DeclareScriptKeyResponse
-	(*ExportAssetWalletBackupRequest)(nil),  // 28: assetwalletrpc.ExportAssetWalletBackupRequest
-	(*ExportAssetWalletBackupResponse)(nil), // 29: assetwalletrpc.ExportAssetWalletBackupResponse
-	(*ImportAssetsFromBackupRequest)(nil),   // 30: assetwalletrpc.ImportAssetsFromBackupRequest
-	(*ImportAssetsFromBackupResponse)(nil),  // 31: assetwalletrpc.ImportAssetsFromBackupResponse
-	nil,                                     // 32: assetwalletrpc.TxTemplate.RecipientsEntry
-	(*taprpc.AddressWithAmount)(nil),        // 33: taprpc.AddressWithAmount
-	(*taprpc.OutPoint)(nil),                 // 34: taprpc.OutPoint
-	(*taprpc.KeyDescriptor)(nil),            // 35: taprpc.KeyDescriptor
-	(*taprpc.ScriptKey)(nil),                // 36: taprpc.ScriptKey
-	(*taprpc.SendAssetResponse)(nil),        // 37: taprpc.SendAssetResponse
+	(TransitionProofVersion)(0),             // 1: assetwalletrpc.TransitionProofVersion
+	(BackupMode)(0),                         // 2: assetwalletrpc.BackupMode
+	(*FundVirtualPsbtRequest)(nil),          // 3: assetwalletrpc.FundVirtualPsbtRequest
+	(*FundVirtualPsbtResponse)(nil),         // 4: assetwalletrpc.FundVirtualPsbtResponse
+	(*TxTemplate)(nil),                      // 5: assetwalletrpc.TxTemplate
+	(*PrevId)(nil),                          // 6: assetwalletrpc.PrevId
+	(*SignVirtualPsbtRequest)(nil),          // 7: assetwalletrpc.SignVirtualPsbtRequest
+	(*SignVirtualPsbtResponse)(nil),         // 8: assetwalletrpc.SignVirtualPsbtResponse
+	(*AnchorVirtualPsbtsRequest)(nil),       // 9: assetwalletrpc.AnchorVirtualPsbtsRequest
+	(*CommitVirtualPsbtsRequest)(nil),       // 10: assetwalletrpc.CommitVirtualPsbtsRequest
+	(*CommitVirtualPsbtsResponse)(nil),      // 11: assetwalletrpc.CommitVirtualPsbtsResponse
+	(*PublishAndLogRequest)(nil),            // 12: assetwalletrpc.PublishAndLogRequest
+	(*NextInternalKeyRequest)(nil),          // 13: assetwalletrpc.NextInternalKeyRequest
+	(*NextInternalKeyResponse)(nil),         // 14: assetwalletrpc.NextInternalKeyResponse
+	(*NextScriptKeyRequest)(nil),            // 15: assetwalletrpc.NextScriptKeyRequest
+	(*NextScriptKeyResponse)(nil),           // 16: assetwalletrpc.NextScriptKeyResponse
+	(*QueryInternalKeyRequest)(nil),         // 17: assetwalletrpc.QueryInternalKeyRequest
+	(*QueryInternalKeyResponse)(nil),        // 18: assetwalletrpc.QueryInternalKeyResponse
+	(*QueryScriptKeyRequest)(nil),           // 19: assetwalletrpc.QueryScriptKeyRequest
+	(*QueryScriptKeyResponse)(nil),          // 20: assetwalletrpc.QueryScriptKeyResponse
+	(*ProveAssetOwnershipRequest)(nil),      // 21: assetwalletrpc.ProveAssetOwnershipRequest
+	(*ProveAssetOwnershipResponse)(nil),     // 22: assetwalletrpc.ProveAssetOwnershipResponse
+	(*VerifyAssetOwnershipRequest)(nil),     // 23: assetwalletrpc.VerifyAssetOwnershipRequest
+	(*VerifyAssetOwnershipResponse)(nil),    // 24: assetwalletrpc.VerifyAssetOwnershipResponse
+	(*RemoveUTXOLeaseRequest)(nil),          // 25: assetwalletrpc.RemoveUTXOLeaseRequest
+	(*RemoveUTXOLeaseResponse)(nil),         // 26: assetwalletrpc.RemoveUTXOLeaseResponse
+	(*DeclareScriptKeyRequest)(nil),         // 27: assetwalletrpc.DeclareScriptKeyRequest
+	(*DeclareScriptKeyResponse)(nil),        // 28: assetwalletrpc.DeclareScriptKeyResponse
+	(*ExportAssetWalletBackupRequest)(nil),  // 29: assetwalletrpc.ExportAssetWalletBackupRequest
+	(*ExportAssetWalletBackupResponse)(nil), // 30: assetwalletrpc.ExportAssetWalletBackupResponse
+	(*ImportAssetsFromBackupRequest)(nil),   // 31: assetwalletrpc.ImportAssetsFromBackupRequest
+	(*ImportAssetsFromBackupResponse)(nil),  // 32: assetwalletrpc.ImportAssetsFromBackupResponse
+	nil,                                     // 33: assetwalletrpc.TxTemplate.RecipientsEntry
+	(*taprpc.AddressWithAmount)(nil),        // 34: taprpc.AddressWithAmount
+	(*taprpc.OutPoint)(nil),                 // 35: taprpc.OutPoint
+	(*taprpc.KeyDescriptor)(nil),            // 36: taprpc.KeyDescriptor
+	(*taprpc.ScriptKey)(nil),                // 37: taprpc.ScriptKey
+	(*taprpc.SendAssetResponse)(nil),        // 38: taprpc.SendAssetResponse
 }
 var file_assetwalletrpc_assetwallet_proto_depIdxs = []int32{
-	4,  // 0: assetwalletrpc.FundVirtualPsbtRequest.raw:type_name -> assetwalletrpc.TxTemplate
+	5,  // 0: assetwalletrpc.FundVirtualPsbtRequest.raw:type_name -> assetwalletrpc.TxTemplate
 	0,  // 1: assetwalletrpc.FundVirtualPsbtRequest.coin_select_type:type_name -> assetwalletrpc.CoinSelectType
-	5,  // 2: assetwalletrpc.TxTemplate.inputs:type_name -> assetwalletrpc.PrevId
-	32, // 3: assetwalletrpc.TxTemplate.recipients:type_name -> assetwalletrpc.TxTemplate.RecipientsEntry
-	33, // 4: assetwalletrpc.TxTemplate.addresses_with_amounts:type_name -> taprpc.AddressWithAmount
-	34, // 5: assetwalletrpc.PrevId.outpoint:type_name -> taprpc.OutPoint
-	34, // 6: assetwalletrpc.CommitVirtualPsbtsResponse.lnd_locked_utxos:type_name -> taprpc.OutPoint
-	34, // 7: assetwalletrpc.PublishAndLogRequest.lnd_locked_utxos:type_name -> taprpc.OutPoint
-	35, // 8: assetwalletrpc.NextInternalKeyResponse.internal_key:type_name -> taprpc.KeyDescriptor
-	36, // 9: assetwalletrpc.NextScriptKeyResponse.script_key:type_name -> taprpc.ScriptKey
-	35, // 10: assetwalletrpc.QueryInternalKeyResponse.internal_key:type_name -> taprpc.KeyDescriptor
-	36, // 11: assetwalletrpc.QueryScriptKeyResponse.script_key:type_name -> taprpc.ScriptKey
-	34, // 12: assetwalletrpc.ProveAssetOwnershipRequest.outpoint:type_name -> taprpc.OutPoint
-	34, // 13: assetwalletrpc.VerifyAssetOwnershipResponse.outpoint:type_name -> taprpc.OutPoint
-	34, // 14: assetwalletrpc.RemoveUTXOLeaseRequest.outpoint:type_name -> taprpc.OutPoint
-	36, // 15: assetwalletrpc.DeclareScriptKeyRequest.script_key:type_name -> taprpc.ScriptKey
-	36, // 16: assetwalletrpc.DeclareScriptKeyResponse.script_key:type_name -> taprpc.ScriptKey
-	1,  // 17: assetwalletrpc.ExportAssetWalletBackupRequest.mode:type_name -> assetwalletrpc.BackupMode
-	2,  // 18: assetwalletrpc.AssetWallet.FundVirtualPsbt:input_type -> assetwalletrpc.FundVirtualPsbtRequest
-	6,  // 19: assetwalletrpc.AssetWallet.SignVirtualPsbt:input_type -> assetwalletrpc.SignVirtualPsbtRequest
-	8,  // 20: assetwalletrpc.AssetWallet.AnchorVirtualPsbts:input_type -> assetwalletrpc.AnchorVirtualPsbtsRequest
-	9,  // 21: assetwalletrpc.AssetWallet.CommitVirtualPsbts:input_type -> assetwalletrpc.CommitVirtualPsbtsRequest
-	11, // 22: assetwalletrpc.AssetWallet.PublishAndLogTransfer:input_type -> assetwalletrpc.PublishAndLogRequest
-	12, // 23: assetwalletrpc.AssetWallet.NextInternalKey:input_type -> assetwalletrpc.NextInternalKeyRequest
-	14, // 24: assetwalletrpc.AssetWallet.NextScriptKey:input_type -> assetwalletrpc.NextScriptKeyRequest
-	16, // 25: assetwalletrpc.AssetWallet.QueryInternalKey:input_type -> assetwalletrpc.QueryInternalKeyRequest
-	18, // 26: assetwalletrpc.AssetWallet.QueryScriptKey:input_type -> assetwalletrpc.QueryScriptKeyRequest
-	20, // 27: assetwalletrpc.AssetWallet.ProveAssetOwnership:input_type -> assetwalletrpc.ProveAssetOwnershipRequest
-	22, // 28: assetwalletrpc.AssetWallet.VerifyAssetOwnership:input_type -> assetwalletrpc.VerifyAssetOwnershipRequest
-	24, // 29: assetwalletrpc.AssetWallet.RemoveUTXOLease:input_type -> assetwalletrpc.RemoveUTXOLeaseRequest
-	26, // 30: assetwalletrpc.AssetWallet.DeclareScriptKey:input_type -> assetwalletrpc.DeclareScriptKeyRequest
-	28, // 31: assetwalletrpc.AssetWallet.ExportAssetWalletBackup:input_type -> assetwalletrpc.ExportAssetWalletBackupRequest
-	30, // 32: assetwalletrpc.AssetWallet.ImportAssetsFromBackup:input_type -> assetwalletrpc.ImportAssetsFromBackupRequest
-	3,  // 33: assetwalletrpc.AssetWallet.FundVirtualPsbt:output_type -> assetwalletrpc.FundVirtualPsbtResponse
-	7,  // 34: assetwalletrpc.AssetWallet.SignVirtualPsbt:output_type -> assetwalletrpc.SignVirtualPsbtResponse
-	37, // 35: assetwalletrpc.AssetWallet.AnchorVirtualPsbts:output_type -> taprpc.SendAssetResponse
-	10, // 36: assetwalletrpc.AssetWallet.CommitVirtualPsbts:output_type -> assetwalletrpc.CommitVirtualPsbtsResponse
-	37, // 37: assetwalletrpc.AssetWallet.PublishAndLogTransfer:output_type -> taprpc.SendAssetResponse
-	13, // 38: assetwalletrpc.AssetWallet.NextInternalKey:output_type -> assetwalletrpc.NextInternalKeyResponse
-	15, // 39: assetwalletrpc.AssetWallet.NextScriptKey:output_type -> assetwalletrpc.NextScriptKeyResponse
-	17, // 40: assetwalletrpc.AssetWallet.QueryInternalKey:output_type -> assetwalletrpc.QueryInternalKeyResponse
-	19, // 41: assetwalletrpc.AssetWallet.QueryScriptKey:output_type -> assetwalletrpc.QueryScriptKeyResponse
-	21, // 42: assetwalletrpc.AssetWallet.ProveAssetOwnership:output_type -> assetwalletrpc.ProveAssetOwnershipResponse
-	23, // 43: assetwalletrpc.AssetWallet.VerifyAssetOwnership:output_type -> assetwalletrpc.VerifyAssetOwnershipResponse
-	25, // 44: assetwalletrpc.AssetWallet.RemoveUTXOLease:output_type -> assetwalletrpc.RemoveUTXOLeaseResponse
-	27, // 45: assetwalletrpc.AssetWallet.DeclareScriptKey:output_type -> assetwalletrpc.DeclareScriptKeyResponse
-	29, // 46: assetwalletrpc.AssetWallet.ExportAssetWalletBackup:output_type -> assetwalletrpc.ExportAssetWalletBackupResponse
-	31, // 47: assetwalletrpc.AssetWallet.ImportAssetsFromBackup:output_type -> assetwalletrpc.ImportAssetsFromBackupResponse
-	33, // [33:48] is the sub-list for method output_type
-	18, // [18:33] is the sub-list for method input_type
-	18, // [18:18] is the sub-list for extension type_name
-	18, // [18:18] is the sub-list for extension extendee
-	0,  // [0:18] is the sub-list for field type_name
+	6,  // 2: assetwalletrpc.TxTemplate.inputs:type_name -> assetwalletrpc.PrevId
+	33, // 3: assetwalletrpc.TxTemplate.recipients:type_name -> assetwalletrpc.TxTemplate.RecipientsEntry
+	34, // 4: assetwalletrpc.TxTemplate.addresses_with_amounts:type_name -> taprpc.AddressWithAmount
+	35, // 5: assetwalletrpc.PrevId.outpoint:type_name -> taprpc.OutPoint
+	1,  // 6: assetwalletrpc.CommitVirtualPsbtsRequest.transition_proof_version:type_name -> assetwalletrpc.TransitionProofVersion
+	35, // 7: assetwalletrpc.CommitVirtualPsbtsResponse.lnd_locked_utxos:type_name -> taprpc.OutPoint
+	35, // 8: assetwalletrpc.PublishAndLogRequest.lnd_locked_utxos:type_name -> taprpc.OutPoint
+	36, // 9: assetwalletrpc.NextInternalKeyResponse.internal_key:type_name -> taprpc.KeyDescriptor
+	37, // 10: assetwalletrpc.NextScriptKeyResponse.script_key:type_name -> taprpc.ScriptKey
+	36, // 11: assetwalletrpc.QueryInternalKeyResponse.internal_key:type_name -> taprpc.KeyDescriptor
+	37, // 12: assetwalletrpc.QueryScriptKeyResponse.script_key:type_name -> taprpc.ScriptKey
+	35, // 13: assetwalletrpc.ProveAssetOwnershipRequest.outpoint:type_name -> taprpc.OutPoint
+	35, // 14: assetwalletrpc.VerifyAssetOwnershipResponse.outpoint:type_name -> taprpc.OutPoint
+	35, // 15: assetwalletrpc.RemoveUTXOLeaseRequest.outpoint:type_name -> taprpc.OutPoint
+	37, // 16: assetwalletrpc.DeclareScriptKeyRequest.script_key:type_name -> taprpc.ScriptKey
+	37, // 17: assetwalletrpc.DeclareScriptKeyResponse.script_key:type_name -> taprpc.ScriptKey
+	2,  // 18: assetwalletrpc.ExportAssetWalletBackupRequest.mode:type_name -> assetwalletrpc.BackupMode
+	3,  // 19: assetwalletrpc.AssetWallet.FundVirtualPsbt:input_type -> assetwalletrpc.FundVirtualPsbtRequest
+	7,  // 20: assetwalletrpc.AssetWallet.SignVirtualPsbt:input_type -> assetwalletrpc.SignVirtualPsbtRequest
+	9,  // 21: assetwalletrpc.AssetWallet.AnchorVirtualPsbts:input_type -> assetwalletrpc.AnchorVirtualPsbtsRequest
+	10, // 22: assetwalletrpc.AssetWallet.CommitVirtualPsbts:input_type -> assetwalletrpc.CommitVirtualPsbtsRequest
+	12, // 23: assetwalletrpc.AssetWallet.PublishAndLogTransfer:input_type -> assetwalletrpc.PublishAndLogRequest
+	13, // 24: assetwalletrpc.AssetWallet.NextInternalKey:input_type -> assetwalletrpc.NextInternalKeyRequest
+	15, // 25: assetwalletrpc.AssetWallet.NextScriptKey:input_type -> assetwalletrpc.NextScriptKeyRequest
+	17, // 26: assetwalletrpc.AssetWallet.QueryInternalKey:input_type -> assetwalletrpc.QueryInternalKeyRequest
+	19, // 27: assetwalletrpc.AssetWallet.QueryScriptKey:input_type -> assetwalletrpc.QueryScriptKeyRequest
+	21, // 28: assetwalletrpc.AssetWallet.ProveAssetOwnership:input_type -> assetwalletrpc.ProveAssetOwnershipRequest
+	23, // 29: assetwalletrpc.AssetWallet.VerifyAssetOwnership:input_type -> assetwalletrpc.VerifyAssetOwnershipRequest
+	25, // 30: assetwalletrpc.AssetWallet.RemoveUTXOLease:input_type -> assetwalletrpc.RemoveUTXOLeaseRequest
+	27, // 31: assetwalletrpc.AssetWallet.DeclareScriptKey:input_type -> assetwalletrpc.DeclareScriptKeyRequest
+	29, // 32: assetwalletrpc.AssetWallet.ExportAssetWalletBackup:input_type -> assetwalletrpc.ExportAssetWalletBackupRequest
+	31, // 33: assetwalletrpc.AssetWallet.ImportAssetsFromBackup:input_type -> assetwalletrpc.ImportAssetsFromBackupRequest
+	4,  // 34: assetwalletrpc.AssetWallet.FundVirtualPsbt:output_type -> assetwalletrpc.FundVirtualPsbtResponse
+	8,  // 35: assetwalletrpc.AssetWallet.SignVirtualPsbt:output_type -> assetwalletrpc.SignVirtualPsbtResponse
+	38, // 36: assetwalletrpc.AssetWallet.AnchorVirtualPsbts:output_type -> taprpc.SendAssetResponse
+	11, // 37: assetwalletrpc.AssetWallet.CommitVirtualPsbts:output_type -> assetwalletrpc.CommitVirtualPsbtsResponse
+	38, // 38: assetwalletrpc.AssetWallet.PublishAndLogTransfer:output_type -> taprpc.SendAssetResponse
+	14, // 39: assetwalletrpc.AssetWallet.NextInternalKey:output_type -> assetwalletrpc.NextInternalKeyResponse
+	16, // 40: assetwalletrpc.AssetWallet.NextScriptKey:output_type -> assetwalletrpc.NextScriptKeyResponse
+	18, // 41: assetwalletrpc.AssetWallet.QueryInternalKey:output_type -> assetwalletrpc.QueryInternalKeyResponse
+	20, // 42: assetwalletrpc.AssetWallet.QueryScriptKey:output_type -> assetwalletrpc.QueryScriptKeyResponse
+	22, // 43: assetwalletrpc.AssetWallet.ProveAssetOwnership:output_type -> assetwalletrpc.ProveAssetOwnershipResponse
+	24, // 44: assetwalletrpc.AssetWallet.VerifyAssetOwnership:output_type -> assetwalletrpc.VerifyAssetOwnershipResponse
+	26, // 45: assetwalletrpc.AssetWallet.RemoveUTXOLease:output_type -> assetwalletrpc.RemoveUTXOLeaseResponse
+	28, // 46: assetwalletrpc.AssetWallet.DeclareScriptKey:output_type -> assetwalletrpc.DeclareScriptKeyResponse
+	30, // 47: assetwalletrpc.AssetWallet.ExportAssetWalletBackup:output_type -> assetwalletrpc.ExportAssetWalletBackupResponse
+	32, // 48: assetwalletrpc.AssetWallet.ImportAssetsFromBackup:output_type -> assetwalletrpc.ImportAssetsFromBackupResponse
+	34, // [34:49] is the sub-list for method output_type
+	19, // [19:34] is the sub-list for method input_type
+	19, // [19:19] is the sub-list for extension type_name
+	19, // [19:19] is the sub-list for extension extendee
+	0,  // [0:19] is the sub-list for field type_name
 }
 
 func init() { file_assetwalletrpc_assetwallet_proto_init() }
@@ -2294,7 +2360,7 @@ func file_assetwalletrpc_assetwallet_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_assetwalletrpc_assetwallet_proto_rawDesc), len(file_assetwalletrpc_assetwallet_proto_rawDesc)),
-			NumEnums:      2,
+			NumEnums:      3,
 			NumMessages:   31,
 			NumExtensions: 0,
 			NumServices:   1,

--- a/taprpc/assetwalletrpc/assetwallet.proto
+++ b/taprpc/assetwalletrpc/assetwallet.proto
@@ -276,6 +276,20 @@ message AnchorVirtualPsbtsRequest {
     repeated bytes virtual_psbts = 1;
 }
 
+enum TransitionProofVersion {
+    /*
+    The first version of the state transition proof. This is the default for
+    backward compatibility.
+    */
+    TRANSITION_PROOF_VERSION_V0 = 0;
+
+    /*
+    The second version of the state transition proof. This version adds spent
+    transaction output (STXO) inclusion and exclusion proofs.
+    */
+    TRANSITION_PROOF_VERSION_V1 = 1;
+}
+
 message CommitVirtualPsbtsRequest {
     /*
     The list of virtual transactions that should be mapped to the given BTC
@@ -356,6 +370,12 @@ message CommitVirtualPsbtsRequest {
     is to create a zero-fee transaction.
     */
     bool skip_funding = 10;
+
+    /*
+    The version to use when generating the state transition proof suffixes.
+    This defaults to TRANSITION_PROOF_VERSION_V0 for backward compatibility.
+    */
+    TransitionProofVersion transition_proof_version = 11;
 }
 
 message CommitVirtualPsbtsResponse {

--- a/taprpc/assetwalletrpc/assetwallet.swagger.json
+++ b/taprpc/assetwalletrpc/assetwallet.swagger.json
@@ -602,6 +602,10 @@
         "skip_funding": {
           "type": "boolean",
           "description": "If set, the psbt funding step will be skipped. This is useful if the intent\nis to create a zero-fee transaction."
+        },
+        "transition_proof_version": {
+          "$ref": "#/definitions/assetwalletrpcTransitionProofVersion",
+          "description": "The version to use when generating the state transition proof suffixes.\nThis defaults to TRANSITION_PROOF_VERSION_V0 for backward compatibility."
         }
       }
     },
@@ -941,6 +945,15 @@
           "description": "The indices of signed inputs."
         }
       }
+    },
+    "assetwalletrpcTransitionProofVersion": {
+      "type": "string",
+      "enum": [
+        "TRANSITION_PROOF_VERSION_V0",
+        "TRANSITION_PROOF_VERSION_V1"
+      ],
+      "default": "TRANSITION_PROOF_VERSION_V0",
+      "description": " - TRANSITION_PROOF_VERSION_V0: The first version of the state transition proof. This is the default for\nbackward compatibility.\n - TRANSITION_PROOF_VERSION_V1: The second version of the state transition proof. This version adds spent\ntransaction output (STXO) inclusion and exclusion proofs."
     },
     "assetwalletrpcTxTemplate": {
       "type": "object",


### PR DESCRIPTION
Dependency for Wavelength Taproot Asset OOR transfers.

- add BIP-371 tapscript output exclusion proofs
- let `CommitVirtualPsbts` select proof version 1
- cover the proof, tapsend, and RPC behavior with focused tests
- trim the development image context used by source-built integration tests
- add release notes for the RPC update