### PR TITLE
tapdb: cap default rapid property-test iterations at 25

### DIFF
--- a/tapdb/main_test.go
+++ b/tapdb/main_test.go
@@ -1,0 +1,33 @@
+package tapdb
+
+import (
+	"flag"
+	"os"
+	"testing"
+)
+
+// defaultRapidChecks caps the number of iterations rapid property
+// tests run per check. The library default of 100 dominates the
+// package's test runtime, in particular under the race detector. An
+// explicit -rapid.checks flag overrides the cap.
+const defaultRapidChecks = "25"
+
+// TestMain lowers the default rapid property-test iteration count.
+func TestMain(m *testing.M) {
+	flag.Parse()
+
+	explicit := false
+	flag.CommandLine.Visit(func(f *flag.Flag) {
+		if f.Name == "rapid.checks" {
+			explicit = true
+		}
+	})
+	if !explicit {
+		err := flag.Set("rapid.checks", defaultRapidChecks)
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	os.Exit(m.Run())
+}


### PR DESCRIPTION
(Fable's summary.)

The multiverse coalescer and reconcile property tests added in #2194 dominate the package's race-detector runtime at rapid's default of 100 iterations: both persist store state across iterations, so per-iteration cost grows with the accumulated universes, and the pair costs roughly 410s under -race, with TestReconcileMultiverseProps alone at ~330s. That roughly doubled tapdb's unit-race package time in CI (~500s to ~1000s), and made it noisy besides: rapid seeds from the wall clock, so the workload differed from run to run.

At 25 iterations the pair costs ~30s. An explicit -rapid.checks flag still overrides the default for deeper runs.