### PR TITLE
tapchannel: authenticate suffixes before accepting state

### DIFF
--- a/asset/asset.go
+++ b/asset/asset.go
@@ -98,6 +98,15 @@ func (s SerializedKey) String() string {
 // ToSerialized serializes a public key in its 33-byte compressed form.
 func ToSerialized(pubKey *btcec.PublicKey) SerializedKey {
 	var serialized SerializedKey
+
+	// A nil public key serializes to all zeroes, which never matches the
+	// serialization of a real key. Decoded structures can carry nil keys
+	// when an optional record is absent, and those must not crash key
+	// derivation.
+	if pubKey == nil {
+		return serialized
+	}
+
 	copy(serialized[:], pubKey.SerializeCompressed())
 
 	return serialized
@@ -2197,6 +2206,10 @@ func (a *Asset) Specifier() Specifier {
 // Validate ensures that an asset is valid.
 func (a *Asset) Validate() error {
 	// TODO(ffranr): Add validation check for remaining fields.
+	if a.ScriptKey.PubKey == nil {
+		return fmt.Errorf("asset script key is missing")
+	}
+
 	return ValidateAssetName(a.Genesis.Tag)
 }
 

--- a/asset/encoding.go
+++ b/asset/encoding.go
@@ -137,6 +137,10 @@ func OutPointDecoder(r io.Reader, val any, buf *[8]byte, _ uint64) error {
 
 func CompressedPubKeyEncoder(w io.Writer, val any, buf *[8]byte) error {
 	if t, ok := val.(**btcec.PublicKey); ok {
+		if *t == nil {
+			return fmt.Errorf("public key cannot be nil")
+		}
+
 		var keyBytes [btcec.PubKeyBytesLenCompressed]byte
 		copy(keyBytes[:], (*t).SerializeCompressed())
 		return tlv.EBytes33(w, &keyBytes, buf)

--- a/proof/append_test.go
+++ b/proof/append_test.go
@@ -321,6 +321,45 @@ func TestVerifyProofSuffix(t *testing.T) {
 	})
 }
 
+// TestMalformedProofNoPanic ensures that structurally incomplete proofs,
+// such as those decoded without mandatory records, are rejected with errors
+// instead of crashing verification or encoding.
+func TestMalformedProofNoPanic(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil script key", func(t *testing.T) {
+		proofFile := buildTransitionProofFile(t, 0, 0)
+		suffix, inputFiles := makeSuffixInputFiles(t, proofFile)
+
+		suffix.Asset.ScriptKey.PubKey = nil
+
+		_, err := suffix.VerifyProofs()
+		require.ErrorContains(t, err, "script key is missing")
+
+		_, err = VerifyProofSuffix(
+			context.Background(), suffix, inputFiles,
+			&BaseVerifier{}, MockVerifierCtx,
+		)
+		require.Error(t, err)
+	})
+
+	t.Run("nil inclusion proof internal key", func(t *testing.T) {
+		proofFile := buildTransitionProofFile(t, 0, 0)
+		suffix, inputFiles := makeSuffixInputFiles(t, proofFile)
+
+		suffix.InclusionProof.InternalKey = nil
+
+		_, err := suffix.VerifyProofs()
+		require.ErrorContains(t, err, "missing the internal key")
+
+		_, err = VerifyProofSuffix(
+			context.Background(), suffix, inputFiles,
+			&BaseVerifier{}, MockVerifierCtx,
+		)
+		require.Error(t, err)
+	})
+}
+
 // runAppendTransitionTest runs the test that makes sure a proof can be appended
 // to an existing proof for an asset transition of the given type and amount.
 func runAppendTransitionTest(t *testing.T, assetType asset.Type, amt uint64,

--- a/proof/append_test.go
+++ b/proof/append_test.go
@@ -147,6 +147,180 @@ func TestFinalProofSkipTimeLockCSV(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// TestVerifyProofSuffix ensures an unconfirmed proof suffix is verified
+// against the fully verified histories of its inputs. The final chain data is
+// intentionally skipped, while the input chain and asset VM remain enforced.
+func makeSuffixInputFiles(t *testing.T,
+	proofFile *File) (*Proof, map[asset.PrevID]*File) {
+
+	t.Helper()
+
+	require.Equal(t, 2, proofFile.NumProofs())
+	inputProof, err := proofFile.ProofAt(0)
+	require.NoError(t, err)
+	suffix, err := proofFile.ProofAt(1)
+	require.NoError(t, err)
+
+	inputFile, err := NewFile(V0, *inputProof)
+	require.NoError(t, err)
+	prevID := asset.PrevID{
+		OutPoint: inputProof.OutPoint(),
+		ID:       inputProof.Asset.ID(),
+		ScriptKey: asset.ToSerialized(
+			inputProof.Asset.ScriptKey.PubKey,
+		),
+	}
+
+	return suffix, map[asset.PrevID]*File{
+		prevID: inputFile,
+	}
+}
+
+func TestVerifyProofSuffix(t *testing.T) {
+	t.Parallel()
+
+	makeInputFiles := makeSuffixInputFiles
+
+	t.Run("valid unconfirmed suffix", func(t *testing.T) {
+		proofFile := buildTransitionProofFile(t, 0, 0)
+		suffix, inputFiles := makeInputFiles(t, proofFile)
+
+		// A proof suffix has no real block data until its anchor
+		// confirms. Make that explicit and ensure the header verifier
+		// is only called for the already confirmed input proof.
+		suffix.BlockHeader = wire.BlockHeader{}
+		suffix.BlockHeight = 0
+		suffix.TxMerkleProof = TxMerkleProof{}
+
+		headerCalls := 0
+		vCtx := MockVerifierCtx
+		vCtx.HeaderVerifier = func(header wire.BlockHeader,
+			height uint32) error {
+
+			headerCalls++
+			require.NotEqual(t, wire.BlockHeader{}, header)
+			require.NotZero(t, height)
+
+			return nil
+		}
+
+		snapshot, err := VerifyProofSuffix(
+			context.Background(), suffix, inputFiles,
+			&BaseVerifier{}, vCtx,
+		)
+		require.NoError(t, err)
+		require.True(t, suffix.Asset.DeepEqual(snapshot.Asset))
+		require.Equal(t, 1, headerCalls)
+	})
+
+	t.Run("fabricated anchor input", func(t *testing.T) {
+		proofFile := buildTransitionProofFile(t, 0, 0)
+		suffix, inputFiles := makeInputFiles(t, proofFile)
+
+		fakePrevOut := test.RandOp(t)
+		suffix.PrevOut = fakePrevOut
+		suffix.AnchorTx.TxIn[0].PreviousOutPoint = fakePrevOut
+
+		// The old structural-only validation accepts this mutation
+		// because the anchor transaction inputs and asset VM aren't
+		// inspected.
+		_, err := suffix.VerifyProofs()
+		require.NoError(t, err)
+
+		_, err = VerifyProofSuffix(
+			context.Background(), suffix, inputFiles,
+			&BaseVerifier{}, MockVerifierCtx,
+		)
+		require.ErrorContains(t, err, "does not match primary input")
+	})
+
+	t.Run("invalid asset witness", func(t *testing.T) {
+		proofFile := buildTransitionProofFile(
+			t, 0, 0, func(a *asset.Asset) {
+				witnesses := a.Witnesses()
+				witnesses[0].TxWitness[0][0] ^= 1
+			},
+		)
+		suffix, inputFiles := makeInputFiles(t, proofFile)
+
+		// The proof commits to the tampered asset, so its structural
+		// proof remains valid. Only executing the VM detects the bad
+		// witness.
+		_, err := suffix.VerifyProofs()
+		require.NoError(t, err)
+
+		_, err = VerifyProofSuffix(
+			context.Background(), suffix, inputFiles,
+			&BaseVerifier{}, MockVerifierCtx,
+		)
+		require.Error(t, err)
+		var vmErr vm.Error
+		require.ErrorAs(t, err, &vmErr)
+		require.Equal(t, vm.ErrInvalidTransferWitness, vmErr.Kind)
+	})
+
+	t.Run("peer-supplied additional inputs", func(t *testing.T) {
+		proofFile := buildTransitionProofFile(t, 0, 0)
+		suffix, inputFiles := makeInputFiles(t, proofFile)
+
+		suffix.AdditionalInputs = []File{*proofFile}
+
+		_, err := VerifyProofSuffix(
+			context.Background(), suffix, inputFiles,
+			&BaseVerifier{}, MockVerifierCtx,
+		)
+		require.ErrorContains(t, err, "carries additional inputs")
+	})
+
+	t.Run("valid multi-input suffix", func(t *testing.T) {
+		suffix, inputFiles := buildMergeSuffix(t, false)
+
+		snapshot, err := VerifyProofSuffix(
+			context.Background(), suffix, inputFiles,
+			&BaseVerifier{}, MockVerifierCtx,
+		)
+		require.NoError(t, err)
+		require.Equal(t, suffix.OutPoint(), snapshot.OutPoint)
+		require.Equal(t, suffix.Asset.Amount, snapshot.Asset.Amount)
+		require.Equal(
+			t, asset.ToSerialized(suffix.Asset.ScriptKey.PubKey),
+			asset.ToSerialized(snapshot.Asset.ScriptKey.PubKey),
+		)
+	})
+
+	t.Run("anchor omits additional input", func(t *testing.T) {
+		suffix, inputFiles := buildMergeSuffix(t, false)
+
+		// Drop the anchor transaction input that consumes the split
+		// leaf. The asset level witnesses still verify, so only the
+		// anchor input spending check can catch this.
+		require.Len(t, suffix.AnchorTx.TxIn, 2)
+		suffix.AnchorTx.TxIn = suffix.AnchorTx.TxIn[:1]
+
+		_, err := VerifyProofSuffix(
+			context.Background(), suffix, inputFiles,
+			&BaseVerifier{}, MockVerifierCtx,
+		)
+		require.ErrorContains(t, err, "does not spend input")
+	})
+
+	t.Run("inputs sharing one anchor outpoint", func(t *testing.T) {
+		suffix, inputFiles := buildMergeSuffix(t, true)
+
+		// Both asset inputs reside in the same Bitcoin UTXO, which the
+		// anchor transaction spends exactly once.
+		require.Len(t, suffix.AnchorTx.TxIn, 1)
+
+		snapshot, err := VerifyProofSuffix(
+			context.Background(), suffix, inputFiles,
+			&BaseVerifier{}, MockVerifierCtx,
+		)
+		require.NoError(t, err)
+		require.Equal(t, suffix.OutPoint(), snapshot.OutPoint)
+		require.Equal(t, suffix.Asset.Amount, snapshot.Asset.Amount)
+	})
+}
+
 // runAppendTransitionTest runs the test that makes sure a proof can be appended
 // to an existing proof for an asset transition of the given type and amount.
 func runAppendTransitionTest(t *testing.T, assetType asset.Type, amt uint64,
@@ -606,7 +780,7 @@ func runAppendTransitionTest(t *testing.T, assetType asset.Type, amt uint64,
 // buildTransitionProofFile constructs a proof file with a genesis proof and a
 // single transfer proof that uses the given lock times.
 func buildTransitionProofFile(t *testing.T, lockTime,
-	relativeLockTime uint64) *File {
+	relativeLockTime uint64, assetMutators ...func(*asset.Asset)) *File {
 
 	t.Helper()
 
@@ -624,6 +798,9 @@ func buildTransitionProofFile(t *testing.T, lockTime,
 	newAsset.RelativeLockTime = relativeLockTime
 
 	signAssetTransfer(t, &genesisProof, &newAsset, senderPrivKey, nil)
+	for _, mutate := range assetMutators {
+		mutate(&newAsset)
+	}
 
 	assetCommitment, err := commitment.NewAssetCommitment(&newAsset)
 	require.NoError(t, err)
@@ -694,6 +871,327 @@ func buildTransitionProofFile(t *testing.T, lockTime,
 	require.NoError(t, f.AppendProof(genesisProof))
 	require.NoError(t, f.AppendProof(*transitionProof))
 	return f
+}
+
+// buildMergeSuffix constructs an unconfirmed two-input merge suffix. A
+// genesis asset is split into a transfer root and a split leaf, which are
+// then merged back into a single output by the suffix. If sharedAnchorOut is
+// true, both split outputs are committed to the same anchor output, so the
+// merge spends two asset inputs that share one Bitcoin outpoint.
+func buildMergeSuffix(t *testing.T, sharedAnchorOut bool) (*Proof,
+	map[asset.PrevID]*File) {
+
+	t.Helper()
+
+	amt := uint64(100)
+	genesisProof, senderPrivKey := genRandomGenesisWithProof(
+		t, asset.Normal, &amt, nil, true, nil, nil, nil, nil, asset.V0,
+	)
+	genesisBlob, err := EncodeAsProofFile(&genesisProof)
+	require.NoError(t, err)
+
+	// Split the genesis asset into a transfer root and a split leaf.
+	rootPrivKey := test.RandPrivKey()
+	leafPrivKey := test.RandPrivKey()
+	rootScriptKey := asset.NewScriptKeyBip86(
+		test.PubToKeyDesc(rootPrivKey.PubKey()),
+	)
+	leafScriptKey := asset.NewScriptKeyBip86(
+		test.PubToKeyDesc(leafPrivKey.PubKey()),
+	)
+
+	leafOutputIndex := uint32(1)
+	if sharedAnchorOut {
+		leafOutputIndex = 0
+	}
+
+	assetID := genesisProof.Asset.ID()
+	rootLocator := &commitment.SplitLocator{
+		OutputIndex: 0,
+		AssetID:     assetID,
+		ScriptKey:   asset.ToSerialized(rootScriptKey.PubKey),
+		Amount:      60,
+	}
+	leafLocator := &commitment.SplitLocator{
+		OutputIndex: leafOutputIndex,
+		AssetID:     assetID,
+		ScriptKey:   asset.ToSerialized(leafScriptKey.PubKey),
+		Amount:      40,
+	}
+	genesisOutpoint := wire.OutPoint{
+		Hash:  genesisProof.AnchorTx.TxHash(),
+		Index: genesisProof.InclusionProof.OutputIndex,
+	}
+	splitCommitment, err := commitment.NewSplitCommitment(
+		context.Background(), []commitment.SplitCommitmentInput{{
+			Asset:    &genesisProof.Asset,
+			OutPoint: genesisOutpoint,
+		}}, rootLocator, leafLocator,
+	)
+	require.NoError(t, err)
+
+	rootAsset := splitCommitment.RootAsset
+	leafAsset := &splitCommitment.SplitAssets[*leafLocator].Asset
+	leafAssetNoSplitProof := leafAsset.Copy()
+	leafAssetNoSplitProof.PrevWitnesses[0].SplitCommitment = nil
+
+	signAssetTransfer(
+		t, &genesisProof, rootAsset, senderPrivKey,
+		[]*asset.Asset{leafAsset},
+	)
+
+	// Commit the split outputs to their anchor output(s).
+	var rootTap, leafTap *commitment.TapCommitment
+	if sharedAnchorOut {
+		sharedAssetCommitment, err := commitment.NewAssetCommitment(
+			rootAsset, leafAssetNoSplitProof,
+		)
+		require.NoError(t, err)
+		rootTap, err = commitment.NewTapCommitment(
+			nil, sharedAssetCommitment,
+		)
+		require.NoError(t, err)
+		leafTap = rootTap
+	} else {
+		rootAssetCommitment, err := commitment.NewAssetCommitment(
+			rootAsset,
+		)
+		require.NoError(t, err)
+		rootTap, err = commitment.NewTapCommitment(
+			nil, rootAssetCommitment,
+		)
+		require.NoError(t, err)
+
+		leafAssetCommitment, err := commitment.NewAssetCommitment(
+			leafAssetNoSplitProof,
+		)
+		require.NoError(t, err)
+		leafTap, err = commitment.NewTapCommitment(
+			nil, leafAssetCommitment,
+		)
+		require.NoError(t, err)
+	}
+
+	rootInternalKey := test.RandPubKey(t)
+	leafInternalKey := rootInternalKey
+	if !sharedAnchorOut {
+		leafInternalKey = test.RandPubKey(t)
+	}
+
+	rootTapscriptRoot := rootTap.TapscriptRoot(nil)
+	rootTaprootKey := txscript.ComputeTaprootOutputKey(
+		rootInternalKey, rootTapscriptRoot[:],
+	)
+	splitTx := &wire.MsgTx{
+		Version: 2,
+		TxIn: []*wire.TxIn{{
+			PreviousOutPoint: genesisOutpoint,
+		}},
+		TxOut: []*wire.TxOut{{
+			PkScript: test.ComputeTaprootScript(t, rootTaprootKey),
+			Value:    330,
+		}},
+	}
+	if !sharedAnchorOut {
+		leafTapscriptRoot := leafTap.TapscriptRoot(nil)
+		leafTaprootKey := txscript.ComputeTaprootOutputKey(
+			leafInternalKey, leafTapscriptRoot[:],
+		)
+		splitTx.TxOut = append(splitTx.TxOut, &wire.TxOut{
+			PkScript: test.ComputeTaprootScript(t, leafTaprootKey),
+			Value:    330,
+		})
+	}
+
+	splitMerkleTree := blockchain.BuildMerkleTreeStore(
+		[]*btcutil.Tx{btcutil.NewTx(splitTx)}, false,
+	)
+	splitMerkleRoot := splitMerkleTree[len(splitMerkleTree)-1]
+	genesisHash := genesisProof.BlockHeader.BlockHash()
+	splitBlockHeader := wire.NewBlockHeader(
+		0, &genesisHash, splitMerkleRoot, 0, 0,
+	)
+	splitBlock := &wire.MsgBlock{
+		Header:       *splitBlockHeader,
+		Transactions: []*wire.MsgTx{splitTx},
+	}
+
+	// With two anchor outputs, each proof needs an exclusion proof for the
+	// respective other output.
+	var rootExclusions, leafExclusions []TaprootProof
+	if !sharedAnchorOut {
+		_, rootInLeafExclusion, err := leafTap.Proof(
+			rootAsset.TapCommitmentKey(),
+			rootAsset.AssetCommitmentKey(),
+		)
+		require.NoError(t, err)
+		rootExclusions = []TaprootProof{{
+			OutputIndex: 1,
+			InternalKey: leafInternalKey,
+			CommitmentProof: &CommitmentProof{
+				Proof: *rootInLeafExclusion,
+			},
+		}}
+
+		_, leafInRootExclusion, err := rootTap.Proof(
+			leafAsset.TapCommitmentKey(),
+			leafAsset.AssetCommitmentKey(),
+		)
+		require.NoError(t, err)
+		leafExclusions = []TaprootProof{{
+			OutputIndex: 0,
+			InternalKey: rootInternalKey,
+			CommitmentProof: &CommitmentProof{
+				Proof: *leafInRootExclusion,
+			},
+		}}
+	}
+
+	rootParams := &TransitionParams{
+		BaseProofParams: BaseProofParams{
+			Block:            splitBlock,
+			Tx:               splitTx,
+			TxIndex:          0,
+			OutputIndex:      0,
+			InternalKey:      rootInternalKey,
+			TaprootAssetRoot: rootTap,
+			ExclusionProofs:  rootExclusions,
+		},
+		NewAsset: rootAsset,
+	}
+	rootBlob, _, err := AppendTransition(
+		genesisBlob, rootParams, MockVerifierCtx,
+		WithVersion(TransitionV0), WithNoSTXOProofs(),
+	)
+	require.NoError(t, err)
+
+	leafParams := &TransitionParams{
+		BaseProofParams: BaseProofParams{
+			Block:            splitBlock,
+			Tx:               splitTx,
+			TxIndex:          0,
+			OutputIndex:      int(leafOutputIndex),
+			InternalKey:      leafInternalKey,
+			TaprootAssetRoot: leafTap,
+			ExclusionProofs:  leafExclusions,
+		},
+		NewAsset:             leafAsset,
+		RootInternalKey:      rootInternalKey,
+		RootOutputIndex:      0,
+		RootTaprootAssetTree: rootTap,
+	}
+	leafBlob, _, err := AppendTransition(
+		genesisBlob, leafParams, MockVerifierCtx,
+		WithVersion(TransitionV0), WithNoSTXOProofs(),
+	)
+	require.NoError(t, err)
+
+	// Now merge the two split outputs back into a single asset output with
+	// an unconfirmed suffix.
+	rootPrevID := &asset.PrevID{
+		OutPoint: wire.OutPoint{
+			Hash:  splitTx.TxHash(),
+			Index: 0,
+		},
+		ID:        assetID,
+		ScriptKey: asset.ToSerialized(rootScriptKey.PubKey),
+	}
+	leafPrevID := &asset.PrevID{
+		OutPoint: wire.OutPoint{
+			Hash:  splitTx.TxHash(),
+			Index: leafOutputIndex,
+		},
+		ID:        assetID,
+		ScriptKey: asset.ToSerialized(leafScriptKey.PubKey),
+	}
+
+	mergePrivKey := test.RandPrivKey()
+	mergedAsset := genesisProof.Asset.Copy()
+	mergedAsset.Amount = amt
+	mergedAsset.ScriptKey = asset.NewScriptKeyBip86(
+		test.PubToKeyDesc(mergePrivKey.PubKey()),
+	)
+	mergedAsset.PrevWitnesses = []asset.Witness{
+		{PrevID: rootPrevID}, {PrevID: leafPrevID},
+	}
+
+	mergeInputs := commitment.InputSet{
+		*rootPrevID: rootAsset,
+		*leafPrevID: leafAsset,
+	}
+	virtualTx, _, err := tapscript.VirtualTx(mergedAsset, mergeInputs)
+	require.NoError(t, err)
+	mergedAsset.PrevWitnesses[0].TxWitness = genTaprootKeySpend(
+		t, *rootPrivKey, virtualTx, rootAsset, mergedAsset, 0,
+	)
+	mergedAsset.PrevWitnesses[1].TxWitness = genTaprootKeySpend(
+		t, *leafPrivKey, virtualTx, leafAsset, mergedAsset, 1,
+	)
+
+	mergeAssetCommitment, err := commitment.NewAssetCommitment(mergedAsset)
+	require.NoError(t, err)
+	mergeTap, err := commitment.NewTapCommitment(nil, mergeAssetCommitment)
+	require.NoError(t, err)
+
+	mergeInternalKey := test.RandPubKey(t)
+	mergeTapscriptRoot := mergeTap.TapscriptRoot(nil)
+	mergeTaprootKey := txscript.ComputeTaprootOutputKey(
+		mergeInternalKey, mergeTapscriptRoot[:],
+	)
+	mergeTx := &wire.MsgTx{
+		Version: 2,
+		TxIn: []*wire.TxIn{{
+			PreviousOutPoint: rootPrevID.OutPoint,
+		}},
+		TxOut: []*wire.TxOut{{
+			PkScript: test.ComputeTaprootScript(t, mergeTaprootKey),
+			Value:    330,
+		}},
+	}
+	if !sharedAnchorOut {
+		mergeTx.TxIn = append(mergeTx.TxIn, &wire.TxIn{
+			PreviousOutPoint: leafPrevID.OutPoint,
+		})
+	}
+
+	mergeMerkleTree := blockchain.BuildMerkleTreeStore(
+		[]*btcutil.Tx{btcutil.NewTx(mergeTx)}, false,
+	)
+	mergeMerkleRoot := mergeMerkleTree[len(mergeMerkleTree)-1]
+	splitHash := splitBlockHeader.BlockHash()
+	mergeBlockHeader := wire.NewBlockHeader(
+		0, &splitHash, mergeMerkleRoot, 0, 0,
+	)
+
+	mergeParams := &TransitionParams{
+		BaseProofParams: BaseProofParams{
+			Block: &wire.MsgBlock{
+				Header:       *mergeBlockHeader,
+				Transactions: []*wire.MsgTx{mergeTx},
+			},
+			Tx:               mergeTx,
+			TxIndex:          0,
+			OutputIndex:      0,
+			InternalKey:      mergeInternalKey,
+			TaprootAssetRoot: mergeTap,
+		},
+		NewAsset: mergedAsset,
+	}
+	suffix, err := CreateTransitionProof(
+		rootPrevID.OutPoint, mergeParams, WithVersion(TransitionV0),
+		WithNoSTXOProofs(),
+	)
+	require.NoError(t, err)
+
+	rootFile := NewEmptyFile(V0)
+	require.NoError(t, rootFile.Decode(bytes.NewReader(rootBlob)))
+	leafFile := NewEmptyFile(V0)
+	require.NoError(t, leafFile.Decode(bytes.NewReader(leafBlob)))
+
+	return suffix, map[asset.PrevID]*File{
+		*rootPrevID: rootFile,
+		*leafPrevID: leafFile,
+	}
 }
 
 // signAssetTransfer creates a virtual transaction for an asset transfer and

--- a/proof/mock.go
+++ b/proof/mock.go
@@ -15,6 +15,7 @@ import (
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/btcutil/v2"
+	"github.com/btcsuite/btcd/chaincfg/v2"
 	"github.com/btcsuite/btcd/chainhash/v2"
 	"github.com/btcsuite/btcd/txscript/v2"
 	"github.com/btcsuite/btcd/wire/v2"
@@ -1187,3 +1188,159 @@ func MockTxProof(t testing.TB) *TxProof {
 		}(),
 	}
 }
+
+// RandGenesisProofWithKey generates a random genesis proof that verifies
+// under MockVerifierCtx, along with the private key controlling the genesis
+// asset's script key. It is the base fixture for building verifiable proof
+// chains in tests.
+func RandGenesisProofWithKey(t testing.TB, assetType asset.Type,
+	amt *uint64, tapscriptPreimage *commitment.TapscriptPreimage,
+	noMetaHash bool, metaReveal *MetaReveal, genesisMutator GenMutator,
+	genesisRevealMutator GenRevealMutator,
+	groupRevealMutator GroupRevealMutator,
+	assetVersion asset.Version) (Proof, *btcec.PrivateKey) {
+
+	t.Helper()
+
+	genesisPrivKey := test.RandPrivKey()
+	genesisPubKey := test.PubToKeyDesc(genesisPrivKey.PubKey())
+
+	// If we have a specified meta reveal, then we'll replace the meta hash
+	// with the hash of the reveal instead.
+	assetGenesis := asset.RandGenesis(t, assetType)
+	assetGenesis.OutputIndex = 0
+	if metaReveal != nil {
+		assetGenesis.MetaHash = metaReveal.MetaHash()
+	} else if noMetaHash {
+		assetGenesis.MetaHash = [32]byte{}
+	}
+
+	if genesisMutator != nil {
+		genesisMutator(&assetGenesis)
+	}
+
+	groupAmt := uint64(1)
+	if amt != nil {
+		groupAmt = *amt
+	}
+
+	protoAsset := asset.NewAssetNoErr(
+		t, assetGenesis, groupAmt, 0, 0,
+		asset.NewScriptKeyBip86(genesisPubKey), nil,
+		asset.WithAssetVersion(assetVersion),
+	)
+	assetGroupKey := asset.RandGroupKey(t, assetGenesis, protoAsset)
+	groupKeyReveal := asset.NewGroupKeyRevealV0(
+		asset.ToSerialized(assetGroupKey.RawKey.PubKey),
+		assetGroupKey.TapscriptRoot,
+	)
+
+	if groupRevealMutator != nil {
+		groupRevealMutator(groupKeyReveal)
+	}
+
+	tapCommitment, assets, err := commitment.Mint(
+		commitment.RandTapCommitVersion(), assetGenesis, assetGroupKey,
+		&commitment.AssetDetails{
+			Type:             assetType,
+			ScriptKey:        genesisPubKey,
+			Amount:           amt,
+			Version:          assetVersion,
+			LockTime:         0,
+			RelativeLockTime: 0,
+		},
+	)
+	require.NoError(t, err)
+
+	// Include 1 or more alt leaves in the anchor output Tap commitment.
+	// Since this is also used for generating the test vectors, we don't
+	// actually want to have zero alt leaves.
+	innerAltLeaves := asset.RandAltLeaves(t, false)
+	altLeaves := asset.ToAltLeaves(innerAltLeaves)
+	err = tapCommitment.MergeAltLeaves(altLeaves)
+	require.NoError(t, err)
+
+	genesisAsset := assets[0]
+	_, commitmentProof, err := tapCommitment.Proof(
+		genesisAsset.TapCommitmentKey(),
+		genesisAsset.AssetCommitmentKey(),
+	)
+	require.NoError(t, err)
+
+	var tapscriptSibling *chainhash.Hash
+	if tapscriptPreimage != nil {
+		tapscriptSibling, err = tapscriptPreimage.TapHash()
+		require.NoError(t, err)
+	}
+
+	internalKey := test.SchnorrPubKey(t, genesisPrivKey)
+	tapscriptRoot := tapCommitment.TapscriptRoot(tapscriptSibling)
+	taprootKey := txscript.ComputeTaprootOutputKey(
+		internalKey, tapscriptRoot[:],
+	)
+	taprootScript := test.ComputeTaprootScript(t, taprootKey)
+	genesisTx := &wire.MsgTx{
+		Version: 2,
+		TxIn: []*wire.TxIn{{
+			PreviousOutPoint: assetGenesis.FirstPrevOut,
+		}},
+		TxOut: []*wire.TxOut{{
+			PkScript: taprootScript,
+			Value:    330,
+		}},
+	}
+	merkleTree := blockchain.BuildMerkleTreeStore(
+		[]*btcutil.Tx{btcutil.NewTx(genesisTx)}, false,
+	)
+	merkleRoot := merkleTree[len(merkleTree)-1]
+
+	// We'll use the genesis hash of the mainnet chain as the parent block.
+	blockHeader := wire.NewBlockHeader(
+		0, chaincfg.MainNetParams.GenesisHash, merkleRoot, 0, 0,
+	)
+	blockHeader.Timestamp = time.Unix(test.RandInt[int64](), 0)
+
+	// We'll set the block height to 1, as the genesis block is at height 0.
+	blockHeight := uint32(1)
+
+	txMerkleProof, err := NewTxMerkleProof([]*wire.MsgTx{genesisTx}, 0)
+	require.NoError(t, err)
+
+	genReveal := &assetGenesis
+	if genesisRevealMutator != nil {
+		genReveal = genesisRevealMutator(genReveal)
+	}
+
+	return Proof{
+		PrevOut:       assetGenesis.FirstPrevOut,
+		BlockHeader:   *blockHeader,
+		BlockHeight:   blockHeight,
+		AnchorTx:      *genesisTx,
+		TxMerkleProof: *txMerkleProof,
+		Asset:         *genesisAsset,
+		InclusionProof: TaprootProof{
+			OutputIndex: 0,
+			InternalKey: internalKey,
+			CommitmentProof: &CommitmentProof{
+				Proof:              *commitmentProof,
+				TapSiblingPreimage: tapscriptPreimage,
+			},
+			TapscriptProof: nil,
+		},
+		MetaReveal:       metaReveal,
+		ExclusionProofs:  nil,
+		AdditionalInputs: nil,
+		GenesisReveal:    genReveal,
+		GroupKeyReveal:   groupKeyReveal,
+		AltLeaves:        altLeaves,
+	}, genesisPrivKey
+}
+
+// GenMutator mutates a genesis before the fixture asset is minted.
+type GenMutator func(*asset.Genesis)
+
+// GroupRevealMutator mutates the group key reveal of a fixture proof.
+type GroupRevealMutator func(asset.GroupKeyReveal)
+
+// GenRevealMutator mutates the genesis reveal of a fixture proof.
+type GenRevealMutator func(*asset.Genesis) *asset.Genesis

--- a/proof/proof_test.go
+++ b/proof/proof_test.go
@@ -11,12 +11,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-	"time"
 
-	"github.com/btcsuite/btcd/blockchain"
-	"github.com/btcsuite/btcd/btcec/v2"
-	"github.com/btcsuite/btcd/btcutil/v2"
-	"github.com/btcsuite/btcd/chaincfg/v2"
 	"github.com/btcsuite/btcd/chainhash/v2"
 	"github.com/btcsuite/btcd/txscript/v2"
 	"github.com/btcsuite/btcd/wire/v2"
@@ -441,154 +436,15 @@ func TestProofEncoding(t *testing.T) {
 	require.ErrorIs(t, err, ErrUnknownVersion)
 }
 
-func genRandomGenesisWithProof(t testing.TB, assetType asset.Type,
-	amt *uint64, tapscriptPreimage *commitment.TapscriptPreimage,
-	noMetaHash bool, metaReveal *MetaReveal, genesisMutator genMutator,
-	genesisRevealMutator genRevealMutator,
-	groupRevealMutator groupRevealMutator,
-	assetVersion asset.Version) (Proof, *btcec.PrivateKey) {
+// genRandomGenesisWithProof is kept as an alias for the exported fixture
+// builder in mock.go, which other packages reuse as well.
+var genRandomGenesisWithProof = RandGenesisProofWithKey
 
-	t.Helper()
+type genMutator = GenMutator
 
-	genesisPrivKey := test.RandPrivKey()
-	genesisPubKey := test.PubToKeyDesc(genesisPrivKey.PubKey())
+type groupRevealMutator = GroupRevealMutator
 
-	// If we have a specified meta reveal, then we'll replace the meta hash
-	// with the hash of the reveal instead.
-	assetGenesis := asset.RandGenesis(t, assetType)
-	assetGenesis.OutputIndex = 0
-	if metaReveal != nil {
-		assetGenesis.MetaHash = metaReveal.MetaHash()
-	} else if noMetaHash {
-		assetGenesis.MetaHash = [32]byte{}
-	}
-
-	if genesisMutator != nil {
-		genesisMutator(&assetGenesis)
-	}
-
-	groupAmt := uint64(1)
-	if amt != nil {
-		groupAmt = *amt
-	}
-
-	protoAsset := asset.NewAssetNoErr(
-		t, assetGenesis, groupAmt, 0, 0,
-		asset.NewScriptKeyBip86(genesisPubKey), nil,
-		asset.WithAssetVersion(assetVersion),
-	)
-	assetGroupKey := asset.RandGroupKey(t, assetGenesis, protoAsset)
-	groupKeyReveal := asset.NewGroupKeyRevealV0(
-		asset.ToSerialized(assetGroupKey.RawKey.PubKey),
-		assetGroupKey.TapscriptRoot,
-	)
-
-	if groupRevealMutator != nil {
-		groupRevealMutator(groupKeyReveal)
-	}
-
-	tapCommitment, assets, err := commitment.Mint(
-		commitment.RandTapCommitVersion(), assetGenesis, assetGroupKey,
-		&commitment.AssetDetails{
-			Type:             assetType,
-			ScriptKey:        genesisPubKey,
-			Amount:           amt,
-			Version:          assetVersion,
-			LockTime:         0,
-			RelativeLockTime: 0,
-		},
-	)
-	require.NoError(t, err)
-
-	// Include 1 or more alt leaves in the anchor output Tap commitment.
-	// Since this is also used for generating the test vectors, we don't
-	// actually want to have zero alt leaves.
-	innerAltLeaves := asset.RandAltLeaves(t, false)
-	altLeaves := asset.ToAltLeaves(innerAltLeaves)
-	err = tapCommitment.MergeAltLeaves(altLeaves)
-	require.NoError(t, err)
-
-	genesisAsset := assets[0]
-	_, commitmentProof, err := tapCommitment.Proof(
-		genesisAsset.TapCommitmentKey(),
-		genesisAsset.AssetCommitmentKey(),
-	)
-	require.NoError(t, err)
-
-	var tapscriptSibling *chainhash.Hash
-	if tapscriptPreimage != nil {
-		tapscriptSibling, err = tapscriptPreimage.TapHash()
-		require.NoError(t, err)
-	}
-
-	internalKey := test.SchnorrPubKey(t, genesisPrivKey)
-	tapscriptRoot := tapCommitment.TapscriptRoot(tapscriptSibling)
-	taprootKey := txscript.ComputeTaprootOutputKey(
-		internalKey, tapscriptRoot[:],
-	)
-	taprootScript := test.ComputeTaprootScript(t, taprootKey)
-	genesisTx := &wire.MsgTx{
-		Version: 2,
-		TxIn: []*wire.TxIn{{
-			PreviousOutPoint: assetGenesis.FirstPrevOut,
-		}},
-		TxOut: []*wire.TxOut{{
-			PkScript: taprootScript,
-			Value:    330,
-		}},
-	}
-	merkleTree := blockchain.BuildMerkleTreeStore(
-		[]*btcutil.Tx{btcutil.NewTx(genesisTx)}, false,
-	)
-	merkleRoot := merkleTree[len(merkleTree)-1]
-
-	// We'll use the genesis hash of the mainnet chain as the parent block.
-	blockHeader := wire.NewBlockHeader(
-		0, chaincfg.MainNetParams.GenesisHash, merkleRoot, 0, 0,
-	)
-	blockHeader.Timestamp = time.Unix(test.RandInt[int64](), 0)
-
-	// We'll set the block height to 1, as the genesis block is at height 0.
-	blockHeight := uint32(1)
-
-	txMerkleProof, err := NewTxMerkleProof([]*wire.MsgTx{genesisTx}, 0)
-	require.NoError(t, err)
-
-	genReveal := &assetGenesis
-	if genesisRevealMutator != nil {
-		genReveal = genesisRevealMutator(genReveal)
-	}
-
-	return Proof{
-		PrevOut:       assetGenesis.FirstPrevOut,
-		BlockHeader:   *blockHeader,
-		BlockHeight:   blockHeight,
-		AnchorTx:      *genesisTx,
-		TxMerkleProof: *txMerkleProof,
-		Asset:         *genesisAsset,
-		InclusionProof: TaprootProof{
-			OutputIndex: 0,
-			InternalKey: internalKey,
-			CommitmentProof: &CommitmentProof{
-				Proof:              *commitmentProof,
-				TapSiblingPreimage: tapscriptPreimage,
-			},
-			TapscriptProof: nil,
-		},
-		MetaReveal:       metaReveal,
-		ExclusionProofs:  nil,
-		AdditionalInputs: nil,
-		GenesisReveal:    genReveal,
-		GroupKeyReveal:   groupKeyReveal,
-		AltLeaves:        altLeaves,
-	}, genesisPrivKey
-}
-
-type genMutator func(*asset.Genesis)
-
-type groupRevealMutator func(asset.GroupKeyReveal)
-
-type genRevealMutator func(*asset.Genesis) *asset.Genesis
+type genRevealMutator = GenRevealMutator
 
 func TestGenesisProofVerification(t *testing.T) {
 	t.Parallel()

--- a/proof/verifier.go
+++ b/proof/verifier.go
@@ -132,6 +132,169 @@ func WithSkipTimeLockValidationForAllProofs() VerifyOption {
 type BaseVerifier struct {
 }
 
+// VerifyProofSuffix verifies an unconfirmed transition proof suffix against
+// the proof files of the assets it spends. The suffix must not carry
+// additional inputs itself; every input, including the primary one, is
+// supplied through inputProofFiles, keyed by the witness PrevID it satisfies.
+//
+// Verification of each input file starts at the first proof contained in
+// that file. Nothing here requires a file to begin at a genesis proof: a
+// file whose first proof carries a challenge witness proves control of the
+// current script key only, and establishes no provenance at all. Callers
+// that need full provenance must supply files rooted at genesis or otherwise
+// independently trusted.
+//
+// The suffix's anchor transaction has not been confirmed yet, so only its
+// block header, transaction merkle proof and time lock checks are skipped.
+// Everything else still runs: proof integrity, inclusion/exclusion proofs,
+// anchor input spending checks, and the asset VM. Consequently, the chain
+// fields of the returned snapshot (anchor block, height, merkle inclusion
+// and time lock maturity) are unverified for the suffix and must not be
+// relied upon until the anchor transaction confirms.
+//
+// The caller also remains responsible for binding the suffix to its
+// expected context: the identity of the anchor transaction, the committed
+// asset root, the anchor output index, and the exact set of assets and
+// amounts the suffix is supposed to cover.
+func VerifyProofSuffix(ctx context.Context, suffix *Proof,
+	inputProofFiles map[asset.PrevID]*File, verifier Verifier,
+	vCtx VerifierCtx) (*AssetSnapshot, error) {
+
+	if suffix == nil {
+		return nil, fmt.Errorf("proof suffix is nil")
+	}
+	if verifier == nil {
+		return nil, fmt.Errorf("proof verifier is nil")
+	}
+	if len(suffix.ChallengeWitness) != 0 {
+		return nil, fmt.Errorf("proof suffix has a challenge witness")
+	}
+	if len(suffix.AdditionalInputs) != 0 {
+		return nil, fmt.Errorf("proof suffix carries additional " +
+			"inputs; inputs must be supplied through the input " +
+			"proof files")
+	}
+
+	primaryPrevID, err := suffix.Asset.PrimaryPrevID()
+	if err != nil {
+		return nil, fmt.Errorf("unable to determine primary input: %w",
+			err)
+	}
+	if primaryPrevID == nil {
+		return nil, fmt.Errorf("primary input is nil")
+	}
+	if suffix.PrevOut != primaryPrevID.OutPoint {
+		return nil, fmt.Errorf("proof suffix previous outpoint %v "+
+			"does not match primary input %v", suffix.PrevOut,
+			primaryPrevID.OutPoint)
+	}
+
+	// Work on a copy because the additional inputs are populated from the
+	// verified input proof files below, and we must not mutate the suffix
+	// that the caller will persist.
+	suffixCopy := *suffix
+
+	witnesses := suffix.Asset.Witnesses()
+	seenInputs := make(map[asset.PrevID]struct{}, len(witnesses))
+	var primaryInputFile *File
+
+	for idx := range witnesses {
+		prevID := witnesses[idx].PrevID
+		if prevID == nil {
+			return nil, fmt.Errorf("input witness %d has no "+
+				"previous ID", idx)
+		}
+		if _, ok := seenInputs[*prevID]; ok {
+			return nil, fmt.Errorf("duplicate input witness %v",
+				*prevID)
+		}
+		seenInputs[*prevID] = struct{}{}
+
+		// The anchor transaction must actually consume every claimed
+		// input, not just the primary one. Multiple assets may reside
+		// in a single UTXO, so re-checking an already spent outpoint
+		// for another witness is fine.
+		if !TxSpendsPrevOut(&suffix.AnchorTx, &prevID.OutPoint) {
+			return nil, fmt.Errorf("anchor transaction does not "+
+				"spend input %v", *prevID)
+		}
+
+		inputFile, ok := inputProofFiles[*prevID]
+		if !ok || inputFile == nil {
+			return nil, fmt.Errorf("no verified input proof for %v",
+				*prevID)
+		}
+
+		lastProof, err := inputFile.LastProof()
+		if err != nil {
+			return nil, fmt.Errorf("unable to read input proof "+
+				"%v: %w", *prevID, err)
+		}
+		lastPrevID := asset.PrevID{
+			OutPoint: lastProof.OutPoint(),
+			ID:       lastProof.Asset.ID(),
+			ScriptKey: asset.ToSerialized(
+				lastProof.Asset.ScriptKey.PubKey,
+			),
+		}
+		if lastPrevID != *prevID {
+			return nil, fmt.Errorf("input proof mismatch: "+
+				"expected %v, got %v", *prevID, lastPrevID)
+		}
+
+		if *prevID == *primaryPrevID {
+			primaryInputFile, err = cloneProofFile(inputFile)
+			if err != nil {
+				return nil, fmt.Errorf("unable to copy "+
+					"primary input proof: %w", err)
+			}
+			continue
+		}
+
+		suffixCopy.AdditionalInputs = append(
+			suffixCopy.AdditionalInputs, *inputFile,
+		)
+	}
+
+	if primaryInputFile == nil {
+		return nil, fmt.Errorf("primary input proof not found")
+	}
+	if err := primaryInputFile.AppendProof(suffixCopy); err != nil {
+		return nil, fmt.Errorf("unable to append proof suffix: %w", err)
+	}
+
+	var proofFileBuf bytes.Buffer
+	if err := primaryInputFile.Encode(&proofFileBuf); err != nil {
+		return nil, fmt.Errorf("unable to encode proof file: %w", err)
+	}
+
+	return verifier.Verify(
+		ctx, bytes.NewReader(proofFileBuf.Bytes()), vCtx,
+		WithSkipChainVerificationForFinalProof(),
+		WithSkipTimeLockValidationForFinalProof(),
+	)
+}
+
+// cloneProofFile returns an independent copy of a proof file.
+func cloneProofFile(file *File) (*File, error) {
+	if file == nil {
+		return nil, fmt.Errorf("proof file is nil")
+	}
+
+	var fileBuf bytes.Buffer
+	if err := file.Encode(&fileBuf); err != nil {
+		return nil, err
+	}
+
+	fileCopy := NewEmptyFile(file.Version)
+	err := fileCopy.Decode(bytes.NewReader(fileBuf.Bytes()))
+	if err != nil {
+		return nil, err
+	}
+
+	return fileCopy, nil
+}
+
 // P2TROutputsSTXOs is used to track stxo proofs per p2tr output in the anchor
 // transaction.
 type P2TROutputsSTXOs = map[uint32]fn.Set[asset.SerializedKey]

--- a/proof/verifier.go
+++ b/proof/verifier.go
@@ -175,6 +175,13 @@ func VerifyProofSuffix(ctx context.Context, suffix *Proof,
 			"proof files")
 	}
 
+	// A structurally incomplete suffix must be rejected before it is
+	// re-encoded below, since the TLV size functions cannot report
+	// errors for missing mandatory fields.
+	if err := checkProofEncodable(suffix); err != nil {
+		return nil, fmt.Errorf("invalid proof suffix: %w", err)
+	}
+
 	primaryPrevID, err := suffix.Asset.PrimaryPrevID()
 	if err != nil {
 		return nil, fmt.Errorf("unable to determine primary input: %w",
@@ -275,6 +282,33 @@ func VerifyProofSuffix(ctx context.Context, suffix *Proof,
 	)
 }
 
+// checkProofEncodable rejects proofs whose mandatory pointer fields are
+// absent. Nothing at the decoding layer enforces the presence of these
+// fields, and the TLV size functions panic on encoding errors, so a decoded
+// proof must be checked before it is re-encoded.
+func checkProofEncodable(p *Proof) error {
+	if err := p.Asset.Validate(); err != nil {
+		return fmt.Errorf("invalid asset: %w", err)
+	}
+
+	if p.InclusionProof.InternalKey == nil {
+		return fmt.Errorf("inclusion proof is missing the internal " +
+			"key")
+	}
+	for idx := range p.ExclusionProofs {
+		if p.ExclusionProofs[idx].InternalKey == nil {
+			return fmt.Errorf("exclusion proof %d is missing "+
+				"the internal key", idx)
+		}
+	}
+	if p.SplitRootProof != nil && p.SplitRootProof.InternalKey == nil {
+		return fmt.Errorf("split root proof is missing the internal " +
+			"key")
+	}
+
+	return nil
+}
+
 // cloneProofFile returns an independent copy of a proof file.
 func cloneProofFile(file *File) (*File, error) {
 	if file == nil {
@@ -324,6 +358,14 @@ func (b *BaseVerifier) Verify(ctx context.Context, blobReader io.Reader,
 func verifyTaprootProof(anchor *wire.MsgTx, proof *TaprootProof,
 	a *asset.Asset, inclusion bool) (*commitment.TapCommitment,
 	error) {
+
+	// The internal key is a mandatory field, but nothing at the decoding
+	// layer enforces its presence, so a malformed proof must be rejected
+	// here rather than crash the key derivation below.
+	if proof.InternalKey == nil {
+		return nil, fmt.Errorf("taproot proof is missing the " +
+			"internal key")
+	}
 
 	// Extract the final taproot key from the output including/excluding the
 	// asset, which we'll use to compare our derived key against.
@@ -1370,6 +1412,14 @@ func (p *Proof) VerifyProofIntegrity(ctx context.Context, vCtx VerifierCtx,
 // VerifyProofs verifies the inclusion and exclusion proofs as well as the split
 // root proof.
 func (p *Proof) VerifyProofs() (*commitment.TapCommitment, error) {
+	// A structurally incomplete asset (such as one decoded without a
+	// script key record) must be rejected before any commitment key
+	// derivation.
+	if err := p.Asset.Validate(); err != nil {
+		return nil, fmt.Errorf("failed to validate proof asset: %w",
+			err)
+	}
+
 	// A valid inclusion proof for the resulting asset is included.
 	tapCommitment, err := p.verifyInclusionProof()
 	if err != nil {

--- a/tapchannel/aux_funding_controller.go
+++ b/tapchannel/aux_funding_controller.go
@@ -326,6 +326,14 @@ type FundingController struct {
 
 	finalizedChans chan funding.PendingChanID
 
+	// validatedFundingsMtx guards validatedFundings.
+	validatedFundingsMtx sync.Mutex
+
+	// validatedFundings tracks the channel funding outpoints whose
+	// funding proofs have already been validated against the confirmed
+	// funding transaction during this process lifetime.
+	validatedFundings map[wire.OutPoint]struct{}
+
 	// ContextGuard provides a wait group and main quit channel that can be
 	// used to create guarded contexts.
 	*fn.ContextGuard
@@ -336,12 +344,13 @@ func NewFundingController(cfg FundingControllerCfg) *FundingController {
 	msgs := fn.NewConcurrentQueue[msgmux.PeerMsg](fn.DefaultQueueSize)
 	msgs.Start()
 	return &FundingController{
-		cfg:             cfg,
-		msgQueue:        msgs,
-		bindFundingReqs: make(chan *bindFundingReq, 10),
-		newFundingReqs:  make(chan *FundReq, 10),
-		rootReqs:        make(chan *assetRootReq, 10),
-		finalizedChans:  make(chan funding.PendingChanID, 10),
+		cfg:               cfg,
+		msgQueue:          msgs,
+		bindFundingReqs:   make(chan *bindFundingReq, 10),
+		newFundingReqs:    make(chan *FundReq, 10),
+		rootReqs:          make(chan *assetRootReq, 10),
+		finalizedChans:    make(chan funding.PendingChanID, 10),
+		validatedFundings: make(map[wire.OutPoint]struct{}),
 		ContextGuard: &fn.ContextGuard{
 			DefaultTimeout: DefaultTimeout,
 			Quit:           make(chan struct{}),
@@ -437,6 +446,12 @@ type pendingAssetFunding struct {
 	pushAmt btcutil.Amount
 
 	inputProofs []*proof.Proof
+
+	// inputProofFiles holds a single-proof file for each verified input
+	// ownership proof, keyed by the input's PrevID. On the responder
+	// side this is populated as input ownership proofs arrive and are
+	// verified.
+	inputProofFiles map[asset.PrevID]*proof.File
 
 	feeRate chainfee.SatPerKWeight
 
@@ -827,6 +842,9 @@ func (f *fundingFlowIndex) fromMsg(chainParams *address.ChainParams,
 			fundingFinalizedSignal: make(chan struct{}),
 			inputProofChunks: make(
 				map[chainhash.Hash][]cmsg.ProofChunk,
+			),
+			inputProofFiles: make(
+				map[asset.PrevID]*proof.File,
 			),
 		}
 		(*f)[pid] = assetFunding
@@ -1584,13 +1602,12 @@ func (f *FundingController) processFundingMsg(ctx context.Context,
 			log.Infof("Validating input proof, prev_out=%v",
 				p.OutPoint())
 
-			vCtx := proof.VerifierCtx{
-				HeaderVerifier: f.cfg.HeaderVerifier,
-				MerkleVerifier: proof.DefaultMerkleVerifier,
-				GroupVerifier:  f.cfg.GroupVerifier,
-				ChainLookupGen: f.cfg.ChainBridge,
-				IgnoreChecker:  f.cfg.IgnoreChecker,
+			if p.Asset.ScriptKey.PubKey == nil {
+				return fmt.Errorf("input proof asset has no " +
+					"script key")
 			}
+
+			vCtx := f.proofVerifierCtx()
 
 			l, err := f.cfg.ChainBridge.GenProofChainLookup(&p)
 			if err != nil {
@@ -1607,8 +1624,31 @@ func (f *FundingController) processFundingMsg(ctx context.Context,
 					"ownership proof: %w", err)
 			}
 
-			// Now that we know the proof is valid, we'll add it to
-			// the funding state.
+			// The ownership proof demonstrates control of a
+			// chain-anchored leaf. The funding flow does not
+			// exchange the leaf's history, so its provenance
+			// rests on the genesis lookup above. Store the proof
+			// as a single-proof file, keyed by the input it
+			// satisfies, for the suffix verification later on.
+			prevID := asset.PrevID{
+				OutPoint: p.OutPoint(),
+				ID:       p.Asset.ID(),
+				ScriptKey: asset.ToSerialized(
+					p.Asset.ScriptKey.PubKey,
+				),
+			}
+			if _, ok := assetFunding.inputProofFiles[prevID]; ok {
+				return fmt.Errorf("duplicate input proof "+
+					"for %v", prevID)
+			}
+
+			inputFile, err := proof.NewFile(proof.V0, p)
+			if err != nil {
+				return fmt.Errorf("unable to create input "+
+					"proof file: %w", err)
+			}
+
+			assetFunding.inputProofFiles[prevID] = inputFile
 			assetFunding.addInputProof(&p)
 
 			return nil
@@ -1665,27 +1705,27 @@ func (f *FundingController) processFundingMsg(ctx context.Context,
 	// AcceptChannel. This includes the suffix proofs for the funding
 	// output/transaction created by the funding output.
 	case *cmsg.AssetFundingCreated:
-		log.Infof("Storing funding output proofs")
+		log.Infof("Validating funding output proofs")
 
-		fundingProofs := fn.Map(
-			assetProof.FundingOutputs.Val.Outputs,
-			func(o *cmsg.AssetOutput) *proof.Proof {
-				return &o.Proof.Val
-			},
+		fundingOutputs := assetProof.FundingOutputs.Val.Outputs
+		err := validateFundingProofs(
+			ctx, f.proofVerifierCtx(), assetFunding,
+			fundingOutputs,
 		)
-
-		err := f.validateProofs(fundingProofs)
 		if err != nil {
 			return tempPID, fmt.Errorf("unable to verify funding "+
 				"proofs: %w", err)
 		}
 
+		fundingProofs := fn.Map(
+			fundingOutputs, func(o *cmsg.AssetOutput) *proof.Proof {
+				return &o.Proof.Val
+			},
+		)
+
 		// We'll just place this in the internal funding state, so we
 		// can derive the funding desc when we need to.
-		assetFunding.fundingOutputProofs = append(
-			assetFunding.fundingOutputProofs,
-			fundingProofs...,
-		)
+		assetFunding.fundingOutputProofs = fundingProofs
 
 	// The remote party is accepting or rejecting our funding attempt.
 	// We'll send the response back to the main goroutine waiting to
@@ -2247,17 +2287,425 @@ func (f *FundingController) channelAcceptor(_ context.Context,
 	}, nil
 }
 
-// validateProofs validates the inclusion/exclusion/split proofs and the
-// transfer witness of the given proofs.
-func (f *FundingController) validateProofs(proofs []*proof.Proof) error {
-	for _, p := range proofs {
-		_, err := p.VerifyProofs()
-		if err != nil {
-			return fmt.Errorf("unable to verify proofs: %w", err)
+// proofVerifierCtx returns the proof verification dependencies owned by the
+// funding controller.
+func (f *FundingController) proofVerifierCtx() proof.VerifierCtx {
+	return proof.VerifierCtx{
+		HeaderVerifier: f.cfg.HeaderVerifier,
+		MerkleVerifier: proof.DefaultMerkleVerifier,
+		GroupVerifier:  f.cfg.GroupVerifier,
+		ChainLookupGen: f.cfg.ChainBridge,
+		IgnoreChecker:  f.cfg.IgnoreChecker,
+	}
+}
+
+// validateFundingProofs fully validates peer-supplied funding proof suffixes
+// before they become channel state. The suffix anchor itself is not confirmed
+// yet, so VerifyProofSuffix skips only its final chain and time lock checks;
+// all input proofs, proof integrity checks and the asset VM are still run.
+func validateFundingProofs(ctx context.Context, vCtx proof.VerifierCtx,
+	fundingState *pendingAssetFunding,
+	outputs []*cmsg.AssetOutput) error {
+
+	if fundingState.fundingAssetCommitment == nil {
+		return fmt.Errorf("funding asset commitment is missing")
+	}
+	if len(fundingState.fundingOutputProofs) != 0 {
+		return fmt.Errorf("funding output proofs already received")
+	}
+	if len(outputs) == 0 {
+		return fmt.Errorf("funding output proofs are missing")
+	}
+
+	// The suffixes are verified against the input proof files collected
+	// while processing the input ownership proofs. Those files are
+	// rooted at the ownership proofs themselves: they establish control
+	// of chain-anchored inputs, not the inputs' history back to
+	// genesis, which the funding flow does not exchange.
+	inputProofFiles := fundingState.inputProofFiles
+	if len(inputProofFiles) == 0 {
+		return fmt.Errorf("no verified funding input proofs")
+	}
+
+	expectedAssetKeys := expectedFundingAssetKeys(
+		fundingState.fundingAssetCommitment,
+	)
+
+	expectedRoot := fundingState.fundingAssetCommitment.TapscriptRoot(nil)
+	seenAssetKeys := make(map[fundingAssetKey]struct{}, len(outputs))
+	seenFundingInputs := make(map[asset.PrevID]struct{})
+	var (
+		anchorHash     chainhash.Hash
+		haveAnchorHash bool
+	)
+
+	// First pass: cheap structural checks plus funding wide input
+	// accounting, before any expensive proof verification runs.
+	for idx, output := range outputs {
+		if output == nil {
+			return fmt.Errorf("funding output %d is nil", idx)
+		}
+
+		proofSuffix := &output.Proof.Val
+		assetID := proofSuffix.Asset.ID()
+		switch {
+		case output.AssetID.Val != assetID:
+			return fmt.Errorf("funding output %d asset ID "+
+				"does not match proof", idx)
+
+		case output.Amount.Val != proofSuffix.Asset.Amount:
+			return fmt.Errorf("funding output %d amount does not "+
+				"match proof", idx)
+
+		case len(proofSuffix.AdditionalInputs) != 0:
+			return fmt.Errorf("funding proof %d contains "+
+				"peer-supplied additional inputs", idx)
+
+		// Funding outputs never legitimately carry a time lock, and
+		// the suffix verification cannot evaluate one before the
+		// funding transaction confirms, so locked outputs are
+		// rejected outright.
+		case proofSuffix.Asset.LockTime != 0 ||
+			proofSuffix.Asset.RelativeLockTime != 0:
+
+			return fmt.Errorf("funding proof %d carries a time "+
+				"lock", idx)
+
+		case proofSuffix.InclusionProof.OutputIndex !=
+			FundingOutputIndex:
+
+			return fmt.Errorf("funding proof %d commits to anchor "+
+				"output %d, expected %d", idx,
+				proofSuffix.InclusionProof.OutputIndex,
+				FundingOutputIndex)
+		}
+
+		proofAnchorHash := proofSuffix.AnchorTx.TxHash()
+		if haveAnchorHash && proofAnchorHash != anchorHash {
+			return fmt.Errorf("funding proof %d has anchor "+
+				"transaction %v, expected %v", idx,
+				proofAnchorHash, anchorHash)
+		}
+		anchorHash = proofAnchorHash
+		haveAnchorHash = true
+
+		// Each asset input may only be consumed by a single funding
+		// output. Without this, a peer could inflate the channel
+		// balance by backing several funding outputs with the same
+		// input. The full PrevID identifies an input here: different
+		// assets may legitimately share one anchor outpoint.
+		for _, witness := range proofSuffix.Asset.Witnesses() {
+			prevID := witness.PrevID
+			if prevID == nil {
+				return fmt.Errorf("funding proof %d has an "+
+					"input witness without previous ID",
+					idx)
+			}
+
+			if _, ok := seenFundingInputs[*prevID]; ok {
+				return fmt.Errorf("funding proof %d reuses "+
+					"input %v", idx, *prevID)
+			}
+			seenFundingInputs[*prevID] = struct{}{}
 		}
 	}
 
+	// Second pass: full cryptographic verification of every suffix
+	// against the verified input proofs.
+	verifier := &proof.BaseVerifier{}
+	for idx, output := range outputs {
+		proofSuffix := &output.Proof.Val
+
+		snapshot, err := proof.VerifyProofSuffix(
+			ctx, proofSuffix, inputProofFiles, verifier, vCtx,
+		)
+		if err != nil {
+			return fmt.Errorf("funding proof %d is invalid: %w",
+				idx, err)
+		}
+
+		actualRoot := snapshot.ScriptRoot.TapscriptRoot(nil)
+		if actualRoot != expectedRoot {
+			return fmt.Errorf("funding proof %d commits to "+
+				"unexpected asset root", idx)
+		}
+
+		assetKey := newFundingAssetKey(&proofSuffix.Asset)
+		if _, ok := expectedAssetKeys[assetKey]; !ok {
+			return fmt.Errorf("funding proof %d contains "+
+				"unexpected asset", idx)
+		}
+		if _, ok := seenAssetKeys[assetKey]; ok {
+			return fmt.Errorf("funding proof %d duplicates "+
+				"asset", idx)
+		}
+		seenAssetKeys[assetKey] = struct{}{}
+	}
+
+	if len(seenAssetKeys) != len(expectedAssetKeys) {
+		return fmt.Errorf("funding proofs cover %d assets, expected %d",
+			len(seenAssetKeys), len(expectedAssetKeys))
+	}
+
 	return nil
+}
+
+// fundingAssetKey uniquely identifies an asset leaf within a funding
+// commitment. The asset commitment key alone is not sufficient: for an
+// ungrouped asset it hashes only the script key, so two assets with
+// different IDs but the same script key would collide without the tap
+// commitment key namespacing.
+type fundingAssetKey struct {
+	tapCommitmentKey   [32]byte
+	assetCommitmentKey [32]byte
+}
+
+// newFundingAssetKey returns the funding commitment key pair of an asset.
+func newFundingAssetKey(a *asset.Asset) fundingAssetKey {
+	return fundingAssetKey{
+		tapCommitmentKey:   a.TapCommitmentKey(),
+		assetCommitmentKey: a.AssetCommitmentKey(),
+	}
+}
+
+// expectedFundingAssetKeys returns the commitment keys of the assets that a
+// set of funding proofs must cover. Alt leaves (such as STXO spend markers)
+// are committed alongside the funding assets but have no funding proof of
+// their own.
+func expectedFundingAssetKeys(
+	commit *commitment.TapCommitment) map[fundingAssetKey]struct{} {
+
+	committedAssets := commit.CommittedAssets()
+	assetKeys := make(map[fundingAssetKey]struct{}, len(committedAssets))
+	for _, committedAsset := range committedAssets {
+		if committedAsset.IsAltLeaf() {
+			continue
+		}
+
+		assetKeys[newFundingAssetKey(committedAsset)] = struct{}{}
+	}
+
+	return assetKeys
+}
+
+// validateConfirmedFunding binds the funding proof suffixes stored in the
+// channel's custom blob to the confirmed funding transaction before the
+// channel is activated. It is idempotent per funding outpoint for the
+// lifetime of the process.
+func (f *FundingController) validateConfirmedFunding(ctx context.Context,
+	channel lnwallet.AuxChanState, chanAssetState *cmsg.OpenChannel) error {
+
+	f.validatedFundingsMtx.Lock()
+	_, alreadyValidated := f.validatedFundings[channel.FundingOutpoint]
+	f.validatedFundingsMtx.Unlock()
+
+	if alreadyValidated {
+		return nil
+	}
+
+	// Fetch the confirmed funding transaction and its block using the
+	// channel's short channel ID.
+	fundingParams, err := proofParamsForShortChanID(
+		ctx, f.cfg.ChainBridge, channel.ShortChannelID,
+	)
+	if err != nil {
+		return fmt.Errorf("unable to fetch confirmed funding "+
+			"transaction: %w", err)
+	}
+
+	err = validateConfirmedFundingProofs(
+		channel, chanAssetState.Assets(), fundingParams,
+	)
+	if err != nil {
+		return err
+	}
+
+	f.validatedFundingsMtx.Lock()
+	f.validatedFundings[channel.FundingOutpoint] = struct{}{}
+	f.validatedFundingsMtx.Unlock()
+
+	return nil
+}
+
+// validateConfirmedFundingProofs binds the funding proof suffixes stored in
+// the channel's custom blob to the confirmed funding transaction. The
+// suffixes were fully verified before the funding descriptor was handed to
+// lnd, but at that point the real funding transaction did not exist yet, so
+// their anchor identity remained unbound. Each suffix must anchor to the
+// channel's funding outpoint, which transitively upgrades the
+// pre-confirmation verification to the confirmed transaction, and that
+// transaction must spend every claimed input exactly once.
+func validateConfirmedFundingProofs(channel lnwallet.AuxChanState,
+	outputs []*cmsg.AssetOutput,
+	fundingParams proof.BaseProofParams) error {
+
+	if len(outputs) == 0 {
+		return fmt.Errorf("channel has no asset funding outputs")
+	}
+	fundingTx := fundingParams.Tx
+	if fundingTx == nil {
+		return fmt.Errorf("confirmed funding transaction is missing")
+	}
+
+	// The confirmed transaction referenced by the short channel ID must
+	// be the funding transaction lnd bound the channel to.
+	fundingTxHash := fundingTx.TxHash()
+	if fundingTxHash != channel.FundingOutpoint.Hash {
+		return fmt.Errorf("confirmed transaction %v does not match "+
+			"channel funding outpoint %v", fundingTxHash,
+			channel.FundingOutpoint)
+	}
+	if channel.FundingOutpoint.Index != FundingOutputIndex {
+		return fmt.Errorf("channel funding outpoint index is %d, "+
+			"expected %d", channel.FundingOutpoint.Index,
+			FundingOutputIndex)
+	}
+
+	if channel.TapscriptRoot.IsNone() {
+		return fmt.Errorf("channel has no tapscript root")
+	}
+	expectedRoot := channel.TapscriptRoot.UnsafeFromSome()
+
+	// The funding output assets must reproduce exactly the commitment
+	// root committed to on chain: no assets missing, none added.
+	err := checkFundingCommitmentRoot(outputs, expectedRoot)
+	if err != nil {
+		return err
+	}
+
+	seenFundingInputs := make(map[asset.PrevID]struct{})
+	seenAssetKeys := make(map[fundingAssetKey]struct{}, len(outputs))
+
+	for idx, output := range outputs {
+		if output == nil {
+			return fmt.Errorf("funding output %d is nil", idx)
+		}
+
+		proofSuffix := &output.Proof.Val
+		assetID := proofSuffix.Asset.ID()
+		switch {
+		case output.AssetID.Val != assetID:
+			return fmt.Errorf("funding output %d asset ID "+
+				"does not match proof", idx)
+
+		case output.Amount.Val != proofSuffix.Asset.Amount:
+			return fmt.Errorf("funding output %d amount does not "+
+				"match proof", idx)
+
+		case len(proofSuffix.AdditionalInputs) != 0:
+			return fmt.Errorf("funding proof %d contains "+
+				"additional inputs", idx)
+
+		case proofSuffix.InclusionProof.OutputIndex !=
+			FundingOutputIndex:
+
+			return fmt.Errorf("funding proof %d commits to anchor "+
+				"output %d, expected %d", idx,
+				proofSuffix.InclusionProof.OutputIndex,
+				FundingOutputIndex)
+		}
+
+		// Bind the suffix to the real funding transaction before any
+		// anchor data is overwritten. A doppelganger transaction with
+		// the same commitment output has a different hash and fails
+		// here. The suffix, including its inclusion proof and
+		// witnesses, was fully verified against its claimed anchor
+		// transaction before the funding descriptor was released, so
+		// anchor identity is all that is left to bind.
+		if proofSuffix.OutPoint() != channel.FundingOutpoint {
+			return fmt.Errorf("funding proof %d anchors to %v, "+
+				"channel funding outpoint is %v", idx,
+				proofSuffix.OutPoint(),
+				channel.FundingOutpoint)
+		}
+
+		for _, witness := range proofSuffix.Asset.Witnesses() {
+			prevID := witness.PrevID
+			if prevID == nil {
+				return fmt.Errorf("funding proof %d has an "+
+					"input witness without previous ID",
+					idx)
+			}
+
+			if _, ok := seenFundingInputs[*prevID]; ok {
+				return fmt.Errorf("funding proof %d reuses "+
+					"input %v", idx, *prevID)
+			}
+			seenFundingInputs[*prevID] = struct{}{}
+
+			// The confirmed funding transaction must spend every
+			// claimed input outpoint.
+			ok := proof.TxSpendsPrevOut(
+				fundingTx, &prevID.OutPoint,
+			)
+			if !ok {
+				return fmt.Errorf("confirmed funding "+
+					"transaction does not spend input %v",
+					*prevID)
+			}
+		}
+
+		assetKey := newFundingAssetKey(&proofSuffix.Asset)
+		if _, ok := seenAssetKeys[assetKey]; ok {
+			return fmt.Errorf("funding proof %d duplicates "+
+				"asset", idx)
+		}
+		seenAssetKeys[assetKey] = struct{}{}
+	}
+
+	return nil
+}
+
+// checkFundingCommitmentRoot reconstructs the funding commitment from the
+// funding output assets and requires it to reproduce the channel's on chain
+// tapscript root. This proves exact asset coverage: an asset missing from or
+// added to the commitment changes the root.
+func checkFundingCommitmentRoot(outputs []*cmsg.AssetOutput,
+	expectedRoot chainhash.Hash) error {
+
+	rebuild := func(stxo bool) (chainhash.Hash, error) {
+		var zero chainhash.Hash
+		rebuilt := &pendingAssetFunding{}
+		for idx, output := range outputs {
+			if output == nil {
+				return zero, fmt.Errorf("funding output %d "+
+					"is nil", idx)
+			}
+
+			fundingAsset := output.Proof.Val.Asset.Copy()
+			err := rebuilt.addToFundingCommitment(
+				fundingAsset, stxo,
+			)
+			if err != nil {
+				return zero, fmt.Errorf("unable to rebuild "+
+					"funding commitment: %w", err)
+			}
+		}
+
+		return rebuilt.fundingAssetCommitment.TapscriptRoot(nil), nil
+	}
+
+	// The channel blob does not record whether STXO alt leaves were used
+	// during funding, so either variant reproducing the on chain root is
+	// accepted.
+	rootNoStxo, err := rebuild(false)
+	if err != nil {
+		return err
+	}
+	if rootNoStxo == expectedRoot {
+		return nil
+	}
+
+	rootStxo, err := rebuild(true)
+	if err != nil {
+		return err
+	}
+	if rootStxo == expectedRoot {
+		return nil
+	}
+
+	return fmt.Errorf("funding outputs do not reproduce the channel " +
+		"tapscript root")
 }
 
 // validateWitness validates the state transition witness for the given asset.
@@ -2475,6 +2923,22 @@ func (f *FundingController) ChannelReady(channel lnwallet.AuxChanState) error {
 	)
 	if err != nil {
 		return fmt.Errorf("unable to decode channel asset state: %w",
+			err)
+	}
+
+	ctx, cancel := f.WithCtxQuitNoTimeout()
+	defer cancel()
+
+	// Before the channel becomes usable (and before any RFQ offers are
+	// installed for it), bind the stored funding proof suffixes to the
+	// confirmed funding transaction. The pre-confirmation validation
+	// could not know the real funding transaction, so this is where a
+	// doppelganger anchor, an unspent claimed input or an immature time
+	// lock is caught. Returning an error here stops lnd from activating
+	// the channel.
+	err = f.validateConfirmedFunding(ctx, channel, chanAssetState)
+	if err != nil {
+		return fmt.Errorf("unable to validate confirmed funding: %w",
 			err)
 	}
 

--- a/tapchannel/aux_funding_controller.go
+++ b/tapchannel/aux_funding_controller.go
@@ -90,6 +90,30 @@ const (
 	// FundingOutputIndex is the anchor output index for channel funding.
 	// Funding outputs are always at index 0; passive assets use index >= 1.
 	FundingOutputIndex uint32 = 0
+
+	// maxActiveFlowsPerPeer is the maximum number of concurrent pending
+	// funding flows a single peer may have open with us.
+	maxActiveFlowsPerPeer = 5
+
+	// maxFundingInputProofs is the maximum number of input proofs (and
+	// pending chunked proof streams) a single funding flow may carry.
+	maxFundingInputProofs = 64
+
+	// maxProofChunks is the maximum number of chunks a single input
+	// proof may be split into, bounding the assembled proof size at
+	// roughly maxProofChunks * proofChunkSize bytes.
+	maxProofChunks = 64
+
+	// fundingFlowMaxAge is the maximum age of a pending funding flow
+	// before the periodic sweep reclaims it. Flows are in-memory only
+	// and just span the pre-broadcast negotiation, so anything this old
+	// is dead: the peer disappeared mid-negotiation, or the flow failed
+	// without a terminal cleanup.
+	fundingFlowMaxAge = 30 * time.Minute
+
+	// fundingFlowSweepInterval is the interval at which expired funding
+	// flows are reclaimed.
+	fundingFlowSweepInterval = time.Minute
 )
 
 // ErrorReporter is used to report an error back to the caller and/or peer that
@@ -297,6 +321,8 @@ type bindFundingReq struct {
 	keyRing lntypes.Dual[lnwallet.CommitmentKeyRing]
 
 	resp chan lfn.Option[lnwallet.AuxFundingDesc]
+
+	errChan chan error
 }
 
 // assetRootReq is a message sent by lnd once we've sent or received the
@@ -306,6 +332,22 @@ type assetRootReq struct {
 	pendingChanID funding.PendingChanID
 
 	resp chan lfn.Option[chainhash.Hash]
+
+	errChan chan error
+}
+
+// assignFundingProofsReq is a request sent by the initiator's funding
+// goroutine to hand the created funding output proofs to the event loop,
+// which owns all pending funding flow state.
+type assignFundingProofsReq struct {
+	pid funding.PendingChanID
+
+	proofs []*proof.Proof
+
+	// result reports the outcome of the assignment back to the
+	// requesting goroutine. It is buffered so the event loop never
+	// blocks on the send.
+	result chan error
 }
 
 // FundingController is used to drive TAP aware channel funding using a backing
@@ -324,7 +366,11 @@ type FundingController struct {
 
 	rootReqs chan *assetRootReq
 
+	assignProofReqs chan *assignFundingProofsReq
+
 	finalizedChans chan funding.PendingChanID
+
+	flowCleanups chan funding.PendingChanID
 
 	// validatedFundingsMtx guards validatedFundings.
 	validatedFundingsMtx sync.Mutex
@@ -349,7 +395,9 @@ func NewFundingController(cfg FundingControllerCfg) *FundingController {
 		bindFundingReqs:   make(chan *bindFundingReq, 10),
 		newFundingReqs:    make(chan *FundReq, 10),
 		rootReqs:          make(chan *assetRootReq, 10),
+		assignProofReqs:   make(chan *assignFundingProofsReq, 10),
 		finalizedChans:    make(chan funding.PendingChanID, 10),
+		flowCleanups:      make(chan funding.PendingChanID, 10),
 		validatedFundings: make(map[wire.OutPoint]struct{}),
 		ContextGuard: &fn.ContextGuard{
 			DefaultTimeout: DefaultTimeout,
@@ -437,6 +485,10 @@ type pendingAssetFunding struct {
 
 	pid funding.PendingChanID
 
+	// createdAt is when this flow was created, used to reclaim flows
+	// that never complete.
+	createdAt time.Time
+
 	initiator bool
 
 	stxo bool
@@ -469,6 +521,12 @@ type pendingAssetFunding struct {
 
 	finalizedCloseOnce sync.Once
 	inputProofChunks   map[chainhash.Hash][]cmsg.ProofChunk
+
+	// failedErr, once set, marks the flow as terminally failed. No
+	// further funding messages are accepted for it, and any funding
+	// descriptor or tapscript root request fails with this error instead
+	// of silently producing empty channel state.
+	failedErr error
 }
 
 // addInputProof adds a new proof to the set of proofs that'll be used to fund
@@ -542,10 +600,21 @@ func (p *pendingAssetFunding) addInputProofChunk(
 
 	type ret = proof.Proof
 
-	// Collect this proof chunk with the rest of the proofs.
+	// Collect this proof chunk with the rest of the proofs. Both the
+	// number of pending proof streams and the number of chunks per proof
+	// are bounded, so a peer cannot grow this state without limit.
 	chunkID := chunk.ChunkSumID.Val
 
-	proofChunks := p.inputProofChunks[chunkID]
+	proofChunks, haveChunks := p.inputProofChunks[chunkID]
+	if !haveChunks && len(p.inputProofChunks) >= maxFundingInputProofs {
+		return lfn.Errf[lfn.Option[ret]]("too many pending input "+
+			"proofs, max is %d", maxFundingInputProofs)
+	}
+	if len(proofChunks) >= maxProofChunks {
+		return lfn.Errf[lfn.Option[ret]]("too many chunks for input "+
+			"proof, max is %d", maxProofChunks)
+	}
+
 	proofChunks = append(proofChunks, chunk)
 	p.inputProofChunks[chunkID] = proofChunks
 
@@ -554,8 +623,11 @@ func (p *pendingAssetFunding) addInputProofChunk(
 		return lfn.Ok(lfn.None[ret]())
 	}
 
-	// Otherwise, this is the last chunk, so we'll extract all the chunks
-	// and assemble the final proof.
+	// This is the last chunk, so the collected chunks are no longer
+	// needed once we return, whether assembly succeeds or not.
+	delete(p.inputProofChunks, chunkID)
+
+	// We'll now extract all the chunks and assemble the final proof.
 	finalProof, err := cmsg.AssembleProofChunks(proofChunks)
 	if err != nil {
 		return lfn.Errf[lfn.Option[ret]]("unable to "+
@@ -830,13 +902,47 @@ func (f *fundingFlowIndex) fromMsg(chainParams *address.ChainParams,
 	pid := assetProof.PID()
 
 	// Next, we'll see if this is already part of an active funding flow.
-	// If not, then we'll make a new one to accumulate this new proof.
 	assetFunding, ok := (*f)[pid]
+
+	// Any message concerning an existing flow must come from the peer
+	// the flow is bound to.
+	if ok && !assetFunding.peerPub.IsEqual(&msg.PeerPub) {
+		return nil, nil, fmt.Errorf("message for funding flow %x "+
+			"from wrong peer", pid[:])
+	}
+
+	// A funding ack never opens a new flow: only the initiator of an
+	// existing flow expects one.
+	if _, isAck := assetProof.(*cmsg.AssetFundingAck); isAck {
+		if !ok {
+			return nil, nil, fmt.Errorf("no funding flow for "+
+				"ack with pending chan ID %x", pid[:])
+		}
+
+		return assetProof, assetFunding, nil
+	}
+
+	// If there's no active flow yet, we'll make a new one to accumulate
+	// this new proof. The number of concurrent flows per peer is bounded
+	// to keep the pending state a peer can create in check.
 	if !ok {
+		var activeFlows int
+		for _, flow := range *f {
+			if flow.peerPub.IsEqual(&msg.PeerPub) {
+				activeFlows++
+			}
+		}
+		if activeFlows >= maxActiveFlowsPerPeer {
+			return nil, nil, fmt.Errorf("too many active funding "+
+				"flows for peer %x",
+				msg.PeerPub.SerializeCompressed())
+		}
+
 		assetFunding = &pendingAssetFunding{
 			chainParams:            chainParams,
 			pid:                    pid,
 			peerPub:                msg.PeerPub,
+			createdAt:              time.Now(),
 			amt:                    assetProof.Amt().UnwrapOr(0),
 			fundingAckChan:         make(chan bool, 1),
 			fundingFinalizedSignal: make(chan struct{}),
@@ -851,6 +957,19 @@ func (f *fundingFlowIndex) fromMsg(chainParams *address.ChainParams,
 	}
 
 	return assetProof, assetFunding, nil
+}
+
+// sweepExpired removes pending funding flows that have exceeded the maximum
+// allowed age.
+func (f *fundingFlowIndex) sweepExpired(now time.Time) {
+	for pid, flow := range *f {
+		age := now.Sub(flow.createdAt)
+		if age > fundingFlowMaxAge {
+			log.Warnf("Removing expired funding flow %x (age %v)",
+				pid[:], age)
+			delete(*f, pid)
+		}
+	}
 }
 
 // fundVirtualPacket attempts to fund a new vPacket using the asset wallet to
@@ -1433,10 +1552,17 @@ func (f *FundingController) completeChannelFunding(ctx context.Context,
 		return nil, fmt.Errorf("unable to anchor vPackets: %w", err)
 	}
 
-	// Now that we've anchored the packets, we'll also set the fundingVOuts
-	// which we'll use later to send the AssetFundingCreated message to the
-	// responder, and also return the full AuxFundingDesc back to lnd.
-	fundingState.fundingOutputProofs = fundingOutputProofs
+	// Now that we've anchored the packets, we'll hand the funding output
+	// proofs to the event loop, which owns all pending funding flow
+	// state. They're used to send the AssetFundingCreated message to the
+	// responder below, and to return the full AuxFundingDesc back to lnd
+	// once the PSBT is bound. This must not be a direct field write: lnd
+	// concurrently drives the event loop's reads of the flow state.
+	err = f.assignFundingProofs(fundingState.pid, fundingOutputProofs)
+	if err != nil {
+		return nil, fmt.Errorf("unable to assign funding output "+
+			"proofs: %w", err)
+	}
 
 	// Before we send the finalized PSBT to lnd, we'll send the
 	// AssetFundingCreated message which will preceded the normal
@@ -1557,13 +1683,37 @@ func (f *FundingController) processFundingMsg(ctx context.Context,
 
 	tempPID = assetFunding.pid
 
+	// A flow that failed validation is terminal: it must not accumulate
+	// any further state.
+	if assetFunding.failedErr != nil {
+		return tempPID, fmt.Errorf("funding flow %x already failed: "+
+			"%w", tempPID[:], assetFunding.failedErr)
+	}
+
 	// Whatever the message from the peer is, it's about funding a channel.
 	// We can only support asset channels if we have the correct proof
 	// courier type configured, so we're ready to receive the channel funds
-	// once the channel is (force) closed.
-	if err := f.validateLocalProofCourier(ctx); err != nil {
-		return tempPID, fmt.Errorf("unable to accept channel funding "+
-			"request, local proof courier is invalid: %w", err)
+	// once the channel is (force) closed. A funding ack only terminates a
+	// flow we initiated (and validated the courier for), so it doesn't
+	// need this potentially slow connectivity check.
+	if _, isAck := proofMsg.(*cmsg.AssetFundingAck); !isAck {
+		if err := f.validateLocalProofCourier(ctx); err != nil {
+			return tempPID, fmt.Errorf("unable to accept channel "+
+				"funding request, local proof courier is "+
+				"invalid: %w", err)
+		}
+	}
+
+	// Messages that drive the responder side of a funding flow must never
+	// mutate the state of a flow we initiated ourselves.
+	switch proofMsg.(type) {
+	case *cmsg.TxAssetInputProof, *cmsg.TxAssetOutputProof,
+		*cmsg.AssetFundingCreated:
+
+		if assetFunding.initiator {
+			return tempPID, fmt.Errorf("unexpected %T for flow "+
+				"we initiated", proofMsg)
+		}
 	}
 
 	switch assetProof := proofMsg.(type) {
@@ -1584,6 +1734,12 @@ func (f *FundingController) processFundingMsg(ctx context.Context,
 		// If there's no final proof yet, we can just return early.
 		if finalProof.IsNone() {
 			return tempPID, nil
+		}
+
+		// The set of input proofs a flow may accumulate is bounded.
+		if len(assetFunding.inputProofs) >= maxFundingInputProofs {
+			return tempPID, fmt.Errorf("too many input proofs, "+
+				"max is %d", maxFundingInputProofs)
 		}
 
 		// Otherwise, we have all the proofs we need.
@@ -1660,6 +1816,14 @@ func (f *FundingController) processFundingMsg(ctx context.Context,
 	// This is an output proof, so now we should be able to verify the
 	// asset funding output with witness intact.
 	case *cmsg.TxAssetOutputProof:
+		// Reject structurally incomplete assets before any key
+		// derivation or witness validation runs on them.
+		outputAsset := assetProof.AssetOutput.Val
+		if err := outputAsset.Validate(); err != nil {
+			return tempPID, fmt.Errorf("invalid funding output "+
+				"asset: %w", err)
+		}
+
 		err := f.validateWitness(
 			assetProof.AssetOutput.Val, assetFunding.inputProofs,
 		)
@@ -1731,11 +1895,56 @@ func (f *FundingController) processFundingMsg(ctx context.Context,
 	// We'll send the response back to the main goroutine waiting to
 	// proceed with funding.
 	case *cmsg.AssetFundingAck:
+		if !assetFunding.initiator {
+			return tempPID, fmt.Errorf("unexpected funding ack " +
+				"for flow we did not initiate")
+		}
+
+		// Deliver the ack without ever blocking the event loop. The
+		// channel is buffered for the single ack the funding
+		// goroutine consumes; any further ack is a duplicate.
 		accept := assetProof.Accept.Val
-		assetFunding.fundingAckChan <- accept
+		select {
+		case assetFunding.fundingAckChan <- accept:
+		default:
+			return tempPID, fmt.Errorf("duplicate funding ack")
+		}
 	}
 
 	return tempPID, nil
+}
+
+// removeFlow asks the event loop to delete the funding flow with the given
+// pending channel ID. This is used by the initiator's funding goroutine once
+// a flow reaches a terminal outcome (success, rejection, timeout or error).
+func (f *FundingController) removeFlow(pid funding.PendingChanID) {
+	if !fn.SendOrQuit(f.flowCleanups, pid, f.Quit) {
+		log.Warnf("Unable to remove funding flow %x, controller "+
+			"shutting down", pid[:])
+	}
+}
+
+// assignFundingProofs hands the created funding output proofs of a flow to
+// the funding controller's event loop and waits until they've been applied.
+func (f *FundingController) assignFundingProofs(pid funding.PendingChanID,
+	proofs []*proof.Proof) error {
+
+	req := &assignFundingProofsReq{
+		pid:    pid,
+		proofs: proofs,
+		result: make(chan error, 1),
+	}
+	if !fn.SendOrQuit(f.assignProofReqs, req, f.Quit) {
+		return fmt.Errorf("funding controller is shutting down")
+	}
+
+	select {
+	case err := <-req.result:
+		return err
+
+	case <-f.Quit:
+		return fmt.Errorf("funding controller is shutting down")
+	}
 }
 
 // processFundingReq processes a new funding request from the main goroutine.
@@ -1795,6 +2004,7 @@ func (f *FundingController) processFundingReq(fundingFlows fundingFlowIndex,
 		chainParams:            &f.cfg.ChainParams,
 		peerPub:                fundReq.PeerPub,
 		pid:                    tempPID,
+		createdAt:              time.Now(),
 		initiator:              true,
 		amt:                    fundReq.AssetAmount,
 		pushAmt:                fundReq.PushAmount,
@@ -1937,6 +2147,7 @@ func (f *FundingController) processFundingReq(fundingFlows fundingFlowIndex,
 		case accept := <-fundingState.fundingAckChan:
 			log.Infof("funding ack received: accept=%v", accept)
 			if !accept {
+				f.removeFlow(tempPID)
 				return
 			}
 
@@ -1945,6 +2156,7 @@ func (f *FundingController) processFundingReq(fundingFlows fundingFlowIndex,
 				ackTimeout)
 			log.Error(err)
 			fundReq.errChan <- err
+			f.removeFlow(tempPID)
 			return
 
 		case <-f.Quit:
@@ -1969,10 +2181,15 @@ func (f *FundingController) processFundingReq(fundingFlows fundingFlowIndex,
 			)
 
 			fundReq.errChan <- err
+			f.removeFlow(tempPID)
 			return
 		}
 
 		completeSuccess = true
+
+		// The funding transaction is broadcast, so the in-memory
+		// funding flow has served its purpose and can be reclaimed.
+		f.removeFlow(tempPID)
 
 		fundReq.respChan <- chanPoint
 	}()
@@ -1992,6 +2209,12 @@ func (f *FundingController) chanFunder() {
 	// the funding transaction. Any state acquired before that can be
 	// in-memory only, the same as it works in lnd.
 	fundingFlows := make(fundingFlowIndex)
+
+	// Flows that never reach a terminal outcome (peer disconnected
+	// mid-negotiation, responder side abandoned, etc.) are reclaimed by
+	// a periodic sweep.
+	sweepTicker := time.NewTicker(fundingFlowSweepInterval)
+	defer sweepTicker.Stop()
 
 	for {
 		select {
@@ -2018,6 +2241,19 @@ func (f *FundingController) chanFunder() {
 					ctxc, msg.PeerPub, tempFundingID, err,
 				)
 				log.Error(err)
+
+				// A message failing validation is terminal
+				// for flows the remote peer opened with us.
+				// The flow is kept (marked failed) so that a
+				// later funding descriptor request fails
+				// loudly instead of building empty channel
+				// state.
+				flow, ok := fundingFlows[tempFundingID]
+				if ok && !flow.initiator &&
+					flow.failedErr == nil {
+
+					flow.failedErr = err
+				}
 			}
 
 		// A new request for a tapscript root has come across. If we
@@ -2036,6 +2272,16 @@ func (f *FundingController) chanFunder() {
 				continue
 			}
 
+			if fundingFlow.failedErr != nil {
+				fErr := fmt.Errorf("funding flow failed: %w",
+					fundingFlow.failedErr)
+				f.cfg.ErrReporter.ReportError(
+					ctxc, fundingFlow.peerPub, pid, fErr,
+				)
+				req.errChan <- fErr
+				continue
+			}
+
 			fundingCommitment := fundingFlow.fundingAssetCommitment
 			if fundingCommitment == nil {
 				fErr := fmt.Errorf("missing funding commitment")
@@ -2043,6 +2289,7 @@ func (f *FundingController) chanFunder() {
 					ctxc, fundingFlow.peerPub, pid,
 					fErr,
 				)
+				req.errChan <- fErr
 				continue
 			}
 
@@ -2069,6 +2316,30 @@ func (f *FundingController) chanFunder() {
 				continue
 			}
 
+			if fundingFlow.failedErr != nil {
+				fErr := fmt.Errorf("funding flow failed: %w",
+					fundingFlow.failedErr)
+				f.cfg.ErrReporter.ReportError(
+					ctxc, fundingFlow.peerPub, pid, fErr,
+				)
+				req.errChan <- fErr
+				continue
+			}
+
+			// A funding descriptor derived from zero asset
+			// outputs would create empty (and thus invalid)
+			// channel state; fail the funding attempt loudly
+			// instead.
+			if len(fundingFlow.fundingOutputProofs) == 0 {
+				fErr := fmt.Errorf("no funding output "+
+					"proofs for flow %x", pid[:])
+				f.cfg.ErrReporter.ReportError(
+					ctxc, fundingFlow.peerPub, pid, fErr,
+				)
+				req.errChan <- fErr
+				continue
+			}
+
 			// We'll want to store the decimal display of the asset
 			// in the funding blob, so let's determine it now.
 			decimalDisplay, err := f.fundingAssetDecimalDisplay(
@@ -2080,6 +2351,7 @@ func (f *FundingController) chanFunder() {
 				f.cfg.ErrReporter.ReportError(
 					ctxc, fundingFlow.peerPub, pid, fErr,
 				)
+				req.errChan <- fErr
 				continue
 			}
 
@@ -2092,6 +2364,7 @@ func (f *FundingController) chanFunder() {
 				f.cfg.ErrReporter.ReportError(
 					ctxc, fundingFlow.peerPub, pid, fErr,
 				)
+				req.errChan <- fErr
 				continue
 			}
 
@@ -2104,6 +2377,7 @@ func (f *FundingController) chanFunder() {
 				f.cfg.ErrReporter.ReportError(
 					ctxc, fundingFlow.peerPub, pid, fErr,
 				)
+				req.errChan <- fErr
 				continue
 			}
 
@@ -2111,6 +2385,21 @@ func (f *FundingController) chanFunder() {
 				limitSpewer.Sdump(fundingDesc))
 
 			req.resp <- lfn.Some(*fundingDesc)
+
+		// The initiator's funding goroutine has created the funding
+		// output proofs and hands them over for the flow state we
+		// own.
+		case req := <-f.assignProofReqs:
+			fundingFlow, ok := fundingFlows[req.pid]
+			if !ok {
+				req.result <- fmt.Errorf("no funding flow "+
+					"with pending chan ID %x to assign "+
+					"funding proofs to", req.pid[:])
+				continue
+			}
+
+			fundingFlow.fundingOutputProofs = req.proofs
+			req.result <- nil
 
 		// A prior channel funding we started can now proceed to the
 		// broadcast phase.
@@ -2128,6 +2417,16 @@ func (f *FundingController) chanFunder() {
 			fundingFlow.finalizedCloseOnce.Do(func() {
 				close(fundingFlow.fundingFinalizedSignal)
 			})
+
+		// A funding flow has reached a terminal outcome, so its
+		// in-memory state can be reclaimed.
+		case pid := <-f.flowCleanups:
+			delete(fundingFlows, pid)
+
+		// Reclaim any funding flows that have long passed their
+		// expected lifetime.
+		case <-sweepTicker.C:
+			fundingFlows.sweepExpired(time.Now())
 
 		case <-f.Quit:
 			return
@@ -2315,6 +2614,10 @@ func validateFundingProofs(ctx context.Context, vCtx proof.VerifierCtx,
 	}
 	if len(outputs) == 0 {
 		return fmt.Errorf("funding output proofs are missing")
+	}
+	if len(outputs) > maxNumAssetIDs {
+		return fmt.Errorf("too many funding outputs, got %d, max "+
+			"is %d", len(outputs), maxNumAssetIDs)
 	}
 
 	// The suffixes are verified against the input proof files collected
@@ -2860,6 +3163,7 @@ func (f *FundingController) DescFromPendingChanID(pid funding.PendingChanID,
 		resp: make(
 			chan lfn.Option[lnwallet.AuxFundingDesc], 1,
 		),
+		errChan: make(chan error, 1),
 	}
 
 	if !fn.SendOrQuit(f.bindFundingReqs, req, f.Quit) {
@@ -2867,10 +3171,10 @@ func (f *FundingController) DescFromPendingChanID(pid funding.PendingChanID,
 			"to funding controller"))
 	}
 
-	resp, err := fn.RecvResp(req.resp, nil, f.Quit)
+	resp, err := fn.RecvResp(req.resp, req.errChan, f.Quit)
 	if err != nil {
-		return lfn.Err[returnType](fmt.Errorf("timeout when waiting "+
-			"for response: %w", err))
+		return lfn.Err[returnType](fmt.Errorf("unable to bind aux "+
+			"funding desc: %w", err))
 	}
 
 	return lfn.Ok(resp)
@@ -2886,6 +3190,7 @@ func (f *FundingController) DeriveTapscriptRoot(
 	req := &assetRootReq{
 		pendingChanID: pid,
 		resp:          make(chan lfn.Option[chainhash.Hash], 1),
+		errChan:       make(chan error, 1),
 	}
 
 	if !fn.SendOrQuit(f.rootReqs, req, f.Quit) {
@@ -2893,10 +3198,10 @@ func (f *FundingController) DeriveTapscriptRoot(
 			"to funding controller"))
 	}
 
-	resp, err := fn.RecvResp(req.resp, nil, f.Quit)
+	resp, err := fn.RecvResp(req.resp, req.errChan, f.Quit)
 	if err != nil {
-		return lfn.Err[returnType](fmt.Errorf("timeout when waiting "+
-			"for response: %w", err))
+		return lfn.Err[returnType](fmt.Errorf("unable to derive "+
+			"tapscript root: %w", err))
 	}
 
 	return lfn.Ok(resp)

--- a/tapchannel/aux_funding_controller_test.go
+++ b/tapchannel/aux_funding_controller_test.go
@@ -5,14 +5,310 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/lightninglabs/taproot-assets/asset"
+	"github.com/lightninglabs/taproot-assets/commitment"
+	"github.com/lightninglabs/taproot-assets/fn"
 	"github.com/lightninglabs/taproot-assets/internal/test"
 	"github.com/lightninglabs/taproot-assets/proof"
+	cmsg "github.com/lightninglabs/taproot-assets/tapchannelmsg"
 	mboxrpc "github.com/lightninglabs/taproot-assets/taprpc/authmailboxrpc"
 	"github.com/lightninglabs/taproot-assets/taprpc/universerpc"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 )
+
+// TestExpectedFundingAssetKeys ensures the set of assets that funding proofs
+// must cover excludes alt leaves, which are committed alongside the funding
+// assets but have no funding proof of their own.
+func TestExpectedFundingAssetKeys(t *testing.T) {
+	t.Parallel()
+
+	fundingAsset := asset.RandAsset(t, asset.Normal)
+	fundingCommitment, err := commitment.FromAssets(
+		fn.Ptr(commitment.TapCommitmentV2), fundingAsset,
+	)
+	require.NoError(t, err)
+
+	altLeaf := asset.RandAltLeaf(t)
+	err = fundingCommitment.MergeAltLeaves(
+		[]asset.AltLeaf[asset.Asset]{altLeaf},
+	)
+	require.NoError(t, err)
+
+	assetKeys := expectedFundingAssetKeys(fundingCommitment)
+	require.Len(t, assetKeys, 1)
+	require.Contains(t, assetKeys, newFundingAssetKey(fundingAsset))
+}
+
+// TestExpectedFundingAssetKeysUngrouped ensures that two ungrouped assets
+// with different asset IDs but the same script key map to distinct keys. The
+// asset commitment key of an ungrouped asset hashes only the script key, so
+// without the tap commitment key namespacing the two assets would collide.
+func TestExpectedFundingAssetKeysUngrouped(t *testing.T) {
+	t.Parallel()
+
+	scriptKey := asset.RandScriptKey(t)
+	asset1 := asset.NewAssetNoErr(
+		t, asset.RandGenesis(t, asset.Normal), 100, 0, 0, scriptKey,
+		nil,
+	)
+	asset2 := asset.NewAssetNoErr(
+		t, asset.RandGenesis(t, asset.Normal), 100, 0, 0, scriptKey,
+		nil,
+	)
+	require.NotEqual(t, asset1.ID(), asset2.ID())
+	require.Equal(
+		t, asset1.AssetCommitmentKey(), asset2.AssetCommitmentKey(),
+	)
+
+	fundingCommitment, err := commitment.FromAssets(
+		fn.Ptr(commitment.TapCommitmentV2), asset1, asset2,
+	)
+	require.NoError(t, err)
+
+	assetKeys := expectedFundingAssetKeys(fundingCommitment)
+	require.Len(t, assetKeys, 2)
+	require.Contains(t, assetKeys, newFundingAssetKey(asset1))
+	require.Contains(t, assetKeys, newFundingAssetKey(asset2))
+}
+
+// randFundingProof returns a random, fully encodable proof. Like the input
+// proofs exchanged during funding, it carries a challenge witness.
+func randFundingProof(t *testing.T) proof.Proof {
+	anchorTx := wire.NewMsgTx(2)
+	anchorTx.AddTxIn(&wire.TxIn{})
+	anchorTx.AddTxOut(&wire.TxOut{Value: 1_000})
+	block := wire.MsgBlock{
+		Header:       wire.BlockHeader{},
+		Transactions: []*wire.MsgTx{anchorTx},
+	}
+
+	p := proof.RandProof(
+		t, asset.RandGenesis(t, asset.Normal), test.RandPubKey(t),
+		block, 0, FundingOutputIndex,
+	)
+
+	// Funding output assets never carry time locks; a randomized lock
+	// would trip the structural checks before the property under test.
+	p.Asset.LockTime = 0
+	p.Asset.RelativeLockTime = 0
+
+	return p
+}
+
+// TestValidateFundingProofs exercises the checks that reject malformed or
+// inconsistent AssetFundingCreated payloads before any proof suffix becomes
+// channel state.
+func TestValidateFundingProofs(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	newState := func(t *testing.T) *pendingAssetFunding {
+		fundingCommitment, err := commitment.FromAssets(
+			fn.Ptr(commitment.TapCommitmentV2),
+			asset.RandAsset(t, asset.Normal),
+		)
+		require.NoError(t, err)
+
+		// Seed a verified input proof file under a random PrevID so
+		// validation proceeds past the input completeness check.
+		inputFile, err := proof.NewFile(proof.V0)
+		require.NoError(t, err)
+
+		return &pendingAssetFunding{
+			fundingAssetCommitment: fundingCommitment,
+			inputProofFiles: map[asset.PrevID]*proof.File{
+				{OutPoint: test.RandOp(t)}: inputFile,
+			},
+		}
+	}
+
+	newOutput := func(p proof.Proof) *cmsg.AssetOutput {
+		return cmsg.NewAssetOutput(p.Asset.ID(), p.Asset.Amount, p)
+	}
+
+	t.Run("missing funding commitment", func(t *testing.T) {
+		err := validateFundingProofs(
+			ctx, proof.MockVerifierCtx, &pendingAssetFunding{},
+			[]*cmsg.AssetOutput{newOutput(randFundingProof(t))},
+		)
+		require.ErrorContains(t, err, "commitment is missing")
+	})
+
+	t.Run("replayed funding proofs", func(t *testing.T) {
+		fundingState := newState(t)
+		fundingState.fundingOutputProofs = []*proof.Proof{{}}
+
+		err := validateFundingProofs(
+			ctx, proof.MockVerifierCtx, fundingState,
+			[]*cmsg.AssetOutput{newOutput(randFundingProof(t))},
+		)
+		require.ErrorContains(t, err, "already received")
+	})
+
+	t.Run("missing outputs", func(t *testing.T) {
+		err := validateFundingProofs(
+			ctx, proof.MockVerifierCtx, newState(t), nil,
+		)
+		require.ErrorContains(t, err, "proofs are missing")
+	})
+
+	t.Run("no verified input proofs", func(t *testing.T) {
+		fundingState := newState(t)
+		fundingState.inputProofFiles = nil
+
+		err := validateFundingProofs(
+			ctx, proof.MockVerifierCtx, fundingState,
+			[]*cmsg.AssetOutput{newOutput(randFundingProof(t))},
+		)
+		require.ErrorContains(t, err, "no verified funding input")
+	})
+
+	t.Run("nil output", func(t *testing.T) {
+		err := validateFundingProofs(
+			ctx, proof.MockVerifierCtx, newState(t),
+			[]*cmsg.AssetOutput{nil},
+		)
+		require.ErrorContains(t, err, "funding output 0 is nil")
+	})
+
+	t.Run("asset ID mismatch", func(t *testing.T) {
+		suffix := randFundingProof(t)
+		output := cmsg.NewAssetOutput(
+			asset.RandID(t), suffix.Asset.Amount, suffix,
+		)
+
+		err := validateFundingProofs(
+			ctx, proof.MockVerifierCtx, newState(t),
+			[]*cmsg.AssetOutput{output},
+		)
+		require.ErrorContains(t, err, "asset ID does not match")
+	})
+
+	t.Run("amount mismatch", func(t *testing.T) {
+		suffix := randFundingProof(t)
+		output := cmsg.NewAssetOutput(
+			suffix.Asset.ID(), suffix.Asset.Amount+1, suffix,
+		)
+
+		err := validateFundingProofs(
+			ctx, proof.MockVerifierCtx, newState(t),
+			[]*cmsg.AssetOutput{output},
+		)
+		require.ErrorContains(t, err, "amount does not match")
+	})
+
+	t.Run("peer-supplied additional inputs", func(t *testing.T) {
+		suffix := randFundingProof(t)
+		suffix.AdditionalInputs = []proof.File{{}}
+
+		outputs := []*cmsg.AssetOutput{newOutput(suffix)}
+		err := validateFundingProofs(
+			ctx, proof.MockVerifierCtx, newState(t), outputs,
+		)
+		require.ErrorContains(t, err, "additional inputs")
+	})
+
+	t.Run("wrong anchor output index", func(t *testing.T) {
+		suffix := randFundingProof(t)
+		suffix.InclusionProof.OutputIndex = FundingOutputIndex + 1
+
+		outputs := []*cmsg.AssetOutput{newOutput(suffix)}
+		err := validateFundingProofs(
+			ctx, proof.MockVerifierCtx, newState(t), outputs,
+		)
+		require.ErrorContains(t, err, "commits to anchor output")
+	})
+
+	t.Run("challenge witness suffix", func(t *testing.T) {
+		suffix := randFundingProof(t)
+
+		outputs := []*cmsg.AssetOutput{newOutput(suffix)}
+		err := validateFundingProofs(
+			ctx, proof.MockVerifierCtx, newState(t), outputs,
+		)
+		require.ErrorContains(t, err, "has a challenge witness")
+	})
+
+	t.Run("unknown input", func(t *testing.T) {
+		suffix := randFundingProof(t)
+		suffix.ChallengeWitness = nil
+		suffix.PrevOut = wire.OutPoint{}
+
+		outputs := []*cmsg.AssetOutput{newOutput(suffix)}
+		err := validateFundingProofs(
+			ctx, proof.MockVerifierCtx, newState(t), outputs,
+		)
+		require.ErrorContains(t, err, "no verified input proof")
+	})
+
+	t.Run("input witness without previous ID", func(t *testing.T) {
+		suffix := randFundingProof(t)
+		suffix.Asset.PrevWitnesses[0].PrevID = nil
+
+		outputs := []*cmsg.AssetOutput{newOutput(suffix)}
+		err := validateFundingProofs(
+			ctx, proof.MockVerifierCtx, newState(t), outputs,
+		)
+		require.ErrorContains(t, err, "without previous ID")
+	})
+
+	t.Run("input reuse across outputs", func(t *testing.T) {
+		// Two funding outputs whose witnesses consume the same input
+		// must be rejected before any proof verification runs; a peer
+		// could otherwise inflate the channel balance by backing
+		// several outputs with one input.
+		suffix1 := randFundingProof(t)
+		suffix2 := randFundingProof(t)
+		prevID := asset.PrevID{
+			OutPoint:  test.RandOp(t),
+			ID:        suffix1.Asset.ID(),
+			ScriptKey: asset.RandSerializedKey(t),
+		}
+		suffix1.Asset.PrevWitnesses[0].PrevID = &prevID
+		suffix2.Asset.PrevWitnesses[0].PrevID = &prevID
+
+		outputs := []*cmsg.AssetOutput{
+			newOutput(suffix1), newOutput(suffix2),
+		}
+		err := validateFundingProofs(
+			ctx, proof.MockVerifierCtx, newState(t), outputs,
+		)
+		require.ErrorContains(t, err, "reuses input")
+	})
+
+	t.Run("distinct inputs sharing an outpoint", func(t *testing.T) {
+		// Two different asset inputs may share one Bitcoin outpoint.
+		// The input accounting must not confuse them, so validation
+		// proceeds past the first pass (and only fails later on the
+		// challenge witness carried by the random test proofs).
+		suffix1 := randFundingProof(t)
+		suffix2 := randFundingProof(t)
+		sharedOutpoint := test.RandOp(t)
+		suffix1.Asset.PrevWitnesses[0].PrevID = &asset.PrevID{
+			OutPoint:  sharedOutpoint,
+			ID:        suffix1.Asset.ID(),
+			ScriptKey: asset.RandSerializedKey(t),
+		}
+		suffix2.Asset.PrevWitnesses[0].PrevID = &asset.PrevID{
+			OutPoint:  sharedOutpoint,
+			ID:        suffix2.Asset.ID(),
+			ScriptKey: asset.RandSerializedKey(t),
+		}
+
+		outputs := []*cmsg.AssetOutput{
+			newOutput(suffix1), newOutput(suffix2),
+		}
+		err := validateFundingProofs(
+			ctx, proof.MockVerifierCtx, newState(t), outputs,
+		)
+		require.NotContains(t, err.Error(), "reuses input")
+		require.ErrorContains(t, err, "has a challenge witness")
+	})
+}
 
 // TestValidateLocalProofCourier tests that the local proof courier is
 // validated correctly.

--- a/tapchannel/aux_funding_controller_test.go
+++ b/tapchannel/aux_funding_controller_test.go
@@ -3,8 +3,13 @@ package tapchannel
 import (
 	"context"
 	"net/url"
+	"strings"
+	"sync"
 	"testing"
+	"time"
 
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/chainhash/v2"
 	"github.com/btcsuite/btcd/wire/v2"
 	"github.com/lightninglabs/taproot-assets/asset"
 	"github.com/lightninglabs/taproot-assets/commitment"
@@ -14,6 +19,10 @@ import (
 	cmsg "github.com/lightninglabs/taproot-assets/tapchannelmsg"
 	mboxrpc "github.com/lightninglabs/taproot-assets/taprpc/authmailboxrpc"
 	"github.com/lightninglabs/taproot-assets/taprpc/universerpc"
+	"github.com/lightningnetwork/lnd/funding"
+	"github.com/lightningnetwork/lnd/lntypes"
+	"github.com/lightningnetwork/lnd/lnwallet"
+	"github.com/lightningnetwork/lnd/msgmux"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -307,6 +316,386 @@ func TestValidateFundingProofs(t *testing.T) {
 		)
 		require.NotContains(t, err.Error(), "reuses input")
 		require.ErrorContains(t, err, "has a challenge witness")
+	})
+}
+
+// noopErrReporter ignores reported funding errors.
+type noopErrReporter struct{}
+
+// ReportError implements the ErrorReporter interface.
+func (noopErrReporter) ReportError(context.Context, btcec.PublicKey,
+	funding.PendingChanID, error) {
+}
+
+// TestAssignFundingProofsConcurrency ensures that handing funding output
+// proofs to the event loop neither blocks nor races with concurrent funding
+// messages for the same flow. The race detector makes this meaningful.
+func TestAssignFundingProofsConcurrency(t *testing.T) {
+	t.Parallel()
+
+	f := NewFundingController(FundingControllerCfg{
+		ErrReporter: noopErrReporter{},
+	})
+	f.Wg.Add(1)
+	go f.chanFunder()
+	t.Cleanup(func() {
+		close(f.Quit)
+		f.Wg.Wait()
+		f.msgQueue.Stop()
+	})
+
+	ctx := context.Background()
+	peer := *test.RandPubKey(t)
+	pid := funding.PendingChanID{7}
+
+	// Seed a funding flow; processing fails at the proof courier check
+	// (none is configured), but the flow entry itself remains.
+	seeded := f.SendMessage(ctx, msgmux.PeerMsg{
+		PeerPub: peer,
+		Message: cmsg.NewAssetFundingCreated(pid, nil),
+	})
+	require.True(t, seeded)
+
+	// Concurrently assign funding output proofs and process incoming
+	// funding messages for the same flow.
+	fundingProof := randFundingProof(t)
+	var wg sync.WaitGroup
+	for i := 0; i < 5; i++ {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+
+			err := f.assignFundingProofs(
+				pid, []*proof.Proof{&fundingProof},
+			)
+			require.NoError(t, err)
+		}()
+		go func() {
+			defer wg.Done()
+
+			ok := f.SendMessage(ctx, msgmux.PeerMsg{
+				PeerPub: peer,
+				Message: cmsg.NewAssetFundingCreated(pid, nil),
+			})
+			require.True(t, ok)
+		}()
+	}
+	wg.Wait()
+
+	// The event loop must still be responsive.
+	res := f.DeriveTapscriptRoot(funding.PendingChanID{8})
+	root, err := res.Unpack()
+	require.NoError(t, err)
+	require.True(t, root.IsNone())
+
+	// Handing proofs to a flow that does not exist must fail loudly
+	// instead of silently dropping them.
+	err = f.assignFundingProofs(
+		funding.PendingChanID{9}, []*proof.Proof{&fundingProof},
+	)
+	require.ErrorContains(t, err, "no funding flow")
+}
+
+// TestFundingFlowLimits exercises the bounds on peer-creatable funding
+// state: flows per peer, pending chunked proofs, chunks per proof, and
+// funding outputs per flow, as well as the reclamation of assembled chunks
+// and of expired flows.
+func TestFundingFlowLimits(t *testing.T) {
+	t.Parallel()
+
+	t.Run("flows per peer", func(t *testing.T) {
+		flows := make(fundingFlowIndex)
+		peer := *test.RandPubKey(t)
+
+		for i := 0; i < maxActiveFlowsPerPeer; i++ {
+			pid := funding.PendingChanID{byte(i + 1)}
+			_, _, err := flows.fromMsg(nil, msgmux.PeerMsg{
+				PeerPub: peer,
+				Message: cmsg.NewAssetFundingCreated(
+					pid, nil,
+				),
+			})
+			require.NoError(t, err)
+		}
+		require.Len(t, flows, maxActiveFlowsPerPeer)
+
+		_, _, err := flows.fromMsg(nil, msgmux.PeerMsg{
+			PeerPub: peer,
+			Message: cmsg.NewAssetFundingCreated(
+				funding.PendingChanID{0xff}, nil,
+			),
+		})
+		require.ErrorContains(t, err, "too many active funding flows")
+
+		// A different peer is not affected by the limit.
+		_, _, err = flows.fromMsg(nil, msgmux.PeerMsg{
+			PeerPub: *test.RandPubKey(t),
+			Message: cmsg.NewAssetFundingCreated(
+				funding.PendingChanID{0xfe}, nil,
+			),
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("pending proof streams", func(t *testing.T) {
+		fundingState := &pendingAssetFunding{
+			inputProofChunks: make(
+				map[chainhash.Hash][]cmsg.ProofChunk,
+			),
+		}
+
+		for i := 0; i < maxFundingInputProofs; i++ {
+			var sum [32]byte
+			sum[0] = byte(i + 1)
+			_, err := fundingState.addInputProofChunk(
+				cmsg.NewProofChunk(sum, []byte{1}, false),
+			).Unpack()
+			require.NoError(t, err)
+		}
+
+		var sum [32]byte
+		sum[31] = 0xff
+		_, err := fundingState.addInputProofChunk(
+			cmsg.NewProofChunk(sum, []byte{1}, false),
+		).Unpack()
+		require.ErrorContains(t, err, "too many pending input proofs")
+	})
+
+	t.Run("chunks per proof", func(t *testing.T) {
+		fundingState := &pendingAssetFunding{
+			inputProofChunks: make(
+				map[chainhash.Hash][]cmsg.ProofChunk,
+			),
+		}
+
+		var sum [32]byte
+		sum[0] = 1
+		for i := 0; i < maxProofChunks; i++ {
+			_, err := fundingState.addInputProofChunk(
+				cmsg.NewProofChunk(sum, []byte{1}, false),
+			).Unpack()
+			require.NoError(t, err)
+		}
+
+		_, err := fundingState.addInputProofChunk(
+			cmsg.NewProofChunk(sum, []byte{1}, false),
+		).Unpack()
+		require.ErrorContains(t, err, "too many chunks")
+	})
+
+	t.Run("assembled chunks are reclaimed", func(t *testing.T) {
+		fundingState := &pendingAssetFunding{
+			inputProofChunks: make(
+				map[chainhash.Hash][]cmsg.ProofChunk,
+			),
+		}
+
+		inputProof := randFundingProof(t)
+		chunks, err := cmsg.CreateProofChunks(inputProof, 100)
+		require.NoError(t, err)
+		require.Greater(t, len(chunks), 1)
+
+		for idx, chunk := range chunks {
+			finalProof, err := fundingState.addInputProofChunk(
+				chunk,
+			).Unpack()
+			require.NoError(t, err)
+
+			if idx < len(chunks)-1 {
+				require.True(t, finalProof.IsNone())
+			} else {
+				require.False(t, finalProof.IsNone())
+			}
+		}
+
+		require.Empty(t, fundingState.inputProofChunks)
+	})
+
+	t.Run("funding output limit", func(t *testing.T) {
+		fundingCommitment, err := commitment.FromAssets(
+			fn.Ptr(commitment.TapCommitmentV2),
+			asset.RandAsset(t, asset.Normal),
+		)
+		require.NoError(t, err)
+
+		inputFile, err := proof.NewFile(proof.V0)
+		require.NoError(t, err)
+		fundingState := &pendingAssetFunding{
+			fundingAssetCommitment: fundingCommitment,
+			inputProofFiles: map[asset.PrevID]*proof.File{
+				{OutPoint: test.RandOp(t)}: inputFile,
+			},
+		}
+
+		outputs := make([]*cmsg.AssetOutput, maxNumAssetIDs+1)
+		for idx := range outputs {
+			suffix := randFundingProof(t)
+			outputs[idx] = cmsg.NewAssetOutput(
+				suffix.Asset.ID(), suffix.Asset.Amount,
+				suffix,
+			)
+		}
+
+		err = validateFundingProofs(
+			context.Background(), proof.MockVerifierCtx,
+			fundingState, outputs,
+		)
+		require.ErrorContains(t, err, "too many funding outputs")
+	})
+
+	t.Run("expired flows are swept", func(t *testing.T) {
+		flows := make(fundingFlowIndex)
+		now := time.Now()
+
+		fresh := funding.PendingChanID{1}
+		expired := funding.PendingChanID{2}
+		flows[fresh] = &pendingAssetFunding{createdAt: now}
+		flows[expired] = &pendingAssetFunding{
+			createdAt: now.Add(-fundingFlowMaxAge - time.Minute),
+		}
+
+		flows.sweepExpired(now)
+		require.Contains(t, flows, fresh)
+		require.NotContains(t, flows, expired)
+	})
+}
+
+// TestFundingFlowFailureIsTerminal ensures a responder flow that failed
+// validation accepts no further messages and fails descriptor and tapscript
+// root requests loudly instead of producing empty channel state.
+func TestFundingFlowFailureIsTerminal(t *testing.T) {
+	t.Parallel()
+
+	f := NewFundingController(FundingControllerCfg{
+		ErrReporter: noopErrReporter{},
+	})
+	f.Wg.Add(1)
+	go f.chanFunder()
+	t.Cleanup(func() {
+		close(f.Quit)
+		f.Wg.Wait()
+		f.msgQueue.Stop()
+	})
+
+	ctx := context.Background()
+	peer := *test.RandPubKey(t)
+	pid := funding.PendingChanID{9}
+
+	// This message creates a responder flow and fails validation (no
+	// proof courier is configured), which must mark the flow as failed.
+	ok := f.SendMessage(ctx, msgmux.PeerMsg{
+		PeerPub: peer,
+		Message: cmsg.NewAssetFundingCreated(pid, nil),
+	})
+	require.True(t, ok)
+
+	// Message processing is asynchronous, so poll until the failure has
+	// been recorded. A funding descriptor request must then fail instead
+	// of returning a descriptor built from zero asset outputs.
+	require.Eventually(t, func() bool {
+		res := f.DescFromPendingChanID(
+			pid, lnwallet.AuxChanState{},
+			lntypes.Dual[lnwallet.CommitmentKeyRing]{}, false,
+		)
+		_, err := res.Unpack()
+
+		return err != nil &&
+			strings.Contains(err.Error(), "funding flow failed")
+	}, 3*time.Second, 10*time.Millisecond)
+
+	// The tapscript root request must fail the same way.
+	rootRes := f.DeriveTapscriptRoot(pid)
+	_, err := rootRes.Unpack()
+	require.ErrorContains(t, err, "funding flow failed")
+}
+
+// TestFundingAckHandling ensures that funding acks can never wedge the
+// funding controller's event loop: unsolicited acks create no state, acks
+// are only accepted from the bound peer on initiator flows, and duplicates
+// are rejected without blocking.
+func TestFundingAckHandling(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	f := &FundingController{}
+
+	peer := *test.RandPubKey(t)
+	otherPeer := *test.RandPubKey(t)
+
+	newAck := func(peerPub btcec.PublicKey, pid funding.PendingChanID,
+		accept bool) msgmux.PeerMsg {
+
+		return msgmux.PeerMsg{
+			PeerPub: peerPub,
+			Message: cmsg.NewAssetFundingAck(pid, accept),
+		}
+	}
+
+	t.Run("unsolicited ack creates no flow", func(t *testing.T) {
+		flows := make(fundingFlowIndex)
+		pid := funding.PendingChanID{1}
+
+		_, err := f.processFundingMsg(
+			ctx, flows, newAck(peer, pid, true),
+		)
+		require.ErrorContains(t, err, "no funding flow for ack")
+		require.NotContains(t, flows, pid)
+	})
+
+	t.Run("ack for flow we did not initiate", func(t *testing.T) {
+		flows := make(fundingFlowIndex)
+		pid := funding.PendingChanID{2}
+		flows[pid] = &pendingAssetFunding{
+			pid:            pid,
+			peerPub:        peer,
+			fundingAckChan: make(chan bool, 1),
+		}
+
+		_, err := f.processFundingMsg(
+			ctx, flows, newAck(peer, pid, true),
+		)
+		require.ErrorContains(t, err, "did not initiate")
+	})
+
+	t.Run("ack from wrong peer", func(t *testing.T) {
+		flows := make(fundingFlowIndex)
+		pid := funding.PendingChanID{3}
+		flows[pid] = &pendingAssetFunding{
+			pid:            pid,
+			peerPub:        peer,
+			initiator:      true,
+			fundingAckChan: make(chan bool, 1),
+		}
+
+		_, err := f.processFundingMsg(
+			ctx, flows, newAck(otherPeer, pid, true),
+		)
+		require.ErrorContains(t, err, "wrong peer")
+	})
+
+	t.Run("duplicate acks do not block", func(t *testing.T) {
+		flows := make(fundingFlowIndex)
+		pid := funding.PendingChanID{4}
+		flows[pid] = &pendingAssetFunding{
+			pid:            pid,
+			peerPub:        peer,
+			initiator:      true,
+			fundingAckChan: make(chan bool, 1),
+		}
+
+		_, err := f.processFundingMsg(
+			ctx, flows, newAck(peer, pid, true),
+		)
+		require.NoError(t, err)
+
+		// A second ack must be rejected instead of blocking the
+		// event loop until the buffered value is consumed.
+		_, err = f.processFundingMsg(
+			ctx, flows, newAck(peer, pid, true),
+		)
+		require.ErrorContains(t, err, "duplicate funding ack")
+
+		require.True(t, <-flows[pid].fundingAckChan)
 	})
 }
 

--- a/tapchannel/aux_funding_harness_test.go
+++ b/tapchannel/aux_funding_harness_test.go
@@ -1,0 +1,474 @@
+package tapchannel
+
+import (
+	"context"
+	"testing"
+
+	"github.com/btcsuite/btcd/blockchain"
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/btcsuite/btcd/btcutil/v2"
+	"github.com/btcsuite/btcd/txscript/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/lightninglabs/taproot-assets/asset"
+	"github.com/lightninglabs/taproot-assets/commitment"
+	"github.com/lightninglabs/taproot-assets/fn"
+	"github.com/lightninglabs/taproot-assets/internal/test"
+	"github.com/lightninglabs/taproot-assets/proof"
+	cmsg "github.com/lightninglabs/taproot-assets/tapchannelmsg"
+	"github.com/lightninglabs/taproot-assets/tapscript"
+	lfn "github.com/lightningnetwork/lnd/fn/v2"
+	"github.com/lightningnetwork/lnd/lnwallet"
+	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/stretchr/testify/require"
+)
+
+// keySpendWitness signs a BIP86 key spend of the given virtual transaction
+// input.
+func keySpendWitness(t *testing.T, privKey *btcec.PrivateKey,
+	virtualTx *wire.MsgTx, input, newAsset *asset.Asset,
+	idx uint32) wire.TxWitness {
+
+	t.Helper()
+
+	virtualTxCopy := asset.VirtualTxWithInput(
+		virtualTx, newAsset.LockTime, newAsset.RelativeLockTime, idx,
+		nil,
+	)
+	sigHash, err := tapscript.InputKeySpendSigHash(
+		virtualTxCopy, input, newAsset, idx, txscript.SigHashDefault,
+	)
+	require.NoError(t, err)
+
+	taprootPrivKey := txscript.TweakTaprootPrivKey(*privKey, nil)
+	sig, err := schnorr.Sign(taprootPrivKey, sigHash)
+	require.NoError(t, err)
+
+	return wire.TxWitness{sig.Serialize()}
+}
+
+// signOwnershipWitness creates the challenge witness of an input ownership
+// proof, mirroring what the initiator's wallet produces during funding.
+func signOwnershipWitness(t *testing.T, ownedAsset *asset.Asset,
+	key *btcec.PrivateKey) wire.TxWitness {
+
+	t.Helper()
+
+	owned := ownedAsset.Copy()
+	prevID, proofAsset := proof.CreateOwnershipProofAsset(
+		owned, fn.None[[32]byte](),
+	)
+	inputs := commitment.InputSet{prevID: owned}
+	virtualTx, _, err := tapscript.VirtualTx(proofAsset, inputs)
+	require.NoError(t, err)
+
+	return keySpendWitness(t, key, virtualTx, owned, proofAsset, 0)
+}
+
+// harnessInput describes one funding input of the harness.
+type harnessInput struct {
+	prevID    asset.PrevID
+	inputFile *proof.File
+	ownership *proof.Proof
+}
+
+// fundingHarness is a fully valid, cryptographically verifiable funding flow
+// fixture: for every asset, an ownership proof of a verifiable genesis leaf
+// carries a production shaped challenge witness and doubles as the
+// single-proof input file, and a funding proof suffix spends the input into
+// the shared funding commitment at the funding output index.
+type fundingHarness struct {
+	fundingState  *pendingAssetFunding
+	outputs       []*cmsg.AssetOutput
+	inputs        []harnessInput
+	fundingTx     *wire.MsgTx
+	fundingParams proof.BaseProofParams
+	channel       lnwallet.AuxChanState
+}
+
+// newFundingHarness builds the fixture for the given number of assets. The
+// lock time is applied to the first funding output asset. If
+// omitLastAnchorInput is set, the funding transaction does not spend the
+// last asset's input outpoint.
+func newFundingHarness(t *testing.T, numAssets int, lockTime uint64,
+	omitLastAnchorInput bool) *fundingHarness {
+
+	t.Helper()
+
+	const amt = uint64(100)
+
+	fundingState := &pendingAssetFunding{
+		inputProofFiles: make(map[asset.PrevID]*proof.File),
+	}
+
+	type stagedAsset struct {
+		genesisProof proof.Proof
+		fundingAsset *asset.Asset
+		prevID       asset.PrevID
+	}
+
+	inputs := make([]harnessInput, numAssets)
+	staged := make([]*stagedAsset, numAssets)
+	for i := range staged {
+		amtCopy := amt
+		genesisProof, senderKey := proof.RandGenesisProofWithKey(
+			t, asset.Normal, &amtCopy, nil, true, nil, nil, nil,
+			nil, asset.V0,
+		)
+
+		prevID := asset.PrevID{
+			OutPoint: genesisProof.OutPoint(),
+			ID:       genesisProof.Asset.ID(),
+			ScriptKey: asset.ToSerialized(
+				genesisProof.Asset.ScriptKey.PubKey,
+			),
+		}
+
+		// The ownership proof is the leaf's proof plus a challenge
+		// witness, exactly like the initiator sends it. Stored as a
+		// single-proof file, it becomes the input proof file the
+		// funding suffix is verified against.
+		ownership := genesisProof
+		ownership.ChallengeWitness = signOwnershipWitness(
+			t, &genesisProof.Asset, senderKey,
+		)
+		inputFile, err := proof.NewFile(proof.V0, ownership)
+		require.NoError(t, err)
+
+		// The funding output asset spends the full input into a
+		// fresh funding script key.
+		fundingKey := test.RandPrivKey()
+		fundingAsset := genesisProof.Asset.Copy()
+		fundingAsset.ScriptKey = asset.NewScriptKeyBip86(
+			test.PubToKeyDesc(fundingKey.PubKey()),
+		)
+		if i == 0 {
+			fundingAsset.LockTime = lockTime
+		}
+		fundingAsset.PrevWitnesses = []asset.Witness{{
+			PrevID: &prevID,
+		}}
+
+		vTxInputs := commitment.InputSet{
+			prevID: &genesisProof.Asset,
+		}
+		virtualTx, _, err := tapscript.VirtualTx(
+			fundingAsset, vTxInputs,
+		)
+		require.NoError(t, err)
+		fundingAsset.PrevWitnesses[0].TxWitness = keySpendWitness(
+			t, senderKey, virtualTx, &genesisProof.Asset,
+			fundingAsset, 0,
+		)
+
+		err = fundingState.addToFundingCommitment(
+			fundingAsset.Copy(), false,
+		)
+		require.NoError(t, err)
+
+		staged[i] = &stagedAsset{
+			genesisProof: genesisProof,
+			fundingAsset: fundingAsset,
+			prevID:       prevID,
+		}
+		inputs[i] = harnessInput{
+			prevID:    prevID,
+			inputFile: inputFile,
+			ownership: &ownership,
+		}
+		fundingState.inputProofFiles[prevID] = inputFile
+	}
+
+	// Build the funding transaction spending every input into the single
+	// funding output that commits to all funding assets.
+	fundingCommitment := fundingState.fundingAssetCommitment
+	internalKey := test.RandPubKey(t)
+	tapscriptRoot := fundingCommitment.TapscriptRoot(nil)
+	taprootKey := txscript.ComputeTaprootOutputKey(
+		internalKey, tapscriptRoot[:],
+	)
+
+	fundingTx := &wire.MsgTx{
+		Version: 2,
+		TxOut: []*wire.TxOut{{
+			PkScript: test.ComputeTaprootScript(t, taprootKey),
+			Value:    100_000,
+		}},
+	}
+	for i, sa := range staged {
+		if omitLastAnchorInput && i == len(staged)-1 {
+			continue
+		}
+
+		fundingTx.TxIn = append(fundingTx.TxIn, &wire.TxIn{
+			PreviousOutPoint: sa.prevID.OutPoint,
+		})
+	}
+
+	merkleTree := blockchain.BuildMerkleTreeStore(
+		[]*btcutil.Tx{btcutil.NewTx(fundingTx)}, false,
+	)
+	merkleRoot := merkleTree[len(merkleTree)-1]
+	genesisHash := staged[0].genesisProof.BlockHeader.BlockHash()
+	blockHeader := wire.NewBlockHeader(0, &genesisHash, merkleRoot, 0, 0)
+	fundingBlock := &wire.MsgBlock{
+		Header:       *blockHeader,
+		Transactions: []*wire.MsgTx{fundingTx},
+	}
+	fundingParams := proof.BaseProofParams{
+		Block:       fundingBlock,
+		BlockHeight: 2,
+		Tx:          fundingTx,
+		TxIndex:     0,
+	}
+
+	// Create the funding proof suffixes for every asset.
+	outputs := make([]*cmsg.AssetOutput, numAssets)
+	for i, sa := range staged {
+		baseParams := proof.BaseProofParams{
+			Block:            fundingBlock,
+			BlockHeight:      2,
+			Tx:               fundingTx,
+			TxIndex:          0,
+			OutputIndex:      int(FundingOutputIndex),
+			InternalKey:      internalKey,
+			TaprootAssetRoot: fundingCommitment,
+		}
+		suffix, err := proof.CreateTransitionProof(
+			sa.prevID.OutPoint, &proof.TransitionParams{
+				BaseProofParams: baseParams,
+				NewAsset:        sa.fundingAsset,
+			}, proof.WithVersion(proof.TransitionV0),
+			proof.WithNoSTXOProofs(),
+		)
+		require.NoError(t, err)
+
+		outputs[i] = cmsg.NewAssetOutput(
+			sa.fundingAsset.ID(), sa.fundingAsset.Amount, *suffix,
+		)
+	}
+
+	channel := lnwallet.AuxChanState{
+		FundingOutpoint: wire.OutPoint{
+			Hash:  fundingTx.TxHash(),
+			Index: FundingOutputIndex,
+		},
+		ShortChannelID: lnwire.ShortChannelID{BlockHeight: 2},
+		TapscriptRoot:  lfn.Some(tapscriptRoot),
+	}
+
+	return &fundingHarness{
+		fundingState:  fundingState,
+		outputs:       outputs,
+		inputs:        inputs,
+		fundingTx:     fundingTx,
+		fundingParams: fundingParams,
+		channel:       channel,
+	}
+}
+
+// TestFundingInputOwnershipProof drives the receive-time input check
+// through its full cryptographic path: the ownership proof's challenge
+// witness must prove control of the claimed leaf.
+func TestFundingInputOwnershipProof(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	t.Run("valid ownership proof", func(t *testing.T) {
+		h := newFundingHarness(t, 1, 0, false)
+		input := h.inputs[0]
+
+		// The ownership proof must verify through the challenge
+		// witness path, like in processFundingMsg.
+		_, err := input.ownership.Verify(
+			ctx, nil, proof.MockChainLookup, proof.MockVerifierCtx,
+		)
+		require.NoError(t, err)
+	})
+
+	t.Run("wrong challenge witness", func(t *testing.T) {
+		h := newFundingHarness(t, 2, 0, false)
+
+		// The witness of one input proves nothing about the leaf of
+		// the other.
+		tampered := *h.inputs[0].ownership
+		tampered.ChallengeWitness =
+			h.inputs[1].ownership.ChallengeWitness
+
+		_, err := tampered.Verify(
+			ctx, nil, proof.MockChainLookup, proof.MockVerifierCtx,
+		)
+		require.Error(t, err)
+	})
+}
+
+// TestValidateFundingProofsSuccess drives validateFundingProofs through the
+// complete successful path (suffix verification, root comparison, membership
+// and exact coverage), then mutates one property per subtest.
+func TestValidateFundingProofsSuccess(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	t.Run("valid single asset funding", func(t *testing.T) {
+		h := newFundingHarness(t, 1, 0, false)
+
+		err := validateFundingProofs(
+			ctx, proof.MockVerifierCtx, h.fundingState, h.outputs,
+		)
+		require.NoError(t, err)
+	})
+
+	t.Run("valid multi asset funding", func(t *testing.T) {
+		h := newFundingHarness(t, 2, 0, false)
+
+		err := validateFundingProofs(
+			ctx, proof.MockVerifierCtx, h.fundingState, h.outputs,
+		)
+		require.NoError(t, err)
+	})
+
+	t.Run("commitment root mismatch", func(t *testing.T) {
+		h := newFundingHarness(t, 1, 0, false)
+
+		// The responder expects a funding commitment that contains an
+		// additional asset, so the suffix commits to the wrong root.
+		err := h.fundingState.addToFundingCommitment(
+			asset.RandAsset(t, asset.Normal), false,
+		)
+		require.NoError(t, err)
+
+		err = validateFundingProofs(
+			ctx, proof.MockVerifierCtx, h.fundingState, h.outputs,
+		)
+		require.ErrorContains(t, err, "unexpected asset root")
+	})
+
+	t.Run("missing asset coverage", func(t *testing.T) {
+		h := newFundingHarness(t, 2, 0, false)
+
+		// Only one of the two committed assets has a funding proof.
+		err := validateFundingProofs(
+			ctx, proof.MockVerifierCtx, h.fundingState,
+			h.outputs[:1],
+		)
+		require.ErrorContains(t, err, "expected 2")
+	})
+
+	t.Run("different anchor transactions", func(t *testing.T) {
+		h := newFundingHarness(t, 2, 0, false)
+
+		h.outputs[1].Proof.Val.AnchorTx.LockTime = 1
+
+		err := validateFundingProofs(
+			ctx, proof.MockVerifierCtx, h.fundingState, h.outputs,
+		)
+		require.ErrorContains(t, err, "has anchor transaction")
+	})
+
+	t.Run("reused input across outputs", func(t *testing.T) {
+		h := newFundingHarness(t, 2, 0, false)
+
+		witnesses := h.outputs[1].Proof.Val.Asset.PrevWitnesses
+		witnesses[0].PrevID = &h.inputs[0].prevID
+
+		err := validateFundingProofs(
+			ctx, proof.MockVerifierCtx, h.fundingState, h.outputs,
+		)
+		require.ErrorContains(t, err, "reuses input")
+	})
+
+	t.Run("missing additional anchor input", func(t *testing.T) {
+		h := newFundingHarness(t, 2, 0, true)
+
+		err := validateFundingProofs(
+			ctx, proof.MockVerifierCtx, h.fundingState, h.outputs,
+		)
+		require.ErrorContains(t, err, "does not spend input")
+	})
+
+	t.Run("swapped input proof files", func(t *testing.T) {
+		h := newFundingHarness(t, 2, 0, false)
+
+		// Swap the two input proof files: their leaves no longer
+		// match the inputs they are keyed under.
+		files := h.fundingState.inputProofFiles
+		files[h.inputs[0].prevID] = h.inputs[1].inputFile
+		files[h.inputs[1].prevID] = h.inputs[0].inputFile
+
+		err := validateFundingProofs(
+			ctx, proof.MockVerifierCtx, h.fundingState,
+			h.outputs,
+		)
+		require.ErrorContains(t, err, "input proof mismatch")
+	})
+
+	t.Run("time locked funding output", func(t *testing.T) {
+		h := newFundingHarness(t, 1, 500, false)
+
+		// Funding outputs never legitimately carry a time lock, and
+		// no lock can be evaluated before the funding transaction
+		// confirms, so the structural pass rejects them outright.
+		err := validateFundingProofs(
+			ctx, proof.MockVerifierCtx, h.fundingState, h.outputs,
+		)
+		require.ErrorContains(t, err, "carries a time lock")
+	})
+}
+
+// TestValidateConfirmedFundingProofs exercises the confirmed-funding
+// validation performed in ChannelReady against the real funding transaction.
+func TestValidateConfirmedFundingProofs(t *testing.T) {
+	t.Parallel()
+
+	t.Run("honest funding flow", func(t *testing.T) {
+		h := newFundingHarness(t, 2, 0, false)
+
+		err := validateConfirmedFundingProofs(
+			h.channel, h.outputs, h.fundingParams,
+		)
+		require.NoError(t, err)
+	})
+
+	t.Run("doppelganger funding transaction", func(t *testing.T) {
+		h := newFundingHarness(t, 1, 0, false)
+
+		// The confirmed transaction differs from the one the peer's
+		// suffixes anchor to, even though it has the same commitment
+		// output.
+		doppelTx := h.fundingTx.Copy()
+		doppelTx.TxIn = append(doppelTx.TxIn, &wire.TxIn{
+			PreviousOutPoint: test.RandOp(t),
+		})
+		h.fundingParams.Tx = doppelTx
+		h.channel.FundingOutpoint.Hash = doppelTx.TxHash()
+
+		err := validateConfirmedFundingProofs(
+			h.channel, h.outputs, h.fundingParams,
+		)
+		require.ErrorContains(t, err, "anchors to")
+	})
+
+	t.Run("funding transaction omits claimed input", func(t *testing.T) {
+		h := newFundingHarness(t, 2, 0, true)
+
+		err := validateConfirmedFundingProofs(
+			h.channel, h.outputs, h.fundingParams,
+		)
+		require.ErrorContains(t, err, "does not spend input")
+	})
+
+	t.Run("tapscript root mismatch", func(t *testing.T) {
+		h := newFundingHarness(t, 1, 0, false)
+
+		h.channel.TapscriptRoot = lfn.Some(test.RandHash())
+
+		err := validateConfirmedFundingProofs(
+			h.channel, h.outputs, h.fundingParams,
+		)
+		require.ErrorContains(
+			t, err, "do not reproduce the channel tapscript root",
+		)
+	})
+}

--- a/tapchannelmsg/wire_msgs.go
+++ b/tapchannelmsg/wire_msgs.go
@@ -201,8 +201,10 @@ func CreateProofChunks(wholeProof proof.Proof,
 	var chunks []ProofChunk
 	for i := 0; i < proofSize; i += chunkSize {
 		// If this is the last chunk, then we'll set the last flag to
-		// true.
-		last := i+chunkSize >= proofBuf.Len()
+		// true. Note that this must compare against the total proof
+		// size: the buffer length shrinks as chunks are consumed
+		// from it below.
+		last := i+chunkSize >= proofSize
 
 		// We'll slice out the next chunk of the proof.
 		chunk := proofBuf.Next(chunkSize)

--- a/tapfreighter/chain_porter.go
+++ b/tapfreighter/chain_porter.go
@@ -1598,78 +1598,23 @@ func (p *ChainPorter) verifyOutputProofPreBroadcast(ctx context.Context,
 			"output_idx=%d)", pktIdx, outIdx)
 	}
 
-	var suffixBuf bytes.Buffer
-	err := vOut.ProofSuffix.Encode(&suffixBuf)
-	if err != nil {
-		return fmt.Errorf("unable to encode proof "+
-			"suffix (vpkt_idx=%d, "+
-			"output_idx=%d): %w", pktIdx,
-			outIdx, err)
-	}
-
-	proofSuffix := &proof.Proof{}
-	if err := proofSuffix.Decode(
-		bytes.NewReader(suffixBuf.Bytes()),
-	); err != nil {
-		return fmt.Errorf("unable to decode proof "+
-			"suffix (vpkt_idx=%d, "+
-			"output_idx=%d): %w", pktIdx,
-			outIdx, err)
-	}
-
-	for idx := 1; idx < len(inputsForAsset); idx++ {
-		additionalInputProofFile, err :=
-			p.fetchInputProof(ctx, inputsForAsset[idx])
+	inputProofFiles := make(
+		map[asset.PrevID]*proof.File, len(inputsForAsset),
+	)
+	for idx := range inputsForAsset {
+		prevID := inputsForAsset[idx]
+		inputProofFile, err := p.fetchInputProof(ctx, prevID)
 		if err != nil {
-			return fmt.Errorf("error fetching "+
-				"additional input proof %d "+
+			return fmt.Errorf("error fetching input proof %d "+
 				"(vpkt_idx=%d, "+
 				"output_idx=%d): %w", idx,
 				pktIdx, outIdx, err)
 		}
-
-		proofSuffix.AdditionalInputs = append(
-			proofSuffix.AdditionalInputs,
-			*additionalInputProofFile,
-		)
+		inputProofFiles[prevID] = inputProofFile
 	}
 
-	inputProofFile, err := p.fetchInputProof(
-		ctx, inputsForAsset[0],
-	)
-	if err != nil {
-		return fmt.Errorf("error fetching input "+
-			"proof (vpkt_idx=%d, "+
-			"output_idx=%d): %w", pktIdx,
-			outIdx, err)
-	}
-
-	if err := inputProofFile.AppendProof(
-		*proofSuffix,
-	); err != nil {
-		return fmt.Errorf("error appending "+
-			"proof suffix (vpkt_idx=%d, "+
-			"output_idx=%d): %w", pktIdx,
-			outIdx, err)
-	}
-
-	var proofFileBuf bytes.Buffer
-	err = inputProofFile.Encode(&proofFileBuf)
-	if err != nil {
-		return fmt.Errorf("error encoding proof "+
-			"file (vpkt_idx=%d, "+
-			"output_idx=%d): %w", pktIdx,
-			outIdx, err)
-	}
-
-	// We skip locktime checks on the final proof (when a locktime is set)
-	// since pre-broadcast validation has no confirmed block to evaluate
-	// against.
-	_, err = verifier.Verify(
-		ctx, bytes.NewReader(proofFileBuf.Bytes()),
-		vCtx,
-		proof.WithSkipChainVerificationForFinalProof(),
-		proof.WithSkipTimeLockValidationForFinalProof(),
+	_, err := proof.VerifyProofSuffix(
+		ctx, vOut.ProofSuffix, inputProofFiles, verifier, vCtx,
 	)
 	if err != nil {
 		return fmt.Errorf("output proof verification "+


### PR DESCRIPTION
Previously funding proof suffixes were checked for internal consistency, but the claimed transition wasn't explicitly tied to the peer's inputs. This just makes sure the check is extended appropriately.
