### PR TITLE
tapfreighter: bound input selection instead of loading every eligible coin

### DIFF
--- a/docs/release-notes/release-notes-0.9.0.md
+++ b/docs/release-notes/release-notes-0.9.0.md
@@ -99,6 +99,18 @@
   on nodes holding many assets
   ([#2249](https://github.com/lightninglabs/taproot-assets/issues/2249)).
 
+* [PR#2252](https://github.com/lightninglabs/taproot-assets/pull/2252)
+  bounds input selection when funding a send. Eligible coins are now
+  listed in pages of descending amounts and listing stops as soon as the
+  accumulated amount covers the send target, instead of loading every
+  eligible coin the node holds
+  ([#2250](https://github.com/lightninglabs/taproot-assets/issues/2250)).
+  Sends that request specific inputs keep listing every eligible coin, as
+  the requested inputs are filtered for after the listing. A send that
+  cannot be funded is somewhat slower than before, as the listing is
+  repeated unbounded before reporting insufficient funds, so that a coin
+  the paged listing may have missed can't be mistaken for missing funds.
+
 ## Deprecations
 
 # Technical and Architectural Updates

--- a/tapdb/assets_store.go
+++ b/tapdb/assets_store.go
@@ -2409,6 +2409,14 @@ func (a *AssetStore) ListEligibleCoins(ctx context.Context,
 		return nil, fmt.Errorf("min amount overflow")
 	}
 
+	// The prev ID filter is applied after the query, so a bounded listing
+	// could return a page that holds none of the requested inputs. The two
+	// can't be combined.
+	if constraints.CoinLimit > 0 && len(constraints.PrevIDs) > 0 {
+		return nil, fmt.Errorf("coin limit cannot be combined with " +
+			"specific prev IDs")
+	}
+
 	// First, we'll map the commitment constraints to our database query
 	// filters.
 	assetFilter, err := a.constraintsToDbFilter(&AssetQueryFilters{
@@ -2426,6 +2434,21 @@ func (a *AssetStore) ListEligibleCoins(ctx context.Context,
 	// unconfirmed assets would otherwise be included). Unconfirmed assets
 	// have a block height of 0, so we set the minimum block height to 1.
 	assetFilter.MinAnchorHeight = sqlInt32(1)
+
+	// If the caller bounds the number of coins, we return them in
+	// descending amount order, so the largest eligible coins are returned
+	// first and a bounded listing can cover a target amount with as few
+	// pages as possible.
+	//
+	// This overrides the pagination the query filters may already carry
+	// from AssetQueryFilters.Limit/Offset, which no caller of this method
+	// sets. Coins are paged through with CoinLimit/CoinOffset instead, as
+	// those live on the constraints the coin selector works with.
+	if constraints.CoinLimit > 0 {
+		assetFilter.NumLimit = constraints.CoinLimit
+		assetFilter.NumOffset = constraints.CoinOffset
+		assetFilter.OrderByAmount = sqlInt32(1)
+	}
 
 	selectedCommitments, err := a.queryCommitments(ctx, assetFilter)
 	if err != nil {

--- a/tapdb/assets_store_test.go
+++ b/tapdb/assets_store_test.go
@@ -1869,6 +1869,99 @@ func TestSelectCommitment(t *testing.T) {
 	}
 }
 
+// TestListEligibleCoinsBounded tests that a bounded eligible coin listing
+// returns coins in pages of descending amounts.
+func TestListEligibleCoinsBounded(t *testing.T) {
+	t.Parallel()
+
+	const numAssets = 5
+
+	assetGen := newAssetGenerator(t, numAssets, 1)
+	_, assetsStore, _ := newAssetStore(t)
+
+	// We create one asset per anchor point, with amounts that are neither
+	// sorted nor aligned with the anchor point order.
+	amounts := []uint64{10, 40, 20, 50, 30}
+	assetDescs := make([]assetDesc, numAssets)
+	for i := 0; i < numAssets; i++ {
+		assetDescs[i] = assetDesc{
+			assetGen:    assetGen.assetGens[0],
+			amt:         amounts[i],
+			anchorPoint: assetGen.anchorPoints[i],
+		}
+	}
+	assetGen.genAssets(t, assetsStore, assetDescs)
+
+	// The genesis (and with it the asset ID) of the generated assets
+	// depends on the anchor point, so we use an empty specifier to match
+	// all the created assets.
+	ctx := context.Background()
+	constraints := tapfreighter.CommitmentConstraints{
+		MinAmt: 1,
+	}
+
+	listAmounts := func(coins []*tapfreighter.AnchoredCommitment) []uint64 {
+		return fn.Map(
+			coins, func(c *tapfreighter.AnchoredCommitment) uint64 {
+				return c.Asset.Amount
+			},
+		)
+	}
+
+	// Page through the coins two at a time, expecting descending amounts.
+	expectedPages := [][]uint64{{50, 40}, {30, 20}, {10}}
+	for idx, expected := range expectedPages {
+		constraints.CoinLimit = 2
+		constraints.CoinOffset = int32(idx * 2)
+
+		coins, err := assetsStore.ListEligibleCoins(ctx, constraints)
+		require.NoError(t, err)
+		require.Equal(t, expected, listAmounts(coins))
+	}
+
+	// A page past the end of the eligible coin set reports that no assets
+	// were found.
+	constraints.CoinOffset = numAssets + 1
+	_, err := assetsStore.ListEligibleCoins(ctx, constraints)
+	require.ErrorIs(t, err, tapfreighter.ErrMatchingAssetsNotFound)
+
+	// An unbounded listing returns all the coins, in no particular order.
+	unbounded, err := assetsStore.ListEligibleCoins(
+		ctx, tapfreighter.CommitmentConstraints{
+			MinAmt: 1,
+		},
+	)
+	require.NoError(t, err)
+	require.Len(t, unbounded, numAssets)
+
+	smallest := unbounded[0]
+	for _, c := range unbounded {
+		if c.Asset.Amount < smallest.Asset.Amount {
+			smallest = c
+		}
+	}
+
+	// Specific inputs can be requested from an unbounded listing, as the
+	// prev ID filter is applied after the query.
+	coins, err := assetsStore.ListEligibleCoins(
+		ctx, tapfreighter.CommitmentConstraints{
+			MinAmt:  1,
+			PrevIDs: []asset.PrevID{smallest.PrevID()},
+		},
+	)
+	require.NoError(t, err)
+	require.Len(t, coins, 1)
+	require.Equal(t, smallest.Asset.Amount, coins[0].Asset.Amount)
+
+	// Combining the two is a programming error, as a bounded listing could
+	// hold none of the requested inputs.
+	constraints.CoinLimit = 1
+	constraints.CoinOffset = 0
+	constraints.PrevIDs = []asset.PrevID{smallest.PrevID()}
+	_, err = assetsStore.ListEligibleCoins(ctx, constraints)
+	require.ErrorContains(t, err, "cannot be combined")
+}
+
 // TestAssetExportLog tests that were able to properly spend/transfer assets on
 // disk. This ensures we can properly commit the end result of an asset
 // transfer initiated at a higher level.

--- a/tapdb/assets_store_test.go
+++ b/tapdb/assets_store_test.go
@@ -1962,6 +1962,62 @@ func TestListEligibleCoinsBounded(t *testing.T) {
 	require.ErrorContains(t, err, "cannot be combined")
 }
 
+// TestListEligibleCoinsBoundedEqualAmounts tests that paging through a bounded
+// eligible coin listing neither repeats nor skips coins when all the coins hold
+// the same amount, which is the case where the amount ordering alone doesn't
+// decide the order of the pages.
+func TestListEligibleCoinsBoundedEqualAmounts(t *testing.T) {
+	t.Parallel()
+
+	const (
+		numAssets = 5
+		amount    = 10
+	)
+
+	assetGen := newAssetGenerator(t, numAssets, 1)
+	_, assetsStore, _ := newAssetStore(t)
+
+	assetDescs := make([]assetDesc, numAssets)
+	for i := 0; i < numAssets; i++ {
+		assetDescs[i] = assetDesc{
+			assetGen:    assetGen.assetGens[0],
+			amt:         amount,
+			anchorPoint: assetGen.anchorPoints[i],
+		}
+	}
+	assetGen.genAssets(t, assetsStore, assetDescs)
+
+	ctx := context.Background()
+	constraints := tapfreighter.CommitmentConstraints{
+		MinAmt: 1,
+	}
+
+	// Page through all the coins, collecting them by prev ID. Every page
+	// must be full until the coins run out.
+	seen := fn.NewSet[asset.PrevID]()
+	for offset := int32(0); offset < numAssets; offset += 2 {
+		constraints.CoinLimit = 2
+		constraints.CoinOffset = offset
+
+		coins, err := assetsStore.ListEligibleCoins(ctx, constraints)
+		require.NoError(t, err)
+
+		expectedLen := min(2, numAssets-int(offset))
+		require.Len(t, coins, expectedLen)
+
+		for _, c := range coins {
+			require.Equal(t, uint64(amount), c.Asset.Amount)
+
+			// A coin must not show up on two pages.
+			require.False(t, seen.Contains(c.PrevID()))
+			seen.Add(c.PrevID())
+		}
+	}
+
+	// And no coin may have been skipped either.
+	require.Equal(t, numAssets, len(seen.ToSlice()))
+}
+
 // TestAssetExportLog tests that were able to properly spend/transfer assets on
 // disk. This ensures we can properly commit the end result of an asset
 // transfer initiated at a higher level.

--- a/tapdb/sqlc/assets.sql.go
+++ b/tapdb/sqlc/assets.sql.go
@@ -2735,12 +2735,14 @@ WHERE (
     $14 >= 0 AND
     $15 >= 0 AND
     COALESCE($16, 0) >= 0 AND
+    COALESCE($17, 0) >= 0 AND
     -- The script_key_type argument must NEVER be an empty slice, otherwise this
     -- query will return no results.
     COALESCE(script_keys.key_type, 0) IN
       (/*SLICE:script_key_type*/?)
 )
 ORDER BY
+    CASE WHEN COALESCE($17, 0) = 1 THEN assets.amount END DESC,
     CASE WHEN COALESCE($16, 0) = 1 THEN assets.asset_id END DESC,
     assets.asset_id ASC
 LIMIT $14 OFFSET $15
@@ -2763,6 +2765,7 @@ type QueryAssetsParams struct {
 	NumLimit         int32
 	NumOffset        int32
 	SortDirection    interface{}
+	OrderByAmount    interface{}
 	ScriptKeyType    []sql.NullInt16
 }
 
@@ -2813,6 +2816,10 @@ type QueryAssetsRow struct {
 // channel balances, and also coin selection. We use the sqlc.narg feature to
 // make the entire statement evaluate to true, if none of these extra args are
 // specified.
+// The trailing sort by asset_id is what makes this a total order, which the
+// paging of a bounded listing relies on: without it, rows that compare equal
+// on the optional terms above could come back in any order and a later page
+// could repeat or skip them. Any ordering term added here must go above it.
 func (q *Queries) QueryAssets(ctx context.Context, arg QueryAssetsParams) ([]QueryAssetsRow, error) {
 	query := QueryAssets
 	var queryParams []interface{}
@@ -2832,6 +2839,7 @@ func (q *Queries) QueryAssets(ctx context.Context, arg QueryAssetsParams) ([]Que
 	queryParams = append(queryParams, arg.NumLimit)
 	queryParams = append(queryParams, arg.NumOffset)
 	queryParams = append(queryParams, arg.SortDirection)
+	queryParams = append(queryParams, arg.OrderByAmount)
 	if len(arg.ScriptKeyType) > 0 {
 		for _, v := range arg.ScriptKeyType {
 			queryParams = append(queryParams, v)

--- a/tapdb/sqlc/querier.go
+++ b/tapdb/sqlc/querier.go
@@ -213,6 +213,10 @@ type Querier interface {
 	// channel balances, and also coin selection. We use the sqlc.narg feature to
 	// make the entire statement evaluate to true, if none of these extra args are
 	// specified.
+	// The trailing sort by asset_id is what makes this a total order, which the
+	// paging of a bounded listing relies on: without it, rows that compare equal
+	// on the optional terms above could come back in any order and a later page
+	// could repeat or skip them. Any ordering term added here must go above it.
 	QueryAssets(ctx context.Context, arg QueryAssetsParams) ([]QueryAssetsRow, error)
 	QueryAuthMailboxMessages(ctx context.Context, arg QueryAuthMailboxMessagesParams) ([]QueryAuthMailboxMessagesRow, error)
 	QueryBurns(ctx context.Context, arg QueryBurnsParams) ([]QueryBurnsRow, error)

--- a/tapdb/sqlc/queries/assets.sql
+++ b/tapdb/sqlc/queries/assets.sql
@@ -527,12 +527,18 @@ WHERE (
     @num_limit >= 0 AND
     @num_offset >= 0 AND
     COALESCE(sqlc.narg('sort_direction'), 0) >= 0 AND
+    COALESCE(sqlc.narg('order_by_amount'), 0) >= 0 AND
     -- The script_key_type argument must NEVER be an empty slice, otherwise this
     -- query will return no results.
     COALESCE(script_keys.key_type, 0) IN
       (sqlc.slice('script_key_type')/*SLICE:script_key_type*/)
 )
+-- The trailing sort by asset_id is what makes this a total order, which the
+-- paging of a bounded listing relies on: without it, rows that compare equal
+-- on the optional terms above could come back in any order and a later page
+-- could repeat or skip them. Any ordering term added here must go above it.
 ORDER BY
+    CASE WHEN COALESCE(sqlc.narg('order_by_amount'), 0) = 1 THEN assets.amount END DESC,
     CASE WHEN COALESCE(sqlc.narg('sort_direction'), 0) = 1 THEN assets.asset_id END DESC,
     assets.asset_id ASC
 LIMIT @num_limit OFFSET @num_offset;

--- a/tapfreighter/coin_select.go
+++ b/tapfreighter/coin_select.go
@@ -2,14 +2,26 @@ package tapfreighter
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 	"sync"
 	"time"
 
 	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/lightninglabs/taproot-assets/asset"
 	"github.com/lightninglabs/taproot-assets/commitment"
 	"github.com/lightninglabs/taproot-assets/fn"
+)
+
+const (
+	// eligibleCoinsPageSize is the number of coins we fetch per query when
+	// listing eligible coins for a send. Coins are listed in descending
+	// amount order, so in most cases a single page is enough to cover the
+	// target amount. Listing a coin is expensive, as the full commitment
+	// of its anchor output is reconstructed, so we only fetch more pages
+	// when the previous ones can't cover the target.
+	eligibleCoinsPageSize = 32
 )
 
 // NewCoinSelect creates a new CoinSelect.
@@ -58,19 +70,43 @@ func (s *CoinSelect) SelectCoins(ctx context.Context,
 		PrevIDs:           constraints.PrevIDs,
 		DistinctSpecifier: constraints.DistinctSpecifier,
 	}
-	eligibleCommitments, err := s.coinLister.ListEligibleCoins(
-		ctx, listConstraints,
-	)
-	if err != nil {
-		return nil, fmt.Errorf("unable to list eligible coins: %w", err)
+
+	// We list the eligible coins in pages of descending amounts, so we can
+	// stop listing as soon as the accumulated amount covers the target,
+	// instead of loading every coin the node holds. If specific inputs are
+	// requested, we can't bound the listing, as those are filtered out of
+	// the full listing.
+	pageSize := int32(eligibleCoinsPageSize)
+	if len(constraints.PrevIDs) > 0 {
+		pageSize = 0
 	}
 
-	if len(eligibleCommitments) == 0 {
-		return nil, ErrMatchingAssetsNotFound
+	listing, err := s.listCoins(
+		ctx, listConstraints, constraints.MinAmt, maxVersion, pageSize,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// Each page is listed by a separate query, so the coin set can shift
+	// between two pages and move a coin out of a page we already read past.
+	// That can only ever hide coins from us, never invent ones, but it
+	// could make us report insufficient funds while the funds are actually
+	// there. So if a listing that took more than one page couldn't cover
+	// the target amount, we repeat it unbounded to be sure. A listing that
+	// took a single page needs no such check, as no offset was applied to
+	// it, so it saw the full coin set at that instant.
+	if listing.numPages > 1 && listing.amountSum < constraints.MinAmt {
+		listing, err = s.listCoins(
+			ctx, listConstraints, constraints.MinAmt, maxVersion, 0,
+		)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	anchorInputs := fn.Map(
-		eligibleCommitments, func(c *AnchoredCommitment) string {
+		listing.eligible, func(c *AnchoredCommitment) string {
 			return c.AnchorPoint.String()
 		},
 	)
@@ -78,19 +114,17 @@ func (s *CoinSelect) SelectCoins(ctx context.Context,
 		"%v", len(anchorInputs), constraints.MinAmt,
 		constraints.String(), anchorInputs)
 
-	// Only select coins anchored in a compatible commitment.
-	compatibleCommitments := fn.Filter(
-		eligibleCommitments, func(c *AnchoredCommitment) bool {
-			return c.Commitment.Version <= maxVersion
-		},
-	)
-	if len(compatibleCommitments) == 0 {
+	if len(listing.eligible) == 0 {
+		return nil, ErrMatchingAssetsNotFound
+	}
+
+	if len(listing.compatible) == 0 {
 		return nil, fmt.Errorf("%w: no compatible commitments for max "+
 			"version %v", ErrMatchingAssetsNotFound, maxVersion)
 	}
 
 	selectedCoins, err := s.selectForAmount(
-		constraints.MinAmt, compatibleCommitments, strategy,
+		constraints.MinAmt, listing.compatible, strategy,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("unable to select coins: %w", err)
@@ -112,6 +146,104 @@ func (s *CoinSelect) SelectCoins(ctx context.Context,
 	}
 
 	return selectedCoins, nil
+}
+
+// coinListing is the set of coins a listing produced.
+type coinListing struct {
+	// eligible are all the coins that satisfied the constraints.
+	eligible []*AnchoredCommitment
+
+	// compatible are the eligible coins that are anchored in a commitment
+	// compatible with the requested maximum commitment version.
+	compatible []*AnchoredCommitment
+
+	// amountSum is the total amount of the compatible coins.
+	amountSum uint64
+
+	// numPages is the number of queries the listing took.
+	numPages int
+}
+
+// listCoins lists the coins that satisfy the given constraints.
+//
+// A non-zero pageSize bounds each query to that many coins, which the store
+// returns in descending amount order, and listing stops as soon as the
+// compatible coins cover the target amount. A zero pageSize lists all coins
+// that satisfy the constraints, in no particular order.
+//
+// A page holding fewer coins than the page size is what tells us that the
+// eligible coins are exhausted, so the lister must only return a short page
+// when it has nothing left to list.
+func (s *CoinSelect) listCoins(ctx context.Context,
+	constraints CommitmentConstraints, targetAmt uint64,
+	maxVersion commitment.TapCommitmentVersion,
+	pageSize int32) (*coinListing, error) {
+
+	var (
+		listing   = &coinListing{}
+		seenCoins = fn.NewSet[asset.PrevID]()
+	)
+	for offset := int32(0); ; offset += pageSize {
+		constraints.CoinLimit = pageSize
+		constraints.CoinOffset = offset
+
+		listing.numPages++
+
+		page, err := s.coinLister.ListEligibleCoins(ctx, constraints)
+		switch {
+		// A page past the end of the eligible coin set comes back
+		// empty, which the lister reports as no assets being found.
+		case errors.Is(err, ErrMatchingAssetsNotFound):
+			page = nil
+
+		case err != nil:
+			return nil, fmt.Errorf("unable to list eligible "+
+				"coins: %w", err)
+		}
+
+		// We use the raw number of listed coins to detect whether we've
+		// exhausted the eligible coins further below. It has to be the
+		// raw count, taken before the filters below: a page made up
+		// entirely of coins we've already seen, or of coins in
+		// incompatible commitments, is still a full page, and stopping
+		// on it would report insufficient funds while spendable coins
+		// sit on a later page.
+		numListed := len(page)
+
+		// The coin set can shift between pages, as the queries run in
+		// separate database transactions. We de-duplicate the coins
+		// here, so a shift can never cause the same coin to be
+		// selected twice.
+		page = fn.Filter(page, func(c *AnchoredCommitment) bool {
+			return !seenCoins.Contains(c.PrevID())
+		})
+		for _, c := range page {
+			seenCoins.Add(c.PrevID())
+		}
+
+		listing.eligible = append(listing.eligible, page...)
+
+		// Only coins anchored in a compatible commitment can be
+		// selected, so only those count towards the target amount.
+		compatible := fn.Filter(page, func(c *AnchoredCommitment) bool {
+			return c.Commitment.Version <= maxVersion
+		})
+		listing.compatible = append(listing.compatible, compatible...)
+		for _, c := range compatible {
+			listing.amountSum += c.Asset.Amount
+		}
+
+		// We stop listing once the compatible coins cover the target
+		// amount, once we've exhausted the eligible coins (which an
+		// unbounded or partial page indicates), or once a page no
+		// longer adds any coin we haven't already seen, which also
+		// guarantees that this loop terminates.
+		if listing.amountSum >= targetAmt || pageSize == 0 ||
+			numListed < int(pageSize) || len(page) == 0 {
+
+			return listing, nil
+		}
+	}
 }
 
 // ReleaseCoins releases/unlocks coins that were previously leased and makes

--- a/tapfreighter/coin_select_test.go
+++ b/tapfreighter/coin_select_test.go
@@ -2,6 +2,8 @@ package tapfreighter
 
 import (
 	"context"
+	"fmt"
+	"sort"
 	"testing"
 	"time"
 
@@ -20,24 +22,49 @@ type mockCoinLister struct {
 	leaseSignals   chan struct{}
 	releaseSignals chan struct{}
 	deleteSignals  chan struct{}
+
+	// listCalls records the constraints of each ListEligibleCoins call.
+	listCalls []CommitmentConstraints
 }
 
 func newMockCoinLister(c []*AnchoredCommitment) *mockCoinLister {
 	return &mockCoinLister{
 		eligibleCommitments: c,
-		listSignals:         make(chan struct{}, 1),
-		leaseSignals:        make(chan struct{}, 1),
-		releaseSignals:      make(chan struct{}, 1),
-		deleteSignals:       make(chan struct{}, 1),
+		listSignals:         make(chan struct{}, 100),
+		leaseSignals:        make(chan struct{}, 100),
+		releaseSignals:      make(chan struct{}, 100),
+		deleteSignals:       make(chan struct{}, 100),
 	}
 }
 
-func (m *mockCoinLister) ListEligibleCoins(context.Context,
-	CommitmentConstraints) ([]*AnchoredCommitment, error) {
+func (m *mockCoinLister) ListEligibleCoins(_ context.Context,
+	constraints CommitmentConstraints) ([]*AnchoredCommitment, error) {
 
 	m.listSignals <- struct{}{}
+	m.listCalls = append(m.listCalls, constraints)
 
-	return m.eligibleCommitments, nil
+	coins := m.eligibleCommitments
+
+	// Emulate the behavior of the database backed lister for bounded
+	// listings: coins are returned in pages of CoinLimit coins, in
+	// descending amount order, and a page past the end of the coin set
+	// reports no matching assets.
+	if constraints.CoinLimit > 0 {
+		coins = append([]*AnchoredCommitment{}, coins...)
+		sort.Slice(coins, func(i, j int) bool {
+			return coins[i].Asset.Amount > coins[j].Asset.Amount
+		})
+
+		start := min(int(constraints.CoinOffset), len(coins))
+		end := min(start+int(constraints.CoinLimit), len(coins))
+		coins = coins[start:end]
+
+		if len(coins) == 0 {
+			return nil, ErrMatchingAssetsNotFound
+		}
+	}
+
+	return coins, nil
 }
 
 func (m *mockCoinLister) LeaseCoins(context.Context, [32]byte, time.Time,
@@ -97,7 +124,8 @@ func TestCoinSelector(t *testing.T) {
 	coinLister.eligibleCommitments = []*AnchoredCommitment{
 		{
 			Asset: &asset.Asset{
-				Amount: 1000,
+				Amount:    1000,
+				ScriptKey: asset.RandScriptKey(t),
 			},
 			Commitment: &commitment.TapCommitment{
 				Version: commitment.TapCommitmentV1,
@@ -269,4 +297,388 @@ func TestCoinSelection(t *testing.T) {
 			require.ErrorContains(t, err, tc.expectedErr)
 		})
 	}
+}
+
+// newTestCommitment creates an anchored commitment with the given amount and
+// commitment version. Each commitment gets a unique script key, so
+// commitments can be told apart by their PrevID.
+func newTestCommitment(t *testing.T, amt uint64,
+	version commitment.TapCommitmentVersion) *AnchoredCommitment {
+
+	return &AnchoredCommitment{
+		Asset: &asset.Asset{
+			Amount:    amt,
+			ScriptKey: asset.RandScriptKey(t),
+		},
+		Commitment: &commitment.TapCommitment{
+			Version: version,
+		},
+	}
+}
+
+// TestCoinSelectionPaging tests that eligible coins are listed in bounded
+// pages and that listing stops as soon as the accumulated compatible amount
+// covers the target.
+func TestCoinSelectionPaging(t *testing.T) {
+	t.Parallel()
+
+	ctxb := context.Background()
+	pageSize := int(eligibleCoinsPageSize)
+
+	repeatCommitments := func(n int, amt uint64,
+		version commitment.TapCommitmentVersion) []*AnchoredCommitment {
+
+		commitments := make([]*AnchoredCommitment, n)
+		for i := 0; i < n; i++ {
+			commitments[i] = newTestCommitment(t, amt, version)
+		}
+
+		return commitments
+	}
+
+	testCases := []struct {
+		name        string
+		commitments []*AnchoredCommitment
+		targetAmt   uint64
+		maxVersion  commitment.TapCommitmentVersion
+		prevIDs     []asset.PrevID
+
+		expectedNumSelected int
+		expectedListCalls   int
+		expectedFallback    bool
+		expectedErr         string
+	}{{
+		// The first page holds more than enough coins, so a single
+		// bounded listing should be issued.
+		name: "first page covers target",
+		commitments: repeatCommitments(
+			3*pageSize, 10, commitment.TapCommitmentV1,
+		),
+		targetAmt:           20,
+		maxVersion:          commitment.TapCommitmentV1,
+		expectedNumSelected: 2,
+		expectedListCalls:   1,
+	}, {
+		// The target amount needs more coins than a single page
+		// holds, so a second page should be fetched.
+		name: "second page covers target",
+		commitments: repeatCommitments(
+			2*pageSize, 1, commitment.TapCommitmentV1,
+		),
+		targetAmt:           uint64(pageSize + 10),
+		maxVersion:          commitment.TapCommitmentV1,
+		expectedNumSelected: pageSize + 10,
+		expectedListCalls:   2,
+	}, {
+		// The coins can't cover the target amount, so all pages
+		// should be fetched, followed by an unbounded listing that
+		// rules out coins a paged listing could have skipped, before
+		// giving up.
+		name: "insufficient total amount",
+		commitments: repeatCommitments(
+			2*pageSize+10, 1, commitment.TapCommitmentV1,
+		),
+		targetAmt:         3 * uint64(pageSize),
+		maxVersion:        commitment.TapCommitmentV1,
+		expectedListCalls: 4,
+		expectedFallback:  true,
+		expectedErr:       "insufficient amount available",
+	}, {
+		// The largest coins are all anchored in incompatible
+		// commitments, so listing should continue past them until a
+		// compatible coin covers the target.
+		name: "incompatible coins on first page",
+		commitments: append(
+			repeatCommitments(
+				pageSize, 100, commitment.TapCommitmentV2,
+			),
+			newTestCommitment(t, 5, commitment.TapCommitmentV1),
+		),
+		targetAmt:           5,
+		maxVersion:          commitment.TapCommitmentV1,
+		expectedNumSelected: 1,
+		expectedListCalls:   2,
+	}, {
+		// When specific inputs are requested, the listing can't be
+		// bounded, so a single unbounded listing should be issued.
+		name: "prev IDs disable paging",
+		commitments: repeatCommitments(
+			2*pageSize, 10, commitment.TapCommitmentV1,
+		),
+		targetAmt:  10,
+		maxVersion: commitment.TapCommitmentV1,
+		prevIDs: []asset.PrevID{{
+			OutPoint: wire.OutPoint{Index: 1},
+		}},
+		expectedNumSelected: 1,
+		expectedListCalls:   1,
+	}}
+
+	for _, tc := range testCases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			coinLister := newMockCoinLister(tc.commitments)
+			coinSelect := NewCoinSelect(coinLister)
+
+			selected, err := coinSelect.SelectCoins(
+				ctxb, CommitmentConstraints{
+					MinAmt:  tc.targetAmt,
+					PrevIDs: tc.prevIDs,
+				}, PreferMaxAmount, tc.maxVersion,
+			)
+
+			require.Len(
+				t, coinLister.listCalls, tc.expectedListCalls,
+			)
+
+			// A listing that couldn't cover the target amount must
+			// be followed by an unbounded one.
+			numBounded := len(coinLister.listCalls)
+			if tc.expectedFallback {
+				numBounded--
+
+				last := coinLister.listCalls[numBounded]
+				require.EqualValues(t, 0, last.CoinLimit)
+			}
+
+			if tc.expectedErr != "" {
+				require.ErrorContains(t, err, tc.expectedErr)
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.Len(t, selected, tc.expectedNumSelected)
+
+			// All selected coins must be compatible with the
+			// maximum commitment version and be distinct coins.
+			seen := fn.NewSet[asset.PrevID]()
+			for _, c := range selected {
+				require.LessOrEqual(
+					t, c.Commitment.Version, tc.maxVersion,
+				)
+				require.False(t, seen.Contains(c.PrevID()))
+				seen.Add(c.PrevID())
+			}
+
+			// The bounded list calls must all use the expected
+			// page size, while requests for specific inputs must
+			// be unbounded.
+			bounded := coinLister.listCalls[:numBounded]
+			for idx, call := range bounded {
+				if len(tc.prevIDs) > 0 {
+					require.EqualValues(
+						t, 0, call.CoinLimit,
+					)
+					continue
+				}
+
+				require.EqualValues(
+					t, pageSize, call.CoinLimit,
+				)
+				require.EqualValues(
+					t, idx*pageSize, call.CoinOffset,
+				)
+			}
+		})
+	}
+}
+
+// scriptedCoinLister is a CoinLister that returns a fixed sequence of pages,
+// regardless of the constraints passed to it. It is used to simulate a coin
+// set that shifts between pages.
+type scriptedCoinLister struct {
+	pages     [][]*AnchoredCommitment
+	listErr   error
+	callCount int
+
+	// unboundedCalls counts the calls that asked for an unbounded listing.
+	unboundedCalls int
+}
+
+func (m *scriptedCoinLister) ListEligibleCoins(_ context.Context,
+	constraints CommitmentConstraints) ([]*AnchoredCommitment, error) {
+
+	if m.listErr != nil {
+		return nil, m.listErr
+	}
+
+	// An unbounded listing sees every coin, as a real lister would, no
+	// matter how the scripted pages are laid out.
+	if constraints.CoinLimit == 0 {
+		m.unboundedCalls++
+
+		seen := fn.NewSet[asset.PrevID]()
+		var all []*AnchoredCommitment
+		for _, page := range m.pages {
+			for _, c := range page {
+				if seen.Contains(c.PrevID()) {
+					continue
+				}
+
+				seen.Add(c.PrevID())
+				all = append(all, c)
+			}
+		}
+
+		return all, nil
+	}
+
+	if m.callCount >= len(m.pages) {
+		return nil, ErrMatchingAssetsNotFound
+	}
+
+	page := m.pages[m.callCount]
+	m.callCount++
+
+	return page, nil
+}
+
+func (m *scriptedCoinLister) LeaseCoins(context.Context, [32]byte, time.Time,
+	...wire.OutPoint) error {
+
+	return nil
+}
+
+func (m *scriptedCoinLister) ReleaseCoins(context.Context,
+	...wire.OutPoint) error {
+
+	return nil
+}
+
+func (m *scriptedCoinLister) DeleteExpiredLeases(context.Context) error {
+	return nil
+}
+
+func (m *scriptedCoinLister) FetchOrphanUTXOs(
+	context.Context) ([]*ZeroValueInput, error) {
+
+	return nil, nil
+}
+
+// TestCoinSelectionPagingDuplicates tests that a coin appearing on two pages,
+// which can happen when the coin set shifts between the paged queries, is
+// only counted and selected once.
+func TestCoinSelectionPagingDuplicates(t *testing.T) {
+	t.Parallel()
+
+	ctxb := context.Background()
+	pageSize := int(eligibleCoinsPageSize)
+
+	firstPage := make([]*AnchoredCommitment, pageSize)
+	for i := 0; i < pageSize; i++ {
+		firstPage[i] = newTestCommitment(
+			t, 1, commitment.TapCommitmentV1,
+		)
+	}
+
+	// The second page repeats the last coin of the first page, followed
+	// by a fresh coin.
+	secondPage := []*AnchoredCommitment{
+		firstPage[pageSize-1],
+		newTestCommitment(t, 1, commitment.TapCommitmentV1),
+	}
+
+	coinLister := &scriptedCoinLister{
+		pages: [][]*AnchoredCommitment{firstPage, secondPage},
+	}
+	coinSelect := NewCoinSelect(coinLister)
+
+	// All distinct coins are needed to cover the target, so the
+	// duplicate must not be double counted or double selected.
+	targetAmt := uint64(pageSize + 1)
+	selected, err := coinSelect.SelectCoins(
+		ctxb, CommitmentConstraints{MinAmt: targetAmt},
+		PreferMaxAmount, commitment.TapCommitmentV1,
+	)
+	require.NoError(t, err)
+	require.Len(t, selected, pageSize+1)
+
+	seen := fn.NewSet[asset.PrevID]()
+	for _, c := range selected {
+		require.False(t, seen.Contains(c.PrevID()))
+		seen.Add(c.PrevID())
+	}
+
+	// Asking for more than the distinct coins can cover must fail, even
+	// though the raw listing returned enough rows when counting the
+	// duplicate twice.
+	coinLister = &scriptedCoinLister{
+		pages: [][]*AnchoredCommitment{firstPage, secondPage},
+	}
+	coinSelect = NewCoinSelect(coinLister)
+
+	_, err = coinSelect.SelectCoins(
+		ctxb, CommitmentConstraints{MinAmt: targetAmt + 1},
+		PreferMaxAmount, commitment.TapCommitmentV1,
+	)
+	require.ErrorContains(t, err, "insufficient amount available")
+
+	// The paged listing couldn't cover the target, so it must have been
+	// repeated unbounded before giving up.
+	require.Equal(t, 1, coinLister.unboundedCalls)
+}
+
+// TestCoinSelectionPagingSkip tests that a coin the paged listing skips, which
+// can happen when the coin set shifts between the paged queries, is still
+// found instead of being reported as insufficient funds.
+func TestCoinSelectionPagingSkip(t *testing.T) {
+	t.Parallel()
+
+	pageSize := int(eligibleCoinsPageSize)
+
+	// The first page is full, so listing continues. The coin that would
+	// have been on the second page is missing from it, as if a larger coin
+	// had confirmed in between and shifted it out of the paging window.
+	firstPage := make([]*AnchoredCommitment, pageSize)
+	for i := 0; i < pageSize; i++ {
+		firstPage[i] = newTestCommitment(
+			t, 1, commitment.TapCommitmentV1,
+		)
+	}
+	skippedPage := []*AnchoredCommitment{
+		newTestCommitment(t, 10, commitment.TapCommitmentV1),
+	}
+
+	coinLister := &scriptedCoinLister{
+		pages: [][]*AnchoredCommitment{firstPage, {}, skippedPage},
+	}
+	coinSelect := NewCoinSelect(coinLister)
+
+	// The target can only be covered with the skipped coin, which the
+	// unbounded listing that follows the paged one must surface.
+	selected, err := coinSelect.SelectCoins(
+		context.Background(),
+		CommitmentConstraints{MinAmt: uint64(pageSize + 5)},
+		PreferMaxAmount, commitment.TapCommitmentV1,
+	)
+	require.NoError(t, err)
+	require.Equal(t, 1, coinLister.unboundedCalls)
+
+	var sum uint64
+	for _, c := range selected {
+		sum += c.Asset.Amount
+	}
+	require.GreaterOrEqual(t, sum, uint64(pageSize+5))
+}
+
+// TestCoinSelectionListError tests that an unexpected listing error aborts the
+// selection instead of being treated as an exhausted coin set.
+func TestCoinSelectionListError(t *testing.T) {
+	t.Parallel()
+
+	coinLister := &scriptedCoinLister{
+		listErr: fmt.Errorf("database on fire"),
+	}
+	coinSelect := NewCoinSelect(coinLister)
+
+	_, err := coinSelect.SelectCoins(
+		context.Background(), CommitmentConstraints{MinAmt: 1},
+		PreferMaxAmount, commitment.TapCommitmentV1,
+	)
+	require.ErrorContains(t, err, "unable to list eligible coins")
+	require.ErrorContains(t, err, "database on fire")
 }

--- a/tapfreighter/interface.go
+++ b/tapfreighter/interface.go
@@ -61,6 +61,20 @@ type CommitmentConstraints struct {
 	// ScriptKeyType is the type of script key the assets are expected to
 	// have. If this is fn.None, then any script key type is allowed.
 	ScriptKeyType fn.Option[asset.ScriptKeyType]
+
+	// CoinLimit is the maximum number of coins to list when set. Bounded
+	// listings return coins in descending amount order, so the largest
+	// eligible coins are returned first. A value of 0 means no limit, in
+	// which case no specific order is guaranteed.
+	//
+	// This cannot be combined with PrevIDs, as those are filtered for
+	// after the listing, so a bounded listing could return a page that
+	// holds none of the requested inputs.
+	CoinLimit int32
+
+	// CoinOffset is the number of coins to skip in a bounded listing. This
+	// is used to page through the eligible coins when a CoinLimit is set.
+	CoinOffset int32
 }
 
 // AssetBurn holds data related to a burn of an asset.
@@ -157,6 +171,12 @@ type CoinLister interface {
 	//
 	// If coin selection cannot be completed, then ErrMatchingAssetsNotFound
 	// should be returned.
+	//
+	// A listing bounded by CoinLimit must return fewer coins than the limit
+	// only when the eligible coins are exhausted, since that is how the
+	// caller learns that paging is done. An implementation that drops coins
+	// after querying them would make a bounded listing look exhausted while
+	// coins remain.
 	ListEligibleCoins(context.Context,
 		CommitmentConstraints) ([]*AnchoredCommitment, error)
 


### PR DESCRIPTION
Funding a send listed every eligible coin the node holds before selecting
inputs: `ListEligibleCoins` was unbounded and the SQL amount filter was passed
1, with the real target applied in Go afterwards. Listing a coin is expensive,
since the full commitment of its anchor output is reconstructed, so the cost of
a send scaled with total holdings instead of with the number of inputs needed.

### Changes

- `CommitmentConstraints` gains `CoinLimit`/`CoinOffset`, and `QueryAssets`
  gains an amount-descending order option that bounded listings use. Bounding
  cannot be combined with pinned `PrevIDs`, since that filter runs after the
  query, so `ListEligibleCoins` now rejects the combination instead of
  silently ignoring the bound.
- `SelectCoins` lists coins in pages of 32 and stops as soon as the compatible
  coins cover the target. A single page covers the common case.
- Pages are separate queries, so the coin set can shift between them. Coins
  are de-duplicated across pages by prev ID, and a listing that took more than
  one page and still could not cover the target is repeated unbounded before
  reporting insufficient funds, so that answer stays as accurate as before. A
  single-page listing needs no retry, as no offset was applied to it.

### Speedups

Measured against a copy of a real regtest node: sqlite, 2461 assets, dominant
asset group holding 621 coins.

| operation | before | this PR | with #2251 too |
|---|---|---|---|
| coin selection, 1-unit group send | 16.57s | 792ms | 68ms |
| coin selection, 181-coin send | 16.56s | 4.69s | 447ms |
| coin selection, 621-coin send | 16.63s | 14.63s | 2.28s |
| coin selection, insufficient funds | 16.62s | 28.93s | 3.81s |

Note the last row: with this PR alone, a send that cannot be funded is 1.7x
slower than before because of the unbounded retry. It only affects that
failure path, and it drops to 3.81s (4.4x faster than baseline) once the
per-asset query batching in #2251 lands as well. The alternative is keyset pagination
on `(amount, assets.asset_id)`, where a cursor cannot skip rows and the retry
becomes unnecessary; happy to do that instead if preferred.

### Behavior

Selection results are unchanged for unequal amounts: `PreferMaxAmount` already
took candidates in descending amount order until the target was covered, and
the pages arrive in that same order.

This PR shrinks the set that gets loaded, #2251 cuts the per-asset query cost
of whatever is loaded, so the two are complementary. End to end with both, a
v2 address send on that node goes from 28.1s to 10.8s median, and stays flat
as the wallet fragments further.

Diffing full dumps of the selected coin sets against baseline (1 unit, 181
coins, 621 coins, single asset ID, pinned prev IDs, insufficient funds):
identical coin count, total and amount multiset in every case, and identical
error strings. The only difference is which coin gets picked among coins of
exactly equal amount, one swap in the 1-unit case and three in the 181-coin
case. Tie order was never defined, since `selectForAmount` sorts with
`sort.Slice`.

The new ordering term is inert for other `QueryAssets` consumers, as its
argument is NULL unless a bounded listing is requested. Verified by hashing
the returned row order for five query shapes; `TestFetchAllAssetsPagination`
covers the same on postgres, where NULL ordering semantics differ.

### Testing

New tests for paging, cross-page duplicates, a skipped coin, the listing error
path, and the bounded listing at the tapdb level. Unit tests pass on sqlite
and postgres, `make lint` and `make sqlc-check` are clean, and itests pass
(`basic_send_unidirectional`, `address_v2_self_send`, `full_value_send`,
`multi_input_send_non-interactive_single_ID`). Every commit builds and compiles
its unit tests standalone.

Closes #2250
