### PR TITLE
rfq: reject quote instead of crashing on scid alias failure

### DIFF
--- a/docs/release-notes/release-notes-0.9.0.md
+++ b/docs/release-notes/release-notes-0.9.0.md
@@ -35,6 +35,11 @@
   or otherwise. Non-asset payments are now excluded, as are the
   same payments in SubscribePayments and TrackPayment.
 
+* [PR#2232](https://github.com/lightninglabs/taproot-assets/pull/2232)
+  fixes a bug in which accepting an RFQ quote could shut down the daemon
+  if the channel selected as the SCID alias base had not negotiated
+  the `option_scid_alias` feature.
+
 # New Features
 
 ## Functional Enhancements

--- a/rfq/manager.go
+++ b/rfq/manager.go
@@ -463,10 +463,19 @@ func (m *Manager) handleIncomingMessage(ctx context.Context,
 			// alias cannot be registered, the quote is unusable,
 			// so we fail it before persisting anything.
 			err := m.addScidAlias(
-				uint64(msg.ShortChannelId()),
+				ctx, uint64(msg.ShortChannelId()),
 				msg.Request.AssetSpecifier, msg.Peer,
 			)
 			if err != nil {
+				// Notify subscribers (such as a waiting
+				// AddAssetBuyOrder RPC call) that the quote is
+				// unusable, so that the caller fails fast
+				// instead of timing out.
+				event := NewInvalidQuoteRespEvent(
+					&msg, ScidAliasErrQuoteRespStatus,
+				)
+				m.publishSubscriberEvent(event)
+
 				m.handleError(
 					fmt.Errorf("error adding local alias: "+
 						"%w", err),
@@ -579,39 +588,39 @@ func (m *Manager) handleOutgoingMessage(ctx context.Context,
 	// Perform type specific handling of the outgoing message.
 	switch msg := outgoingMsg.(type) {
 	case *rfqmsg.BuyAccept:
-		// Since our peer is going to buy assets from us, we need to
-		// make sure we can identify the forwarded asset payment by the
-		// outgoing SCID alias within the onion packet. If the alias
-		// cannot be registered, the quote is unusable, so we send the
-		// peer a reject instead of the accept.
-		err := m.addScidAlias(
-			uint64(msg.ShortChannelId()),
-			msg.Request.AssetSpecifier, msg.Peer,
-		)
-		if err != nil {
-			reject := rfqmsg.NewReject(
-				msg.Peer, msg.ID, rfqmsg.ErrUnknownReject,
-			)
-			sendErr := m.streamHandler.HandleOutgoingMessage(
-				ctx, reject,
-			)
-			if sendErr != nil {
-				log.Errorf("Error sending quote reject "+
-					"message: %v", sendErr)
-			}
-
-			return fmt.Errorf("error adding local alias: %w", err)
-		}
-
 		// A peer sent us an asset buy quote request in an attempt to
 		// buy an asset from us. Having accepted the request, but before
 		// we inform our peer of our decision, we inform the order
 		// handler that we are willing to sell the asset subject to a
 		// sale policy.
-		err = m.orderHandler.RegisterAssetSalePolicy(ctx, *msg)
+		err := m.orderHandler.RegisterAssetSalePolicy(ctx, *msg)
 		if err != nil {
+			m.rejectQuote(
+				ctx, msg.Peer, msg.ID,
+				"failed to register asset sale policy",
+			)
+
 			return fmt.Errorf("registering asset sale "+
 				"policy: %w", err)
+		}
+
+		// Since our peer is going to buy assets from us, we need to
+		// make sure we can identify the forwarded asset payment by the
+		// outgoing SCID alias within the onion packet. The alias is
+		// registered after the sale policy on purpose: expired
+		// policies are swept together with their alias, whereas an
+		// alias registered without a policy would never be cleaned up.
+		err = m.addScidAlias(
+			ctx, uint64(msg.ShortChannelId()),
+			msg.Request.AssetSpecifier, msg.Peer,
+		)
+		if err != nil {
+			m.rejectQuote(
+				ctx, msg.Peer, msg.ID,
+				"failed to register SCID alias",
+			)
+
+			return fmt.Errorf("error adding local alias: %w", err)
 		}
 
 	case *rfqmsg.SellAccept:
@@ -620,8 +629,17 @@ func (m *Manager) handleOutgoingMessage(ctx context.Context,
 		// we inform our peer of our decision, we inform the order
 		// handler that we are willing to buy the asset subject to a
 		// purchase policy.
+		//
+		// Note that unlike the buy accept case, no SCID alias is
+		// registered here: purchase policies match HTLCs on the RFQ ID
+		// in their custom records, not on an SCID alias.
 		err := m.orderHandler.RegisterAssetPurchasePolicy(ctx, *msg)
 		if err != nil {
+			m.rejectQuote(
+				ctx, msg.Peer, msg.ID,
+				"failed to register asset purchase policy",
+			)
+
 			return fmt.Errorf("registering asset purchase "+
 				"policy: %w", err)
 		}
@@ -637,39 +655,71 @@ func (m *Manager) handleOutgoingMessage(ctx context.Context,
 	return nil
 }
 
-// addScidAlias adds a SCID alias to the alias manager.
-func (m *Manager) addScidAlias(scidAlias uint64, assetSpecifier asset.Specifier,
-	peer route.Vertex) error {
+// rejectQuote informs a peer that a quote we had already accepted cannot be
+// honoured after all, so that the peer treats the session as terminated
+// instead of waiting out its own timeout for a response that never arrives.
+//
+// The reject is handed to the stream handler directly rather than being
+// enqueued on the outgoing message channel: that channel is unbuffered and
+// drained by the very goroutine that calls this method, so enqueueing here
+// would deadlock.
+func (m *Manager) rejectQuote(ctx context.Context, peer route.Vertex,
+	id rfqmsg.ID, reason string) {
 
-	ctxb := context.Background()
-	peerChans, err := m.FetchChannel(
-		ctxb, assetSpecifier, &peer, NoIntention,
-	)
-	if err != nil && !strings.Contains(
+	reject := rfqmsg.NewReject(peer, id, rfqmsg.NewRejectErr(reason))
+
+	err := m.streamHandler.HandleOutgoingMessage(ctx, reject)
+	if err != nil {
+		log.Errorf("Error sending quote reject message: %v", err)
+	}
+}
+
+// isNoMatchingChannelErr reports whether err indicates that FetchChannel
+// found no channels matching an asset specifier, as opposed to a failure to
+// list or evaluate channels.
+func isNoMatchingChannelErr(err error) bool {
+	return strings.Contains(
 		err.Error(), "no asset channel balance found for",
-	) {
+	) || strings.Contains(err.Error(), "no asset channels found for")
+}
 
+// addScidAlias adds a SCID alias to the alias manager.
+func (m *Manager) addScidAlias(ctx context.Context, scidAlias uint64,
+	assetSpecifier asset.Specifier, peer route.Vertex) error {
+
+	peerChans, err := m.FetchChannel(
+		ctx, assetSpecifier, &peer, NoIntention,
+	)
+	if err != nil && !isNoMatchingChannelErr(err) {
 		return err
 	}
 
-	// Only channels that negotiated the option-scid-alias feature can
-	// serve as the base of an alias mapping; lnd rejects the mapping for
-	// any other channel.
+	// Only channels for which lnd already holds at least one alias
+	// mapping can serve as the base of a new alias: this is precisely
+	// what lnd's XAddLocalChanAliases validates against, and covers both
+	// option_scid_alias and zero-conf channels. A channel without a real
+	// channel ID cannot serve as a base either.
 	aliasCapable := func(c TapChannel) bool {
-		return len(c.ChannelInfo.AliasScids) > 0
+		return c.ChannelInfo.ChannelID != 0 &&
+			len(c.ChannelInfo.AliasScids) > 0
 	}
 	baseChans := fn.Filter(peerChans[peer], aliasCapable)
 
-	// As a fallback, if we didn't find any compatible channels with the
-	// peer, let's pick any alias-capable channel that is available with
-	// this peer. This is okay, because non-strict forwarding will ask each
-	// channel if the bandwidth matches the provided specifier.
-	if len(baseChans) == 0 {
+	// As a fallback, if we didn't find any channels matching the
+	// specifier with the peer, let's pick any alias-capable channel that
+	// is available with this peer. This is okay, because non-strict
+	// forwarding will ask each channel if the bandwidth matches the
+	// provided specifier. Note that if matching asset channels exist but
+	// none of them is alias-capable, we deliberately do not widen the
+	// search: the alias would silently map onto a channel that cannot
+	// carry the asset.
+	if len(peerChans[peer]) == 0 {
 		peerChans, err = m.FetchChannel(
-			ctxb, asset.Specifier{}, &peer, NoIntention,
+			ctx, asset.Specifier{}, &peer, NoIntention,
 		)
 		if err != nil {
-			return err
+			return fmt.Errorf("fallback channel lookup for %s: %w",
+				&assetSpecifier, err)
 		}
 
 		baseChans = fn.Filter(peerChans[peer], aliasCapable)
@@ -693,7 +743,7 @@ func (m *Manager) addScidAlias(scidAlias uint64, assetSpecifier asset.Specifier,
 	log.Debugf("Adding SCID alias %d for base SCID %d", scidAlias, baseSCID)
 
 	err = m.cfg.AliasManager.AddLocalAlias(
-		ctxb, lnwire.NewShortChanIDFromInt(scidAlias),
+		ctx, lnwire.NewShortChanIDFromInt(scidAlias),
 		lnwire.NewShortChanIDFromInt(baseSCID),
 	)
 	if err != nil {
@@ -1502,6 +1552,10 @@ const (
 	// FillExceedsMaxQuoteRespStatus indicates that the negotiated
 	// fill amount exceeds the requester's maximum.
 	FillExceedsMaxQuoteRespStatus QuoteRespStatus = 8
+
+	// ScidAliasErrQuoteRespStatus indicates that a SCID alias could not
+	// be registered for the accepted quote, making the quote unusable.
+	ScidAliasErrQuoteRespStatus QuoteRespStatus = 9
 )
 
 // InvalidQuoteRespEvent is an event that is broadcast when the RFQ manager

--- a/rfq/manager.go
+++ b/rfq/manager.go
@@ -456,6 +456,24 @@ func (m *Manager) handleIncomingMessage(ctx context.Context,
 				return
 			}
 
+			// Since we're going to buy assets from our peer, we
+			// need to make sure we can identify the incoming asset
+			// payment by the SCID alias through which it comes in
+			// and compare it to the one in the invoice. If the
+			// alias cannot be registered, the quote is unusable,
+			// so we fail it before persisting anything.
+			err := m.addScidAlias(
+				uint64(msg.ShortChannelId()),
+				msg.Request.AssetSpecifier, msg.Peer,
+			)
+			if err != nil {
+				m.handleError(
+					fmt.Errorf("error adding local alias: "+
+						"%w", err),
+				)
+				return
+			}
+
 			// The quote request has been accepted. Persist to
 			// DB first so that on restart the quote is not
 			// silently lost.
@@ -475,22 +493,6 @@ func (m *Manager) handleIncomingMessage(ctx context.Context,
 			// DB write succeeded; populate the in-memory
 			// cache.
 			m.orderHandler.peerBuyQuotes.Store(scid, msg)
-
-			// Since we're going to buy assets from our peer, we
-			// need to make sure we can identify the incoming asset
-			// payment by the SCID alias through which it comes in
-			// and compare it to the one in the invoice.
-			err := m.addScidAlias(
-				uint64(msg.ShortChannelId()),
-				msg.Request.AssetSpecifier, msg.Peer,
-			)
-			if err != nil {
-				m.handleError(
-					fmt.Errorf("error adding local alias: "+
-						"%w", err),
-				)
-				return
-			}
 
 			// Notify subscribers of the incoming peer accepted
 			// asset buy quote.
@@ -577,26 +579,39 @@ func (m *Manager) handleOutgoingMessage(ctx context.Context,
 	// Perform type specific handling of the outgoing message.
 	switch msg := outgoingMsg.(type) {
 	case *rfqmsg.BuyAccept:
+		// Since our peer is going to buy assets from us, we need to
+		// make sure we can identify the forwarded asset payment by the
+		// outgoing SCID alias within the onion packet. If the alias
+		// cannot be registered, the quote is unusable, so we send the
+		// peer a reject instead of the accept.
+		err := m.addScidAlias(
+			uint64(msg.ShortChannelId()),
+			msg.Request.AssetSpecifier, msg.Peer,
+		)
+		if err != nil {
+			reject := rfqmsg.NewReject(
+				msg.Peer, msg.ID, rfqmsg.ErrUnknownReject,
+			)
+			sendErr := m.streamHandler.HandleOutgoingMessage(
+				ctx, reject,
+			)
+			if sendErr != nil {
+				log.Errorf("Error sending quote reject "+
+					"message: %v", sendErr)
+			}
+
+			return fmt.Errorf("error adding local alias: %w", err)
+		}
+
 		// A peer sent us an asset buy quote request in an attempt to
 		// buy an asset from us. Having accepted the request, but before
 		// we inform our peer of our decision, we inform the order
 		// handler that we are willing to sell the asset subject to a
 		// sale policy.
-		err := m.orderHandler.RegisterAssetSalePolicy(ctx, *msg)
+		err = m.orderHandler.RegisterAssetSalePolicy(ctx, *msg)
 		if err != nil {
 			return fmt.Errorf("registering asset sale "+
 				"policy: %w", err)
-		}
-
-		// Since our peer is going to buy assets from us, we need to
-		// make sure we can identify the forwarded asset payment by the
-		// outgoing SCID alias within the onion packet.
-		err = m.addScidAlias(
-			uint64(msg.ShortChannelId()),
-			msg.Request.AssetSpecifier, msg.Peer,
-		)
-		if err != nil {
-			return fmt.Errorf("error adding local alias: %w", err)
 		}
 
 	case *rfqmsg.SellAccept:
@@ -637,26 +652,36 @@ func (m *Manager) addScidAlias(scidAlias uint64, assetSpecifier asset.Specifier,
 		return err
 	}
 
+	// Only channels that negotiated the option-scid-alias feature can
+	// serve as the base of an alias mapping; lnd rejects the mapping for
+	// any other channel.
+	aliasCapable := func(c TapChannel) bool {
+		return len(c.ChannelInfo.AliasScids) > 0
+	}
+	baseChans := fn.Filter(peerChans[peer], aliasCapable)
+
 	// As a fallback, if we didn't find any compatible channels with the
-	// peer, let's pick any channel that is available with this peer. This
-	// is okay, because non-strict forwarding will ask each channel if the
-	// bandwidth matches the provided specifier.
-	if len(peerChans[peer]) == 0 {
+	// peer, let's pick any alias-capable channel that is available with
+	// this peer. This is okay, because non-strict forwarding will ask each
+	// channel if the bandwidth matches the provided specifier.
+	if len(baseChans) == 0 {
 		peerChans, err = m.FetchChannel(
 			ctxb, asset.Specifier{}, &peer, NoIntention,
 		)
 		if err != nil {
 			return err
 		}
+
+		baseChans = fn.Filter(peerChans[peer], aliasCapable)
 	}
 
-	if len(peerChans[peer]) == 0 {
+	if len(baseChans) == 0 {
 		return fmt.Errorf("cannot add scid alias with peer=%v, no "+
-			"compatible channels found for %s", peer,
+			"scid-alias-capable channels found for %s", peer,
 			&assetSpecifier)
 	}
 
-	baseSCID := peerChans[peer][0].ChannelInfo.ChannelID
+	baseSCID := baseChans[0].ChannelInfo.ChannelID
 
 	// At this point, if the base SCID is still not found, we return an
 	// error. We can't map the SCID alias to a base SCID.
@@ -672,12 +697,8 @@ func (m *Manager) addScidAlias(scidAlias uint64, assetSpecifier asset.Specifier,
 		lnwire.NewShortChanIDFromInt(baseSCID),
 	)
 	if err != nil {
-		// Not being able to call lnd to add the alias is a critical
-		// error, which warrants shutting down, as something is wrong.
-		return fn.NewCriticalError(
-			fmt.Errorf("add alias: error adding SCID alias to "+
-				"lnd alias manager: %w", err),
-		)
+		return fmt.Errorf("add alias: error adding SCID alias to "+
+			"lnd alias manager: %w", err)
 	}
 
 	return nil

--- a/rfq/manager_test.go
+++ b/rfq/manager_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/decred/dcrd/dcrec/secp256k1/v4"
@@ -15,6 +16,7 @@ import (
 	"github.com/lightninglabs/taproot-assets/asset"
 	"github.com/lightninglabs/taproot-assets/fn"
 	"github.com/lightninglabs/taproot-assets/proof"
+	"github.com/lightninglabs/taproot-assets/rfqmath"
 	"github.com/lightninglabs/taproot-assets/rfqmsg"
 	tpchmsg "github.com/lightninglabs/taproot-assets/tapchannelmsg"
 	"github.com/lightningnetwork/lnd/lnwallet"
@@ -717,22 +719,45 @@ func (m *mockChannelLister) ListChannels(_ context.Context, _, _ bool,
 	return m.channels, nil
 }
 
-// mockAliasManager is a mock ScidAliasManager that records the base SCIDs
-// passed to AddLocalAlias and can be configured to fail.
+// aliasReq records the arguments of a single AddLocalAlias call.
+type aliasReq struct {
+	alias, base lnwire.ShortChannelID
+}
+
+// callTrace records an ordered sequence of mock invocations, so that tests can
+// assert the order in which subsystems were called.
+type callTrace struct {
+	calls []string
+}
+
+// record appends a call to the trace.
+func (c *callTrace) record(name string) {
+	c.calls = append(c.calls, name)
+}
+
+// mockAliasManager is a mock ScidAliasManager that records AddLocalAlias
+// calls and can be configured to fail.
 type mockAliasManager struct {
 	failAdd bool
 
-	addedBases []lnwire.ShortChannelID
+	// trace, if set, records each AddLocalAlias call.
+	trace *callTrace
+
+	added []aliasReq
 }
 
-func (m *mockAliasManager) AddLocalAlias(_ context.Context, _,
+func (m *mockAliasManager) AddLocalAlias(_ context.Context, alias,
 	baseScid lnwire.ShortChannelID) error {
+
+	if m.trace != nil {
+		m.trace.record("alias")
+	}
 
 	if m.failAdd {
 		return fmt.Errorf("add alias failure")
 	}
 
-	m.addedBases = append(m.addedBases, baseScid)
+	m.added = append(m.added, aliasReq{alias: alias, base: baseScid})
 
 	return nil
 }
@@ -766,13 +791,20 @@ func newAliasTestManager(t *testing.T, channels []lndclient.ChannelInfo,
 }
 
 // TestAddScidAliasChannelSelection verifies that addScidAlias maps the alias
-// onto an alias-capable base channel, skipping channels that did not
-// negotiate the option-scid-alias feature.
+// onto an alias-capable base channel, skipping channels for which lnd holds
+// no alias mapping as well as channels without a real channel ID.
 func TestAddScidAliasChannelSelection(t *testing.T) {
 	t.Parallel()
 
+	ctx := context.Background()
+
 	aliasMgr := &mockAliasManager{}
 	manager := newAliasTestManager(t, []lndclient.ChannelInfo{
+		{
+			ChannelID:   0,
+			PubKeyBytes: peer1,
+			AliasScids:  []uint64{16_000_000},
+		},
 		{
 			ChannelID:   100,
 			PubKeyBytes: peer1,
@@ -780,15 +812,21 @@ func TestAddScidAliasChannelSelection(t *testing.T) {
 		{
 			ChannelID:   200,
 			PubKeyBytes: peer1,
-			AliasScids:  []uint64{16_000_000},
+			AliasScids:  []uint64{16_000_001},
+		},
+		{
+			ChannelID:   300,
+			PubKeyBytes: peer1,
+			AliasScids:  []uint64{16_000_002},
 		},
 	}, aliasMgr)
 
-	err := manager.addScidAlias(42, asset.Specifier{}, peer1)
+	err := manager.addScidAlias(ctx, 42, asset.Specifier{}, peer1)
 	require.NoError(t, err)
 
-	require.Len(t, aliasMgr.addedBases, 1)
-	require.EqualValues(t, 200, aliasMgr.addedBases[0].ToUint64())
+	require.Len(t, aliasMgr.added, 1)
+	require.EqualValues(t, 42, aliasMgr.added[0].alias.ToUint64())
+	require.EqualValues(t, 200, aliasMgr.added[0].base.ToUint64())
 }
 
 // TestAddScidAliasNoCapableChannel verifies that addScidAlias fails with a
@@ -798,6 +836,8 @@ func TestAddScidAliasChannelSelection(t *testing.T) {
 func TestAddScidAliasNoCapableChannel(t *testing.T) {
 	t.Parallel()
 
+	ctx := context.Background()
+
 	aliasMgr := &mockAliasManager{}
 	manager := newAliasTestManager(t, []lndclient.ChannelInfo{
 		{
@@ -806,10 +846,10 @@ func TestAddScidAliasNoCapableChannel(t *testing.T) {
 		},
 	}, aliasMgr)
 
-	err := manager.addScidAlias(42, asset.Specifier{}, peer1)
+	err := manager.addScidAlias(ctx, 42, asset.Specifier{}, peer1)
 	require.ErrorContains(t, err, "no scid-alias-capable channels")
 	require.False(t, fn.ErrorAs[*fn.CriticalError](err))
-	require.Empty(t, aliasMgr.addedBases)
+	require.Empty(t, aliasMgr.added)
 }
 
 // TestAddScidAliasFailureNotCritical verifies that a failure to register the
@@ -817,6 +857,8 @@ func TestAddScidAliasNoCapableChannel(t *testing.T) {
 // single failed quote cannot shut down the daemon.
 func TestAddScidAliasFailureNotCritical(t *testing.T) {
 	t.Parallel()
+
+	ctx := context.Background()
 
 	aliasMgr := &mockAliasManager{failAdd: true}
 	manager := newAliasTestManager(t, []lndclient.ChannelInfo{
@@ -827,7 +869,461 @@ func TestAddScidAliasFailureNotCritical(t *testing.T) {
 		},
 	}, aliasMgr)
 
-	err := manager.addScidAlias(42, asset.Specifier{}, peer1)
+	err := manager.addScidAlias(ctx, 42, asset.Specifier{}, peer1)
 	require.ErrorContains(t, err, "add alias")
 	require.False(t, fn.ErrorAs[*fn.CriticalError](err))
+}
+
+// TestAddScidAliasAssetChannelPreferred verifies that a channel matching the
+// asset specifier is preferred as the alias base over other channels with the
+// same peer.
+func TestAddScidAliasAssetChannelPreferred(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	assetChan := createChannelWithCustomData(
+		t, testAssetID3, 1_000, 1_000, proof3, peer1,
+	)
+	assetChan.ChannelID = 100
+	assetChan.AliasScids = []uint64{16_000_000}
+
+	btcChan := lndclient.ChannelInfo{
+		ChannelID:   200,
+		PubKeyBytes: peer1,
+		AliasScids:  []uint64{16_000_001},
+	}
+
+	aliasMgr := &mockAliasManager{}
+	manager := newAliasTestManager(
+		t, []lndclient.ChannelInfo{btcChan, assetChan}, aliasMgr,
+	)
+
+	spec := asset.NewSpecifierFromId(testAssetID3)
+	err := manager.addScidAlias(ctx, 42, spec, peer1)
+	require.NoError(t, err)
+
+	require.Len(t, aliasMgr.added, 1)
+	require.EqualValues(t, 100, aliasMgr.added[0].base.ToUint64())
+}
+
+// TestAddScidAliasAssetChannelNotCapable verifies that when channels matching
+// the asset specifier exist but none of them supports SCID aliases, the
+// selection fails rather than silently mapping the alias onto an unrelated
+// channel with the peer.
+func TestAddScidAliasAssetChannelNotCapable(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	assetChan := createChannelWithCustomData(
+		t, testAssetID3, 1_000, 1_000, proof3, peer1,
+	)
+	assetChan.ChannelID = 100
+
+	btcChan := lndclient.ChannelInfo{
+		ChannelID:   200,
+		PubKeyBytes: peer1,
+		AliasScids:  []uint64{16_000_001},
+	}
+
+	aliasMgr := &mockAliasManager{}
+	manager := newAliasTestManager(
+		t, []lndclient.ChannelInfo{assetChan, btcChan}, aliasMgr,
+	)
+
+	spec := asset.NewSpecifierFromId(testAssetID3)
+	err := manager.addScidAlias(ctx, 42, spec, peer1)
+	require.ErrorContains(t, err, "no scid-alias-capable channels")
+	require.Empty(t, aliasMgr.added)
+}
+
+// TestAddScidAliasFallback verifies that when the peer has no channels
+// matching the asset specifier at all, the alias is mapped onto any
+// alias-capable channel with the peer. This exercises the peer-specific "no
+// asset channels found" error from FetchChannel, which must be tolerated for
+// the fallback to be reachable.
+func TestAddScidAliasFallback(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	// The only asset channel lives with another peer, so the specifier
+	// pass fails with a peer-specific error and the fallback applies.
+	assetChan := createChannelWithCustomData(
+		t, testAssetID3, 1_000, 1_000, proof3, peer2,
+	)
+	assetChan.ChannelID = 100
+	assetChan.AliasScids = []uint64{16_000_000}
+
+	btcChan := lndclient.ChannelInfo{
+		ChannelID:   200,
+		PubKeyBytes: peer1,
+		AliasScids:  []uint64{16_000_001},
+	}
+
+	aliasMgr := &mockAliasManager{}
+	manager := newAliasTestManager(
+		t, []lndclient.ChannelInfo{assetChan, btcChan}, aliasMgr,
+	)
+
+	spec := asset.NewSpecifierFromId(testAssetID3)
+	err := manager.addScidAlias(ctx, 42, spec, peer1)
+	require.NoError(t, err)
+
+	require.Len(t, aliasMgr.added, 1)
+	require.EqualValues(t, 200, aliasMgr.added[0].base.ToUint64())
+}
+
+// traceStore is a PolicyStore mock that records policy registrations in a
+// shared call trace, counts persisted peer accepted quotes, and can be
+// configured to fail policy registration.
+type traceStore struct {
+	mockPolicyStore
+
+	trace      *callTrace
+	failPolicy bool
+
+	peerQuotes int
+}
+
+func (s *traceStore) StoreSalePolicy(context.Context, rfqmsg.BuyAccept) error {
+	s.trace.record("policy")
+
+	if s.failPolicy {
+		return fmt.Errorf("policy store failure")
+	}
+
+	return nil
+}
+
+func (s *traceStore) StorePurchasePolicy(context.Context,
+	rfqmsg.SellAccept) error {
+
+	s.trace.record("policy")
+
+	if s.failPolicy {
+		return fmt.Errorf("policy store failure")
+	}
+
+	return nil
+}
+
+func (s *traceStore) StorePeerAcceptedBuyQuote(context.Context,
+	rfqmsg.BuyAccept) error {
+
+	s.peerQuotes++
+
+	return nil
+}
+
+// mockPeerMessenger is a PeerMessenger that records the raw messages sent to
+// peers.
+type mockPeerMessenger struct {
+	sent []lndclient.CustomMessage
+}
+
+func (m *mockPeerMessenger) SubscribeCustomMessages(context.Context) (
+	<-chan lndclient.CustomMessage, <-chan error, error) {
+
+	return make(chan lndclient.CustomMessage), make(chan error), nil
+}
+
+func (m *mockPeerMessenger) SendCustomMessage(_ context.Context,
+	msg lndclient.CustomMessage) error {
+
+	m.sent = append(m.sent, msg)
+
+	return nil
+}
+
+// aliasCapableChans returns a single channel with peer1 for which lnd holds an
+// alias mapping, so that alias registration can proceed.
+func aliasCapableChans() []lndclient.ChannelInfo {
+	return []lndclient.ChannelInfo{{
+		ChannelID:   200,
+		PubKeyBytes: peer1,
+		AliasScids:  []uint64{16_000_000},
+	}}
+}
+
+// testQuoteRate returns an asset rate that is valid for the next hour.
+func testQuoteRate() rfqmsg.AssetRate {
+	return rfqmsg.NewAssetRate(
+		rfqmath.NewBigIntFixedPoint(100, 0),
+		time.Now().UTC().Add(time.Hour),
+	)
+}
+
+// testBuyAccept returns a buy accept message for a quote request made by
+// peer1, along with the request it responds to. The session ID is generated
+// the way it is in production, so that the SCID alias derived from it is a
+// valid one.
+func testBuyAccept(t *testing.T) (*rfqmsg.BuyAccept, *rfqmsg.BuyRequest) {
+	id, err := rfqmsg.NewID()
+	require.NoError(t, err)
+
+	request := &rfqmsg.BuyRequest{
+		Peer:        peer1,
+		ID:          id,
+		AssetMaxAmt: 1_000,
+	}
+
+	return rfqmsg.NewBuyAcceptFromRequest(
+		*request, testQuoteRate(), fn.None[uint64](),
+	), request
+}
+
+// testSellAccept returns a sell accept message for a quote request made by
+// peer1, along with the request it responds to.
+func testSellAccept(t *testing.T) (*rfqmsg.SellAccept, *rfqmsg.SellRequest) {
+	id, err := rfqmsg.NewID()
+	require.NoError(t, err)
+
+	request := &rfqmsg.SellRequest{
+		Peer:          peer1,
+		ID:            id,
+		PaymentMaxAmt: 1_000,
+	}
+
+	return rfqmsg.NewSellAcceptFromRequest(
+		*request, testQuoteRate(), fn.None[uint64](),
+	), request
+}
+
+// newOutgoingTestManager creates a Manager with its order handler and stream
+// handler wired up to mocks, for exercising handleOutgoingMessage.
+func newOutgoingTestManager(t *testing.T, store PolicyStore,
+	aliasMgr ScidAliasManager, messenger PeerMessenger) *Manager {
+
+	manager, err := NewManager(ManagerCfg{
+		GroupLookup: &GroupLookupMock{},
+		PolicyStore: store,
+		ChannelLister: &mockChannelLister{
+			channels: aliasCapableChans(),
+		},
+		AliasManager: aliasMgr,
+	})
+	require.NoError(t, err)
+
+	manager.orderHandler, err = NewOrderHandler(OrderHandlerCfg{
+		PolicyStore: store,
+	})
+	require.NoError(t, err)
+
+	manager.streamHandler, err = NewStreamHandler(
+		context.Background(), StreamHandlerCfg{
+			PeerMessenger: messenger,
+		},
+	)
+	require.NoError(t, err)
+
+	return manager
+}
+
+// TestHandleOutgoingAccept verifies that an accept message handed to the
+// outgoing message path always yields exactly one message to the peer: the
+// accept itself once every registration has succeeded, and a reject if any of
+// them failed. It also pins the order of the two registrations on the buy
+// path, since an alias registered before its sale policy would never be
+// cleaned up.
+func TestHandleOutgoingAccept(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name       string
+		sell       bool
+		failPolicy bool
+		failAlias  bool
+		wantTrace  []string
+		wantMsgTyp lnwire.MessageType
+		wantReason string
+		wantErr    bool
+	}{
+		{
+			name:       "buy accept",
+			wantTrace:  []string{"policy", "alias"},
+			wantMsgTyp: rfqmsg.MsgTypeAccept,
+		},
+		{
+			name:       "buy accept, policy failure",
+			failPolicy: true,
+			wantTrace:  []string{"policy"},
+			wantMsgTyp: rfqmsg.MsgTypeReject,
+			wantReason: "failed to register asset sale policy",
+			wantErr:    true,
+		},
+		{
+			name:       "buy accept, alias failure",
+			failAlias:  true,
+			wantTrace:  []string{"policy", "alias"},
+			wantMsgTyp: rfqmsg.MsgTypeReject,
+			wantReason: "failed to register SCID alias",
+			wantErr:    true,
+		},
+		{
+			name:       "sell accept",
+			sell:       true,
+			wantTrace:  []string{"policy"},
+			wantMsgTyp: rfqmsg.MsgTypeAccept,
+		},
+		{
+			name:       "sell accept, policy failure",
+			sell:       true,
+			failPolicy: true,
+			wantTrace:  []string{"policy"},
+			wantMsgTyp: rfqmsg.MsgTypeReject,
+			wantReason: "failed to register asset purchase policy",
+			wantErr:    true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			trace := &callTrace{}
+			store := &traceStore{
+				trace:      trace,
+				failPolicy: tc.failPolicy,
+			}
+			aliasMgr := &mockAliasManager{
+				trace:   trace,
+				failAdd: tc.failAlias,
+			}
+			messenger := &mockPeerMessenger{}
+			manager := newOutgoingTestManager(
+				t, store, aliasMgr, messenger,
+			)
+
+			// The session lookup used to decode any reject stands
+			// in for the peer's view of the session, so it must
+			// hold the request that the accept responds to.
+			var (
+				outgoing rfqmsg.OutgoingMsg
+				request  rfqmsg.OutgoingMsg
+				quoteID  rfqmsg.ID
+			)
+			if tc.sell {
+				accept, req := testSellAccept(t)
+				outgoing, request, quoteID = accept, req,
+					accept.ID
+			} else {
+				accept, req := testBuyAccept(t)
+				outgoing, request, quoteID = accept, req,
+					accept.ID
+			}
+
+			err := manager.handleOutgoingMessage(
+				context.Background(), outgoing,
+			)
+			if tc.wantErr {
+				require.Error(t, err)
+
+				// A single unusable quote must never take down
+				// the daemon.
+				require.False(
+					t, fn.ErrorAs[*fn.CriticalError](err),
+				)
+			} else {
+				require.NoError(t, err)
+			}
+
+			require.Equal(t, tc.wantTrace, trace.calls)
+
+			// Whatever the outcome, the peer hears back exactly
+			// once.
+			require.Len(t, messenger.sent, 1)
+
+			sent := messenger.sent[0]
+			require.EqualValues(t, tc.wantMsgTyp, sent.MsgType)
+			require.Equal(t, peer1, sent.Peer)
+
+			if tc.wantMsgTyp != rfqmsg.MsgTypeReject {
+				return
+			}
+
+			// The reject must terminate the session the accept
+			// belonged to, and say which step failed.
+			msgType := lnwire.MessageType(sent.MsgType)
+			reject, err := rfqmsg.NewQuoteRejectFromWireMsg(
+				rfqmsg.WireMessage{
+					Peer:    sent.Peer,
+					MsgType: msgType,
+					Data:    sent.Data,
+				},
+				func(_ rfqmsg.ID) (rfqmsg.OutgoingMsg, bool) {
+					return request, true
+				},
+			)
+			require.NoError(t, err)
+			require.Equal(t, quoteID, reject.ID.Val)
+			require.Equal(t, peer1, reject.Peer)
+			require.Equal(t, tc.wantReason, reject.Err.Val.Msg)
+		})
+	}
+}
+
+// TestHandleIncomingBuyAcceptAliasFailure verifies that when the SCID alias
+// for an incoming buy accept cannot be registered, the quote is failed right
+// away: subscribers are notified with a dedicated status so that a waiting
+// caller does not block until its own timeout, the unusable quote is neither
+// persisted nor cached, and the daemon's error channel is left untouched.
+func TestHandleIncomingBuyAcceptAliasFailure(t *testing.T) {
+	t.Parallel()
+
+	store := &traceStore{trace: &callTrace{}}
+	errChan := make(chan error, 1)
+
+	manager, err := NewManager(ManagerCfg{
+		GroupLookup: &GroupLookupMock{},
+		PolicyStore: store,
+		ChannelLister: &mockChannelLister{
+			channels: aliasCapableChans(),
+		},
+		AliasManager: &mockAliasManager{failAdd: true},
+		ErrChan:      errChan,
+	})
+	require.NoError(t, err)
+
+	manager.orderHandler = &OrderHandler{}
+	manager.negotiator, err = NewNegotiator(NegotiatorCfg{
+		SkipQuoteAcceptVerify: true,
+	})
+	require.NoError(t, err)
+
+	receiver := fn.NewEventReceiver[fn.Event](fn.DefaultQueueSize)
+	require.NoError(t, manager.RegisterSubscriber(receiver, false, 0))
+	defer func() {
+		require.NoError(t, manager.RemoveSubscriber(receiver))
+	}()
+
+	accept, _ := testBuyAccept(t)
+
+	err = manager.handleIncomingMessage(context.Background(), accept)
+	require.NoError(t, err)
+
+	// The caller waiting on the quote is told that it is unusable.
+	var event fn.Event
+	select {
+	case event = <-receiver.NewItemCreated.ChanOut():
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for quote response event")
+	}
+
+	invalid, ok := event.(*InvalidQuoteRespEvent)
+	require.True(t, ok, "expected invalid quote event, got %T", event)
+	require.Equal(t, ScidAliasErrQuoteRespStatus, invalid.Status)
+	require.Equal(t, accept.ID, invalid.QuoteResponse.MsgID())
+
+	// The unusable quote is neither persisted nor cached.
+	require.Zero(t, store.peerQuotes)
+
+	_, ok = manager.orderHandler.peerBuyQuotes.Load(
+		accept.ShortChannelId(),
+	)
+	require.False(t, ok)
+
+	// A quote that cannot be honoured must not shut down the daemon.
+	require.Empty(t, errChan)
 }

--- a/rfq/manager_test.go
+++ b/rfq/manager_test.go
@@ -13,10 +13,12 @@ import (
 	"github.com/lightninglabs/neutrino/cache/lru"
 	"github.com/lightninglabs/taproot-assets/address"
 	"github.com/lightninglabs/taproot-assets/asset"
+	"github.com/lightninglabs/taproot-assets/fn"
 	"github.com/lightninglabs/taproot-assets/proof"
 	"github.com/lightninglabs/taproot-assets/rfqmsg"
 	tpchmsg "github.com/lightninglabs/taproot-assets/tapchannelmsg"
 	"github.com/lightningnetwork/lnd/lnwallet"
+	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/routing/route"
 	"github.com/stretchr/testify/require"
 )
@@ -701,4 +703,131 @@ func pubKeyFromUint64(num uint64) *btcec.PublicKey {
 	binary.BigEndian.PutUint64(buf, num)
 	_ = scalar.SetByteSlice(buf)
 	return secp256k1.NewPrivateKey(scalar).PubKey()
+}
+
+// mockChannelLister is a mock ChannelLister that returns a fixed set of
+// channels.
+type mockChannelLister struct {
+	channels []lndclient.ChannelInfo
+}
+
+func (m *mockChannelLister) ListChannels(_ context.Context, _, _ bool,
+	_ ...lndclient.ListChannelsOption) ([]lndclient.ChannelInfo, error) {
+
+	return m.channels, nil
+}
+
+// mockAliasManager is a mock ScidAliasManager that records the base SCIDs
+// passed to AddLocalAlias and can be configured to fail.
+type mockAliasManager struct {
+	failAdd bool
+
+	addedBases []lnwire.ShortChannelID
+}
+
+func (m *mockAliasManager) AddLocalAlias(_ context.Context, _,
+	baseScid lnwire.ShortChannelID) error {
+
+	if m.failAdd {
+		return fmt.Errorf("add alias failure")
+	}
+
+	m.addedBases = append(m.addedBases, baseScid)
+
+	return nil
+}
+
+func (m *mockAliasManager) DeleteLocalAlias(_ context.Context, _,
+	_ lnwire.ShortChannelID) error {
+
+	return nil
+}
+
+func (m *mockAliasManager) FetchBaseAlias(_ context.Context,
+	_ lnwire.ShortChannelID) (lnwire.ShortChannelID, error) {
+
+	return lnwire.ShortChannelID{}, nil
+}
+
+// newAliasTestManager creates a Manager wired up with the given channels and
+// alias manager.
+func newAliasTestManager(t *testing.T, channels []lndclient.ChannelInfo,
+	aliasMgr ScidAliasManager) *Manager {
+
+	manager, err := NewManager(ManagerCfg{
+		GroupLookup:   &GroupLookupMock{},
+		PolicyStore:   mockPolicyStore{},
+		ChannelLister: &mockChannelLister{channels: channels},
+		AliasManager:  aliasMgr,
+	})
+	require.NoError(t, err)
+
+	return manager
+}
+
+// TestAddScidAliasChannelSelection verifies that addScidAlias maps the alias
+// onto an alias-capable base channel, skipping channels that did not
+// negotiate the option-scid-alias feature.
+func TestAddScidAliasChannelSelection(t *testing.T) {
+	t.Parallel()
+
+	aliasMgr := &mockAliasManager{}
+	manager := newAliasTestManager(t, []lndclient.ChannelInfo{
+		{
+			ChannelID:   100,
+			PubKeyBytes: peer1,
+		},
+		{
+			ChannelID:   200,
+			PubKeyBytes: peer1,
+			AliasScids:  []uint64{16_000_000},
+		},
+	}, aliasMgr)
+
+	err := manager.addScidAlias(42, asset.Specifier{}, peer1)
+	require.NoError(t, err)
+
+	require.Len(t, aliasMgr.addedBases, 1)
+	require.EqualValues(t, 200, aliasMgr.addedBases[0].ToUint64())
+}
+
+// TestAddScidAliasNoCapableChannel verifies that addScidAlias fails with a
+// non-critical error when no channel with the peer supports SCID aliases,
+// without attempting to register the alias with lnd. A critical error here
+// would shut down the daemon on a per-quote data condition.
+func TestAddScidAliasNoCapableChannel(t *testing.T) {
+	t.Parallel()
+
+	aliasMgr := &mockAliasManager{}
+	manager := newAliasTestManager(t, []lndclient.ChannelInfo{
+		{
+			ChannelID:   100,
+			PubKeyBytes: peer1,
+		},
+	}, aliasMgr)
+
+	err := manager.addScidAlias(42, asset.Specifier{}, peer1)
+	require.ErrorContains(t, err, "no scid-alias-capable channels")
+	require.False(t, fn.ErrorAs[*fn.CriticalError](err))
+	require.Empty(t, aliasMgr.addedBases)
+}
+
+// TestAddScidAliasFailureNotCritical verifies that a failure to register the
+// alias with lnd surfaces as a normal error rather than a critical one, so a
+// single failed quote cannot shut down the daemon.
+func TestAddScidAliasFailureNotCritical(t *testing.T) {
+	t.Parallel()
+
+	aliasMgr := &mockAliasManager{failAdd: true}
+	manager := newAliasTestManager(t, []lndclient.ChannelInfo{
+		{
+			ChannelID:   200,
+			PubKeyBytes: peer1,
+			AliasScids:  []uint64{16_000_000},
+		},
+	}, aliasMgr)
+
+	err := manager.addScidAlias(42, asset.Specifier{}, peer1)
+	require.ErrorContains(t, err, "add alias")
+	require.False(t, fn.ErrorAs[*fn.CriticalError](err))
 }


### PR DESCRIPTION
Resolves #2229. Fable's summary follows:

When accepting an RFQ quote, the manager registers a local SCID alias that maps the quote SCID onto a base channel shared with the peer. The base channel was chosen blindly as the first channel returned for the peer, and a failure to register the alias with lnd was classified as a critical error, shutting down the daemon.

lnd only permits alias mappings onto channels that negotiated the option-scid-alias feature, so a peer sharing only a legacy channel could take the node down simply by requesting a quote.

Fix this by:

- filtering base channel candidates down to alias-capable channels (those with a non-empty AliasScids set),
- treating alias registration failure as a normal per-quote error rather than a critical one,
- sending the peer a reject message when the alias cannot be registered for an outgoing buy accept, instead of leaving the peer to time out, and
- registering the alias before persisting an incoming buy accept, so a failed registration does not leave a stored quote behind.

