### PR TITLE
rfq: fix HTLC race in order policies

### DIFF
--- a/docs/release-notes/release-notes-0.8.0.md
+++ b/docs/release-notes/release-notes-0.8.0.md
@@ -242,6 +242,11 @@
   transfers until restart in the event of a silently-dropped TCP
   connection.
 
+* [PR#2239](https://github.com/lightninglabs/taproot-assets/pull/2239)
+  fixes a check-then-track race in the RFQ order policies by which
+  concurrently intercepted HTLCs could collectively exceed the agreed
+  maximum amount of an accepted quote.
+
 ## Functional Updates
 
 - [PR#1775](https://github.com/lightninglabs/taproot-assets/pull/1775)

--- a/rfq/order.go
+++ b/rfq/order.go
@@ -146,7 +146,10 @@ func computeHtlcAssetAmount(ctx context.Context, policy Policy,
 // asset sale/purchase channel HTLC is accepted or rejected.
 type Policy interface {
 	// CheckHtlcCompliance returns an error if the given HTLC intercept
-	// descriptor does not satisfy the subject policy.
+	// descriptor does not satisfy the subject policy. If the HTLC complies
+	// with the policy, it is tracked atomically as part of the check, such
+	// that concurrently checked HTLCs cannot collectively exceed the
+	// policy's agreed maximum amount.
 	CheckHtlcCompliance(ctx context.Context, htlc lndclient.InterceptedHtlc,
 		specifierChecker rfqmsg.SpecifierChecker) error
 
@@ -259,7 +262,10 @@ func NewAssetSalePolicy(quote rfqmsg.BuyAccept, noop bool,
 }
 
 // CheckHtlcCompliance returns an error if the given HTLC intercept descriptor
-// does not satisfy the subject policy.
+// does not satisfy the subject policy. If the HTLC complies with the policy,
+// it is tracked atomically as part of the check, such that concurrently
+// checked HTLCs cannot collectively exceed the policy's agreed maximum
+// amount.
 //
 // The HTLC examined by this function was likely created by a peer unaware of
 // the RFQ agreement (i.e., they are simply paying an invoice), with the SCID
@@ -269,10 +275,12 @@ func NewAssetSalePolicy(quote rfqmsg.BuyAccept, noop bool,
 func (c *AssetSalePolicy) CheckHtlcCompliance(_ context.Context,
 	htlc lndclient.InterceptedHtlc, _ rfqmsg.SpecifierChecker) error {
 
-	// Since we will be reading CurrentAmountMsat value we acquire a read
-	// lock.
-	c.stateMutex.RLock()
-	defer c.stateMutex.RUnlock()
+	// We acquire a write lock such that the compliance check and the
+	// tracking of the HTLC are executed atomically. Otherwise concurrent
+	// HTLCs could all pass the check below before any of them is tracked,
+	// exceeding the policy's agreed maximum amount.
+	c.stateMutex.Lock()
+	defer c.stateMutex.Unlock()
 
 	// Check that the channel SCID is as expected.
 	htlcScid := SerialisedScid(htlc.OutgoingChannelID.ToUint64())
@@ -323,6 +331,10 @@ func (c *AssetSalePolicy) CheckHtlcCompliance(_ context.Context,
 			c.expiry)
 	}
 
+	// The HTLC complies with the policy. Track it whilst still holding the
+	// write lock, such that the check above and the tracking are atomic.
+	c.trackAcceptedHtlc(htlc.IncomingCircuitKey, htlc.AmountOutMsat)
+
 	return nil
 }
 
@@ -333,6 +345,14 @@ func (c *AssetSalePolicy) TrackAcceptedHtlc(circuitKey models.CircuitKey,
 
 	c.stateMutex.Lock()
 	defer c.stateMutex.Unlock()
+
+	c.trackAcceptedHtlc(circuitKey, amt)
+}
+
+// trackAcceptedHtlc accounts for the newly accepted HTLC. The caller must
+// hold the policy's state mutex.
+func (c *AssetSalePolicy) trackAcceptedHtlc(circuitKey models.CircuitKey,
+	amt lnwire.MilliSatoshi) {
 
 	// If we already tracked this HTLC, we only account for the difference,
 	// as UntrackHtlc will only ever subtract the amount once.
@@ -535,15 +555,20 @@ func NewAssetPurchasePolicy(quote rfqmsg.SellAccept) *AssetPurchasePolicy {
 }
 
 // CheckHtlcCompliance returns an error if the given HTLC intercept descriptor
-// does not satisfy the subject policy.
+// does not satisfy the subject policy. If the HTLC complies with the policy,
+// it is tracked atomically as part of the check, such that concurrently
+// checked HTLCs cannot collectively exceed the policy's maximum agreed BTC
+// payment.
 func (c *AssetPurchasePolicy) CheckHtlcCompliance(ctx context.Context,
 	htlc lndclient.InterceptedHtlc,
 	specifierChecker rfqmsg.SpecifierChecker) error {
 
-	// Since we will be reading CurrentAmountMsat value we acquire a read
-	// lock.
-	c.stateMutex.RLock()
-	defer c.stateMutex.RUnlock()
+	// We acquire a write lock such that the compliance check and the
+	// tracking of the HTLC are executed atomically. Otherwise concurrent
+	// HTLCs could all pass the check below before any of them is tracked,
+	// exceeding the policy's maximum agreed BTC payment.
+	c.stateMutex.Lock()
+	defer c.stateMutex.Unlock()
 
 	// Check that the HTLC contains the accepted quote ID.
 	htlcRecord, err := parseHtlcCustomRecords(htlc.InWireCustomRecords)
@@ -616,6 +641,10 @@ func (c *AssetPurchasePolicy) CheckHtlcCompliance(ctx context.Context,
 			c.expiry)
 	}
 
+	// The HTLC complies with the policy. Track it whilst still holding the
+	// write lock, such that the check above and the tracking are atomic.
+	c.trackAcceptedHtlc(htlc.IncomingCircuitKey, htlc.AmountOutMsat)
+
 	return nil
 }
 
@@ -626,6 +655,14 @@ func (c *AssetPurchasePolicy) TrackAcceptedHtlc(circuitKey models.CircuitKey,
 
 	c.stateMutex.Lock()
 	defer c.stateMutex.Unlock()
+
+	c.trackAcceptedHtlc(circuitKey, amt)
+}
+
+// trackAcceptedHtlc accounts for the newly accepted HTLC. The caller must
+// hold the policy's state mutex.
+func (c *AssetPurchasePolicy) trackAcceptedHtlc(circuitKey models.CircuitKey,
+	amt lnwire.MilliSatoshi) {
 
 	// If we already tracked this HTLC, we only account for the difference,
 	// as UntrackHtlc will only ever subtract the amount once.
@@ -759,7 +796,8 @@ func NewAssetForwardPolicy(incoming, outgoing Policy) (*AssetForwardPolicy,
 }
 
 // CheckHtlcCompliance returns an error if the given HTLC intercept descriptor
-// does not satisfy the subject policy.
+// does not satisfy the subject policy. If the HTLC complies with the policy,
+// it is tracked atomically as part of the check.
 func (a *AssetForwardPolicy) CheckHtlcCompliance(ctx context.Context,
 	htlc lndclient.InterceptedHtlc, sChk rfqmsg.SpecifierChecker) error {
 
@@ -773,6 +811,10 @@ func (a *AssetForwardPolicy) CheckHtlcCompliance(ctx context.Context,
 	if err := a.outgoingPolicy.CheckHtlcCompliance(
 		ctx, htlc, sChk,
 	); err != nil {
+		// The incoming policy has already tracked the HTLC. Roll back
+		// that tracking, as the HTLC will be rejected.
+		a.incomingPolicy.UntrackHtlc(htlc.IncomingCircuitKey)
+
 		return fmt.Errorf("error checking forward policy, outbound "+
 			"HTLC does not comply with policy: %w", err)
 	}
@@ -1120,7 +1162,9 @@ func (h *OrderHandler) resolveIncomingHtlc(ctx context.Context,
 
 	// At this point, we know that a policy exists and has not expired
 	// whilst sitting in the local cache. We can now check that the HTLC
-	// complies with the policy.
+	// complies with the policy. The compliance check atomically tracks the
+	// HTLC if it complies, such that concurrently handled HTLCs cannot
+	// collectively exceed the policy's agreed maximum amount.
 	err = policy.CheckHtlcCompliance(ctx, htlc, h.cfg.SpecifierChecker)
 	if err != nil {
 		log.Warnf("HTLC does not comply with policy: %v "+
@@ -1132,10 +1176,6 @@ func (h *OrderHandler) resolveIncomingHtlc(ctx context.Context,
 	}
 
 	h.htlcToPolicy.Store(htlc.IncomingCircuitKey, policy)
-
-	// The HTLC passed the compliance checks, so now we keep track of the
-	// accepted HTLC.
-	policy.TrackAcceptedHtlc(htlc.IncomingCircuitKey, htlc.AmountOutMsat)
 
 	// Log the forwarding event when the HTLC is accepted. We store the
 	// circuit key

--- a/rfq/order_test.go
+++ b/rfq/order_test.go
@@ -1,6 +1,9 @@
 package rfq
 
 import (
+	"context"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -222,4 +225,192 @@ func TestPolicyAccountingIdempotent(t *testing.T) {
 		p.UntrackHtlc(circuitKey)
 		require.Zero(t, p.CurrentAmountMsat)
 	})
+}
+
+// TestAssetSalePolicyConcurrentHtlcCap tests that concurrently accepted
+// HTLCs referencing the same asset sale policy never exceed the policy's
+// agreed maximum amount, even though the HTLC interceptor invokes the
+// handler in a new goroutine per HTLC.
+func TestAssetSalePolicyConcurrentHtlcCap(t *testing.T) {
+	t.Parallel()
+
+	spec := asset.NewSpecifierFromId(asset.ID{0x01})
+	peer := route.Vertex{0x0A}
+	rate := rfqmsg.NewAssetRate(
+		rfqmath.NewBigIntFixedPoint(100, 0),
+		time.Now().Add(time.Hour),
+	)
+
+	buyReq := &rfqmsg.BuyRequest{
+		Peer:           peer,
+		AssetSpecifier: spec,
+		AssetMaxAmt:    1000,
+	}
+	accept := rfqmsg.BuyAccept{
+		Peer:      peer,
+		Request:   *buyReq,
+		AssetRate: rate,
+	}
+	policy := NewAssetSalePolicy(accept, false, nil)
+
+	// Compute the policy's maximum outgoing amount in millisatoshis. A
+	// single HTLC of this size exactly exhausts the policy.
+	maxAssetAmount := rfqmath.NewBigIntFixedPoint(
+		policy.MaxOutboundAssetAmount, 0,
+	)
+	capMsat, err := rfqmath.UnitsToMilliSatoshi(
+		maxAssetAmount, policy.AskAssetRate,
+	)
+	require.NoError(t, err)
+
+	// Fire many concurrent HTLCs at the policy, mimicking the HTLC
+	// interceptor invoking the handler in a new goroutine per HTLC. Each
+	// HTLC carries the full cap amount, so exactly one HTLC's worth can be
+	// accepted.
+	const numHtlcs = 32
+
+	var (
+		wg       sync.WaitGroup
+		accepted atomic.Int32
+	)
+	start := make(chan struct{})
+
+	for i := 0; i < numHtlcs; i++ {
+		wg.Add(1)
+
+		go func(i int) {
+			defer wg.Done()
+			<-start
+
+			htlc := lndclient.InterceptedHtlc{
+				IncomingCircuitKey: models.CircuitKey{
+					ChanID: lnwire.NewShortChanIDFromInt(1),
+					HtlcID: uint64(i),
+				},
+				OutgoingChannelID: lnwire.NewShortChanIDFromInt(
+					uint64(policy.AcceptedQuoteId.Scid()),
+				),
+				AmountOutMsat: capMsat,
+			}
+
+			// A compliant HTLC is tracked by the policy
+			// atomically as part of the compliance check.
+			err := policy.CheckHtlcCompliance(
+				context.Background(), htlc, nil,
+			)
+			if err != nil {
+				return
+			}
+
+			accepted.Add(1)
+		}(i)
+	}
+
+	close(start)
+	wg.Wait()
+
+	// Exactly one HTLC's worth must have been accepted: the tracked total
+	// equals the agreed maximum exactly. A check-then-track race would let
+	// multiple HTLCs through and exceed the cap, while a policy that never
+	// tracks accepted HTLCs would leave the total at zero.
+	require.EqualValues(t, 1, accepted.Load())
+	require.Equal(t, capMsat, policy.CurrentAmountMsat)
+}
+
+// TestAssetPurchasePolicyConcurrentHtlcCap tests that concurrently accepted
+// HTLCs referencing the same asset purchase policy never exceed the policy's
+// maximum agreed BTC payment, even though the HTLC interceptor invokes the
+// handler in a new goroutine per HTLC.
+func TestAssetPurchasePolicyConcurrentHtlcCap(t *testing.T) {
+	t.Parallel()
+
+	spec := asset.NewSpecifierFromId(asset.ID{0x01})
+	peer := route.Vertex{0x0A}
+	rate := rfqmsg.NewAssetRate(
+		rfqmath.NewBigIntFixedPoint(100, 0),
+		time.Now().Add(time.Hour),
+	)
+
+	sellReq := &rfqmsg.SellRequest{
+		Peer:           peer,
+		AssetSpecifier: spec,
+		PaymentMaxAmt:  1000,
+	}
+	accept := rfqmsg.SellAccept{
+		Peer:      peer,
+		Request:   *sellReq,
+		AssetRate: rate,
+	}
+	policy := NewAssetPurchasePolicy(accept)
+
+	// Build the HTLC custom records once. Every HTLC carries an asset
+	// balance large enough to cover the outgoing msat amount.
+	htlcRecord := rfqmsg.NewHtlc(
+		[]*rfqmsg.AssetBalance{
+			rfqmsg.NewAssetBalance(asset.ID{0x01}, 1),
+		},
+		fn.Some(policy.AcceptedQuoteId),
+		fn.None[[]rfqmsg.ID](),
+	)
+	customRecords, err := lnwire.ParseCustomRecords(htlcRecord.Bytes())
+	require.NoError(t, err)
+
+	specifierChecker := rfqmsg.SpecifierChecker(
+		func(_ context.Context, _ asset.Specifier,
+			_ asset.ID) (bool, error) {
+
+			return true, nil
+		},
+	)
+
+	// Fire many concurrent HTLCs at the policy, mimicking the HTLC
+	// interceptor invoking the handler in a new goroutine per HTLC. Each
+	// HTLC carries the full maximum payment amount, so exactly one HTLC's
+	// worth can be accepted.
+	const numHtlcs = 32
+
+	var (
+		wg       sync.WaitGroup
+		accepted atomic.Int32
+	)
+	start := make(chan struct{})
+
+	for i := 0; i < numHtlcs; i++ {
+		wg.Add(1)
+
+		go func(i int) {
+			defer wg.Done()
+			<-start
+
+			htlc := lndclient.InterceptedHtlc{
+				IncomingCircuitKey: models.CircuitKey{
+					ChanID: lnwire.NewShortChanIDFromInt(1),
+					HtlcID: uint64(i),
+				},
+				AmountOutMsat:       policy.PaymentMaxAmt,
+				InWireCustomRecords: customRecords,
+			}
+
+			// A compliant HTLC is tracked by the policy
+			// atomically as part of the compliance check.
+			err := policy.CheckHtlcCompliance(
+				context.Background(), htlc, specifierChecker,
+			)
+			if err != nil {
+				return
+			}
+
+			accepted.Add(1)
+		}(i)
+	}
+
+	close(start)
+	wg.Wait()
+
+	// Exactly one HTLC's worth must have been accepted: the tracked total
+	// equals the maximum agreed payment exactly. A check-then-track race
+	// would let multiple HTLCs through and exceed the cap, while a policy
+	// that never tracks accepted HTLCs would leave the total at zero.
+	require.EqualValues(t, 1, accepted.Load())
+	require.Equal(t, policy.PaymentMaxAmt, policy.CurrentAmountMsat)
 }


### PR DESCRIPTION
### Description

`CheckHtlcCompliance` checked the agreed payment ceiling under RLock while `TrackAcceptedHtlc` incremented under a separate lock. A burst of concurrent HTLCs could lead to a race where the write/read values are not in sync.
