### PR TITLE
rfq: don't shut down when an HTLC is resolved on chain

### DIFF
--- a/cmd/tapd-integrated/main.go
+++ b/cmd/tapd-integrated/main.go
@@ -250,13 +250,22 @@ func run() error {
 	// lndclient doesn't try to load macaroon files from disk (which
 	// don't exist). lnd won't validate the macaroon anyway.
 	activeNet := cfg.Lnd.ActiveNetParams.Name
+	// NOTE: We must not block on lnd being fully synced to chain here.
+	// lnd's block processing can be blocked on tapd's aux components (for
+	// example on the aux sweeper, if a channel is being resolved on
+	// chain), and those only become available once we configure and start
+	// the tapd server below. Since lnd only reports itself as synced to
+	// chain once its blockbeat dispatcher caught up, waiting for that here
+	// would deadlock the startup. We do wait for the chain notifier to be
+	// ready though, as tapd needs it to subscribe to new blocks.
 	svcsCfg := &lndclient.LndServicesConfig{
-		LndAddress:            lndAddr,
-		Network:               lndclient.Network(activeNet),
-		Insecure:              true,
-		BlockUntilChainSynced: true,
-		BlockUntilUnlocked:    true,
-		CallerCtx:             ctx,
+		LndAddress:              lndAddr,
+		Network:                 lndclient.Network(activeNet),
+		Insecure:                true,
+		BlockUntilChainSynced:   false,
+		BlockUntilChainNotifier: true,
+		BlockUntilUnlocked:      true,
+		CallerCtx:               ctx,
 	}
 	if cfg.Lnd.NoMacaroons {
 		// Use a dummy macaroon that lndclient can deserialize.

--- a/docs/release-notes/release-notes-0.9.0.md
+++ b/docs/release-notes/release-notes-0.9.0.md
@@ -40,6 +40,15 @@
   if the channel selected as the SCID alias base had not negotiated
   the `option_scid_alias` feature.
 
+* [PR#2235](https://github.com/lightninglabs/taproot-assets/pull/2235)
+  fixes a bug in which a forwarded HTLC that ends up being resolved on
+  chain could shut down the daemon, and prevent it from starting again,
+  because `lnd` rejects any resolution the HTLC interceptor sends for
+  such an HTLC. It also makes the RFQ order handler act on final HTLC
+  events, which `lnd` sends without an event type and which were
+  therefore dropped, and makes the quote accounting idempotent for HTLCs
+  that `lnd` offers more than once.
+
 # New Features
 
 ## Functional Enhancements

--- a/itest/custom_channels/custom_channels_test.go
+++ b/itest/custom_channels/custom_channels_test.go
@@ -131,6 +131,10 @@ var testCases = []*ccTestCase{
 		name: "list invoices and payments",
 		test: testCustomChannelsListInvoicesAndPayments,
 	},
+	{
+		name: "on chain htlc intercept",
+		test: testCustomChannelsOnChainHtlcIntercept,
+	},
 }
 
 // TestCustomChannels is the main entry point for running custom channel

--- a/itest/custom_channels/onchain_htlc_intercept_test.go
+++ b/itest/custom_channels/onchain_htlc_intercept_test.go
@@ -1,0 +1,255 @@
+//go:build itest
+
+package custom_channels
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/lightninglabs/taproot-assets/itest"
+	"github.com/lightninglabs/taproot-assets/proof"
+	"github.com/lightninglabs/taproot-assets/taprpc"
+	"github.com/lightninglabs/taproot-assets/taprpc/mintrpc"
+	"github.com/lightningnetwork/lnd/lnrpc"
+	"github.com/lightningnetwork/lnd/lntest"
+	"github.com/lightningnetwork/lnd/lntest/node"
+	"github.com/lightningnetwork/lnd/lntest/port"
+	"github.com/lightningnetwork/lnd/lntest/wait"
+	"github.com/stretchr/testify/require"
+)
+
+// testCustomChannelsOnChainHtlcIntercept reproduces the bug reported in issue
+// #2223, where tapd refuses to (re)start with:
+//
+//	cannot resume held htlc in the on-chain flow
+//
+// Topology:
+//
+//	Charlie --[assets]--> Dave --[sats]--> Erin --[assets]--> Fabia
+//
+// Fabia creates a hodl invoice which Charlie pays with assets, so the HTLC
+// stays in flight on every hop. We then force close the normal Dave <-> Erin
+// channel, which means Erin's *incoming* HTLC has to be resolved on chain. Erin
+// is an RFQ edge node, so its tapd has an HTLC interceptor registered with lnd.
+//
+// lnd's contract court offers such an on-chain HTLC to the registered HTLC
+// interceptor (tapd's RFQ order handler) via the preimage beacon, and the
+// interceptable switch keeps it in its held HTLC set. Any resolution the
+// interceptor sends back for an on-chain forward is rejected by lnd with
+// ErrCannotResume/ErrCannotFail ("cannot resume in the on-chain flow"), which
+// tears down the whole ForwardHtlcInterceptor stream. Since PR #1899, tapd
+// treats a failure of the interception stream as a critical error, so the
+// daemon shuts down. On a restart the held HTLC is replayed to the freshly
+// connected interceptor, so tapd never manages to come up again.
+func testCustomChannelsOnChainHtlcIntercept(ctx context.Context,
+	net *itest.IntegratedNetworkHarness, t *ccHarnessTest) {
+
+	lndArgs := slices.Clone(lndArgsTemplate)
+	tapdArgs := slices.Clone(tapdArgsTemplate)
+
+	charliePort := port.NextAvailablePort()
+	tapdArgs = append(tapdArgs, fmt.Sprintf(
+		"--proofcourieraddr=%s://%s",
+		proof.UniverseRpcCourierType,
+		fmt.Sprintf(node.ListenerFormat, charliePort),
+	))
+
+	charlieLndArgs := slices.Clone(lndArgs)
+	charlieLndArgs = append(charlieLndArgs, fmt.Sprintf(
+		"--rpclisten=127.0.0.1:%d", charliePort,
+	))
+	charlie := net.NewNode("Charlie", charlieLndArgs, tapdArgs)
+	dave := net.NewNode("Dave", lndArgs, tapdArgs)
+	erin := net.NewNode("Erin", lndArgs, tapdArgs)
+	fabia := net.NewNode("Fabia", lndArgs, tapdArgs)
+	yara := net.NewNode("Yara", lndArgs, tapdArgs)
+
+	nodes := []*itest.IntegratedNode{charlie, dave, erin, fabia, yara}
+	connectAllNodes(t.t, net, nodes)
+	fundAllNodes(t.t, net, nodes)
+
+	// Create the normal (BTC) channel between Dave and Erin.
+	t.Logf("Opening normal channel between Dave and Erin...")
+	channelOp := openChannelAndAssert(
+		t, net, dave, erin, lntest.OpenChannelParams{
+			Amt:         10_000_000,
+			SatPerVByte: 5,
+		},
+	)
+
+	// Everyone needs to know about the only public channel.
+	assertChannelKnown(t.t, charlie, channelOp)
+	assertChannelKnown(t.t, fabia, channelOp)
+
+	// Mint an asset on Charlie and sync universes.
+	mintedAssets := itest.MintAssetsConfirmBatch(
+		t.t, net.Miner, asTapd(charlie),
+		[]*mintrpc.MintAssetRequest{
+			{
+				Asset: ccItestAsset,
+			},
+		},
+	)
+	cents := mintedAssets[0]
+	assetID := cents.AssetGenesis.AssetId
+
+	t.Logf("Minted %d lightning cents, syncing universes...", cents.Amount)
+	syncUniverses(t.t, charlie, dave, erin, fabia, yara)
+	t.Logf("Universes synced, creating asset network...")
+
+	const (
+		assetSendAmount   = uint64(400_000)
+		daveFundingAmount = uint64(400_000)
+		erinFundingAmount = uint64(200_000)
+	)
+	charlieFundingAmount := cents.Amount - (2 * assetSendAmount)
+
+	createTestAssetNetwork(
+		t, net, charlie, dave, erin, fabia, yara, charlie,
+		cents, assetSendAmount, charlieFundingAmount,
+		daveFundingAmount, erinFundingAmount, DefaultPushSat,
+	)
+
+	// Ensure nodes know each other in the graph.
+	require.NoError(t.t, net.AssertNodeKnown(charlie, dave))
+	require.NoError(t.t, net.AssertNodeKnown(dave, charlie))
+	require.NoError(t.t, net.AssertNodeKnown(erin, fabia))
+	require.NoError(t.t, net.AssertNodeKnown(fabia, erin))
+	require.NoError(t.t, net.AssertNodeKnown(charlie, erin))
+
+	logBalance(t.t, nodes, assetID, "initial")
+
+	// Fabia creates a hodl invoice, so the multi-hop HTLC will be stuck in
+	// flight until we force close below.
+	const invoiceAssetAmount = 20_000
+	hodlInvoice := createAssetHodlInvoice(
+		t.t, erin, fabia, invoiceAssetAmount, assetID,
+	)
+
+	t.Logf("Charlie paying Fabia's hodl invoice, HTLC will stay in " +
+		"flight...")
+	payInvoiceWithAssets(
+		t.t, charlie, dave, hodlInvoice.payReq, assetID,
+		withFailure(lnrpc.Payment_IN_FLIGHT, failureNone),
+	)
+
+	// Make sure Dave actually has the forwarded HTLC on both of his
+	// channels before we go on chain.
+	assertNumHtlcs(t.t, dave, 2)
+
+	logBalance(t.t, nodes, assetID, "with in-flight HTLC")
+
+	// Now we force close the normal channel between Dave and Erin. This
+	// forces Erin to resolve its incoming HTLC on chain, which makes lnd
+	// hand that HTLC to tapd's HTLC interceptor.
+	t.Logf("Force closing the Dave <-> Erin channel...")
+	_, closeTxid, err := net.CloseChannel(dave, channelOp, true)
+	require.NoError(t.t, err)
+
+	t.Logf("Channel force closed, close_txid=%v, mining blocks...",
+		closeTxid)
+
+	// Confirm the force close transaction, which starts the contract
+	// resolution on Erin's side.
+	mineBlocks(t, net, 1, 1)
+
+	// Erin's contract court now hands the incoming HTLC to the registered
+	// HTLC interceptor. tapd must survive that. Before the fix it goes down
+	// with a critical error, because lnd rejects any resolution for an
+	// on-chain HTLC and tears down the whole interception stream.
+	t.Logf("Asserting Erin stays alive during the on-chain resolution...")
+	assertNodeAlive(t.t, erin, 30*time.Second)
+
+	// Sanity check that the on-chain HTLC resolution actually started.
+	assertPendingForceCloseHtlcs(t.t, erin, 1)
+
+	// And finally, a restart must work as well: on startup lnd replays all
+	// held HTLCs (including the on-chain one) to the newly connected
+	// interceptor.
+	t.Logf("Restarting Erin...")
+	erin.Restart()
+
+	assertNodeAlive(t.t, erin, ccShortTimeout)
+}
+
+// assertPendingForceCloseHtlcs waits until the given node reports at least the
+// given number of pending HTLCs across all its pending force closing channels.
+func assertPendingForceCloseHtlcs(t *testing.T, n *itest.IntegratedNode,
+	expected int) {
+
+	t.Helper()
+
+	err := wait.NoError(func() error {
+		ctxt, cancel := context.WithTimeout(
+			context.Background(), ccShortTimeout,
+		)
+		defer cancel()
+
+		resp, err := n.PendingChannels(
+			ctxt, &lnrpc.PendingChannelsRequest{},
+		)
+		if err != nil {
+			return err
+		}
+
+		var numHtlcs int
+		for _, c := range resp.PendingForceClosingChannels {
+			numHtlcs += len(c.PendingHtlcs)
+		}
+
+		if numHtlcs < expected {
+			return fmt.Errorf("expected at least %d pending "+
+				"HTLCs, got %d", expected, numHtlcs)
+		}
+
+		return nil
+	}, 2*time.Minute)
+	require.NoError(t, err)
+}
+
+// assertNodeAlive polls the given node's lnd and tapd RPCs for the given
+// duration and fails as soon as the daemon stops responding.
+//
+// NOTE: The poll loop only queries lnd, as tapd's GetInfo blocks while a new
+// block is being processed. That is enough to detect the failure we're guarding
+// against: the integrated binary runs lnd in-process, so a critical tapd error
+// takes lnd down with it. We then check tapd itself once at the end.
+func assertNodeAlive(t *testing.T, n *itest.IntegratedNode, d time.Duration) {
+	t.Helper()
+
+	deadline := time.Now().Add(d)
+	for time.Now().Before(deadline) {
+		ctxt, cancel := context.WithTimeout(
+			context.Background(), ccShortTimeout,
+		)
+		_, err := n.LightningClient.GetInfo(
+			ctxt, &lnrpc.GetInfoRequest{},
+		)
+		cancel()
+
+		require.NoErrorf(t, err, "node %s went down", n.Cfg.Name)
+
+		time.Sleep(time.Second)
+	}
+
+	// tapd's GetInfo blocks while a new block is being processed, so we
+	// allow for a couple of retries here.
+	err := wait.NoError(func() error {
+		ctxt, cancel := context.WithTimeout(
+			context.Background(), ccShortTimeout,
+		)
+		defer cancel()
+
+		_, err := n.TaprootAssetsClient.GetInfo(
+			ctxt, &taprpc.GetInfoRequest{},
+		)
+
+		return err
+	}, 3*ccShortTimeout)
+	require.NoErrorf(
+		t, err, "tapd of node %s is not responding", n.Cfg.Name,
+	)
+}

--- a/rfq/order.go
+++ b/rfq/order.go
@@ -305,7 +305,13 @@ func (c *AssetSalePolicy) CheckHtlcCompliance(_ context.Context,
 			"mSat: %w", err)
 	}
 
-	if (c.CurrentAmountMsat + htlc.AmountOutMsat) > policyMaxOutMsat {
+	// lnd may offer the same HTLC to us more than once, and asks
+	// interceptor clients to handle those replays idempotently. If we
+	// already track this HTLC, its amount is part of CurrentAmountMsat
+	// already and must not be counted a second time.
+	currentAmtMsat := c.currentAmountExcluding(htlc.IncomingCircuitKey)
+
+	if (currentAmtMsat + htlc.AmountOutMsat) > policyMaxOutMsat {
 		return fmt.Errorf("HTLC out amount is greater than the policy "+
 			"maximum (htlc_out_msat=%d, policy_max_out_msat=%d)",
 			htlc.AmountOutMsat, policyMaxOutMsat)
@@ -328,9 +334,31 @@ func (c *AssetSalePolicy) TrackAcceptedHtlc(circuitKey models.CircuitKey,
 	c.stateMutex.Lock()
 	defer c.stateMutex.Unlock()
 
+	// If we already tracked this HTLC, we only account for the difference,
+	// as UntrackHtlc will only ever subtract the amount once.
+	if prevAmt, ok := c.htlcToAmt[circuitKey]; ok {
+		c.CurrentAmountMsat -= prevAmt
+	}
+
 	c.CurrentAmountMsat += amt
 
 	c.htlcToAmt[circuitKey] = amt
+}
+
+// currentAmountExcluding returns the total amount currently tracked by this
+// policy, without the amount of the given HTLC, if that HTLC is already being
+// tracked.
+//
+// NOTE: The caller must hold at least the read lock of the state mutex.
+func (c *AssetSalePolicy) currentAmountExcluding(
+	circuitKey models.CircuitKey) lnwire.MilliSatoshi {
+
+	prevAmt, ok := c.htlcToAmt[circuitKey]
+	if !ok {
+		return c.CurrentAmountMsat
+	}
+
+	return c.CurrentAmountMsat - prevAmt
 }
 
 // UntrackHtlc stops tracking the uniquely identified HTLC.
@@ -571,7 +599,11 @@ func (c *AssetPurchasePolicy) CheckHtlcCompliance(ctx context.Context,
 
 	// Ensure that the outbound HTLC amount is less than the maximum agreed
 	// BTC payment.
-	if (c.CurrentAmountMsat + htlc.AmountOutMsat) > c.PaymentMaxAmt {
+	// See the comment on the sale policy's compliance check: a replayed
+	// HTLC must not be counted twice.
+	currentAmtMsat := c.currentAmountExcluding(htlc.IncomingCircuitKey)
+
+	if (currentAmtMsat + htlc.AmountOutMsat) > c.PaymentMaxAmt {
 		return fmt.Errorf("HTLC out amount is more than the maximum "+
 			"agreed BTC payment (htlc_out_msat=%d, "+
 			"payment_max_amt=%d)", htlc.AmountOutMsat,
@@ -595,9 +627,31 @@ func (c *AssetPurchasePolicy) TrackAcceptedHtlc(circuitKey models.CircuitKey,
 	c.stateMutex.Lock()
 	defer c.stateMutex.Unlock()
 
+	// If we already tracked this HTLC, we only account for the difference,
+	// as UntrackHtlc will only ever subtract the amount once.
+	if prevAmt, ok := c.htlcToAmt[circuitKey]; ok {
+		c.CurrentAmountMsat -= prevAmt
+	}
+
 	c.CurrentAmountMsat += amt
 
 	c.htlcToAmt[circuitKey] = amt
+}
+
+// currentAmountExcluding returns the total amount currently tracked by this
+// policy, without the amount of the given HTLC, if that HTLC is already being
+// tracked.
+//
+// NOTE: The caller must hold at least the read lock of the state mutex.
+func (c *AssetPurchasePolicy) currentAmountExcluding(
+	circuitKey models.CircuitKey) lnwire.MilliSatoshi {
+
+	prevAmt, ok := c.htlcToAmt[circuitKey]
+	if !ok {
+		return c.CurrentAmountMsat
+	}
+
+	return c.CurrentAmountMsat - prevAmt
 }
 
 // UntrackHtlc stops tracking the uniquely identified HTLC.

--- a/rfq/order.go
+++ b/rfq/order.go
@@ -1269,8 +1269,24 @@ func (h *OrderHandler) subscribeHtlcs(ctx context.Context) error {
 				h.resolvedHtlcs.Delete(circuitKey)
 			}
 
-			// We only care about forwarding events for the rest of
-			// the handling below.
+			// A final HTLC event is the only signal we get for an
+			// HTLC that was resolved on chain: the incoming link is
+			// gone by then, so there is neither a settle nor a
+			// forward fail event. lnd doesn't set an event type on
+			// those events, so we must handle them before we filter
+			// on forwards below, or the accounting for every
+			// on-chain resolution is silently skipped.
+			if finalHtlcEvent != nil {
+				if finalHtlcEvent.Settled {
+					h.handleHtlcSettle(ctx, circuitKey)
+				} else {
+					h.handleHtlcFail(ctx, circuitKey)
+				}
+
+				continue
+			}
+
+			// Everything below only applies to forwards.
 			if event.GetEventType() != routerrpc.HtlcEvent_FORWARD {
 				continue
 			}
@@ -1280,15 +1296,6 @@ func (h *OrderHandler) subscribeHtlcs(ctx context.Context) error {
 				// HTLC settled successfully - update the
 				// forwarding event record.
 				h.handleHtlcSettle(ctx, circuitKey)
-
-			case finalHtlcEvent != nil:
-				// HTLC resolved on-chain (force close
-				// scenario).
-				if finalHtlcEvent.Settled {
-					h.handleHtlcSettle(ctx, circuitKey)
-				} else {
-					h.handleHtlcFail(ctx, circuitKey)
-				}
 
 			case failEvent != nil:
 				fallthrough

--- a/rfq/order.go
+++ b/rfq/order.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -27,6 +28,36 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
+
+const (
+	// minInterceptorRetryBackoff is the initial delay we wait before we
+	// re-establish a torn down HTLC interception stream.
+	minInterceptorRetryBackoff = 500 * time.Millisecond
+
+	// maxInterceptorRetryBackoff is the maximum delay we wait before we
+	// re-establish a torn down HTLC interception stream.
+	maxInterceptorRetryBackoff = 30 * time.Second
+
+	// interceptorHealthyUptime is the duration an interception stream needs
+	// to be up for before we consider it healthy and reset the retry
+	// backoff.
+	interceptorHealthyUptime = time.Minute
+
+	// resolvedHtlcRetention is the duration after which we forget that we
+	// resolved an HTLC, in case we never learn about its final state. This
+	// is a fallback only, entries are normally removed as soon as lnd
+	// reports the HTLC as settled or failed.
+	resolvedHtlcRetention = 24 * time.Hour
+)
+
+// recoverableInterceptorErrs is the list of error strings that indicate that
+// the HTLC interception stream was torn down for a reason that we can recover
+// from by re-establishing the stream. See lnd's ErrCannotResume, ErrCannotFail
+// and ErrFwdNotExists.
+var recoverableInterceptorErrs = []string{
+	"in the on-chain flow",
+	"forward does not exist",
+}
 
 // parseHtlcCustomRecords parses a HTLC custom record to extract any data which
 // is relevant to the RFQ service. If the custom records map is nil or a
@@ -888,6 +919,14 @@ type OrderHandler struct {
 	// needed for logging. This is populated when an HTLC is accepted.
 	htlcToForward lnutils.SyncMap[models.CircuitKey, *ForwardInput]
 
+	// resolvedHtlcs maps the circuit key of every HTLC we already sent a
+	// resolution for to the time we sent it. lnd only accepts a single
+	// resolution per intercepted HTLC and terminates the whole interception
+	// stream if we send another one. Entries are removed again once lnd
+	// tells us the HTLC reached its final state, and are swept by age as a
+	// fallback.
+	resolvedHtlcs lnutils.SyncMap[models.CircuitKey, time.Time]
+
 	// forwardStore persists forwarding events for accounting.
 	forwardStore ForwardStore
 
@@ -910,11 +949,79 @@ func NewOrderHandler(cfg OrderHandlerCfg) (*OrderHandler, error) {
 	}, nil
 }
 
-// handleIncomingHtlc handles an incoming HTLC.
+// handleIncomingHtlc handles an incoming HTLC. It makes sure we never send more
+// than a single resolution per HTLC, then hands the HTLC over to
+// resolveIncomingHtlc for the actual policy evaluation.
 //
 // NOTE: This function must be thread safe. It is used by an external
 // interceptor service.
 func (h *OrderHandler) handleIncomingHtlc(ctx context.Context,
+	htlc lndclient.InterceptedHtlc) (*lndclient.InterceptedHtlcResponse,
+	error) {
+
+	// We claim the HTLC before resolving it, so we can be sure we only ever
+	// send a single resolution for it. lnd offers an HTLC to the
+	// interceptor a second time if it ends up being resolved on chain (see
+	// lnd's incoming contest resolver, which notifies the interceptor
+	// through the preimage beacon). Any resolution we send for such an HTLC
+	// is rejected by lnd, which terminates the whole interception stream
+	// and would take the RFQ subsystem (and with it the daemon) down with
+	// it. There is nothing we can do about an HTLC that is already being
+	// resolved on chain, so we simply don't answer. lnd doesn't require an
+	// answer either, it removes those HTLCs from its held set again with
+	// the next block.
+	//
+	// NOTE: A replay on its own is not proof that an HTLC is being resolved
+	// on chain, lnd asks interceptor clients to handle replayed circuit
+	// keys idempotently. What makes this safe is that with lnd's default
+	// configuration a disconnecting interceptor releases the off-chain held
+	// HTLCs (see releaseAllOffChainHeld in lnd's interceptable switch), so
+	// the ones that are still replayed to us afterwards are the on-chain
+	// ones. With lnd's requireinterceptor option the off-chain held HTLCs
+	// are retained instead, and we would also stay silent for those, which
+	// leaves them held until lnd's own expiry safety net fails them back.
+	_, alreadyResolved := h.resolvedHtlcs.LoadOrStore(
+		htlc.IncomingCircuitKey, time.Now(),
+	)
+	if alreadyResolved {
+		log.Warnf("HTLC %v was already resolved by us, not responding "+
+			"again (it is most likely being resolved on chain)",
+			htlc.IncomingCircuitKey)
+
+		// We can neither return a response nor an error here, as both
+		// would tear down the interception stream. So we just wait
+		// until the stream itself goes away.
+		select {
+		case <-ctx.Done():
+		case <-h.Quit:
+		}
+
+		// We only ever get here because the stream or the whole daemon
+		// is shutting down. Any error we return now is the one the
+		// interceptor exits with, so it must be one that isn't treated
+		// as critical, otherwise we'd report a critical error on every
+		// shutdown that happens while we hold an HTLC.
+		return nil, context.Canceled
+	}
+
+	resp, err := h.resolveIncomingHtlc(ctx, htlc)
+	if err != nil {
+		// We're not going to send a resolution after all, so we forget
+		// about this HTLC again.
+		h.resolvedHtlcs.Delete(htlc.IncomingCircuitKey)
+
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+// resolveIncomingHtlc decides how an incoming HTLC should be resolved, based on
+// the RFQ policy that applies to it.
+//
+// NOTE: This function must be thread safe. It is used by an external
+// interceptor service.
+func (h *OrderHandler) resolveIncomingHtlc(ctx context.Context,
 	htlc lndclient.InterceptedHtlc) (*lndclient.InterceptedHtlcResponse,
 	error) {
 
@@ -1028,22 +1135,80 @@ func (h *OrderHandler) handleIncomingHtlc(ctx context.Context,
 	return policy.GenerateInterceptorResponse(htlc)
 }
 
-// setupHtlcIntercept sets up HTLC interception.
+// setupHtlcIntercept sets up HTLC interception and keeps the interception
+// stream alive for as long as the given context is alive.
+//
+// lnd tears down the whole interception stream if we send a resolution it can't
+// apply, which can happen for HTLCs that are (already) being resolved on chain.
+// Those errors are recoverable: we simply re-establish the stream. Any other
+// error is returned to the caller, which treats it as critical.
 func (h *OrderHandler) setupHtlcIntercept(ctx context.Context) error {
-	// Intercept incoming HTLCs. This call passes the handleIncomingHtlc
-	// function to the interceptor. The interceptor will call this function
-	// in a separate goroutine.
-	err := h.cfg.HtlcInterceptor.InterceptHtlcs(ctx, h.handleIncomingHtlc)
-	if err != nil {
-		if fn.IsCanceled(err) {
+	backoff := minInterceptorRetryBackoff
+
+	for {
+		// Intercept incoming HTLCs. This call passes the
+		// handleIncomingHtlc function to the interceptor. The
+		// interceptor will call this function in a separate goroutine.
+		// The call blocks until the stream is torn down.
+		startTime := time.Now()
+		err := h.cfg.HtlcInterceptor.InterceptHtlcs(
+			ctx, h.handleIncomingHtlc,
+		)
+
+		switch {
+		case err == nil, fn.IsCanceled(err):
+			return nil
+
+		case !isRecoverableInterceptorErr(err):
+			return fmt.Errorf("unable to setup incoming HTLC "+
+				"interceptor: %w", err)
+		}
+
+		// The stream was torn down because lnd rejected one of our
+		// resolutions. That is not fatal, we just need to re-establish
+		// it. If the last stream was up for a while, we start over with
+		// the minimum backoff.
+		if time.Since(startTime) >= interceptorHealthyUptime {
+			backoff = minInterceptorRetryBackoff
+		}
+
+		log.Warnf("HTLC interception stream terminated, re-"+
+			"establishing in %v: %v", backoff, err)
+
+		select {
+		case <-time.After(backoff):
+		case <-ctx.Done():
+			return nil
+
+		case <-h.Quit:
 			return nil
 		}
 
-		return fmt.Errorf("unable to setup incoming HTLC "+
-			"interceptor: %w", err)
+		backoff = min(backoff*2, maxInterceptorRetryBackoff)
+	}
+}
+
+// isRecoverableInterceptorErr returns true if the given error, which terminated
+// the HTLC interception stream, is one we can recover from by simply
+// re-establishing the stream.
+//
+// The errors we look for are lnd's ErrCannotResume/ErrCannotFail (returned for
+// HTLCs that are being resolved on chain) and ErrFwdNotExists (returned if an
+// HTLC is no longer held by lnd's interceptable switch). We have to match on
+// the error string, as these errors reach us as opaque gRPC status errors.
+func isRecoverableInterceptorErr(err error) bool {
+	if err == nil {
+		return false
 	}
 
-	return nil
+	errStr := err.Error()
+	for _, recoverable := range recoverableInterceptorErrs {
+		if strings.Contains(errStr, recoverable) {
+			return true
+		}
+	}
+
+	return false
 }
 
 // mainEventLoop executes the main event handling loop.
@@ -1060,6 +1225,7 @@ func (h *OrderHandler) mainEventLoop() {
 			log.Debug("Cleaning up any stale policy from the " +
 				"order handler")
 			h.cleanupStalePolicies()
+			h.cleanupResolvedHtlcs()
 		case <-h.Quit:
 			log.Debug("Received quit signal. Stopping negotiator " +
 				"event loop")
@@ -1081,11 +1247,6 @@ func (h *OrderHandler) subscribeHtlcs(ctx context.Context) error {
 	for {
 		select {
 		case event := <-events:
-			// We only care about forwarding events.
-			if event.GetEventType() != routerrpc.HtlcEvent_FORWARD {
-				continue
-			}
-
 			// Retrieve the event instances that may be relevant.
 			failEvent := event.GetForwardFailEvent()
 			linkFail := event.GetLinkFailEvent()
@@ -1098,6 +1259,20 @@ func (h *OrderHandler) subscribeHtlcs(ctx context.Context) error {
 					event.IncomingChannelId,
 				),
 				HtlcID: event.IncomingHtlcId,
+			}
+
+			// Once an HTLC reached a final state, we can
+			// forget that we sent a resolution for it.
+			if failEvent != nil || linkFail != nil ||
+				settleEvent != nil || finalHtlcEvent != nil {
+
+				h.resolvedHtlcs.Delete(circuitKey)
+			}
+
+			// We only care about forwarding events for the rest of
+			// the handling below.
+			if event.GetEventType() != routerrpc.HtlcEvent_FORWARD {
+				continue
 			}
 
 			switch {
@@ -1695,6 +1870,32 @@ func (h *OrderHandler) cleanupStalePolicies() {
 	if staleCounter > 0 {
 		log.Tracef("Removed stale policies from the order handler: "+
 			"(count=%d)", staleCounter)
+	}
+}
+
+// cleanupResolvedHtlcs removes entries from the resolved HTLC set that we never
+// saw a final state for. Entries are normally removed as soon as lnd reports
+// the HTLC as settled or failed, this is only a fallback to make sure the set
+// can't grow indefinitely.
+func (h *OrderHandler) cleanupResolvedHtlcs() {
+	staleCounter := 0
+
+	h.resolvedHtlcs.ForEach(
+		func(key models.CircuitKey, resolvedAt time.Time) error {
+			if time.Since(resolvedAt) < resolvedHtlcRetention {
+				return nil
+			}
+
+			staleCounter++
+			h.resolvedHtlcs.Delete(key)
+
+			return nil
+		},
+	)
+
+	if staleCounter > 0 {
+		log.Tracef("Removed stale resolved HTLCs from the order "+
+			"handler: (count=%d)", staleCounter)
 	}
 }
 

--- a/rfq/order_events_test.go
+++ b/rfq/order_events_test.go
@@ -1,0 +1,70 @@
+package rfq
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/lightningnetwork/lnd/graph/db/models"
+	"github.com/lightningnetwork/lnd/lnrpc/routerrpc"
+	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSubscribeHtlcsFinalEvent tests that a final HTLC event is acted on even
+// though lnd doesn't set an event type on it. That event is the only signal we
+// get for an HTLC that was resolved on chain, so dropping it would leave the
+// policy accounting for that HTLC inflated until the quote expires.
+func TestSubscribeHtlcsFinalEvent(t *testing.T) {
+	t.Parallel()
+
+	subscriber := newMockHtlcSubscriber()
+	handler, err := NewOrderHandler(OrderHandlerCfg{
+		CleanupInterval: time.Hour,
+		HtlcInterceptor: newMockHtlcInterceptor(),
+		HtlcSubscriber:  subscriber,
+	})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		_ = handler.subscribeHtlcs(ctx)
+	}()
+
+	// Track an HTLC against a policy, the way an accepted forward would.
+	circuitKey := testCircuitKey(1)
+	policy := &AssetSalePolicy{
+		htlcToAmt: make(map[models.CircuitKey]lnwire.MilliSatoshi),
+	}
+	policy.TrackAcceptedHtlc(circuitKey, 1000)
+	handler.htlcToPolicy.Store(circuitKey, policy)
+
+	// lnd reports the HTLC as resolved on chain. Note that it does not set
+	// an event type on final HTLC events, which is exactly the case we need
+	// to handle.
+	subscriber.events <- &routerrpc.HtlcEvent{
+		IncomingChannelId: circuitKey.ChanID.ToUint64(),
+		IncomingHtlcId:    circuitKey.HtlcID,
+		Event: &routerrpc.HtlcEvent_FinalHtlcEvent{
+			FinalHtlcEvent: &routerrpc.FinalHtlcEvent{
+				Settled: true,
+			},
+		},
+	}
+
+	// The HTLC must no longer be tracked against the policy, and its amount
+	// must have been released again.
+	require.Eventually(t, func() bool {
+		_, tracked := handler.htlcToPolicy.Load(circuitKey)
+		if tracked {
+			return false
+		}
+
+		policy.stateMutex.Lock()
+		defer policy.stateMutex.Unlock()
+
+		return policy.CurrentAmountMsat == 0
+	}, 10*time.Second, 10*time.Millisecond)
+}

--- a/rfq/order_intercept_test.go
+++ b/rfq/order_intercept_test.go
@@ -1,0 +1,456 @@
+package rfq
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/lightninglabs/lndclient"
+	"github.com/lightninglabs/taproot-assets/fn"
+	"github.com/lightningnetwork/lnd/graph/db/models"
+	"github.com/lightningnetwork/lnd/lnrpc"
+	"github.com/lightningnetwork/lnd/lnrpc/routerrpc"
+	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// mockHtlcInterceptor is a mock implementation of the HtlcInterceptor interface
+// that returns a pre-defined list of errors, one per call. Once the list is
+// exhausted, it blocks until the passed context is canceled, mimicking a
+// healthy interception stream.
+type mockHtlcInterceptor struct {
+	sync.Mutex
+
+	// errs are the errors returned by consecutive InterceptHtlcs calls.
+	errs []error
+
+	// numCalls is the number of times InterceptHtlcs was called.
+	numCalls int
+}
+
+func newMockHtlcInterceptor(errs ...error) *mockHtlcInterceptor {
+	return &mockHtlcInterceptor{
+		errs: errs,
+	}
+}
+
+// InterceptHtlcs implements the HtlcInterceptor interface.
+func (m *mockHtlcInterceptor) InterceptHtlcs(ctx context.Context,
+	_ lndclient.HtlcInterceptHandler) error {
+
+	m.Lock()
+	m.numCalls++
+
+	var err error
+	if len(m.errs) > 0 {
+		err, m.errs = m.errs[0], m.errs[1:]
+	}
+	m.Unlock()
+
+	if err != nil {
+		return err
+	}
+
+	// No more errors to return, so we act like a healthy stream that only
+	// terminates once the context is canceled.
+	<-ctx.Done()
+
+	return ctx.Err()
+}
+
+// calls returns the number of times InterceptHtlcs was called.
+func (m *mockHtlcInterceptor) calls() int {
+	m.Lock()
+	defer m.Unlock()
+
+	return m.numCalls
+}
+
+var _ HtlcInterceptor = (*mockHtlcInterceptor)(nil)
+
+// mockHtlcSubscriber is a mock implementation of the HtlcSubscriber interface
+// that forwards the events sent to its events channel.
+type mockHtlcSubscriber struct {
+	events chan *routerrpc.HtlcEvent
+	errs   chan error
+}
+
+func newMockHtlcSubscriber() *mockHtlcSubscriber {
+	return &mockHtlcSubscriber{
+		events: make(chan *routerrpc.HtlcEvent, 8),
+		errs:   make(chan error, 1),
+	}
+}
+
+// SubscribeHtlcEvents implements the HtlcSubscriber interface.
+func (m *mockHtlcSubscriber) SubscribeHtlcEvents(_ context.Context) (
+	<-chan *routerrpc.HtlcEvent, <-chan error, error) {
+
+	return m.events, m.errs, nil
+}
+
+// LookupHtlcResolution implements the HtlcSubscriber interface.
+func (m *mockHtlcSubscriber) LookupHtlcResolution(_ context.Context, _ uint64,
+	_ uint64) (*lnrpc.LookupHtlcResolutionResponse, error) {
+
+	return nil, errors.New("unimplemented")
+}
+
+var _ HtlcSubscriber = (*mockHtlcSubscriber)(nil)
+
+// newTestOrderHandler creates an order handler that only has the given HTLC
+// interceptor configured, which is all that's needed for the interception
+// related tests.
+func newTestOrderHandler(t *testing.T,
+	interceptor HtlcInterceptor) *OrderHandler {
+
+	t.Helper()
+
+	handler, err := NewOrderHandler(OrderHandlerCfg{
+		CleanupInterval: time.Hour,
+		HtlcInterceptor: interceptor,
+	})
+	require.NoError(t, err)
+
+	return handler
+}
+
+// testCircuitKey returns a circuit key for the given HTLC ID.
+func testCircuitKey(htlcID uint64) models.CircuitKey {
+	return models.CircuitKey{
+		ChanID: lnwire.NewShortChanIDFromInt(1234),
+		HtlcID: htlcID,
+	}
+}
+
+// TestIsRecoverableInterceptorErr tests that we correctly identify the errors
+// that lnd returns when it can't apply a resolution we sent for an intercepted
+// HTLC. Those errors reach us as opaque gRPC status errors, which is why we
+// need to match on their string representation.
+func TestIsRecoverableInterceptorErr(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name        string
+		err         error
+		recoverable bool
+	}{{
+		name:        "nil error",
+		err:         nil,
+		recoverable: false,
+	}, {
+		// This is lnd's ErrCannotResume, as it reaches us over the
+		// wire.
+		name: "cannot resume",
+		err: status.Error(
+			codes.Unknown, "cannot resume in the on-chain flow",
+		),
+		recoverable: true,
+	}, {
+		// This is lnd's ErrCannotFail, as it reaches us over the wire.
+		name: "cannot fail",
+		err: status.Error(
+			codes.Unknown, "cannot fail in the on-chain flow",
+		),
+		recoverable: true,
+	}, {
+		// This is lnd's ErrFwdNotExists, returned if we resolve an
+		// HTLC that lnd doesn't hold (anymore).
+		name: "forward does not exist",
+		err: status.Error(
+			codes.Unknown, "forward does not exist",
+		),
+		recoverable: true,
+	}, {
+		name: "wrapped recoverable error",
+		err: fmt.Errorf("stream terminated: %w", status.Error(
+			codes.Unknown, "cannot fail in the on-chain flow",
+		)),
+		recoverable: true,
+	}, {
+		name:        "unrelated error",
+		err:         errors.New("connection refused"),
+		recoverable: false,
+	}, {
+		name: "interceptor already registered",
+		err: status.Error(
+			codes.Unavailable, "interceptor already registered",
+		),
+		recoverable: false,
+	}}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(
+				t, tc.recoverable,
+				isRecoverableInterceptorErr(tc.err),
+			)
+		})
+	}
+}
+
+// TestSetupHtlcInterceptRecovers tests that the order handler re-establishes
+// the HTLC interception stream if lnd tears it down because it couldn't apply
+// one of our resolutions. This is the regression test for the case where a
+// single HTLC that is being resolved on chain took the whole daemon down.
+func TestSetupHtlcInterceptRecovers(t *testing.T) {
+	t.Parallel()
+
+	onChainErr := status.Error(
+		codes.Unknown, "cannot fail in the on-chain flow",
+	)
+	interceptor := newMockHtlcInterceptor(onChainErr, onChainErr)
+	handler := newTestOrderHandler(t, interceptor)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	errChan := make(chan error, 1)
+	go func() {
+		errChan <- handler.setupHtlcIntercept(ctx)
+	}()
+
+	// The interceptor should be re-established twice, after which the mock
+	// blocks until we cancel the context.
+	require.Eventually(t, func() bool {
+		return interceptor.calls() == 3
+	}, 10*time.Second, 10*time.Millisecond)
+
+	// We're still running, no critical error was reported.
+	require.Len(t, errChan, 0)
+
+	// Once the context is canceled, we expect a clean exit.
+	cancel()
+
+	select {
+	case err := <-errChan:
+		require.NoError(t, err)
+
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout waiting for setupHtlcIntercept to return")
+	}
+}
+
+// TestSetupHtlcInterceptFatalError tests that an error that isn't related to
+// the on-chain resolution flow is still reported to the caller, so a tapd
+// instance without a working RFQ subsystem doesn't keep running.
+func TestSetupHtlcInterceptFatalError(t *testing.T) {
+	t.Parallel()
+
+	fatalErr := errors.New("interceptor already registered")
+	interceptor := newMockHtlcInterceptor(fatalErr)
+	handler := newTestOrderHandler(t, interceptor)
+
+	err := handler.setupHtlcIntercept(context.Background())
+	require.ErrorIs(t, err, fatalErr)
+	require.Equal(t, 1, interceptor.calls())
+}
+
+// TestSetupHtlcInterceptShutdown tests that a canceled context doesn't lead to
+// an error being reported.
+func TestSetupHtlcInterceptShutdown(t *testing.T) {
+	t.Parallel()
+
+	interceptor := newMockHtlcInterceptor()
+	handler := newTestOrderHandler(t, interceptor)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	require.NoError(t, handler.setupHtlcIntercept(ctx))
+}
+
+// TestHandleIncomingHtlcNoDoubleResolution tests that we only ever send a
+// single resolution per HTLC. lnd offers an HTLC to the interceptor a second
+// time when it ends up being resolved on chain, and rejects any resolution we
+// send for it, which would tear down the interception stream.
+func TestHandleIncomingHtlcNoDoubleResolution(t *testing.T) {
+	t.Parallel()
+
+	handler := newTestOrderHandler(t, newMockHtlcInterceptor())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	circuitKey := testCircuitKey(1)
+	htlc := lndclient.InterceptedHtlc{
+		IncomingCircuitKey: circuitKey,
+	}
+
+	// The first time we see the HTLC, we don't have a policy for it, so we
+	// resume it.
+	resp, err := handler.handleIncomingHtlc(ctx, htlc)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Equal(t, lndclient.InterceptorActionResume, resp.Action)
+
+	// We should now know that we resolved this HTLC.
+	_, resolved := handler.resolvedHtlcs.Load(circuitKey)
+	require.True(t, resolved)
+
+	// A different HTLC is still resolved normally.
+	otherHtlc := lndclient.InterceptedHtlc{
+		IncomingCircuitKey: testCircuitKey(2),
+	}
+	resp, err = handler.handleIncomingHtlc(ctx, otherHtlc)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	// But if lnd offers us the same HTLC again, we must not answer, since
+	// any answer would terminate the interception stream. So the call
+	// blocks until the stream (or the daemon) shuts down.
+	type result struct {
+		resp *lndclient.InterceptedHtlcResponse
+		err  error
+	}
+	resultChan := make(chan result, 1)
+	go func() {
+		resp, err := handler.handleIncomingHtlc(ctx, htlc)
+		resultChan <- result{resp: resp, err: err}
+	}()
+
+	select {
+	case res := <-resultChan:
+		t.Fatalf("expected handler to block, got %v, %v", res.resp,
+			res.err)
+
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	// Once the stream context is canceled, the handler returns without
+	// producing a response.
+	cancel()
+
+	select {
+	case res := <-resultChan:
+		require.Nil(t, res.resp)
+
+		// The error must be one that the interceptor setup treats as a
+		// clean shutdown. Anything else would make us report a critical
+		// error every time we shut down while holding an HTLC.
+		require.True(t, fn.IsCanceled(res.err), "error %v is not a "+
+			"cancellation", res.err)
+		require.False(t, isRecoverableInterceptorErr(res.err))
+
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout waiting for handler to return")
+	}
+}
+
+// TestHandleIncomingHtlcForgetsFinalHtlcs tests that we forget about a resolved
+// HTLC once lnd tells us it reached a final state, so the set of resolved HTLCs
+// doesn't grow indefinitely.
+func TestHandleIncomingHtlcForgetsFinalHtlcs(t *testing.T) {
+	t.Parallel()
+
+	subscriber := newMockHtlcSubscriber()
+	handler, err := NewOrderHandler(OrderHandlerCfg{
+		CleanupInterval: time.Hour,
+		HtlcInterceptor: newMockHtlcInterceptor(),
+		HtlcSubscriber:  subscriber,
+	})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		_ = handler.subscribeHtlcs(ctx)
+	}()
+
+	circuitKey := testCircuitKey(1)
+	htlc := lndclient.InterceptedHtlc{
+		IncomingCircuitKey: circuitKey,
+	}
+
+	_, err = handler.handleIncomingHtlc(ctx, htlc)
+	require.NoError(t, err)
+
+	_, resolved := handler.resolvedHtlcs.Load(circuitKey)
+	require.True(t, resolved)
+
+	// A settle event for the HTLC means we can forget about it. We use a
+	// receive event here to make sure we also clean up HTLCs that weren't
+	// forwards.
+	subscriber.events <- &routerrpc.HtlcEvent{
+		IncomingChannelId: circuitKey.ChanID.ToUint64(),
+		IncomingHtlcId:    circuitKey.HtlcID,
+		EventType:         routerrpc.HtlcEvent_RECEIVE,
+		Event: &routerrpc.HtlcEvent_SettleEvent{
+			SettleEvent: &routerrpc.SettleEvent{},
+		},
+	}
+
+	require.Eventually(t, func() bool {
+		_, ok := handler.resolvedHtlcs.Load(circuitKey)
+		return !ok
+	}, 10*time.Second, 10*time.Millisecond)
+
+	// And we're able to resolve it again (which in practice can't happen,
+	// but shows the entry is truly gone).
+	resp, err := handler.handleIncomingHtlc(ctx, htlc)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+}
+
+// TestCleanupResolvedHtlcs tests that stale entries are removed from the set of
+// resolved HTLCs, in case we never learn about their final state.
+func TestCleanupResolvedHtlcs(t *testing.T) {
+	t.Parallel()
+
+	handler := newTestOrderHandler(t, newMockHtlcInterceptor())
+
+	staleKey := testCircuitKey(1)
+	freshKey := testCircuitKey(2)
+
+	handler.resolvedHtlcs.Store(
+		staleKey, time.Now().Add(-resolvedHtlcRetention-time.Minute),
+	)
+	handler.resolvedHtlcs.Store(freshKey, time.Now())
+
+	handler.cleanupResolvedHtlcs()
+
+	_, ok := handler.resolvedHtlcs.Load(staleKey)
+	require.False(t, ok)
+
+	_, ok = handler.resolvedHtlcs.Load(freshKey)
+	require.True(t, ok)
+}
+
+// TestSetupHtlcInterceptCriticalError tests that a non-recoverable interception
+// error is reported as a critical error through the order handler's Start
+// method, which is what makes tapd shut down.
+func TestSetupHtlcInterceptCriticalError(t *testing.T) {
+	t.Parallel()
+
+	fatalErr := errors.New("some fatal error")
+	interceptor := newMockHtlcInterceptor(fatalErr)
+
+	errChan := make(chan error, 1)
+	handler, err := NewOrderHandler(OrderHandlerCfg{
+		CleanupInterval: time.Hour,
+		HtlcInterceptor: interceptor,
+		ErrChan:         errChan,
+	})
+	require.NoError(t, err)
+
+	go func() {
+		err := handler.setupHtlcIntercept(context.Background())
+		if err != nil {
+			handler.ReportMainChanError(fn.NewCriticalError(err))
+		}
+	}()
+
+	select {
+	case err := <-errChan:
+		require.ErrorIs(t, err, fatalErr)
+
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout waiting for critical error")
+	}
+}

--- a/rfq/order_test.go
+++ b/rfq/order_test.go
@@ -4,10 +4,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/lightninglabs/lndclient"
 	"github.com/lightninglabs/taproot-assets/asset"
 	"github.com/lightninglabs/taproot-assets/fn"
 	"github.com/lightninglabs/taproot-assets/rfqmath"
 	"github.com/lightninglabs/taproot-assets/rfqmsg"
+	"github.com/lightningnetwork/lnd/graph/db/models"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/routing/route"
 	"github.com/stretchr/testify/require"
@@ -152,4 +154,72 @@ func TestNewAssetPurchasePolicyFillCap(t *testing.T) {
 			)
 		})
 	}
+}
+
+// TestPolicyAccountingIdempotent tests that tracking and checking the same
+// HTLC twice doesn't count its amount twice. lnd asks interceptor clients to
+// handle replayed HTLCs idempotently, and it does replay held HTLCs to every
+// newly connected interceptor.
+func TestPolicyAccountingIdempotent(t *testing.T) {
+	t.Parallel()
+
+	const htlcAmt = 1000
+
+	circuitKey := testCircuitKey(1)
+	htlc := lndclient.InterceptedHtlc{
+		IncomingCircuitKey: circuitKey,
+		AmountOutMsat:      htlcAmt,
+	}
+
+	t.Run("sale policy", func(t *testing.T) {
+		p := &AssetSalePolicy{
+			htlcToAmt: make(
+				map[models.CircuitKey]lnwire.MilliSatoshi,
+			),
+		}
+
+		p.TrackAcceptedHtlc(circuitKey, htlcAmt)
+		p.TrackAcceptedHtlc(circuitKey, htlcAmt)
+		require.EqualValues(t, htlcAmt, p.CurrentAmountMsat)
+
+		// The already tracked amount must not be counted again.
+		require.EqualValues(
+			t, 0, p.currentAmountExcluding(circuitKey),
+		)
+		require.EqualValues(
+			t, htlcAmt, p.currentAmountExcluding(testCircuitKey(2)),
+		)
+
+		// Untracking releases the amount exactly once.
+		p.UntrackHtlc(circuitKey)
+		require.Zero(t, p.CurrentAmountMsat)
+	})
+
+	t.Run("purchase policy", func(t *testing.T) {
+		p := &AssetPurchasePolicy{
+			htlcToAmt: make(
+				map[models.CircuitKey]lnwire.MilliSatoshi,
+			),
+			PaymentMaxAmt: htlcAmt,
+		}
+
+		p.TrackAcceptedHtlc(circuitKey, htlcAmt)
+		p.TrackAcceptedHtlc(circuitKey, htlcAmt)
+		require.EqualValues(t, htlcAmt, p.CurrentAmountMsat)
+
+		// A replay of the very same HTLC must not be counted against
+		// the quote a second time, which is what would make it exceed
+		// the policy maximum.
+		require.EqualValues(
+			t, 0, p.currentAmountExcluding(circuitKey),
+		)
+		require.Less(
+			t, uint64(p.currentAmountExcluding(circuitKey)+
+				htlc.AmountOutMsat),
+			uint64(p.PaymentMaxAmt)+1,
+		)
+
+		p.UntrackHtlc(circuitKey)
+		require.Zero(t, p.CurrentAmountMsat)
+	})
 }


### PR DESCRIPTION
### Description

Fixes #2223.

When a forwarded HTLC ends up being resolved on chain, lnd offers it to the HTLC interceptor a second time but rejects every resolution we can send (`ErrCannotResume` / `ErrCannotFail`), and a single rejection terminates the whole interception stream.

This is treated as a critical error since #1899, so one such HTLC took the daemon down and kept it down, as the held HTLC is replayed to every interceptor that connects.

We now claim each incoming circuit key before resolving it and simply don't answer an HTLC we already resolved (lnd doesn't need the answer as it drops those from its held set with the next block), and if the stream does die from one of those rejections we re-establish it with a backoff instead of exiting, while all other errors stay fatal. 