### PR TITLE
tapchannel: fix cooperative close for merged funding outputs

### DIFF
--- a/docs/release-notes/release-notes-0.8.2.md
+++ b/docs/release-notes/release-notes-0.8.2.md
@@ -21,6 +21,14 @@
 
 # Bug Fixes
 
+- [PR#2246](https://github.com/lightninglabs/taproot-assets/pull/2246)
+  fixes a bug in which a cooperative close never finalized for a channel
+  whose funding output merged several asset UTXOs. Only the first input
+  proof was fetched when the funding output was imported, leaving the
+  virtual transaction impossible to reconstruct, so the channel stayed
+  in `waiting_close` and the peer's assets were not swept. Every input
+  proof is now fetched and verified.
+
 # New Features
 
 ## Functional Enhancements

--- a/itest/custom_channels/single_asset_multi_input_test.go
+++ b/itest/custom_channels/single_asset_multi_input_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/lightninglabs/taproot-assets/taprpc"
 	"github.com/lightninglabs/taproot-assets/taprpc/mintrpc"
 	tchrpc "github.com/lightninglabs/taproot-assets/taprpc/tapchannelrpc"
+	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/lightningnetwork/lnd/lntest/node"
 	"github.com/lightningnetwork/lnd/lntest/port"
 	"github.com/stretchr/testify/require"
@@ -140,4 +141,25 @@ func testCustomChannelsSingleAssetMultiInput(ctx context.Context,
 		t.t, charlie, dave, 2*halfCentsAmount,
 		[]*taprpc.Asset{cents},
 	)
+
+	// Cooperatively close the multi-input channel. The non-initiator must
+	// fetch both funding input proof files to verify and import the merged
+	// funding output before it can finalize the close.
+	chanPoint := &lnrpc.ChannelPoint{
+		OutputIndex: uint32(fundRespCD.OutputIndex),
+		FundingTxid: &lnrpc.ChannelPoint_FundingTxidStr{
+			FundingTxidStr: fundRespCD.Txid,
+		},
+	}
+	closeAssetChannelAndAssert(
+		t, net, dave, charlie, chanPoint, [][]byte{assetID}, nil,
+		charlie, assertDefaultCoOpCloseBalance(false, false),
+	)
+
+	assertBalance(
+		t.t, dave, cents.Amount, itest.WithAssetID(assetID),
+		itest.WithNumUtxos(1),
+		itest.WithScriptKeyType(asset.ScriptKeyBip86),
+	)
+	assertBalance(t.t, charlie, 0, itest.WithAssetID(assetID))
 }

--- a/tapchannel/aux_funding_controller.go
+++ b/tapchannel/aux_funding_controller.go
@@ -452,7 +452,7 @@ func (f *FundingController) Start() error {
 
 // Stop stops the funding controller.
 func (f *FundingController) Stop() error {
-	if !f.stopped.CompareAndSwap(true, false) {
+	if !f.stopped.CompareAndSwap(false, true) {
 		return nil
 	}
 

--- a/tapchannel/aux_funding_controller_test.go
+++ b/tapchannel/aux_funding_controller_test.go
@@ -782,3 +782,26 @@ func TestValidateLocalProofCourier(t *testing.T) {
 		})
 	}
 }
+
+// TestFundingControllerStop ensures that stopping the funding controller
+// closes its quit channel and reaps the event loop.
+func TestFundingControllerStop(t *testing.T) {
+	t.Parallel()
+
+	f := NewFundingController(FundingControllerCfg{
+		ErrReporter: noopErrReporter{},
+	})
+	f.Wg.Add(1)
+	go f.chanFunder()
+
+	require.NoError(t, f.Stop())
+
+	select {
+	case <-f.Quit:
+	default:
+		t.Fatal("quit channel still open after Stop")
+	}
+
+	// A second stop must be a no-op instead of a double close.
+	require.NoError(t, f.Stop())
+}

--- a/tapchannel/aux_sweeper.go
+++ b/tapchannel/aux_sweeper.go
@@ -185,7 +185,7 @@ func (a *AuxSweeper) Start() error {
 
 // Stop stops the AuxSweeper.
 func (a *AuxSweeper) Stop() error {
-	if !a.stopped.CompareAndSwap(true, false) {
+	if !a.stopped.CompareAndSwap(false, true) {
 		return nil
 	}
 

--- a/tapchannel/aux_sweeper.go
+++ b/tapchannel/aux_sweeper.go
@@ -1455,6 +1455,168 @@ func (a *AuxSweeper) importOutputScriptKeys(desc tapscriptSweepDescs) error {
 	)
 }
 
+// fetchInputProofFiles fetches and validates the proof file for every input
+// spent by an output proof. The first returned file is the output asset's
+// direct lineage; the remaining files prove the merge's additional inputs.
+func fetchInputProofFiles(ctx context.Context, outputProof *proof.Proof,
+	courierAddr *url.URL,
+	proofDispatch proof.CourierDispatch) ([]proof.File, error) {
+
+	if outputProof == nil {
+		return nil, fmt.Errorf("output proof is nil")
+	}
+	if len(outputProof.AdditionalInputs) != 0 {
+		return nil, fmt.Errorf("output proof carries additional inputs")
+	}
+
+	prevWitnesses := outputProof.Asset.Witnesses()
+	if len(prevWitnesses) == 0 {
+		return nil, fmt.Errorf("asset missing previous witnesses")
+	}
+	if len(prevWitnesses) > maxFundingInputProofs {
+		return nil, fmt.Errorf(
+			"too many funding input witnesses, got %d, max is %d",
+			len(prevWitnesses), maxFundingInputProofs,
+		)
+	}
+
+	type inputProofRequest struct {
+		prevID    asset.PrevID
+		recipient proof.Recipient
+		locator   proof.Locator
+	}
+
+	requests := make([]inputProofRequest, len(prevWitnesses))
+	seenInputs := make(map[asset.PrevID]struct{}, len(prevWitnesses))
+	for idx := range prevWitnesses {
+		proofPrevID := prevWitnesses[idx].PrevID
+		if proofPrevID == nil {
+			return nil, fmt.Errorf(
+				"funding input witness %d has no "+
+					"previous ID", idx,
+			)
+		}
+		if _, ok := seenInputs[*proofPrevID]; ok {
+			return nil, fmt.Errorf("duplicate funding input %v",
+				*proofPrevID)
+		}
+		seenInputs[*proofPrevID] = struct{}{}
+
+		if idx == 0 && outputProof.PrevOut != proofPrevID.OutPoint {
+			return nil, fmt.Errorf(
+				"output proof previous outpoint %v does "+
+					"not match primary input %v",
+				outputProof.PrevOut,
+				proofPrevID.OutPoint,
+			)
+		}
+		spendsInput := proof.TxSpendsPrevOut(
+			&outputProof.AnchorTx, &proofPrevID.OutPoint,
+		)
+		if !spendsInput {
+			return nil, fmt.Errorf(
+				"funding transaction does not spend input %v",
+				*proofPrevID,
+			)
+		}
+
+		scriptKey, err := proofPrevID.ScriptKey.ToPubKey()
+		if err != nil {
+			return nil, fmt.Errorf(
+				"unable to convert input %d script key "+
+					"to pubkey: %w",
+				idx, err,
+			)
+		}
+
+		inputProofLocator := proof.Locator{
+			AssetID:   &proofPrevID.ID,
+			ScriptKey: *scriptKey,
+			OutPoint:  &proofPrevID.OutPoint,
+		}
+		if outputProof.Asset.GroupKey != nil {
+			groupKey := outputProof.Asset.GroupKey.GroupPubKey
+			inputProofLocator.GroupKey = &groupKey
+		}
+
+		requests[idx] = inputProofRequest{
+			prevID: *proofPrevID,
+			recipient: proof.Recipient{
+				ScriptKey: scriptKey,
+				AssetID:   proofPrevID.ID,
+
+				// PrevID has no amount. This field is only for
+				// logging, so use the output amount.
+				Amount: outputProof.Asset.Amount,
+			},
+			locator: inputProofLocator,
+		}
+	}
+
+	proofFetcher, err := proofDispatch.NewCourier(ctx, courierAddr, true)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"unable to create proof courier: %w", err,
+		)
+	}
+	defer func() {
+		_ = proofFetcher.Close()
+	}()
+
+	inputProofFiles := make([]proof.File, len(requests))
+	for idx := range requests {
+		request := &requests[idx]
+		log.Infof(
+			"Fetching funding input proof %d of %d, locator=%v",
+			idx+1, len(requests),
+			limitSpewer.Sdump(request.locator),
+		)
+
+		inputProof, err := proofFetcher.ReceiveProof(
+			ctx, request.recipient, request.locator,
+		)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"unable to fetch input proof %d (%v): %w", idx,
+				request.prevID, err,
+			)
+		}
+
+		err = inputProofFiles[idx].Decode(
+			bytes.NewReader(inputProof.Blob),
+		)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"unable to decode input proof %d (%v): %w", idx,
+				request.prevID, err,
+			)
+		}
+
+		lastProof, err := inputProofFiles[idx].LastProof()
+		if err != nil {
+			return nil, fmt.Errorf(
+				"unable to read input proof %d (%v): %w", idx,
+				request.prevID, err,
+			)
+		}
+		actualPrevID := asset.PrevID{
+			OutPoint: lastProof.OutPoint(),
+			ID:       lastProof.Asset.ID(),
+			ScriptKey: asset.ToSerialized(
+				lastProof.Asset.ScriptKey.PubKey,
+			),
+		}
+		if actualPrevID != request.prevID {
+			return nil, fmt.Errorf(
+				"input proof mismatch: expected %v, got %v",
+				request.prevID, actualPrevID,
+			)
+		}
+	}
+
+	return inputProofFiles, nil
+}
+
 // importOutputProofs imports the output proofs into the pending asset funding
 // into our local database. This preps us to be able to detect force closes.
 func importOutputProofs(ctx context.Context, scid lnwire.ShortChannelID,
@@ -1464,14 +1626,50 @@ func importOutputProofs(ctx context.Context, scid lnwire.ShortChannelID,
 
 	// TODO(roasbeef): should be part of post confirmation funding validate
 	// (chanvalidate)
+	if len(outputProofs) == 0 {
+		return fmt.Errorf("funding output proofs are missing")
+	}
 
+	seenInputs := make(map[asset.PrevID]struct{})
+	totalInputs := 0
+	for outputIdx, outputProof := range outputProofs {
+		if outputProof == nil {
+			return fmt.Errorf(
+				"funding output proof %d is nil", outputIdx,
+			)
+		}
+		if outputProof.Asset.ScriptKey.PubKey == nil {
+			return fmt.Errorf(
+				"funding output proof %d has no "+
+					"script key", outputIdx,
+			)
+		}
+
+		witnesses := outputProof.Asset.Witnesses()
+		if len(witnesses) > maxFundingInputProofs-totalInputs {
+			return fmt.Errorf("too many funding inputs, max is %d",
+				maxFundingInputProofs)
+		}
+		totalInputs += len(witnesses)
+
+		for _, witness := range witnesses {
+			if witness.PrevID == nil {
+				continue
+			}
+			if _, ok := seenInputs[*witness.PrevID]; ok {
+				return fmt.Errorf(
+					"funding output proof %d reuses "+
+						"input %v",
+					outputIdx, *witness.PrevID,
+				)
+			}
+			seenInputs[*witness.PrevID] = struct{}{}
+		}
+	}
 	log.Infof("Importing %v proofs for ChannelPoint(%v)",
 		len(outputProofs), outputProofs[0].OutPoint())
 
-	// With the fetcher created, we'll have it fetch each of the proofs for
-	// the funding outputs we need.
-	//
-	// TODO(roasbeef): assume single asset for now, also additional inputs
+	// Fetch and import the proof for each funding output.
 	for _, proofToImport := range outputProofs {
 		// Check if the proof is already imported to avoid redundant
 		// work.
@@ -1491,66 +1689,12 @@ func importOutputProofs(ctx context.Context, scid lnwire.ShortChannelID,
 			continue
 		}
 
-		proofPrevID, err := proofToImport.Asset.PrimaryPrevID()
-		if err != nil {
-			return fmt.Errorf("unable to get primary prev "+
-				"ID: %w", err)
-		}
-
-		scriptKey, err := proofPrevID.ScriptKey.ToPubKey()
-		if err != nil {
-			return fmt.Errorf("unable to convert script key to "+
-				"pubkey: %w", err)
-		}
-
-		inputProofLocator := proof.Locator{
-			AssetID:   &proofPrevID.ID,
-			ScriptKey: *scriptKey,
-			OutPoint:  &proofPrevID.OutPoint,
-		}
-		if proofToImport.Asset.GroupKey != nil {
-			groupKey := proofToImport.Asset.GroupKey.GroupPubKey
-			inputProofLocator.GroupKey = &groupKey
-		}
-
-		log.Infof("Fetching funding input proof, locator=%v",
-			limitSpewer.Sdump(inputProofLocator))
-
-		// First, we'll make a courier to use in fetching the proofs we
-		// need.
-		proofFetcher, err := proofDispatch.NewCourier(
-			ctx, courierAddr, true,
-		)
-		if err != nil {
-			return fmt.Errorf("unable to create proof courier: %w",
-				err)
-		}
-
-		recipient := proof.Recipient{
-			ScriptKey: scriptKey,
-			AssetID:   proofPrevID.ID,
-			Amount:    proofToImport.Asset.Amount,
-		}
-		prefixProof, err := proofFetcher.ReceiveProof(
-			ctx, recipient, inputProofLocator,
-		)
-
-		// Always attempt to close the courier, even if we encounter an
-		// error.
-		_ = proofFetcher.Close()
-
-		// Handle any error that occurred during the proof fetch.
-		if err != nil {
-			return fmt.Errorf("unable to fetch prefix "+
-				"proof: %w", err)
-		}
-
-		log.Infof("All proofs fetched, importing locator=%v",
-			limitSpewer.Sdump(inputProofLocator))
-
-		// Before we combine the proofs below, we'll be sure to update
-		// the transition proof to include the proper block+merkle proof
-		// information.
+		// Before we fetch or combine any proofs below, we'll be sure to
+		// update the transition proof to include the proper
+		// block+merkle proof information. This also replaces the
+		// peer-supplied anchor transaction with the confirmed one, so
+		// that the input validation done while fetching is bound to the
+		// funding transaction that actually made it into the chain.
 		err = updateProofsFromShortChanID(
 			ctx, chainBridge, scid, []*proof.Proof{proofToImport},
 		)
@@ -1559,16 +1703,42 @@ func importOutputProofs(ctx context.Context, scid lnwire.ShortChannelID,
 				"proof: %w", err)
 		}
 
-		// Now that we have the entire prefix proof, we'll append the
-		// New funding output, then import it into our archive.
-		//
-		// TODO(roasbeef): way to do this w/o decoding again?
-		var proofFile proof.File
-		err = proofFile.Decode(bytes.NewReader(prefixProof.Blob))
+		inputProofFiles, err := fetchInputProofFiles(
+			ctx, proofToImport, courierAddr, proofDispatch,
+		)
 		if err != nil {
-			return fmt.Errorf("unable to decode proof: %w", err)
+			return fmt.Errorf(
+				"unable to fetch funding input proofs: %w", err,
+			)
 		}
-		if err := proofFile.AppendProof(*proofToImport); err != nil {
+
+		log.Infof("All %d input proofs fetched, importing locator=%v",
+			len(inputProofFiles), limitSpewer.Sdump(fundingLocator))
+
+		// The first input remains the direct proof-file lineage.
+		// Embed the remaining input proof files in the transition proof
+		// so the VM can verify the full virtual transaction.
+		proofWithInputs := *proofToImport
+		proofWithInputs.AdditionalInputs = slices.Clone(
+			inputProofFiles[1:],
+		)
+
+		proofBytes, err := proofWithInputs.Bytes()
+		if err != nil {
+			return fmt.Errorf(
+				"unable to encode output proof: %w", err,
+			)
+		}
+		if len(proofBytes) > proof.FileMaxProofSizeBytes {
+			return fmt.Errorf(
+				"output proof is too large: %d bytes, "+
+					"max is %d",
+				len(proofBytes), proof.FileMaxProofSizeBytes,
+			)
+		}
+
+		proofFile := &inputProofFiles[0]
+		if err := proofFile.AppendProofRaw(proofBytes); err != nil {
 			return fmt.Errorf("unable to append proof: %w", err)
 		}
 

--- a/tapchannel/aux_sweeper.go
+++ b/tapchannel/aux_sweeper.go
@@ -30,6 +30,7 @@ import (
 	"github.com/lightningnetwork/lnd/input"
 	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/lightningnetwork/lnd/lntypes"
+	"github.com/lightningnetwork/lnd/lnutils"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/sweep"
@@ -1925,8 +1926,10 @@ func (a *AuxSweeper) importCommitTx(req lnwallet.ResolutionReq,
 		ChainLookupGen: a.cfg.ChainBridge,
 		IgnoreChecker:  a.cfg.IgnoreChecker,
 	}
+	proofCtx, cancel := lnutils.ContextFromQuit(a.quit)
+	defer cancel()
 	err = importOutputProofs(
-		ctxb, req.ShortChanID, maps.Values(fundingInputProofs),
+		proofCtx, req.ShortChanID, maps.Values(fundingInputProofs),
 		a.cfg.DefaultCourierAddr, a.cfg.ProofFetcher,
 		a.cfg.ChainBridge, vCtx, a.cfg.ProofArchive,
 	)
@@ -1936,7 +1939,7 @@ func (a *AuxSweeper) importCommitTx(req lnwallet.ResolutionReq,
 	}
 
 	err = updateProofsFromShortChanID(
-		ctxb, a.cfg.ChainBridge, req.ShortChanID,
+		proofCtx, a.cfg.ChainBridge, req.ShortChanID,
 		maps.Values(fundingInputProofs),
 	)
 	if err != nil {

--- a/tapchannel/aux_sweeper_test.go
+++ b/tapchannel/aux_sweeper_test.go
@@ -1,0 +1,327 @@
+package tapchannel
+
+import (
+	"bytes"
+	"context"
+	"net/url"
+	"testing"
+
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/lightninglabs/taproot-assets/asset"
+	"github.com/lightninglabs/taproot-assets/internal/test"
+	"github.com/lightninglabs/taproot-assets/proof"
+	"github.com/lightninglabs/taproot-assets/tapnode"
+	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/stretchr/testify/require"
+)
+
+// importProofChainBridge returns the block containing the funding transaction.
+// The embedded interface supplies the methods importOutputProofs doesn't use.
+type importProofChainBridge struct {
+	tapnode.ChainBridge
+
+	block *wire.MsgBlock
+}
+
+func (b *importProofChainBridge) GetBlockByHeight(context.Context,
+	int64) (*wire.MsgBlock, error) {
+
+	return b.block, nil
+}
+
+// recordingProofCourier records the locators requested from its underlying
+// courier.
+type recordingProofCourier struct {
+	proof.Courier
+
+	received []proof.Locator
+}
+
+func (c *recordingProofCourier) ReceiveProof(ctx context.Context,
+	recipient proof.Recipient,
+	locator proof.Locator) (*proof.AnnotatedProof, error) {
+
+	c.received = append(c.received, locator)
+	return c.Courier.ReceiveProof(ctx, recipient, locator)
+}
+
+// fetchInputTestProof returns an output proof with one structurally valid
+// input reference. Tests can mutate it to exercise preflight validation.
+func fetchInputTestProof(t *testing.T) (proof.Proof, asset.PrevID) {
+	t.Helper()
+
+	outputProof := randFundingProof(t)
+	prevID := asset.PrevID{
+		OutPoint: test.RandOp(t),
+		ID:       outputProof.Asset.ID(),
+		ScriptKey: asset.ToSerialized(
+			outputProof.Asset.ScriptKey.PubKey,
+		),
+	}
+	outputProof.Asset.PrevWitnesses = []asset.Witness{{PrevID: &prevID}}
+	outputProof.PrevOut = prevID.OutPoint
+	outputProof.AdditionalInputs = nil
+	outputProof.AnchorTx.TxIn = []*wire.TxIn{{
+		PreviousOutPoint: prevID.OutPoint,
+	}}
+
+	return outputProof, prevID
+}
+
+// TestImportOutputProofsMerge is an assembly-level test that ensures a funding
+// output merging multiple inputs fetches and embeds every input proof. The
+// single-asset multi-input itest covers verification and cooperative close.
+func TestImportOutputProofsMerge(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	genesis := asset.RandGenesis(t, asset.Normal)
+
+	inputTx := wire.NewMsgTx(2)
+	inputTx.AddTxIn(&wire.TxIn{})
+	inputTx.AddTxOut(&wire.TxOut{Value: 1_000})
+	inputTx.AddTxOut(&wire.TxOut{Value: 1_000})
+	inputBlock := wire.MsgBlock{
+		Transactions: []*wire.MsgTx{inputTx},
+	}
+
+	inputProofs := []proof.Proof{
+		proof.RandProof(
+			t, genesis, test.RandPubKey(t), inputBlock, 0, 0,
+		),
+		proof.RandProof(
+			t, genesis, test.RandPubKey(t), inputBlock, 0, 1,
+		),
+	}
+	prevIDs := make([]asset.PrevID, len(inputProofs))
+	inputProofs[1].Asset.GroupKey = inputProofs[0].Asset.GroupKey
+	for idx := range inputProofs {
+		prevIDs[idx] = asset.PrevID{
+			OutPoint: inputProofs[idx].OutPoint(),
+			ID:       inputProofs[idx].Asset.ID(),
+			ScriptKey: asset.ToSerialized(
+				inputProofs[idx].Asset.ScriptKey.PubKey,
+			),
+		}
+	}
+
+	mergedAsset := inputProofs[0].Asset.Copy()
+	mergedAsset.Amount = inputProofs[0].Asset.Amount +
+		inputProofs[1].Asset.Amount
+	mergedAsset.ScriptKey = asset.NewScriptKey(test.RandPubKey(t))
+	mergedAsset.PrevWitnesses = []asset.Witness{
+		{PrevID: &prevIDs[0]},
+		{PrevID: &prevIDs[1]},
+	}
+
+	outputProof := randFundingProof(t)
+	outputProof.Asset = *mergedAsset
+	outputProof.PrevOut = prevIDs[0].OutPoint
+	outputProof.ChallengeWitness = nil
+	outputProof.AnchorTx.TxIn = []*wire.TxIn{
+		{PreviousOutPoint: prevIDs[0].OutPoint},
+		{PreviousOutPoint: prevIDs[1].OutPoint},
+	}
+
+	fundingBlock := &wire.MsgBlock{
+		Header:       outputProof.BlockHeader,
+		Transactions: []*wire.MsgTx{&outputProof.AnchorTx},
+	}
+	chainBridge := &importProofChainBridge{block: fundingBlock}
+
+	courier := proof.NewMockProofCourier()
+	for idx := range inputProofs {
+		inputFile, err := proof.NewFile(proof.V0, inputProofs[idx])
+		require.NoError(t, err)
+
+		var inputFileBuf bytes.Buffer
+		require.NoError(t, inputFile.Encode(&inputFileBuf))
+
+		scriptKey := inputProofs[idx].Asset.ScriptKey.PubKey
+		err = courier.DeliverProof(
+			ctx, proof.Recipient{}, &proof.AnnotatedProof{
+				Locator: proof.Locator{
+					AssetID:   &prevIDs[idx].ID,
+					ScriptKey: *scriptKey,
+					OutPoint:  &prevIDs[idx].OutPoint,
+				},
+				Blob:          inputFileBuf.Bytes(),
+				AssetSnapshot: &proof.AssetSnapshot{},
+			}, nil,
+		)
+		require.NoError(t, err)
+	}
+
+	archive := proof.NewMockProofArchive()
+	recordingCourier := &recordingProofCourier{Courier: courier}
+	dispatch := &proof.MockProofCourierDispatcher{
+		Courier: recordingCourier,
+	}
+	err := importOutputProofs(
+		ctx, lnwire.ShortChannelID{}, []*proof.Proof{&outputProof},
+		&url.URL{}, dispatch, chainBridge, proof.MockVerifierCtx,
+		archive,
+	)
+	require.NoError(t, err)
+	require.Len(t, recordingCourier.received, len(inputProofs))
+	for _, locator := range recordingCourier.received {
+		require.NotNil(t, locator.GroupKey)
+		require.True(
+			t, locator.GroupKey.IsEqual(
+				&mergedAsset.GroupKey.GroupPubKey,
+			),
+		)
+	}
+
+	outputOutPoint := outputProof.OutPoint()
+	importedBlob, err := archive.FetchProof(ctx, proof.Locator{
+		AssetID:   &prevIDs[0].ID,
+		ScriptKey: *mergedAsset.ScriptKey.PubKey,
+		OutPoint:  &outputOutPoint,
+	})
+	require.NoError(t, err)
+
+	var importedFile proof.File
+	require.NoError(t, importedFile.Decode(bytes.NewReader(importedBlob)))
+	require.Equal(t, 2, importedFile.NumProofs())
+
+	lineageInput, err := importedFile.ProofAt(0)
+	require.NoError(t, err)
+	require.Equal(t, prevIDs[0].OutPoint, lineageInput.OutPoint())
+	require.Equal(
+		t, prevIDs[0].ScriptKey,
+		asset.ToSerialized(lineageInput.Asset.ScriptKey.PubKey),
+	)
+
+	importedOutput, err := importedFile.LastProof()
+	require.NoError(t, err)
+	require.Len(t, importedOutput.AdditionalInputs, 1)
+
+	additionalInput, err := importedOutput.AdditionalInputs[0].LastProof()
+	require.NoError(t, err)
+	require.Equal(t, prevIDs[1].OutPoint, additionalInput.OutPoint())
+	require.Equal(
+		t, prevIDs[1].ScriptKey,
+		asset.ToSerialized(additionalInput.Asset.ScriptKey.PubKey),
+	)
+}
+
+// TestFetchInputProofFilesRejectsMalformed ensures malformed persisted funding
+// proofs fail before any courier is created.
+func TestFetchInputProofFilesRejectsMalformed(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name      string
+		mutate    func(*proof.Proof, asset.PrevID)
+		expectErr string
+	}{
+		{
+			name: "peer supplied additional inputs",
+			mutate: func(p *proof.Proof, _ asset.PrevID) {
+				p.AdditionalInputs = []proof.File{{}}
+			},
+			expectErr: "carries additional inputs",
+		},
+		{
+			name: "missing witnesses",
+			mutate: func(p *proof.Proof, _ asset.PrevID) {
+				p.Asset.PrevWitnesses = nil
+			},
+			expectErr: "missing previous witnesses",
+		},
+		{
+			name: "too many witnesses",
+			mutate: func(p *proof.Proof, prevID asset.PrevID) {
+				numInputs := maxFundingInputProofs + 1
+				p.Asset.PrevWitnesses = make(
+					[]asset.Witness, numInputs,
+				)
+				for idx := range p.Asset.PrevWitnesses {
+					witness := &p.Asset.PrevWitnesses[idx]
+					witness.PrevID = &prevID
+				}
+			},
+			expectErr: "too many funding input witnesses",
+		},
+		{
+			name: "nil previous ID",
+			mutate: func(p *proof.Proof, _ asset.PrevID) {
+				p.Asset.PrevWitnesses = []asset.Witness{{}}
+			},
+			expectErr: "has no previous ID",
+		},
+		{
+			name: "duplicate input",
+			mutate: func(p *proof.Proof, prevID asset.PrevID) {
+				p.Asset.PrevWitnesses = []asset.Witness{
+					{PrevID: &prevID}, {PrevID: &prevID},
+				}
+			},
+			expectErr: "duplicate funding input",
+		},
+		{
+			name: "primary outpoint mismatch",
+			mutate: func(p *proof.Proof, _ asset.PrevID) {
+				p.PrevOut = test.RandOp(t)
+			},
+			expectErr: "does not match primary input",
+		},
+		{
+			name: "unspent anchor input",
+			mutate: func(p *proof.Proof, _ asset.PrevID) {
+				p.AnchorTx.TxIn = nil
+			},
+			expectErr: "does not spend input",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			outputProof, prevID := fetchInputTestProof(t)
+			testCase.mutate(&outputProof, prevID)
+
+			_, err := fetchInputProofFiles(
+				context.Background(), &outputProof,
+				&url.URL{}, nil,
+			)
+			require.ErrorContains(t, err, testCase.expectErr)
+		})
+	}
+}
+
+// TestFetchInputProofFilesRejectsMismatchedProof ensures a courier cannot
+// satisfy a locator with a proof file whose tip identifies another input.
+func TestFetchInputProofFilesRejectsMismatchedProof(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	outputProof, prevID := fetchInputTestProof(t)
+
+	wrongProof := randFundingProof(t)
+	wrongFile, err := proof.NewFile(proof.V0, wrongProof)
+	require.NoError(t, err)
+
+	var wrongFileBuf bytes.Buffer
+	require.NoError(t, wrongFile.Encode(&wrongFileBuf))
+
+	courier := proof.NewMockProofCourier()
+	err = courier.DeliverProof(
+		ctx, proof.Recipient{}, &proof.AnnotatedProof{
+			Locator: proof.Locator{
+				AssetID:   &prevID.ID,
+				ScriptKey: *outputProof.Asset.ScriptKey.PubKey,
+				OutPoint:  &prevID.OutPoint,
+			},
+			Blob:          wrongFileBuf.Bytes(),
+			AssetSnapshot: &proof.AssetSnapshot{},
+		}, nil,
+	)
+	require.NoError(t, err)
+
+	dispatch := &proof.MockProofCourierDispatcher{Courier: courier}
+	_, err = fetchInputProofFiles(
+		ctx, &outputProof, &url.URL{}, dispatch,
+	)
+	require.ErrorContains(t, err, "input proof mismatch")
+}

--- a/tapchannel/aux_sweeper_test.go
+++ b/tapchannel/aux_sweeper_test.go
@@ -325,3 +325,22 @@ func TestFetchInputProofFilesRejectsMismatchedProof(t *testing.T) {
 	)
 	require.ErrorContains(t, err, "input proof mismatch")
 }
+
+// TestAuxSweeperStop ensures that stopping the sweeper closes its quit
+// channel, which is what aborts any in-flight funding proof import.
+func TestAuxSweeperStop(t *testing.T) {
+	t.Parallel()
+
+	sweeper := NewAuxSweeper(&AuxSweeperCfg{})
+	require.NoError(t, sweeper.Start())
+	require.NoError(t, sweeper.Stop())
+
+	select {
+	case <-sweeper.quit:
+	default:
+		t.Fatal("quit channel still open after Stop")
+	}
+
+	// A second stop must be a no-op instead of a double close.
+	require.NoError(t, sweeper.Stop())
+}


### PR DESCRIPTION
Fixes #2243.

A channel funded from several UTXOs of the same asset merges them into a single funding output. When importing that output, we only ever fetched the provenance of its first input. A proof asserting several inputs cannot be verified from just one of them, so the responder was unable to validate the funding output and the cooperative close never finalized: the channel sat in `waiting_close` and the peer's assets were never swept. Channels funded from a single UTXO were unaffected, and no integration test closed a multi-input channel, so the gap went unnoticed. A TODO above the import loop had flagged the case.

We now fetch provenance for every input claimed by the funding output, carrying the non-primary proof files in the transition proof—the same merge shape produced by the ordinary send path. This close-time import also performs structural validation of the funding-input list before retrieving proofs. These checks provide defense in depth alongside the confirmed-funding validation performed during ChannelReady, and turn malformed input data into precise errors rather than an opaque verifier failure. The existing multi-input funding test is extended through a cooperative close, reproducing the original failure and guarding the fix.
