### PR TITLE
tapdb: batch per-asset witness and proof queries

### DIFF
--- a/docs/release-notes/release-notes-0.9.0.md
+++ b/docs/release-notes/release-notes-0.9.0.md
@@ -91,6 +91,14 @@
 
 ## Performance Improvements
 
+* [PR#2251](https://github.com/lightninglabs/taproot-assets/pull/2251)
+  batches the per-asset witness and proof queries issued when loading
+  assets from the database. Loading assets previously issued one witness
+  query per asset, and reconstructing input commitments issued one proof
+  query per asset, which dominated every path that materialises assets
+  on nodes holding many assets
+  ([#2249](https://github.com/lightninglabs/taproot-assets/issues/2249)).
+
 ## Deprecations
 
 # Technical and Architectural Updates

--- a/tapdb/assets_store.go
+++ b/tapdb/assets_store.go
@@ -278,10 +278,9 @@ type ActiveAssetsStore interface {
 	// database.
 	UpsertAssetWitness(context.Context, PrevInput) error
 
-	// FetchAssetWitnesses attempts to fetch either all the asset witnesses
-	// on disk (NULL param), or the witness for a given asset ID.
-	FetchAssetWitnesses(context.Context, sql.NullInt64) ([]AssetWitness,
-		error)
+	// FetchAssetWitnesses fetches the witnesses for the assets identified
+	// by the passed set of asset primary keys.
+	FetchAssetWitnesses(context.Context, []int64) ([]AssetWitness, error)
 
 	// FetchManagedUTXO fetches a managed UTXO based on either the outpoint
 	// or the transaction that anchors it.
@@ -565,27 +564,61 @@ type AssetHumanReadable struct {
 // input (witness) information.
 type assetWitnesses map[int64][]AssetWitness
 
+// queryIDChunkSize is the maximum number of IDs we pass to a single batched
+// query. Both SQLite and Postgres limit the number of bind parameters a
+// statement may carry (32766 and 65535 respectively), so larger ID sets are
+// queried in chunks of this size.
+const queryIDChunkSize = 512
+
+// forEachIDChunk calls the given function for each chunk of at most
+// queryIDChunkSize of the given IDs. Queries that take a set of IDs must be
+// issued in chunks, as the number of bind parameters a statement may carry is
+// limited. An empty ID set results in no calls at all, which also keeps us
+// from issuing a query with an empty ID set, which no such query supports.
+//
+// The IDs must be distinct. A duplicate ID that lands in a different chunk
+// than its twin is queried twice, so a caller that accumulates the rows of
+// each chunk would count that ID's rows twice.
+func forEachIDChunk(ids []int64, f func(chunk []int64) error) error {
+	for start := 0; start < len(ids); start += queryIDChunkSize {
+		end := min(start+queryIDChunkSize, len(ids))
+
+		if err := f(ids[start:end]); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 // fetchAssetWitnesses attempts to fetch all the asset witnesses that belong to
 // the set of passed asset IDs.
 func fetchAssetWitnesses(ctx context.Context, db ActiveAssetsStore,
 	assetIDs []int64) (assetWitnesses, error) {
 
 	assetWitnesses := make(map[int64][]AssetWitness)
-	for _, assetID := range assetIDs {
-		witnesses, err := db.FetchAssetWitnesses(
-			ctx, sqlInt64(assetID),
-		)
+
+	// We fetch the witnesses of many assets per query and then group them
+	// by the asset's primary key. The query orders by asset ID and witness
+	// index, so the witnesses of each asset retain their original order. A
+	// genesis asset has no witnesses stored, so it won't appear in the
+	// map, which'll give it the genesis witness.
+	err := forEachIDChunk(assetIDs, func(chunk []int64) error {
+		witnesses, err := db.FetchAssetWitnesses(ctx, chunk)
 		if err != nil {
-			return nil, err
+			return err
 		}
 
-		// We'll insert a nil witness for genesis asset, so we don't
-		// add it to the map, which'll give it the genesis witness.
-		if len(witnesses) == 0 {
-			continue
+		for _, witness := range witnesses {
+			assetWitnesses[witness.AssetID] = append(
+				assetWitnesses[witness.AssetID], witness,
+			)
 		}
 
-		assetWitnesses[assetID] = witnesses
+		return nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	return assetWitnesses, nil
@@ -1035,6 +1068,9 @@ func fetchAssetsWithWitness(ctx context.Context, q ActiveAssetsStore,
 		return nil, nil, fmt.Errorf("unable to read db assets: %w", err)
 	}
 
+	// QueryAssets joins on unique columns only, so it returns each asset
+	// primary key at most once. The witness fetch below relies on that,
+	// since it groups the witnesses of the assets it is given.
 	assetIDs := fMap(dbAssets, func(a ConfirmedAsset) int64 {
 		return a.AssetPrimaryKey
 	})

--- a/tapdb/assets_store.go
+++ b/tapdb/assets_store.go
@@ -59,6 +59,10 @@ type (
 	// its asset ID.
 	AssetProofByIDRow = sqlc.FetchAssetProofsByAssetIDRow
 
+	// AssetProofsByIDsRow is the asset proof for a given asset, identified
+	// by its asset primary key.
+	AssetProofsByIDsRow = sqlc.FetchAssetProofsByIDsRow
+
 	// PrevInput stores the full input information including the prev out,
 	// and also the witness information itself.
 	PrevInput = sqlc.UpsertAssetWitnessParams
@@ -252,6 +256,11 @@ type ActiveAssetsStore interface {
 	// ID.
 	FetchAssetProofsByAssetID(ctx context.Context,
 		assetID []byte) ([]AssetProofByIDRow, error)
+
+	// FetchAssetProofsByIDs fetches the asset proofs for the assets
+	// identified by the passed set of asset primary keys.
+	FetchAssetProofsByIDs(ctx context.Context,
+		assetIds []int64) ([]AssetProofsByIDsRow, error)
 
 	// UpsertChainTx inserts a new or updates an existing chain tx into the
 	// DB.
@@ -692,6 +701,10 @@ func parseAssetWitness(input AssetWitness) (asset.Witness, error) {
 // dbAssetsToChainAssets maps a set of confirmed assets in the database, and
 // the witnesses of those assets to a set of normal ChainAsset structs needed
 // by a higher level application.
+//
+// The returned slice is index-aligned with the input: chainAssets[i] is built
+// from dbAssets[i]. Callers rely on this to map a chain asset back to its
+// database row.
 func dbAssetsToChainAssets(dbAssets []ConfirmedAsset, witnesses assetWitnesses,
 	dbClock clock.Clock) ([]*asset.ChainAsset, error) {
 
@@ -1533,7 +1546,7 @@ func (a *AssetStore) FetchOrphanUTXOs(ctx context.Context) (
 			// Query all assets anchored at this outpoint.
 			// We include spent assets here because tombstones are
 			// marked as spent when created.
-			assetsAtAnchor, err := a.queryChainAssets(
+			_, assetsAtAnchor, err := a.queryChainAssets(
 				ctx, q, QueryAssetFilters{
 					AnchorPoint: u.Outpoint,
 					Now:         sqlTime(now),
@@ -2323,23 +2336,26 @@ func (a *AssetStore) RemoveSubscriber(
 
 // queryChainAssets queries the database for assets matching the passed filter.
 // The returned assets have all anchor and witness information populated.
+// The returned chain assets are index-aligned with the returned raw database
+// rows, so callers can map a chain asset back to its database row.
 func (a *AssetStore) queryChainAssets(ctx context.Context, q ActiveAssetsStore,
-	filter QueryAssetFilters) ([]*asset.ChainAsset, error) {
+	filter QueryAssetFilters) ([]ConfirmedAsset, []*asset.ChainAsset,
+	error) {
 
 	dbAssets, assetWitnesses, err := fetchAssetsWithWitness(
 		ctx, q, filter,
 	)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	matchingAssets, err := dbAssetsToChainAssets(
 		dbAssets, assetWitnesses, a.clock,
 	)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	return matchingAssets, nil
+	return dbAssets, matchingAssets, nil
 }
 
 // FetchCommitment returns a specific commitment identified by the given asset
@@ -2544,20 +2560,85 @@ func (a *AssetStore) queryCommitments(ctx context.Context,
 			map[wire.OutPoint][]asset.AltLeaf[asset.Asset],
 		)
 		matchingAssetProofs = make(map[wire.OutPoint]proof.Blob)
-		err                 error
 	)
 
 	readOpts := NewAssetStoreReadTx()
 	dbErr := a.db.ExecTx(ctx, &readOpts, func(q ActiveAssetsStore) error {
 		// Now that we have the set of filters we need we'll query the
-		// DB for the set of assets that matches them.
-		matchingAssets, err = a.queryChainAssets(ctx, q, assetFilter)
+		// DB for the set of assets that matches them. We keep the raw
+		// DB assets as well, since we need their primary keys to batch
+		// fetch the proofs below.
+		dbAssets, assets, err := a.queryChainAssets(
+			ctx, q, assetFilter,
+		)
 		if err != nil {
 			return err
 		}
 
+		matchingAssets = assets
 		if len(matchingAssets) == 0 {
 			return tapfreighter.ErrMatchingAssetsNotFound
+		}
+
+		// TODO(jhb): replace full proof fetch with
+		// outpoint -> alt leaf table / index
+		// We also need to fetch an input proof for each anchor point,
+		// in order to fetch any committed alt leaves. The alt leaves
+		// of a proof are the ones committed to by the anchor output as
+		// a whole (see the TaprootAssetRoot.FetchAltLeaves call in
+		// proof.CreateTransitionProof), so every asset at an anchor
+		// point carries the same set and one proof per distinct anchor
+		// point is enough.
+		//
+		// We therefore pick a representative asset per anchor point
+		// and fetch the proofs of all representatives in batched
+		// queries, keyed by the assets' primary keys. The
+		// representative is the lowest primary key at the anchor
+		// point, which doesn't depend on the order the assets were
+		// queried in. An asset that has no proof stored still fails
+		// the query below if it is the representative of its anchor
+		// point.
+		repAssetIDs := make(map[wire.OutPoint]int64)
+		for idx := range matchingAssets {
+			anchorPoint := matchingAssets[idx].AnchorOutpoint
+			primaryKey := dbAssets[idx].AssetPrimaryKey
+
+			existing, ok := repAssetIDs[anchorPoint]
+			if !ok || primaryKey < existing {
+				repAssetIDs[anchorPoint] = primaryKey
+			}
+		}
+
+		assetIDs := make([]int64, 0, len(repAssetIDs))
+		anchorByAssetID := make(
+			map[int64]wire.OutPoint, len(repAssetIDs),
+		)
+		for anchorPoint, primaryKey := range repAssetIDs {
+			assetIDs = append(assetIDs, primaryKey)
+			anchorByAssetID[primaryKey] = anchorPoint
+		}
+
+		err = forEachIDChunk(assetIDs, func(chunk []int64) error {
+			dbProofs, err := q.FetchAssetProofsByIDs(ctx, chunk)
+			if err != nil {
+				return err
+			}
+
+			for _, dbProof := range dbProofs {
+				anchor := anchorByAssetID[dbProof.AssetID]
+				matchingAssetProofs[anchor] = dbProof.ProofFile
+			}
+
+			return nil
+		})
+		if err != nil {
+			return err
+		}
+
+		// Every anchor point must have a proof, as each proof row is
+		// unique per asset.
+		if len(matchingAssetProofs) != len(repAssetIDs) {
+			return proof.ErrProofNotFound
 		}
 
 		// At this point, we have the set of assets that match our
@@ -2582,7 +2663,7 @@ func (a *AssetStore) queryCommitments(ctx context.Context,
 				Now:         sqlTime(a.clock.Now().UTC()),
 			}
 
-			anchoredAssets, err := a.queryChainAssets(
+			_, anchoredAssets, err := a.queryChainAssets(
 				ctx, q, outpointQuery,
 			)
 			if err != nil {
@@ -2601,31 +2682,6 @@ func (a *AssetStore) queryCommitments(ctx context.Context,
 			}
 
 			anchorPoints[anchorPoint] = anchorUTXO
-
-			// TODO(jhb): replace full proof fetch with
-			// outpoint -> alt leaf table / index
-			// We also need to fetch the input proof here, in order
-			// to fetch any committed alt leaves.
-			assetLoc := proof.Locator{
-				AssetID:   fn.Ptr(matchingAsset.ID()),
-				ScriptKey: *matchingAsset.ScriptKey.PubKey,
-				OutPoint:  &matchingAsset.AnchorOutpoint,
-			}
-			proofArgs, err := locatorToProofQuery(assetLoc)
-			if err != nil {
-				return err
-			}
-
-			var assetProof proof.Blob
-			assetProof, err = fetchProof(ctx, q, proofArgs)
-			switch {
-			case errors.Is(err, sql.ErrNoRows):
-				return proof.ErrProofNotFound
-			case err != nil:
-				return err
-			}
-
-			matchingAssetProofs[anchorPoint] = assetProof
 		}
 
 		return nil

--- a/tapdb/assets_store.go
+++ b/tapdb/assets_store.go
@@ -2564,6 +2564,16 @@ func (a *AssetStore) queryCommitments(ctx context.Context,
 
 	readOpts := NewAssetStoreReadTx()
 	dbErr := a.db.ExecTx(ctx, &readOpts, func(q ActiveAssetsStore) error {
+		// The transaction may retry the closure wholesale, so reset
+		// any state a previous attempt may have gathered. A stale
+		// entry would otherwise make the dedup logic below skip the
+		// work of a failed attempt.
+		chainAnchorToAssets = make(
+			map[wire.OutPoint][]*asset.ChainAsset,
+		)
+		anchorPoints = make(map[wire.OutPoint]AnchorPoint)
+		matchingAssetProofs = make(map[wire.OutPoint]proof.Blob)
+
 		// Now that we have the set of filters we need we'll query the
 		// DB for the set of assets that matches them. We keep the raw
 		// DB assets as well, since we need their primary keys to batch
@@ -2652,6 +2662,14 @@ func (a *AssetStore) queryCommitments(ctx context.Context,
 		for idx := range matchingAssets {
 			matchingAsset := matchingAssets[idx]
 			anchorPoint := matchingAsset.AnchorOutpoint
+
+			// Multiple matching assets may be anchored at the same
+			// outpoint, in which case we've already fetched the
+			// anchored assets and managed UTXO for it.
+			if _, ok := chainAnchorToAssets[anchorPoint]; ok {
+				continue
+			}
+
 			anchorPointBytes, err := encodeOutpoint(
 				matchingAsset.AnchorOutpoint,
 			)

--- a/tapdb/assets_store_test.go
+++ b/tapdb/assets_store_test.go
@@ -46,6 +46,8 @@ type assetGenOptions struct {
 
 	genesisAsset bool
 
+	numWitnesses int
+
 	groupKeyPriv *btcec.PrivateKey
 
 	amt uint64
@@ -138,6 +140,15 @@ func withGenesisAsset() assetGenOpt {
 	}
 }
 
+// withNumWitnesses makes the generated asset carry exactly num non-genesis
+// witnesses. The number must be positive: zero keeps the default behavior of
+// a randomly chosen witness shape.
+func withNumWitnesses(num int) assetGenOpt {
+	return func(opt *assetGenOptions) {
+		opt.numWitnesses = num
+	}
+}
+
 func randAsset(t *testing.T, genOpts ...assetGenOpt) *asset.Asset {
 	opts := defaultAssetGenOpts(t)
 	for _, optFunc := range genOpts {
@@ -222,16 +233,22 @@ func randAsset(t *testing.T, genOpts ...assetGenOpt) *asset.Asset {
 	}
 
 	// For the witnesses, we'll flip a coin: we'll either make a genesis
-	// witness, or a set of actual witnesses.
+	// witness, or a set of actual witnesses. A specific number of
+	// witnesses can also be requested explicitly.
 	var witnesses []asset.Witness
-	if opts.genesisAsset || test.RandInt[int]()%2 == 0 {
+	if opts.numWitnesses == 0 &&
+		(opts.genesisAsset || test.RandInt[int]()%2 == 0) {
+
 		witnesses = append(witnesses, asset.Witness{
 			PrevID:          &asset.PrevID{},
 			TxWitness:       nil,
 			SplitCommitment: nil,
 		})
 	} else {
-		numWitness := test.RandInt[int]() % 10
+		numWitness := opts.numWitnesses
+		if numWitness == 0 {
+			numWitness = test.RandInt[int]() % 10
+		}
 		if numWitness == 0 {
 			numWitness++
 		}
@@ -277,6 +294,173 @@ func assertAssetEqual(t *testing.T, a, b *asset.Asset) {
 		// check succeeds (which shouldn't be the case).
 		t.Fatalf("asset equality failed!")
 	}
+}
+
+// TestFetchAssetWitnesses tests that the witnesses of multiple assets are
+// fetched correctly by the batched witness query, with the per-asset witness
+// order preserved.
+func TestFetchAssetWitnesses(t *testing.T) {
+	t.Parallel()
+
+	var (
+		ctxb     = context.Background()
+		dbHandle = NewDbHandle(t)
+	)
+
+	// We create one genesis asset and two assets with multiple witnesses
+	// each, so the batched witness query has to group and order the
+	// witnesses of several assets correctly.
+	expected := make(map[asset.SerializedKey]*asset.Asset)
+	numWitnesses := []int{0, 3, 5}
+	for _, num := range numWitnesses {
+		opts := []assetGenOpt{withNoGroupKey()}
+		if num == 0 {
+			opts = append(opts, withGenesisAsset())
+		} else {
+			opts = append(opts, withNumWitnesses(num))
+		}
+
+		testAsset, _ := dbHandle.AddRandomAssetProof(t, opts...)
+		require.Len(t, testAsset.PrevWitnesses, max(num, 1))
+
+		key := asset.ToSerialized(testAsset.ScriptKey.PubKey)
+		expected[key] = testAsset
+	}
+
+	dbAssets, err := dbHandle.AssetStore.FetchAllAssets(
+		ctxb, false, false, nil,
+	)
+	require.NoError(t, err)
+	require.Len(t, dbAssets, len(numWitnesses))
+
+	// Every asset read back from disk must match the imported one exactly,
+	// including the order of its witnesses.
+	for _, dbAsset := range dbAssets {
+		key := asset.ToSerialized(dbAsset.ScriptKey.PubKey)
+		require.Contains(t, expected, key)
+		assertAssetEqual(t, expected[key], dbAsset.Asset)
+	}
+}
+
+// TestQueryCommitmentsMissingProof tests that querying commitments for an
+// asset that has no proof stored on disk reports the missing proof.
+func TestQueryCommitmentsMissingProof(t *testing.T) {
+	t.Parallel()
+
+	db := NewTestDB(t)
+	_, assetsStore := newAssetStoreFromDB(db.BaseDB)
+
+	assetGen := newAssetGenerator(t, 1, 1)
+	assetGen.genAssets(t, assetsStore, []assetDesc{{
+		assetGen:    assetGen.assetGens[0],
+		amt:         10,
+		anchorPoint: assetGen.anchorPoints[0],
+	}})
+
+	ctx := context.Background()
+	constraints := tapfreighter.CommitmentConstraints{
+		MinAmt: 1,
+	}
+
+	// With the proof present, the asset is listed as an eligible coin.
+	coins, err := assetsStore.ListEligibleCoins(ctx, constraints)
+	require.NoError(t, err)
+	require.Len(t, coins, 1)
+
+	// After removing the proof from disk, the same query must report the
+	// missing proof.
+	_, err = db.ExecContext(ctx, "DELETE FROM asset_proofs")
+	require.NoError(t, err)
+
+	_, err = assetsStore.ListEligibleCoins(ctx, constraints)
+	require.ErrorIs(t, err, proof.ErrProofNotFound)
+}
+
+// TestQueryCommitmentsSharedAnchor tests querying commitments for multiple
+// assets that are anchored at the same outpoint. Only one proof per anchor
+// point is read, so which of the assets misses its proof decides whether the
+// query still succeeds.
+func TestQueryCommitmentsSharedAnchor(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	constraints := tapfreighter.CommitmentConstraints{
+		MinAmt: 1,
+	}
+
+	// The two assets live at the same anchor point, so they end up in the
+	// same Taproot Asset commitment.
+	genAssets := func(t *testing.T) (*AssetStore, *BaseDB) {
+		db := NewTestDB(t)
+		_, assetsStore := newAssetStoreFromDB(db.BaseDB)
+
+		assetGen := newAssetGenerator(t, 2, 1)
+		assetGen.genAssets(t, assetsStore, []assetDesc{
+			{
+				assetGen:    assetGen.assetGens[0],
+				amt:         10,
+				anchorPoint: assetGen.anchorPoints[0],
+				noGroupKey:  true,
+			},
+			{
+				assetGen:    assetGen.assetGens[1],
+				amt:         20,
+				anchorPoint: assetGen.anchorPoints[0],
+				noGroupKey:  true,
+			},
+		})
+
+		return assetsStore, db.BaseDB
+	}
+
+	// Both assets are listed, and each one carries the commitment of the
+	// anchor point they share.
+	assetsStore, _ := genAssets(t)
+	coins, err := assetsStore.ListEligibleCoins(ctx, constraints)
+	require.NoError(t, err)
+	require.Len(t, coins, 2)
+
+	require.Equal(t, coins[0].AnchorPoint, coins[1].AnchorPoint)
+	assertAssetsEqual(t, coins[0].Commitment, coins[1].Commitment)
+
+	// Each asset must also be reachable on its own, with the same
+	// commitment as the listing returned.
+	for _, coin := range coins {
+		commit, err := assetsStore.FetchCommitment(
+			ctx, coin.Asset.ID(), coin.AnchorPoint,
+			coin.Asset.GroupKey, &coin.Asset.ScriptKey, false,
+		)
+		require.NoError(t, err)
+
+		assertAssetEqual(t, coin.Asset, commit.Asset)
+		assertAssetsEqual(t, coin.Commitment, commit.Commitment)
+	}
+
+	// The proof of the anchor point's representative asset, which is the
+	// one with the lowest primary key, is the one that gets read. Dropping
+	// any other asset's proof leaves the listing working.
+	assetsStore, db := genAssets(t)
+	_, err = db.ExecContext(
+		ctx, "DELETE FROM asset_proofs WHERE asset_id = "+
+			"(SELECT MAX(asset_id) FROM asset_proofs)",
+	)
+	require.NoError(t, err)
+
+	coins, err = assetsStore.ListEligibleCoins(ctx, constraints)
+	require.NoError(t, err)
+	require.Len(t, coins, 2)
+
+	// Dropping the representative's proof makes the query report the
+	// missing proof instead.
+	assetsStore, db = genAssets(t)
+	_, err = db.ExecContext(
+		ctx, "DELETE FROM asset_proofs WHERE asset_id = "+
+			"(SELECT MIN(asset_id) FROM asset_proofs)",
+	)
+	require.NoError(t, err)
+
+	_, err = assetsStore.ListEligibleCoins(ctx, constraints)
+	require.ErrorIs(t, err, proof.ErrProofNotFound)
 }
 
 // TestImportAssetProof tests that given a valid asset proof (mainly the final
@@ -2200,7 +2384,9 @@ func TestAssetGroupComplexWitness(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	genAssetID, err := upsertGenesis(ctx, db, genesisPointID, groupAnchorGen)
+	genAssetID, err := upsertGenesis(
+		ctx, db, genesisPointID, groupAnchorGen,
+	)
 	require.NoError(t, err)
 
 	groupKey := asset.GroupKey{

--- a/tapdb/sqlc/assets.sql.go
+++ b/tapdb/sqlc/assets.sql.go
@@ -925,16 +925,14 @@ func (q *Queries) FetchAssetProofsSizes(ctx context.Context) ([]FetchAssetProofs
 }
 
 const FetchAssetWitnesses = `-- name: FetchAssetWitnesses :many
-SELECT 
-    assets.asset_id, prev_out_point, prev_asset_id, prev_script_key, 
+SELECT
+    assets.asset_id, prev_out_point, prev_asset_id, prev_script_key,
     witness_stack, split_commitment_proof
 FROM asset_witnesses
 JOIN assets
     ON asset_witnesses.asset_id = assets.asset_id
-WHERE (
-    (assets.asset_id = $1) OR ($1 IS NULL)
-)
-ORDER BY witness_index
+WHERE assets.asset_id IN (/*SLICE:asset_ids*/?)
+ORDER BY assets.asset_id, witness_index
 `
 
 type FetchAssetWitnessesRow struct {
@@ -946,8 +944,23 @@ type FetchAssetWitnessesRow struct {
 	SplitCommitmentProof []byte
 }
 
-func (q *Queries) FetchAssetWitnesses(ctx context.Context, assetID sql.NullInt64) ([]FetchAssetWitnessesRow, error) {
-	rows, err := q.db.QueryContext(ctx, FetchAssetWitnesses, assetID)
+// The witnesses of all assets identified by the passed set of asset primary
+// keys are fetched in a single query.
+//
+// The asset_ids argument must NEVER be an empty slice, otherwise this query
+// will return no results.
+func (q *Queries) FetchAssetWitnesses(ctx context.Context, assetIds []int64) ([]FetchAssetWitnessesRow, error) {
+	query := FetchAssetWitnesses
+	var queryParams []interface{}
+	if len(assetIds) > 0 {
+		for _, v := range assetIds {
+			queryParams = append(queryParams, v)
+		}
+		query = strings.Replace(query, "/*SLICE:asset_ids*/?", makeQueryParams(len(queryParams), len(assetIds)), 1)
+	} else {
+		query = strings.Replace(query, "/*SLICE:asset_ids*/?", "NULL", 1)
+	}
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err
 	}

--- a/tapdb/sqlc/assets.sql.go
+++ b/tapdb/sqlc/assets.sql.go
@@ -886,6 +886,55 @@ func (q *Queries) FetchAssetProofsByAssetID(ctx context.Context, assetID []byte)
 	return items, nil
 }
 
+const FetchAssetProofsByIDs = `-- name: FetchAssetProofsByIDs :many
+SELECT asset_id, proof_file
+FROM asset_proofs
+WHERE asset_proofs.asset_id IN (/*SLICE:asset_ids*/?)
+`
+
+type FetchAssetProofsByIDsRow struct {
+	AssetID   int64
+	ProofFile []byte
+}
+
+// The proofs of all assets identified by the passed set of asset primary keys
+// are fetched in a single query.
+//
+// The asset_ids argument must NEVER be an empty slice, otherwise this query
+// will return no results.
+func (q *Queries) FetchAssetProofsByIDs(ctx context.Context, assetIds []int64) ([]FetchAssetProofsByIDsRow, error) {
+	query := FetchAssetProofsByIDs
+	var queryParams []interface{}
+	if len(assetIds) > 0 {
+		for _, v := range assetIds {
+			queryParams = append(queryParams, v)
+		}
+		query = strings.Replace(query, "/*SLICE:asset_ids*/?", makeQueryParams(len(queryParams), len(assetIds)), 1)
+	} else {
+		query = strings.Replace(query, "/*SLICE:asset_ids*/?", "NULL", 1)
+	}
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []FetchAssetProofsByIDsRow
+	for rows.Next() {
+		var i FetchAssetProofsByIDsRow
+		if err := rows.Scan(&i.AssetID, &i.ProofFile); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const FetchAssetProofsSizes = `-- name: FetchAssetProofsSizes :many
 SELECT script_keys.tweaked_script_key AS script_key, 
        LENGTH(asset_proofs.proof_file) AS proof_file_length

--- a/tapdb/sqlc/querier.go
+++ b/tapdb/sqlc/querier.go
@@ -69,6 +69,12 @@ type Querier interface {
 	FetchAssetProof(ctx context.Context, arg FetchAssetProofParams) ([]FetchAssetProofRow, error)
 	FetchAssetProofs(ctx context.Context) ([]FetchAssetProofsRow, error)
 	FetchAssetProofsByAssetID(ctx context.Context, assetID []byte) ([]FetchAssetProofsByAssetIDRow, error)
+	// The proofs of all assets identified by the passed set of asset primary keys
+	// are fetched in a single query.
+	//
+	// The asset_ids argument must NEVER be an empty slice, otherwise this query
+	// will return no results.
+	FetchAssetProofsByIDs(ctx context.Context, assetIds []int64) ([]FetchAssetProofsByIDsRow, error)
 	FetchAssetProofsSizes(ctx context.Context) ([]FetchAssetProofsSizesRow, error)
 	// The witnesses of all assets identified by the passed set of asset primary
 	// keys are fetched in a single query.

--- a/tapdb/sqlc/querier.go
+++ b/tapdb/sqlc/querier.go
@@ -70,7 +70,12 @@ type Querier interface {
 	FetchAssetProofs(ctx context.Context) ([]FetchAssetProofsRow, error)
 	FetchAssetProofsByAssetID(ctx context.Context, assetID []byte) ([]FetchAssetProofsByAssetIDRow, error)
 	FetchAssetProofsSizes(ctx context.Context) ([]FetchAssetProofsSizesRow, error)
-	FetchAssetWitnesses(ctx context.Context, assetID sql.NullInt64) ([]FetchAssetWitnessesRow, error)
+	// The witnesses of all assets identified by the passed set of asset primary
+	// keys are fetched in a single query.
+	//
+	// The asset_ids argument must NEVER be an empty slice, otherwise this query
+	// will return no results.
+	FetchAssetWitnesses(ctx context.Context, assetIds []int64) ([]FetchAssetWitnessesRow, error)
 	FetchAssetsByAnchorTx(ctx context.Context, anchorUtxoID sql.NullInt64) ([]Asset, error)
 	// We use a LEFT JOIN here as not every asset has a meta data entry.
 	// We use a LEFT JOIN here as not every asset has a group key, so this'll

--- a/tapdb/sqlc/queries/assets.sql
+++ b/tapdb/sqlc/queries/assets.sql
@@ -839,6 +839,16 @@ FROM asset_proofs
 JOIN asset_info
   ON asset_info.asset_id = asset_proofs.asset_id;
 
+-- name: FetchAssetProofsByIDs :many
+SELECT asset_id, proof_file
+FROM asset_proofs
+-- The proofs of all assets identified by the passed set of asset primary keys
+-- are fetched in a single query.
+--
+-- The asset_ids argument must NEVER be an empty slice, otherwise this query
+-- will return no results.
+WHERE asset_proofs.asset_id IN (sqlc.slice('asset_ids')/*SLICE:asset_ids*/);
+
 -- name: HasAssetProof :one
 WITH asset_info AS (
     SELECT assets.asset_id

--- a/tapdb/sqlc/queries/assets.sql
+++ b/tapdb/sqlc/queries/assets.sql
@@ -867,16 +867,19 @@ INSERT INTO asset_witnesses (
                   split_commitment_proof = EXCLUDED.split_commitment_proof;
 
 -- name: FetchAssetWitnesses :many
-SELECT 
-    assets.asset_id, prev_out_point, prev_asset_id, prev_script_key, 
+SELECT
+    assets.asset_id, prev_out_point, prev_asset_id, prev_script_key,
     witness_stack, split_commitment_proof
 FROM asset_witnesses
 JOIN assets
     ON asset_witnesses.asset_id = assets.asset_id
-WHERE (
-    (assets.asset_id = sqlc.narg('asset_id')) OR (sqlc.narg('asset_id') IS NULL)
-)
-ORDER BY witness_index;
+-- The witnesses of all assets identified by the passed set of asset primary
+-- keys are fetched in a single query.
+--
+-- The asset_ids argument must NEVER be an empty slice, otherwise this query
+-- will return no results.
+WHERE assets.asset_id IN (sqlc.slice('asset_ids')/*SLICE:asset_ids*/)
+ORDER BY assets.asset_id, witness_index;
 
 -- name: DeleteManagedUTXO :exec
 DELETE FROM managed_utxos


### PR DESCRIPTION
Loading assets from the database issued one witness query per asset, and
reconstructing input commitments issued one proof query per asset. That cost
dominates every path that materialises assets on a node holding many assets.

### Changes

- `FetchAssetWitnesses` takes a set of asset primary keys instead of one, and
  the rows are grouped in Go. Chunked at 512 IDs, since SQLite caps bind
  parameters at 32766 and Postgres at 65535.
- `queryCommitments` fetches proofs through a new `FetchAssetProofsByIDs`
  query. The proof is only read for the anchor's alt leaves, which commit to
  the anchor output as a whole, so one proof per distinct anchor point is
  enough instead of one per asset.
- Anchor points already handled are skipped in the commitment reconstruction
  loop. The result maps are reset at the top of the `ExecTx` closure, since it
  may be retried wholesale.

### Speedups

Measured against a copy of a real regtest node: sqlite, 2461 assets, dominant
asset group holding 621 coins.

| operation | before | this PR | with #2252 too |
|---|---|---|---|
| coin selection, 1-unit group send | 16.57s | 1.55s | 68ms |
| coin selection, 181-coin send | 16.56s | 1.53s | 447ms |
| `FetchAllAssets` (2461 assets) | 802ms | 244ms | 236ms |
| `FetchCommitment` | 33ms | 24ms | 25ms |

This also speeds up callers outside the send path: `ListAssets`, `FetchAsset`,
`ListUtxos`, `ExportAssetWalletBackup`, `ProveAssetOwnership`,
`AnchorVirtualPsbts`, and the Prometheus asset balance collector, which pays
the `FetchAllAssets` cost on every scrape.

#2252 bounds how many coins input selection loads in the first place, so the
two are complementary. End to end with both, a v2 address send on that node
goes from 28.1s to 10.8s median.

### Behavior

Checked by diffing full dumps of every asset returned (amount, anchor
outpoint, script key, witness count) and of the selected coin sets, baseline
against this PR: byte identical.

One deliberate change: `queryCommitments` used to read every matching asset's
proof, so it failed when any of them was missing. It now reads one proof per
anchor point, the one belonging to the lowest asset primary key there, so a
missing proof only fails coin selection when it is that asset's. For any other
asset at the same anchor point it surfaces later, when the funding path fetches
input proofs.

### Testing

New tests for multi-asset witness grouping and ordering, for two assets
sharing an anchor point, and for both missing-proof cases (the representative's
proof and another asset's). Unit tests pass on sqlite and postgres, `make lint` and
`make sqlc-check` are clean, and itests pass (`basic_send_unidirectional`,
`address_v2_self_send`, `multi_input_send_non-interactive_single_ID`). Every
commit builds and compiles its unit tests standalone.

Closes #2249
