### PR TITLE
rpcserver: report invalid proofs instead of failing VerifyProof

### DIFF
--- a/docs/release-notes/release-notes-0.9.0.md
+++ b/docs/release-notes/release-notes-0.9.0.md
@@ -25,6 +25,11 @@
   fixes a bug that could cause minted assets to commit to the wrong
   address.
 
+* [PR#2228](https://github.com/lightninglabs/taproot-assets/pull/2228)
+  fixes `VerifyProof` failing the whole RPC for an invalid proof when
+  decoding the last proof requires unknown asset metadata; it now
+  returns `valid=false` as documented.
+
 # New Features
 
 ## Functional Enhancements

--- a/rpcserver/rpcserver.go
+++ b/rpcserver/rpcserver.go
@@ -2178,10 +2178,17 @@ func (r *RPCServer) VerifyProof(ctx context.Context,
 	if err != nil {
 		// We don't want to fail the RPC request because of a proof
 		// verification error, but we do want to log it for easier
-		// debugging.
+		// debugging. The decoded proof is only returned for valid
+		// proof files, so we can respond right away. Decoding the
+		// last proof here could itself fail (for example when the
+		// asset is entirely unknown to this node) and would turn an
+		// already-classified invalid proof into an RPC failure.
 		rpcsLog.Errorf("Proof verification failed with err: %v", err)
+
+		return &taprpc.VerifyProofResponse{
+			Valid: false,
+		}, nil
 	}
-	valid := err == nil
 
 	p, err := proofFile.LastProof()
 	if err != nil {
@@ -2196,7 +2203,7 @@ func (r *RPCServer) VerifyProof(ctx context.Context,
 	decodedProof.NumberOfProofs = uint32(proofFile.NumProofs())
 
 	return &taprpc.VerifyProofResponse{
-		Valid:        valid,
+		Valid:        true,
 		DecodedProof: decodedProof,
 	}, nil
 }

--- a/rpcserver/verifyproof_test.go
+++ b/rpcserver/verifyproof_test.go
@@ -1,0 +1,47 @@
+package rpcserver
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/lightninglabs/taproot-assets/proof"
+	"github.com/lightninglabs/taproot-assets/tapconfig"
+	"github.com/lightninglabs/taproot-assets/taprpc"
+	"github.com/stretchr/testify/require"
+)
+
+// TestVerifyProofInvalidProofResponse ensures that a proof file that fails
+// verification results in a successful RPC response with valid=false and no
+// decoded proof, instead of failing the whole RPC. Decoding the last proof
+// of an invalid file can itself fail (for example when the asset is unknown
+// to the node), which previously surfaced as an RPC error.
+func TestVerifyProofInvalidProofResponse(t *testing.T) {
+	t.Parallel()
+
+	server := newTestServer()
+
+	// The verifier context promotes fields through the embedded
+	// database config, which must therefore be present. Its stores can
+	// stay unset: verification fails before any of them is consulted.
+	server.cfg.DatabaseConfig = &tapconfig.DatabaseConfig{}
+
+	// Build a well-encoded proof file that is guaranteed to fail
+	// verification at its very first step: an unknown proof file
+	// version. This keeps the test hermetic, as verification aborts
+	// before any chain or Universe dependency is consulted.
+	proofFile, err := proof.NewFile(proof.V0)
+	require.NoError(t, err)
+	require.NoError(t, proofFile.AppendProofRaw([]byte{0x01, 0x02, 0x03}))
+	proofFile.Version = proof.Version(99)
+
+	var buf bytes.Buffer
+	require.NoError(t, proofFile.Encode(&buf))
+
+	resp, err := server.VerifyProof(context.Background(), &taprpc.ProofFile{
+		RawProofFile: buf.Bytes(),
+	})
+	require.NoError(t, err)
+	require.False(t, resp.Valid)
+	require.Nil(t, resp.DecodedProof)
+}


### PR DESCRIPTION
Fixes #2227.

`VerifyProof` intentionally treats a proof verification failure as data: it logs the verifier error and should respond with `valid=false`. However, it then unconditionally decodes and marshals the last proof. On a node that does not know the asset (for example a fresh receiver verifying a grouped proof), marshaling the optional decimal display metadata performs a Universe lookup that fails, and the caller receives an RPC error instead of `valid=false`.

This change returns `valid=false` immediately when verification fails, before decoding the last proof. That matches the documented response contract: `decoded_proof` is only set when the proof file is valid.

The regression test builds an encodable proof file with an unknown file version, so verification fails deterministically before any chain or Universe dependency is consulted; on the previous code the same request failed the whole RPC.