### PR TITLE
universe: only log NEW_PROOF events for leaves we didn't already have

### DIFF
--- a/bench/fixture/sync.go
+++ b/bench/fixture/sync.go
@@ -209,7 +209,7 @@ func (r *directRegistrar) UpsertProofLeafBatch(ctx context.Context,
 
 	r.metrics.UpsertBatches.Add(1)
 	r.metrics.LeavesInserted.Add(int64(len(items)))
-	err := r.multiverse.UpsertProofLeafBatch(ctx, items)
+	_, err := r.multiverse.UpsertProofLeafBatch(ctx, items)
 	r.classify(err)
 	return err
 }
@@ -399,7 +399,7 @@ func seedType(tb testing.TB, ctx context.Context, f *SyncFixture,
 			}
 		}
 
-		err := f.Remote.Multiverse.UpsertProofLeafBatch(
+		_, err := f.Remote.Multiverse.UpsertProofLeafBatch(
 			ctx, remoteItems,
 		)
 		require.NoError(tb, err)
@@ -408,7 +408,7 @@ func seedType(tb testing.TB, ctx context.Context, f *SyncFixture,
 			continue
 		}
 
-		err = f.Local.Multiverse.UpsertProofLeafBatch(
+		_, err = f.Local.Multiverse.UpsertProofLeafBatch(
 			ctx, remoteItems[:rootLocalCount],
 		)
 		require.NoError(tb, err)

--- a/bench/fixture/sync.go
+++ b/bench/fixture/sync.go
@@ -199,7 +199,7 @@ func (r *directRegistrar) UpsertProofLeaf(ctx context.Context,
 	leaf *universe.Leaf) (*universe.Proof, error) {
 
 	r.metrics.LeavesInserted.Add(1)
-	p, err := r.multiverse.UpsertProofLeaf(ctx, id, key, leaf, nil)
+	p, _, err := r.multiverse.UpsertProofLeaf(ctx, id, key, leaf, nil)
 	r.classify(err)
 	return p, err
 }
@@ -435,7 +435,7 @@ func (f *SyncFixture) AddRemoteDivergence(tb testing.TB,
 
 	ctx := context.Background()
 	for i := 0; i < n; i++ {
-		_, err := f.Remote.Multiverse.UpsertProofLeaf(
+		_, _, err := f.Remote.Multiverse.UpsertProofLeaf(
 			ctx, id, randLeafKey(tb),
 			randMintingLeafFor(tb, assetGen), nil,
 		)

--- a/bench/fixture/sync_test.go
+++ b/bench/fixture/sync_test.go
@@ -120,14 +120,16 @@ func TestSyncFixture_StaleContentAtSharedKeys(t *testing.T) {
 		}
 	}
 
-	require.NoError(t, f.Remote.Multiverse.UpsertProofLeafBatch(
+	_, err := f.Remote.Multiverse.UpsertProofLeafBatch(
 		ctx, remoteItems,
-	))
-	require.NoError(t, f.Local.Multiverse.UpsertProofLeafBatch(
+	)
+	require.NoError(t, err)
+	_, err = f.Local.Multiverse.UpsertProofLeafBatch(
 		ctx, localItems,
-	))
+	)
+	require.NoError(t, err)
 
-	_, err := f.Syncer.SyncUniverse(
+	_, err = f.Syncer.SyncUniverse(
 		ctx, universe.ServerAddr{}, universe.SyncFull,
 		GlobalSyncConfig(),
 	)
@@ -192,14 +194,16 @@ func TestSyncFixture_RemoteBehindPeer(t *testing.T) {
 		}
 	}
 
-	require.NoError(t, f.Remote.Multiverse.UpsertProofLeafBatch(
+	_, err := f.Remote.Multiverse.UpsertProofLeafBatch(
 		ctx, shared,
-	))
-	require.NoError(t, f.Local.Multiverse.UpsertProofLeafBatch(
+	)
+	require.NoError(t, err)
+	_, err = f.Local.Multiverse.UpsertProofLeafBatch(
 		ctx, append(shared, extras...),
-	))
+	)
+	require.NoError(t, err)
 
-	_, err := f.Syncer.SyncUniverse(
+	_, err = f.Syncer.SyncUniverse(
 		ctx, universe.ServerAddr{}, universe.SyncFull,
 		GlobalSyncConfig(),
 	)

--- a/docs/release-notes/release-notes-0.9.0.md
+++ b/docs/release-notes/release-notes-0.9.0.md
@@ -97,11 +97,18 @@
   held was still logged as a new proof, so `num_total_proofs` in the
   universe stats counted insert attempts rather than proofs held, and
   the `universe_events` table grew with sync traffic rather than with
-  universe size. Note that this stops the over-counting, it does not
-  correct a count that has already been inflated.
+  universe size.
+
+  Database migration 67 redefines the `universe_stats` view to derive
+  the proof count from the universe leaves actually held instead of
+  from the event log, so a database that already accumulated duplicate
+  events reports the correct figure from the upgrade onwards. No event
+  rows are deleted, as the per-day statistics still read them. Note
+  that the count can now decrease when a proof leaf is deleted, which
+  it previously did not.
 
   This also changes the meaning of `new_proof_events` in `QueryEvents`,
-  which is fed by the same rows: it now counts leaves newly acquired
+  which is fed by the event rows: it now counts leaves newly acquired
   per day rather than registration attempts per day, so on a
   long-running node the series steps down. The per-day `sync_events`
   series is unchanged and still reflects sync traffic volume.

--- a/docs/release-notes/release-notes-0.9.0.md
+++ b/docs/release-notes/release-notes-0.9.0.md
@@ -92,6 +92,20 @@
   concurrent batch snapshot can never observe state that disk does
   not yet hold.
 
+* [PR#2255](https://github.com/lightninglabs/taproot-assets/pull/2255)
+  fixes a bug in which registering a proof leaf the universe already
+  held was still logged as a new proof, so `num_total_proofs` in the
+  universe stats counted insert attempts rather than proofs held, and
+  the `universe_events` table grew with sync traffic rather than with
+  universe size. Note that this stops the over-counting, it does not
+  correct a count that has already been inflated.
+
+  This also changes the meaning of `new_proof_events` in `QueryEvents`,
+  which is fed by the same rows: it now counts leaves newly acquired
+  per day rather than registration attempts per day, so on a
+  long-running node the series steps down. The per-day `sync_events`
+  series is unchanged and still reflects sync traffic volume.
+
 # New Features
 
 ## Functional Enhancements

--- a/rpcserver/syncdelta_test.go
+++ b/rpcserver/syncdelta_test.go
@@ -89,7 +89,7 @@ func seedUniverse(t *testing.T, mv *tapdb.MultiverseStore,
 			),
 		}
 
-		_, err = mv.UpsertProofLeaf(ctx, id, key, leaf, nil)
+		_, _, err = mv.UpsertProofLeaf(ctx, id, key, leaf, nil)
 		require.NoError(t, err)
 	}
 }

--- a/tapcustody/custodian_test.go
+++ b/tapcustody/custodian_test.go
@@ -354,7 +354,9 @@ func (h *custodianHarness) addProofFileToMultiverse(p *proof.AnnotatedProof) {
 			"into multiverse",
 			key.ScriptKey.PubKey.SerializeCompressed(),
 			key.OutPoint)
-		_, err = h.multiverse.UpsertProofLeaf(ctxt, id, key, leaf, nil)
+		_, _, err = h.multiverse.UpsertProofLeaf(
+			ctxt, id, key, leaf, nil,
+		)
 		require.NoError(h.t, err)
 	}
 }

--- a/tapdb/burn_tree.go
+++ b/tapdb/burn_tree.go
@@ -131,7 +131,7 @@ func insertBurnsInternal(ctx context.Context, db BaseUniverseStore,
 				"tree type to universe proof type: %w", err)
 		}
 
-		_, _, _, err = universeUpsertProofLeaf(
+		_, _, err = universeUpsertProofLeaf(
 			ctx, db, subNs, uniProofType, groupKey, leafKey, leaf,
 			nil, blockHeight,
 		)

--- a/tapdb/ingest_bench_test.go
+++ b/tapdb/ingest_bench_test.go
@@ -54,7 +54,7 @@ func BenchmarkMultiverseLeafIngest(b *testing.B) {
 				items := benchIngestItems(b, batch)
 				b.StartTimer()
 
-				err := store.UpsertProofLeafBatch(ctx, items)
+				_, err := store.UpsertProofLeafBatch(ctx, items)
 				require.NoError(b, err)
 			}
 		})
@@ -72,7 +72,7 @@ func BenchmarkMultiverseLeafIngestSingle(b *testing.B) {
 	store, _ := newTestMultiverse(b)
 
 	seed := benchIngestItems(b, seedLeaves)
-	err := store.UpsertProofLeafBatch(ctx, seed)
+	_, err := store.UpsertProofLeafBatch(ctx, seed)
 	require.NoError(b, err)
 
 	id := seed[0].ID
@@ -122,7 +122,10 @@ func BenchmarkMultiverseLeafIngestConcurrent(b *testing.B) {
 			wg.Add(1)
 			go func(items []*universe.Item) {
 				defer wg.Done()
-				errs <- store.UpsertProofLeafBatch(ctx, items)
+				_, err := store.UpsertProofLeafBatch(
+					ctx, items,
+				)
+				errs <- err
 			}(batches[w])
 		}
 		wg.Wait()

--- a/tapdb/ingest_bench_test.go
+++ b/tapdb/ingest_bench_test.go
@@ -87,7 +87,7 @@ func BenchmarkMultiverseLeafIngestSingle(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, err := store.UpsertProofLeaf(
+		_, _, err := store.UpsertProofLeaf(
 			ctx, id, keys[i], &leaves[i], nil,
 		)
 		require.NoError(b, err)

--- a/tapdb/migrations.go
+++ b/tapdb/migrations.go
@@ -24,7 +24,7 @@ const (
 	// daemon.
 	//
 	// NOTE: This MUST be updated when a new migration is added.
-	LatestMigrationVersion = 66
+	LatestMigrationVersion = 67
 )
 
 // DatabaseBackend is an interface that contains all methods our different

--- a/tapdb/migrations_test.go
+++ b/tapdb/migrations_test.go
@@ -2086,3 +2086,147 @@ func TestMigration61CancelsDuplicatePreBroadcastBatches(t *testing.T) {
 	`).Scan(&cancelledCount))
 	require.Equal(t, 3, cancelledCount)
 }
+
+// TestMigration67UniverseStatsFromLeaves tests that the universe stats view
+// starts reporting the number of leaves held rather than the number of
+// NEW_PROOF events logged, and that it does so for a database that already
+// accumulated duplicate events. It also checks that supply commitment
+// sub-tree leaves, which live in the same table, stay excluded.
+func TestMigration67UniverseStatsFromLeaves(t *testing.T) {
+	ctx := context.Background()
+
+	// Start just before the migration under test.
+	db := NewTestDBWithVersion(t, 66)
+
+	// Build a universe holding two leaves, with the NEW_PROOF event log
+	// inflated to five entries the way a pre-fix node's would be, plus a
+	// burn sub-tree root with a leaf of its own.
+	_, err := db.ExecContext(ctx, transformByteLiterals(t, db.BaseDB, `
+	  INSERT INTO mssmt_nodes (
+	      hash_key, l_hash_key, r_hash_key, key, value, sum, namespace
+	  ) VALUES (
+	    X'2222222222222222222222222222222222222222222222222222222222222222',
+	    NULL, NULL, X'00', X'00', 0, 'ns_issuance'
+	  ), (
+	    X'3333333333333333333333333333333333333333333333333333333333333333',
+	    NULL, NULL, X'00', X'00', 0, 'ns_burn'
+	  );
+
+	  INSERT INTO mssmt_roots (namespace, root_hash) VALUES (
+	    'ns_issuance',
+	    X'2222222222222222222222222222222222222222222222222222222222222222'
+	  ), (
+	    'ns_burn',
+	    X'3333333333333333333333333333333333333333333333333333333333333333'
+	  );
+
+	  INSERT INTO genesis_points (genesis_id, prev_out)
+	  VALUES (1, X'0011');
+
+	  INSERT INTO genesis_assets (
+	      gen_asset_id, asset_id, asset_tag, output_index, asset_type,
+	      genesis_point_id
+	  ) VALUES (
+	    1,
+	    X'4444444444444444444444444444444444444444444444444444444444444444',
+	    'stats-asset', 0, 0, 1
+	  );
+
+	  INSERT INTO universe_roots (
+	      id, namespace_root, asset_id, group_key, proof_type
+	  ) VALUES (
+	    1, 'ns_issuance',
+	    X'4444444444444444444444444444444444444444444444444444444444444444',
+	    NULL, 'issuance'
+	  ), (
+	    2, 'ns_burn',
+	    X'4444444444444444444444444444444444444444444444444444444444444444',
+	    NULL, 'burn'
+	  );
+
+	  INSERT INTO universe_leaves (
+	      id, asset_genesis_id, minting_point, script_key_bytes,
+	      universe_root_id, leaf_node_key, leaf_node_namespace
+	  ) VALUES
+(1, 1, X'0011',
+X'0101010101010101010101010101010101010101010101010101010101010101',
+1, X'aa', 'ns_issuance'),
+(2, 1, X'0011',
+X'0202020202020202020202020202020202020202020202020202020202020202',
+1, X'bb', 'ns_issuance'),
+(3, 1, X'0011',
+X'0303030303030303030303030303030303030303030303030303030303030303',
+2, X'cc', 'ns_burn');
+
+	  INSERT INTO universe_events (
+	      event_id, event_type, universe_root_id, event_time,
+	      event_timestamp
+	  ) VALUES
+	    (1, 'NEW_PROOF', 1, '2024-01-01 00:00:00', 1704067200),
+	    (2, 'NEW_PROOF', 1, '2024-01-01 00:00:00', 1704067200),
+	    (3, 'NEW_PROOF', 1, '2024-01-01 00:00:00', 1704067200),
+	    (4, 'NEW_PROOF', 1, '2024-01-01 00:00:00', 1704067200),
+	    (5, 'NEW_PROOF', 1, '2024-01-01 00:00:00', 1704067200),
+	    (6, 'SYNC', 1, '2024-01-01 00:00:00', 1704067200),
+	    (7, 'SYNC', 1, '2024-01-01 00:00:00', 1704067200);
+	`))
+	require.NoError(t, err)
+
+	// Before the migration the view counts the five event rows.
+	var preProofs, preSyncs int64
+	err = db.QueryRowContext(ctx, `
+		SELECT COALESCE(SUM(total_asset_proofs), 0),
+		       COALESCE(SUM(total_asset_syncs), 0)
+		FROM universe_stats
+	`).Scan(&preProofs, &preSyncs)
+	require.NoError(t, err)
+	require.EqualValues(t, 5, preProofs)
+	require.EqualValues(t, 2, preSyncs)
+
+	// Migrate.
+	require.NoError(t, db.ExecuteMigrations(TargetLatest))
+
+	// The proof count now reflects the two leaves we actually hold. The
+	// burn sub-tree leaf is not counted, and the sync count is untouched.
+	var postProofs, postSyncs int64
+	err = db.QueryRowContext(ctx, `
+		SELECT COALESCE(SUM(total_asset_proofs), 0),
+		       COALESCE(SUM(total_asset_syncs), 0)
+		FROM universe_stats
+	`).Scan(&postProofs, &postSyncs)
+	require.NoError(t, err)
+	require.EqualValues(t, 2, postProofs)
+	require.EqualValues(t, 2, postSyncs)
+
+	// The event rows are left alone: QueryAssetStatsPerDay still reads
+	// them, so the migration must not delete history.
+	var events int64
+	err = db.QueryRowContext(ctx, `
+		SELECT COUNT(*) FROM universe_events
+		WHERE event_type = 'NEW_PROOF'
+	`).Scan(&events)
+	require.NoError(t, err)
+	require.EqualValues(t, 5, events)
+
+	// The burn root is absent from the view entirely, as before: it has no
+	// sync events and its leaves aren't counted.
+	var burnRows int64
+	err = db.QueryRowContext(ctx, `
+		SELECT COUNT(*) FROM universe_stats WHERE proof_type = 'burn'
+	`).Scan(&burnRows)
+	require.NoError(t, err)
+	require.Zero(t, burnRows)
+
+	// Downgrading restores the event-derived count, so an operator rolling
+	// back to an older tapd gets the view that release expects.
+	require.NoError(t, db.ExecuteMigrations(TargetVersion(66)))
+
+	err = db.QueryRowContext(ctx, `
+		SELECT COALESCE(SUM(total_asset_proofs), 0),
+		       COALESCE(SUM(total_asset_syncs), 0)
+		FROM universe_stats
+	`).Scan(&preProofs, &preSyncs)
+	require.NoError(t, err)
+	require.EqualValues(t, 5, preProofs)
+	require.EqualValues(t, 2, preSyncs)
+}

--- a/tapdb/multiverse.go
+++ b/tapdb/multiverse.go
@@ -1072,14 +1072,21 @@ func journalUniverseLeaves(ctx context.Context, db BaseUniverseStore,
 // superseded this one before the multiverse update was flushed, the
 // receipt is rebuilt from the newer state, so its universe root may be
 // fresher than the root this call's own transaction committed.
+//
+// The returned boolean reports whether the upsert created a new universe leaf,
+// as opposed to replacing the proof of one we already held. It is determined
+// inside the write transaction, so it stays correct under concurrent inserts
+// of the same leaf: serializable isolation makes exactly one of them the
+// creator. It is set in the pending case too, as the leaf is committed by then.
 func (b *MultiverseStore) UpsertProofLeaf(ctx context.Context,
 	id universe.Identifier, key universe.LeafKey, leaf *universe.Leaf,
-	metaReveal *proof.MetaReveal) (*universe.Proof, error) {
+	metaReveal *proof.MetaReveal) (*universe.Proof, bool, error) {
 
 	var (
-		writeTx    BaseMultiverseOptions
-		uniProof   *universe.Proof
-		rootStatus universeRootStatus
+		writeTx      BaseMultiverseOptions
+		uniProof     *universe.Proof
+		rootStatus   universeRootStatus
+		leafInserted bool
 	)
 
 	execTxFunc := func(dbTx BaseMultiverseStore) error {
@@ -1099,6 +1106,7 @@ func (b *MultiverseStore) UpsertProofLeaf(ctx context.Context,
 			return fmt.Errorf("failed universe upsert: %w", err)
 		}
 		rootStatus = res.rootStatus
+		leafInserted = res.leafInserted
 
 		if shouldJournalLeaf(id) {
 			err = journalUniverseLeaves(
@@ -1113,7 +1121,7 @@ func (b *MultiverseStore) UpsertProofLeaf(ctx context.Context,
 	}
 	dbErr := b.db.ExecTx(ctx, &writeTx, execTxFunc)
 	if dbErr != nil {
-		return nil, dbErr
+		return nil, leafInserted, dbErr
 	}
 
 	// The universe leaf is now durably committed, so run the
@@ -1157,7 +1165,8 @@ func (b *MultiverseStore) UpsertProofLeaf(ctx context.Context,
 	// update in the background.
 	update, err := b.rootCoalescer.updateRoot(ctx, id)
 	if err != nil {
-		return nil, fmt.Errorf("failed multiverse upsert: %w", err)
+		return nil, leafInserted, fmt.Errorf("failed multiverse "+
+			"upsert: %w", err)
 	}
 
 	// If a concurrent insert into the same universe committed between
@@ -1176,17 +1185,17 @@ func (b *MultiverseStore) UpsertProofLeaf(ctx context.Context,
 	if !mssmt.IsEqualNode(update.universeRoot, uniProof.UniverseRoot) {
 		proofs, err := b.fetchProofLeaf(ctx, id, key, true)
 		if err != nil {
-			return nil, fmt.Errorf("%w: failed superseded "+
-				"proof fetch: %w",
+			return nil, leafInserted, fmt.Errorf("%w: failed "+
+				"superseded proof fetch: %w",
 				universe.ErrMultiversePending, err)
 		}
 		if len(proofs) != 1 {
-			return nil, fmt.Errorf("%w: expected one proof "+
-				"for superseded upsert, got %d",
+			return nil, leafInserted, fmt.Errorf("%w: expected "+
+				"one proof for superseded upsert, got %d",
 				universe.ErrMultiversePending, len(proofs))
 		}
 
-		return proofs[0], nil
+		return proofs[0], leafInserted, nil
 	}
 
 	// Populate the multiverse fields in the proof object now that the
@@ -1194,7 +1203,7 @@ func (b *MultiverseStore) UpsertProofLeaf(ctx context.Context,
 	uniProof.MultiverseRoot = update.multiverseRoot
 	uniProof.MultiverseInclusionProof = update.inclusionProof
 
-	return uniProof, nil
+	return uniProof, leafInserted, nil
 }
 
 // UpsertProofLeafBatch upserts a proof leaf batch within the multiverse tree

--- a/tapdb/multiverse.go
+++ b/tapdb/multiverse.go
@@ -1087,10 +1087,10 @@ func (b *MultiverseStore) UpsertProofLeaf(ctx context.Context,
 		// tree. The block height is extracted from the decoded proof
 		// by universeUpsertProofLeaf itself.
 		var (
-			err    error
-			leafID int64
+			res universeUpsertResult
+			err error
 		)
-		uniProof, rootStatus, leafID, err = universeUpsertProofLeaf(
+		uniProof, res, err = universeUpsertProofLeaf(
 			ctx, dbTx, id.String(), id.ProofType,
 			id.GroupKey, key, leaf, metaReveal,
 			lfn.None[uint32](),
@@ -1098,10 +1098,11 @@ func (b *MultiverseStore) UpsertProofLeaf(ctx context.Context,
 		if err != nil {
 			return fmt.Errorf("failed universe upsert: %w", err)
 		}
+		rootStatus = res.rootStatus
 
 		if shouldJournalLeaf(id) {
 			err = journalUniverseLeaves(
-				ctx, dbTx, []int64{leafID},
+				ctx, dbTx, []int64{res.leafID},
 			)
 			if err != nil {
 				return err
@@ -1206,13 +1207,17 @@ func (b *MultiverseStore) UpsertProofLeaf(ctx context.Context,
 // coalescer retries the updates in the background until they commit,
 // and ReconcileMultiverse repairs any update abandoned by a shutdown
 // at the next startup.
+//
+// The returned slice holds the subset of items that resulted in a new universe
+// leaf; items the universe already held are left out.
 func (b *MultiverseStore) UpsertProofLeafBatch(ctx context.Context,
-	items []*universe.Item) error {
+	items []*universe.Item) ([]*universe.Item, error) {
 
 	var (
 		writeTx      BaseMultiverseOptions
 		uniProofs    []*universe.Proof
 		rootStatuses []universeRootStatus
+		newItems     []*universe.Item
 	)
 	// Track the universes the batch touches, in first-touch order, so
 	// the shared multiverse tree is refreshed once per universe rather
@@ -1225,6 +1230,7 @@ func (b *MultiverseStore) UpsertProofLeafBatch(ctx context.Context,
 			rootStatuses = make(
 				[]universeRootStatus, len(items),
 			)
+			newItems = make([]*universe.Item, 0, len(items))
 
 			dirtyUniverses = make(
 				[]universe.Identifier, 0, len(items),
@@ -1239,7 +1245,7 @@ func (b *MultiverseStore) UpsertProofLeafBatch(ctx context.Context,
 				// start with. The block height is extracted
 				// from the decoded proof by
 				// universeUpsertProofLeaf itself.
-				uniProof, status, leafID, err :=
+				uniProof, res, err :=
 					universeUpsertProofLeaf(
 						ctx, store, item.ID.String(),
 						item.ID.ProofType,
@@ -1253,7 +1259,11 @@ func (b *MultiverseStore) UpsertProofLeafBatch(ctx context.Context,
 						idx, err)
 				}
 				uniProofs[idx] = uniProof
-				rootStatuses[idx] = status
+				rootStatuses[idx] = res.rootStatus
+
+				if res.leafInserted {
+					newItems = append(newItems, item)
+				}
 
 				key := item.ID.String()
 				if _, ok := seen[key]; !ok {
@@ -1265,7 +1275,7 @@ func (b *MultiverseStore) UpsertProofLeafBatch(ctx context.Context,
 
 				if shouldJournalLeaf(item.ID) {
 					journalIDs = append(
-						journalIDs, leafID,
+						journalIDs, res.leafID,
 					)
 				}
 			}
@@ -1276,7 +1286,7 @@ func (b *MultiverseStore) UpsertProofLeafBatch(ctx context.Context,
 		},
 	)
 	if dbErr != nil {
-		return dbErr
+		return nil, dbErr
 	}
 
 	// The universe leaves are now durably committed, so run the
@@ -1351,12 +1361,16 @@ func (b *MultiverseStore) UpsertProofLeafBatch(ctx context.Context,
 	// fails, the universe leaves above remain committed, and the
 	// coalescer keeps retrying the multiverse updates in the
 	// background.
+	//
+	// The new leaves are reported either way: they are committed, so they
+	// count towards the universe stats even while their multiverse entry
+	// is still outstanding.
 	err := b.rootCoalescer.updateRoots(ctx, dirtyUniverses)
 	if err != nil {
-		return fmt.Errorf("failed multiverse upsert: %w", err)
+		return newItems, fmt.Errorf("failed multiverse upsert: %w", err)
 	}
 
-	return nil
+	return newItems, nil
 }
 
 // DeleteUniverse delete an entire universe sub-tree.

--- a/tapdb/multiverse_cache_test.go
+++ b/tapdb/multiverse_cache_test.go
@@ -136,7 +136,7 @@ func TestRootNodeCacheTargetedInvalidation(t *testing.T) {
 	items := make([]*universe.Item, numAssets)
 	for i := range items {
 		items[i] = genRandomAsset(t)
-		_, err := multiverse.UpsertProofLeaf(
+		_, _, err := multiverse.UpsertProofLeaf(
 			ctx, items[i].ID, items[i].Key, items[i].Leaf, nil,
 		)
 		require.NoError(t, err)
@@ -148,7 +148,7 @@ func TestRootNodeCacheTargetedInvalidation(t *testing.T) {
 		leaf := randMintingLeaf(
 			t, item.Leaf.Genesis, item.ID.GroupKey,
 		)
-		uniProof, err := multiverse.UpsertProofLeaf(
+		uniProof, _, err := multiverse.UpsertProofLeaf(
 			ctx, item.ID, randLeafKey(t), &leaf, nil,
 		)
 		require.NoError(t, err)
@@ -200,7 +200,7 @@ func TestRootNodeCacheTargetedInvalidation(t *testing.T) {
 	// composition, so it must invalidate all cached pages: re-reading
 	// refills all three of them.
 	newItem := genRandomAsset(t)
-	_, err := multiverse.UpsertProofLeaf(
+	_, _, err := multiverse.UpsertProofLeaf(
 		ctx, newItem.ID, newItem.Key, newItem.Leaf, nil,
 	)
 	require.NoError(t, err)
@@ -292,7 +292,7 @@ func TestRootNodeCacheTargetedInvalidation(t *testing.T) {
 	requireSameRoots(t, freshView(), roots)
 
 	before = misses()
-	_, err = multiverse.UpsertProofLeaf(
+	_, _, err = multiverse.UpsertProofLeaf(
 		ctx, victim.ID, victim.Key, victim.Leaf, nil,
 	)
 	require.NoError(t, err)
@@ -513,7 +513,7 @@ func TestRootNodeCacheConcurrency(t *testing.T) {
 	seed := make([]*universe.Item, numSeed)
 	for i := range seed {
 		seed[i] = genRandomAsset(t)
-		_, err := multiverse.UpsertProofLeaf(
+		_, _, err := multiverse.UpsertProofLeaf(
 			ctx, seed[i].ID, seed[i].Key, seed[i].Leaf, nil,
 		)
 		require.NoError(t, err)
@@ -595,7 +595,7 @@ func TestRootNodeCacheConcurrency(t *testing.T) {
 			}
 
 			for _, op := range ops {
-				_, err := multiverse.UpsertProofLeaf(
+				_, _, err := multiverse.UpsertProofLeaf(
 					ctx, op.ID, op.Key, op.Leaf, nil,
 				)
 				if err != nil {
@@ -834,7 +834,7 @@ func TestSyncerCacheDeleteProofLeaf(t *testing.T) {
 	items := genUniverseItemsWithType(t, universe.ProofTypeIssuance, 2)
 	id := items[0].ID
 	for _, item := range items {
-		_, err := multiverse.UpsertProofLeaf(
+		_, _, err := multiverse.UpsertProofLeaf(
 			ctx, item.ID, item.Key, item.Leaf, item.MetaReveal,
 		)
 		require.NoError(t, err)
@@ -843,7 +843,7 @@ func TestSyncerCacheDeleteProofLeaf(t *testing.T) {
 	const numOthers = 3
 	for i := 0; i < numOthers; i++ {
 		other := genRandomAsset(t)
-		_, err := multiverse.UpsertProofLeaf(
+		_, _, err := multiverse.UpsertProofLeaf(
 			ctx, other.ID, other.Key, other.Leaf,
 			other.MetaReveal,
 		)

--- a/tapdb/multiverse_cache_test.go
+++ b/tapdb/multiverse_cache_test.go
@@ -36,7 +36,7 @@ func TestMultiverseRootsCachePerformance(t *testing.T) {
 		allLeaves = append(allLeaves, leaf)
 
 		if i != 0 && (i+1)%100 == 0 {
-			err := multiverse.UpsertProofLeafBatch(ctx, batch)
+			_, err := multiverse.UpsertProofLeafBatch(ctx, batch)
 			require.NoError(t, err)
 
 			t.Logf("Inserted %d assets", i+1)
@@ -248,7 +248,8 @@ func TestRootNodeCacheTargetedInvalidation(t *testing.T) {
 			Leaf: &leaf,
 		}
 	}
-	require.NoError(t, multiverse.UpsertProofLeafBatch(ctx, updateItems))
+	_, err = multiverse.UpsertProofLeafBatch(ctx, updateItems)
+	require.NoError(t, err)
 
 	before = misses()
 	roots = queryRoots(t, multiverse, pageSize)
@@ -268,7 +269,8 @@ func TestRootNodeCacheTargetedInvalidation(t *testing.T) {
 			Leaf: &leaf,
 		},
 	}
-	require.NoError(t, multiverse.UpsertProofLeafBatch(ctx, mixedBatch))
+	_, err = multiverse.UpsertProofLeafBatch(ctx, mixedBatch)
+	require.NoError(t, err)
 
 	before = misses()
 	roots = queryRoots(t, multiverse, pageSize)
@@ -579,9 +581,10 @@ func TestRootNodeCacheConcurrency(t *testing.T) {
 				const chunk = 5
 				for i := 0; i < len(ops); i += chunk {
 					end := min(i+chunk, len(ops))
-					err := multiverse.UpsertProofLeafBatch(
-						ctx, ops[i:end],
-					)
+					_, err := multiverse.
+						UpsertProofLeafBatch(
+							ctx, ops[i:end],
+						)
 					if err != nil {
 						errs <- err
 						return
@@ -672,7 +675,7 @@ func TestMultiverseSyncerCache(t *testing.T) {
 		allLeaves = append(allLeaves, leaf)
 	}
 
-	err := multiverse.UpsertProofLeafBatch(ctx, allLeaves)
+	_, err := multiverse.UpsertProofLeafBatch(ctx, allLeaves)
 	require.NoError(t, err)
 
 	// We query all roots and make sure they are all there. This will also

--- a/tapdb/multiverse_coalescer_test.go
+++ b/tapdb/multiverse_coalescer_test.go
@@ -80,7 +80,7 @@ func insertUniverseLeafOnly(ctx context.Context,
 	)
 	err := multiverse.db.ExecTx(
 		ctx, &writeTx, func(store BaseMultiverseStore) error {
-			uniProof, _, _, err := universeUpsertProofLeaf(
+			uniProof, _, err := universeUpsertProofLeaf(
 				ctx, store, item.ID.String(),
 				item.ID.ProofType, item.ID.GroupKey, item.Key,
 				item.Leaf, item.MetaReveal, lfn.None[uint32](),

--- a/tapdb/multiverse_coalescer_test.go
+++ b/tapdb/multiverse_coalescer_test.go
@@ -684,7 +684,7 @@ func TestUpsertProofLeafSameUniverseConcurrent(t *testing.T) {
 		go func(i int) {
 			defer wg.Done()
 
-			receipts[i], errs[i] = multiverse.UpsertProofLeaf(
+			receipts[i], _, errs[i] = multiverse.UpsertProofLeaf(
 				ctx, items[i].ID, items[i].Key,
 				items[i].Leaf, items[i].MetaReveal,
 			)
@@ -869,7 +869,7 @@ func TestFetchProofLeafUnderConcurrentInserts(t *testing.T) {
 	items := genUniverseItems(t, numLeaves)
 	id := items[0].ID
 
-	_, err := multiverse.UpsertProofLeaf(
+	_, _, err := multiverse.UpsertProofLeaf(
 		ctx, items[0].ID, items[0].Key, items[0].Leaf,
 		items[0].MetaReveal,
 	)
@@ -883,7 +883,7 @@ func TestFetchProofLeafUnderConcurrentInserts(t *testing.T) {
 		defer close(writerDone)
 
 		for _, item := range items[1:] {
-			_, err := multiverse.UpsertProofLeaf(
+			_, _, err := multiverse.UpsertProofLeaf(
 				ctx, item.ID, item.Key, item.Leaf,
 				item.MetaReveal,
 			)
@@ -972,7 +972,7 @@ func TestUpsertProofLeafConcurrentDelete(t *testing.T) {
 	id := items[0].ID
 
 	// Seed the universe so the deletion has something to delete.
-	_, err := multiverse.UpsertProofLeaf(
+	_, _, err := multiverse.UpsertProofLeaf(
 		ctx, items[0].ID, items[0].Key, items[0].Leaf,
 		items[0].MetaReveal,
 	)
@@ -989,7 +989,7 @@ func TestUpsertProofLeafConcurrentDelete(t *testing.T) {
 		go func(i int) {
 			defer wg.Done()
 
-			receipts[i], errs[i] = multiverse.UpsertProofLeaf(
+			receipts[i], _, errs[i] = multiverse.UpsertProofLeaf(
 				ctx, items[i].ID, items[i].Key,
 				items[i].Leaf, items[i].MetaReveal,
 			)
@@ -1276,7 +1276,7 @@ func TestUpsertProofLeafFlushFailure(t *testing.T) {
 
 	// Insert a first leaf and fetch it, so the proof cache holds an
 	// entry that the failing insert below must evict.
-	_, err = multiverse.UpsertProofLeaf(
+	_, _, err = multiverse.UpsertProofLeaf(
 		ctx, items[0].ID, items[0].Key, items[0].Leaf,
 		items[0].MetaReveal,
 	)
@@ -1309,7 +1309,7 @@ func TestUpsertProofLeafFlushFailure(t *testing.T) {
 	// report the typed partial-commit error, as the universe leaf
 	// committed while the multiverse update did not.
 	failDB.failing.Store(true)
-	_, err = multiverse.UpsertProofLeaf(
+	_, _, err = multiverse.UpsertProofLeaf(
 		ctx, items[1].ID, items[1].Key, items[1].Leaf,
 		items[1].MetaReveal,
 	)
@@ -1446,7 +1446,7 @@ func TestUpsertProofLeafSuperseded(t *testing.T) {
 	}
 	hookDB.beforeFlush.Store(&hook)
 
-	receipt, err := multiverse.UpsertProofLeaf(
+	receipt, _, err := multiverse.UpsertProofLeaf(
 		ctx, items[0].ID, items[0].Key, items[0].Leaf,
 		items[0].MetaReveal,
 	)
@@ -1490,7 +1490,7 @@ func TestUpsertProofLeafSupersededRebuildFailure(t *testing.T) {
 	}
 	hookDB.beforeFlush.Store(&hook)
 
-	_, err := multiverse.UpsertProofLeaf(
+	_, _, err := multiverse.UpsertProofLeaf(
 		ctx, items[0].ID, items[0].Key, items[0].Leaf,
 		items[0].MetaReveal,
 	)
@@ -1530,7 +1530,7 @@ func TestUpsertProofLeafSupersededStaleCache(t *testing.T) {
 
 	// Store and fetch the first version of the leaf, so a receipt
 	// predating everything below exists to poison the cache with.
-	_, err := multiverse.UpsertProofLeaf(
+	_, _, err := multiverse.UpsertProofLeaf(
 		ctx, items[0].ID, items[0].Key, items[0].Leaf,
 		items[0].MetaReveal,
 	)
@@ -1556,7 +1556,7 @@ func TestUpsertProofLeafSupersededStaleCache(t *testing.T) {
 	}
 	hookDB.beforeFlush.Store(&hook)
 
-	receipt, err := multiverse.UpsertProofLeaf(
+	receipt, _, err := multiverse.UpsertProofLeaf(
 		ctx, items[1].ID, items[1].Key, items[1].Leaf,
 		items[1].MetaReveal,
 	)
@@ -1623,7 +1623,7 @@ func TestUpsertProofLeafDeletedInGap(t *testing.T) {
 	}
 	hookDB.beforeFlush.Store(&hook)
 
-	_, err := multiverse.UpsertProofLeaf(
+	_, _, err := multiverse.UpsertProofLeaf(
 		ctx, items[0].ID, items[0].Key, items[0].Leaf,
 		items[0].MetaReveal,
 	)
@@ -1914,7 +1914,7 @@ func TestUpsertProofLeafFlushRecovery(t *testing.T) {
 	// Every flush fails, as under a database outage.
 	hookDB.failFrom.Store(1)
 
-	_, err := multiverse.UpsertProofLeaf(
+	_, _, err := multiverse.UpsertProofLeaf(
 		ctx, item.ID, item.Key, item.Leaf, item.MetaReveal,
 	)
 	require.ErrorIs(t, err, universe.ErrMultiversePending)

--- a/tapdb/multiverse_delta_test.go
+++ b/tapdb/multiverse_delta_test.go
@@ -49,7 +49,7 @@ func insertDeltaLeaf(t *testing.T, ctx context.Context,
 	key := randLeafKey(t)
 	leaf := randMintingLeaf(t, u.gen, u.id.GroupKey)
 
-	_, err := store.UpsertProofLeaf(ctx, u.id, key, &leaf, nil)
+	_, _, err := store.UpsertProofLeaf(ctx, u.id, key, &leaf, nil)
 	require.NoError(t, err)
 
 	return key, leaf
@@ -135,7 +135,7 @@ func TestMultiverseFetchLeavesSince(t *testing.T) {
 	// Re-upserting an existing leaf must not produce a new sequence
 	// number: re-org style rewrites are invisible to the delta, which is
 	// why root comparison stays authoritative.
-	_, err = store.UpsertProofLeaf(
+	_, _, err = store.UpsertProofLeaf(
 		ctx, all[0].id, all[0].key, &all[0].leaf, nil,
 	)
 	require.NoError(t, err)
@@ -337,7 +337,7 @@ func TestMultiverseFetchDeltaPageSnapshot(t *testing.T) {
 
 			key := randLeafKey(t)
 			leaf := randMintingLeaf(t, u.gen, u.id.GroupKey)
-			_, err := store.UpsertProofLeaf(
+			_, _, err := store.UpsertProofLeaf(
 				ctx, u.id, key, &leaf, nil,
 			)
 			if err != nil {
@@ -426,7 +426,7 @@ func TestMultiverseLeafJournalCommitOrder(t *testing.T) {
 	go func() {
 		keyB := randLeafKey(t)
 		leafB := randMintingLeaf(t, uniB.gen, uniB.id.GroupKey)
-		_, err := store.UpsertProofLeaf(
+		_, _, err := store.UpsertProofLeaf(
 			ctx, uniB.id, keyB, &leafB, nil,
 		)
 		bDone <- err

--- a/tapdb/multiverse_delta_test.go
+++ b/tapdb/multiverse_delta_test.go
@@ -199,7 +199,7 @@ func TestMultiverseLeafJournalReupsertGap(t *testing.T) {
 	// Batch: re-upsert the existing leaf together with a new one.
 	key1 := randLeafKey(t)
 	leaf1 := randMintingLeaf(t, u.gen, u.id.GroupKey)
-	err = store.UpsertProofLeafBatch(ctx, []*universe.Item{
+	_, err = store.UpsertProofLeafBatch(ctx, []*universe.Item{
 		{ID: u.id, Key: key0, Leaf: &leaf0},
 		{ID: u.id, Key: key1, Leaf: &leaf1},
 	})
@@ -391,7 +391,7 @@ func TestMultiverseLeafJournalCommitOrder(t *testing.T) {
 		aDone <- store.db.ExecTx(
 			ctx, &writeTx,
 			func(dbTx BaseMultiverseStore) error {
-				_, _, leafID, err := universeUpsertProofLeaf(
+				_, res, err := universeUpsertProofLeaf(
 					ctx, dbTx, uniA.id.String(),
 					uniA.id.ProofType, uniA.id.GroupKey,
 					keyA, &leafA, nil,
@@ -402,7 +402,7 @@ func TestMultiverseLeafJournalCommitOrder(t *testing.T) {
 				}
 
 				err = journalUniverseLeaves(
-					ctx, dbTx, []int64{leafID},
+					ctx, dbTx, []int64{res.leafID},
 				)
 				if err != nil {
 					return err

--- a/tapdb/multiverse_reconcile_test.go
+++ b/tapdb/multiverse_reconcile_test.go
@@ -121,7 +121,7 @@ func TestReconcileMultiverseProps(t *testing.T) {
 
 			switch kind {
 			case "healthy":
-				_, err := multiverse.UpsertProofLeaf(
+				_, _, err := multiverse.UpsertProofLeaf(
 					ctx, item.ID, item.Key, item.Leaf,
 					item.MetaReveal,
 				)
@@ -135,7 +135,7 @@ func TestReconcileMultiverseProps(t *testing.T) {
 				expectDiverged++
 
 			case "tampered":
-				_, err := multiverse.UpsertProofLeaf(
+				_, _, err := multiverse.UpsertProofLeaf(
 					ctx, item.ID, item.Key, item.Leaf,
 					item.MetaReveal,
 				)
@@ -183,7 +183,7 @@ func TestReconcileMultiversePagination(t *testing.T) {
 		// Alternate healthy and orphaned universes, so divergence
 		// appears on every page of the scan.
 		if i%2 == 0 {
-			_, err := multiverse.UpsertProofLeaf(
+			_, _, err := multiverse.UpsertProofLeaf(
 				ctx, item.ID, item.Key, item.Leaf,
 				item.MetaReveal,
 			)
@@ -377,7 +377,7 @@ func TestReconcileMultiverseSyncerCache(t *testing.T) {
 	const numHealthy = 4
 	for i := 0; i < numHealthy; i++ {
 		item := genRandomAsset(t)
-		_, err := multiverse.UpsertProofLeaf(
+		_, _, err := multiverse.UpsertProofLeaf(
 			ctx, item.ID, item.Key, item.Leaf, item.MetaReveal,
 		)
 		require.NoError(t, err)

--- a/tapdb/multiverse_reconcile_test.go
+++ b/tapdb/multiverse_reconcile_test.go
@@ -63,7 +63,8 @@ func TestReconcileMultiverse(t *testing.T) {
 	for i := range items {
 		items[i] = genRandomAsset(t)
 	}
-	require.NoError(t, multiverse.UpsertProofLeafBatch(ctx, items))
+	_, err = multiverse.UpsertProofLeafBatch(ctx, items)
+	require.NoError(t, err)
 
 	updates, err = multiverse.multiverseDivergence(ctx)
 	require.NoError(t, err)

--- a/tapdb/sqlc/migrations/000067_universe_stats_proofs_from_leaves.down.sql
+++ b/tapdb/sqlc/migrations/000067_universe_stats_proofs_from_leaves.down.sql
@@ -1,0 +1,38 @@
+-- Restore the event-derived proof count from migration 29.
+DROP VIEW universe_stats;
+
+CREATE VIEW universe_stats AS
+WITH sync_counts AS (
+    SELECT universe_root_id, COUNT(*) AS count
+    FROM universe_events
+    WHERE event_type = 'SYNC'
+    GROUP BY universe_root_id
+), proof_counts AS (
+    SELECT universe_root_id, event_type, COUNT(*) AS count
+    FROM universe_events
+    WHERE event_type = 'NEW_PROOF'
+    GROUP BY universe_root_id, event_type
+), aggregated AS (
+    SELECT COALESCE(SUM(count), 0) as total_asset_syncs,
+           0 AS total_asset_proofs,
+           universe_root_id
+    FROM sync_counts
+    GROUP BY universe_root_id
+    UNION ALL
+    SELECT 0 AS total_asset_syncs,
+           COALESCE(SUM(count), 0) as total_asset_proofs,
+           universe_root_id
+    FROM proof_counts
+    GROUP BY universe_root_id
+)
+SELECT
+    SUM(ag.total_asset_syncs) AS total_asset_syncs,
+    SUM(ag.total_asset_proofs) AS total_asset_proofs,
+    roots.asset_id,
+    roots.group_key,
+    roots.proof_type
+FROM aggregated ag
+JOIN universe_roots roots
+    ON ag.universe_root_id = roots.id
+GROUP BY roots.asset_id, roots.group_key, roots.proof_type
+ORDER BY roots.asset_id, roots.group_key, roots.proof_type;

--- a/tapdb/sqlc/migrations/000067_universe_stats_proofs_from_leaves.up.sql
+++ b/tapdb/sqlc/migrations/000067_universe_stats_proofs_from_leaves.up.sql
@@ -1,0 +1,52 @@
+-- Derive the universe proof count from the leaves we actually hold rather
+-- than from the NEW_PROOF event log.
+--
+-- total_asset_proofs used to be a COUNT(*) over universe_events, which counts
+-- registration attempts: a peer re-pushing a leaf we already had wrote another
+-- row. Counting universe_leaves reports what the universe holds, and does so
+-- for databases that already accumulated duplicate events.
+--
+-- The sync count is unchanged and still comes from the event log, which is
+-- where "how much traffic did we see" belongs.
+DROP VIEW universe_stats;
+
+CREATE VIEW universe_stats AS
+WITH sync_counts AS (
+    SELECT universe_root_id, COUNT(*) AS count
+    FROM universe_events
+    WHERE event_type = 'SYNC'
+    GROUP BY universe_root_id
+), proof_counts AS (
+    SELECT leaves.universe_root_id, COUNT(*) AS count
+    FROM universe_leaves leaves
+    JOIN universe_roots roots
+        ON leaves.universe_root_id = roots.id
+    -- The supply commitment sub-trees (burn, ignore and mint_supply) store
+    -- their leaves in this table too, but they are not universe proofs and
+    -- were never counted here, as they never produced a NEW_PROOF event.
+    WHERE roots.proof_type IN ('issuance', 'transfer')
+    GROUP BY leaves.universe_root_id
+), aggregated AS (
+    SELECT COALESCE(SUM(count), 0) as total_asset_syncs,
+           0 AS total_asset_proofs,
+           universe_root_id
+    FROM sync_counts
+    GROUP BY universe_root_id
+    UNION ALL
+    SELECT 0 AS total_asset_syncs,
+           COALESCE(SUM(count), 0) as total_asset_proofs,
+           universe_root_id
+    FROM proof_counts
+    GROUP BY universe_root_id
+)
+SELECT
+    SUM(ag.total_asset_syncs) AS total_asset_syncs,
+    SUM(ag.total_asset_proofs) AS total_asset_proofs,
+    roots.asset_id,
+    roots.group_key,
+    roots.proof_type
+FROM aggregated ag
+JOIN universe_roots roots
+    ON ag.universe_root_id = roots.id
+GROUP BY roots.asset_id, roots.group_key, roots.proof_type
+ORDER BY roots.asset_id, roots.group_key, roots.proof_type;

--- a/tapdb/sqlc/querier.go
+++ b/tapdb/sqlc/querier.go
@@ -317,6 +317,7 @@ type Querier interface {
 	// TODO(roasbeef): use the universe id instead for the grouping? so namespace
 	// root, simplifies queries
 	QueryUniverseAssetStats(ctx context.Context, arg QueryUniverseAssetStatsParams) ([]QueryUniverseAssetStatsRow, error)
+	QueryUniverseLeafID(ctx context.Context, arg QueryUniverseLeafIDParams) (int64, error)
 	QueryUniverseLeaves(ctx context.Context, arg QueryUniverseLeavesParams) ([]QueryUniverseLeavesRow, error)
 	QueryUniverseServers(ctx context.Context, arg QueryUniverseServersParams) ([]UniverseServer, error)
 	QueryUniverseStats(ctx context.Context) (QueryUniverseStatsRow, error)

--- a/tapdb/sqlc/queries/universe.sql
+++ b/tapdb/sqlc/queries/universe.sql
@@ -36,6 +36,13 @@ WHERE universe_root_id = (SELECT id FROM root_id);
 DELETE FROM universe_roots
 WHERE namespace_root = @namespace_root;
 
+-- name: QueryUniverseLeafID :one
+SELECT id
+FROM universe_leaves
+WHERE leaf_node_namespace = @namespace
+  AND minting_point = @minting_point
+  AND script_key_bytes = @script_key_bytes;
+
 -- name: UpsertUniverseLeaf :one
 INSERT INTO universe_leaves (
     asset_genesis_id, script_key_bytes, universe_root_id, leaf_node_key,

--- a/tapdb/sqlc/schemas/generated_schema.sql
+++ b/tapdb/sqlc/schemas/generated_schema.sql
@@ -1292,10 +1292,15 @@ WITH sync_counts AS (
     WHERE event_type = 'SYNC'
     GROUP BY universe_root_id
 ), proof_counts AS (
-    SELECT universe_root_id, event_type, COUNT(*) AS count
-    FROM universe_events
-    WHERE event_type = 'NEW_PROOF'
-    GROUP BY universe_root_id, event_type
+    SELECT leaves.universe_root_id, COUNT(*) AS count
+    FROM universe_leaves leaves
+    JOIN universe_roots roots
+        ON leaves.universe_root_id = roots.id
+    -- The supply commitment sub-trees (burn, ignore and mint_supply) store
+    -- their leaves in this table too, but they are not universe proofs and
+    -- were never counted here, as they never produced a NEW_PROOF event.
+    WHERE roots.proof_type IN ('issuance', 'transfer')
+    GROUP BY leaves.universe_root_id
 ), aggregated AS (
     SELECT COALESCE(SUM(count), 0) as total_asset_syncs,
            0 AS total_asset_proofs,

--- a/tapdb/sqlc/universe.sql.go
+++ b/tapdb/sqlc/universe.sql.go
@@ -1041,6 +1041,27 @@ func (q *Queries) QueryUniverseAssetStats(ctx context.Context, arg QueryUniverse
 	return items, nil
 }
 
+const QueryUniverseLeafID = `-- name: QueryUniverseLeafID :one
+SELECT id
+FROM universe_leaves
+WHERE leaf_node_namespace = $1
+  AND minting_point = $2
+  AND script_key_bytes = $3
+`
+
+type QueryUniverseLeafIDParams struct {
+	Namespace      string
+	MintingPoint   []byte
+	ScriptKeyBytes []byte
+}
+
+func (q *Queries) QueryUniverseLeafID(ctx context.Context, arg QueryUniverseLeafIDParams) (int64, error) {
+	row := q.db.QueryRowContext(ctx, QueryUniverseLeafID, arg.Namespace, arg.MintingPoint, arg.ScriptKeyBytes)
+	var id int64
+	err := row.Scan(&id)
+	return id, err
+}
+
 const QueryUniverseLeaves = `-- name: QueryUniverseLeaves :many
 SELECT leaves.script_key_bytes, gen.gen_asset_id, nodes.value AS genesis_proof,
        nodes.sum AS sum_amt, gen.asset_id

--- a/tapdb/sqlutils_test.go
+++ b/tapdb/sqlutils_test.go
@@ -205,7 +205,7 @@ func (d *DbHandler) AddUniProofLeaf(t *testing.T, testAsset *asset.Asset,
 		Amt:      testAsset.Amount,
 	}
 
-	uniProof, err := d.MultiverseStore.UpsertProofLeaf(
+	uniProof, _, err := d.MultiverseStore.UpsertProofLeaf(
 		ctx, uniId, leafKey, &leaf, nil,
 	)
 	require.NoError(t, err)

--- a/tapdb/supply_tree.go
+++ b/tapdb/supply_tree.go
@@ -469,7 +469,7 @@ func registerMintSupplyInternal(ctx context.Context, dbTx BaseUniverseStore,
 			"to universe proof type: %w", err)
 	}
 
-	mintSupplyProof, _, _, err := universeUpsertProofLeaf(
+	mintSupplyProof, _, err := universeUpsertProofLeaf(
 		ctx, dbTx, subNs, uniProofType, groupKey,
 		key, leaf, metaReveal, blockHeight,
 	)

--- a/tapdb/universe.go
+++ b/tapdb/universe.go
@@ -32,6 +32,10 @@ type (
 	// insertion journal.
 	InsertUniverseLeafJournal = sqlc.InsertUniverseLeafJournalParams
 
+	// UniverseLeafIDQuery is used to look up the primary key of a single
+	// universe leaf.
+	UniverseLeafIDQuery = sqlc.QueryUniverseLeafIDParams
+
 	// NewUniverseRoot is used to insert a new universe root.
 	NewUniverseRoot = sqlc.UpsertUniverseRootParams
 
@@ -117,6 +121,12 @@ type BaseUniverseStore interface {
 	// key.
 	FetchUniverseRoot(ctx context.Context,
 		namespace string) (UniverseRoot, error)
+
+	// QueryUniverseLeafID returns the primary key of the universe leaf
+	// identified by the given namespace, minting point and script key. It
+	// returns sql.ErrNoRows if no such leaf exists.
+	QueryUniverseLeafID(ctx context.Context,
+		arg UniverseLeafIDQuery) (int64, error)
 
 	// UpsertUniverseLeaf upserts a Universe leaf in the database,
 	// returning the leaf's primary key.
@@ -785,7 +795,7 @@ func (b *BaseUniverseTree) UpsertProofLeaf(ctx context.Context,
 
 		// The block height is extracted from the decoded proof by
 		// universeUpsertProofLeaf itself.
-		issuanceProof, _, leafID, err := universeUpsertProofLeaf(
+		issuanceProof, res, err := universeUpsertProofLeaf(
 			ctx, dbTx, namespace, b.id.ProofType,
 			b.id.GroupKey, key, leaf, metaReveal,
 			lfn.None[uint32](),
@@ -793,7 +803,6 @@ func (b *BaseUniverseTree) UpsertProofLeaf(ctx context.Context,
 		if err != nil {
 			return fmt.Errorf("failed universe upsert: %w", err)
 		}
-
 		err = upsertMultiverseLeafEntry(
 			ctx, dbTx, b.id, issuanceProof.UniverseRoot,
 		)
@@ -814,7 +823,7 @@ func (b *BaseUniverseTree) UpsertProofLeaf(ctx context.Context,
 
 		if shouldJournalLeaf(b.id) {
 			err = journalUniverseLeaves(
-				ctx, dbTx, []int64{leafID},
+				ctx, dbTx, []int64{res.leafID},
 			)
 			if err != nil {
 				return err
@@ -1071,13 +1080,33 @@ const (
 	universeRootUpdated
 )
 
+// universeUpsertResult reports what an upsert of a proof leaf changed within
+// its universe tree. Both fields are deliberately safe in their zero value,
+// so an error return that never sets them drives the conservative path:
+// a full cache wipe, and no new proof event.
+type universeUpsertResult struct {
+	// rootStatus indicates whether the upsert created the universe tree
+	// or updated one that already existed.
+	rootStatus universeRootStatus
+
+	// leafInserted is true if the upsert created a new universe leaf, and
+	// false if it replaced the proof of a leaf the universe already held.
+	// Callers use this to avoid counting a re-registration of a leaf we
+	// already have as a new proof.
+	leafInserted bool
+
+	// leafID is the primary key of the upserted universe leaf. It is only
+	// set when the upsert succeeds.
+	leafID int64
+}
+
 // universeUpsertProofLeaf upserts a proof leaf within the universe tree (stored
 // at the proof leaf key). It handles the insertion into the specific universe's
 // SMT and updates the relevant database tables for that universe.
 //
 // This function returns the inserted/updated proof leaf, whether the upsert
-// created the universe tree, and the leaf's database id. It does NOT insert
-// into the top-level multiverse tree.
+// created the universe tree, whether it created the leaf itself, and the
+// leaf's database id. It does NOT insert into the top-level multiverse tree.
 //
 // NOTE: This function accepts a db transaction, as it's used when making
 // broader DB updates.
@@ -1085,8 +1114,8 @@ func universeUpsertProofLeaf(ctx context.Context, dbTx BaseUniverseStore,
 	namespace string, proofType universe.ProofType,
 	groupKey *btcec.PublicKey,
 	key universe.LeafKey, leaf *universe.Leaf, metaReveal *proof.MetaReveal,
-	blockHeight lfn.Option[uint32]) (*universe.Proof, universeRootStatus,
-	int64, error) {
+	blockHeight lfn.Option[uint32]) (*universe.Proof, universeUpsertResult,
+	error) {
 
 	// With the tree store created, we'll now obtain byte representation of
 	// the minting key, as that'll be the key in the SMT itself.
@@ -1101,16 +1130,18 @@ func universeUpsertProofLeaf(ctx context.Context, dbTx BaseUniverseStore,
 		groupKeyBytes = schnorr.SerializePubKey(groupKey)
 	}
 
-	// rootStatus reports whether this upsert created the universe tree.
-	// The zero value is the safe, over-invalidating universeRootCreated,
-	// which is what all error returns below hand back; the status is
-	// only meaningful when the upsert succeeds.
-	var rootStatus universeRootStatus
+	// res reports what this upsert changed. Its zero value is the safe,
+	// over-invalidating universeRootCreated with no leaf insertion, which
+	// is what all error returns below hand back; the result is only
+	// meaningful when the upsert succeeds.
+	var res universeUpsertResult
 
 	mintingPointBytes, err := encodeOutpoint(key.LeafOutPoint())
 	if err != nil {
-		return nil, rootStatus, 0, err
+		return nil, res, err
 	}
+
+	scriptKeyBytes := schnorr.SerializePubKey(key.LeafScriptKey().PubKey)
 
 	var (
 		leafInclusionProof *mssmt.Proof
@@ -1131,17 +1162,42 @@ func universeUpsertProofLeaf(ctx context.Context, dbTx BaseUniverseStore,
 	// non-empty root.
 	existingRoot, err := universeTree.Root(ctx)
 	if err != nil {
-		return nil, rootStatus, 0, err
+		return nil, res, err
 	}
 	if existingRoot.NodeHash() != mssmt.EmptyTreeRootHash {
-		rootStatus = universeRootUpdated
+		res.rootStatus = universeRootUpdated
+	}
+
+	// Whether we're about to create the leaf or replace the proof of one
+	// we already hold decides if this counts as a new proof for the
+	// universe stats. A universe tree that didn't exist can't have held
+	// the leaf, so the lookup is only needed for an existing tree.
+	var leafInserted bool
+	switch res.rootStatus {
+	case universeRootCreated:
+		leafInserted = true
+
+	case universeRootUpdated:
+		_, err := dbTx.QueryUniverseLeafID(ctx, UniverseLeafIDQuery{
+			Namespace:      namespace,
+			MintingPoint:   mintingPointBytes,
+			ScriptKeyBytes: scriptKeyBytes,
+		})
+		switch {
+		case errors.Is(err, sql.ErrNoRows):
+			leafInserted = true
+
+		case err != nil:
+			return nil, res, fmt.Errorf("unable to query "+
+				"universe leaf: %w", err)
+		}
 	}
 
 	// Now that we have a tree instance linked to this DB transaction, we'll
 	// insert the leaf into the tree based on its SMT key.
 	_, err = universeTree.Insert(ctx, smtKey, leafNode)
 	if err != nil {
-		return nil, rootStatus, 0, err
+		return nil, res, err
 	}
 
 	// Next, we'll upsert the universe root in the DB, which gives us the
@@ -1153,7 +1209,7 @@ func universeUpsertProofLeaf(ctx context.Context, dbTx BaseUniverseStore,
 		ProofType:     sqlStr(proofType.String()),
 	})
 	if err != nil {
-		return nil, rootStatus, 0, err
+		return nil, res, err
 	}
 
 	// Before we insert the asset genesis, we'll insert the meta first. The
@@ -1161,7 +1217,7 @@ func universeUpsertProofLeaf(ctx context.Context, dbTx BaseUniverseStore,
 	// meta blob on disk.
 	_, err = maybeUpsertAssetMeta(ctx, dbTx, &leaf.Genesis, metaReveal)
 	if err != nil {
-		return nil, rootStatus, 0, err
+		return nil, res, err
 	}
 
 	// On the ingest path the archive has already decoded and memoized the
@@ -1169,7 +1225,7 @@ func universeUpsertProofLeaf(ctx context.Context, dbTx BaseUniverseStore,
 	// transaction.
 	leafProof, err := leaf.DecodedProof()
 	if err != nil {
-		return nil, rootStatus, 0, err
+		return nil, res, err
 	}
 
 	// Upsert into the DB: the genesis point, asset genesis,
@@ -1179,7 +1235,7 @@ func universeUpsertProofLeaf(ctx context.Context, dbTx BaseUniverseStore,
 		ctx, dbTx, leaf.Genesis, leaf.GroupKey, leafProof,
 	)
 	if err != nil {
-		return nil, rootStatus, 0, err
+		return nil, res, err
 	}
 
 	// If the asset group supports supply commitments and this is an
@@ -1189,8 +1245,8 @@ func universeUpsertProofLeaf(ctx context.Context, dbTx BaseUniverseStore,
 		ctx, dbTx, proofType, *leafProof, metaReveal,
 	)
 	if err != nil {
-		return nil, rootStatus, 0, fmt.Errorf("unable to upsert "+
-			"supply pre-commit: %w", err)
+		return nil, res, fmt.Errorf("unable to upsert supply "+
+			"pre-commit: %w", err)
 	}
 
 	// If the block height isn't specified, then we'll attempt to extract it
@@ -1208,8 +1264,6 @@ func universeUpsertProofLeaf(ctx context.Context, dbTx BaseUniverseStore,
 		},
 	)
 
-	scriptKey := key.LeafScriptKey()
-	scriptKeyBytes := schnorr.SerializePubKey(scriptKey.PubKey)
 	leafID, err := dbTx.UpsertUniverseLeaf(ctx, UpsertUniverseLeaf{
 		AssetGenesisID:    assetGenID,
 		ScriptKeyBytes:    scriptKeyBytes,
@@ -1220,22 +1274,26 @@ func universeUpsertProofLeaf(ctx context.Context, dbTx BaseUniverseStore,
 		BlockHeight:       sqlBlockHeight,
 	})
 	if err != nil {
-		return nil, rootStatus, 0, err
+		return nil, res, err
 	}
 
 	// Finally, we'll obtain the merkle proof from the tree for the leaf we
 	// just inserted.
 	leafInclusionProof, err = universeTree.MerkleProof(ctx, smtKey)
 	if err != nil {
-		return nil, rootStatus, 0, err
+		return nil, res, err
 	}
 
 	// With the insertion complete, we'll now fetch the root of the tree as
 	// it stands and return it to the caller.
 	universeRoot, err = universeTree.Root(ctx)
 	if err != nil {
-		return nil, rootStatus, 0, err
+		return nil, res, err
 	}
+
+	// The upsert succeeded, so the leaf-level outcome is now meaningful.
+	res.leafInserted = leafInserted
+	res.leafID = leafID
 
 	// Return the proof containing only universe-level information.
 	// Multiverse details will be added by the caller if needed.
@@ -1244,7 +1302,7 @@ func universeUpsertProofLeaf(ctx context.Context, dbTx BaseUniverseStore,
 		UniverseRoot:           universeRoot,
 		UniverseInclusionProof: leafInclusionProof,
 		Leaf:                   leaf,
-	}, rootStatus, leafID, nil
+	}, res, nil
 }
 
 // FetchProof retrieves a universe proof corresponding to the given key. If the

--- a/tapdb/universe_stats_test.go
+++ b/tapdb/universe_stats_test.go
@@ -193,6 +193,17 @@ func TestUniverseStatsProofCount(t *testing.T) {
 	stats, err := statsDB.AggregateSyncStats(ctx)
 	require.NoError(t, err)
 	require.EqualValues(t, numLeaves, stats.NumTotalProofs)
+
+	// The count is derived from the leaves, so it would report the right
+	// number even if we logged an event per attempt. Assert on the event
+	// rows directly as well, since the table is what grows without bound.
+	var events int
+	err = db.BaseDB.QueryRowContext(ctx, `
+		SELECT COUNT(*) FROM universe_events
+		WHERE event_type = 'NEW_PROOF'
+	`).Scan(&events)
+	require.NoError(t, err)
+	require.Equal(t, numLeaves, events)
 }
 
 // TestUniverseStatsEvents tests that we're able to properly insert, and also
@@ -220,12 +231,14 @@ func TestUniverseStatsEvents(t *testing.T) {
 		}
 	}
 
-	// Before we insert anything into the DB, we should have all zeroes for
-	// the main events.
+	// Before we log any events we should have all zeroes for the event
+	// driven stats. The proof count is not one of those: it reports the
+	// leaves the harness inserted above, whether or not anything was
+	// logged for them.
 	sh.assertUniverseStatsEqual(t, universe.AggregateStats{
 		NumTotalAssets: numTranches,
 		NumTotalGroups: numGroups,
-		NumTotalProofs: 0,
+		NumTotalProofs: numTranches,
 		NumTotalSyncs:  0,
 	})
 
@@ -239,8 +252,8 @@ func TestUniverseStatsEvents(t *testing.T) {
 		testClock.SetTime(testClock.Now().Add(24 * time.Hour))
 	}
 
-	// We'll now query for the set of aggregate Universe stats. It should
-	// show 3 assets, and one new proof for each of those assets.
+	// We'll now query for the set of aggregate Universe stats. The proof
+	// count is unmoved by the logging, as it counts leaves held.
 	sh.assertUniverseStatsEqual(t, universe.AggregateStats{
 		NumTotalAssets: numTranches,
 		NumTotalGroups: numGroups,

--- a/tapdb/universe_stats_test.go
+++ b/tapdb/universe_stats_test.go
@@ -139,6 +139,62 @@ func (u *uniStatsHarness) addEvents(numAssets int) {
 	}
 }
 
+// TestUniverseStatsProofCount tests that the total proof count reported by the
+// universe stats tracks the number of leaves we hold, not the number of times
+// a leaf was registered with us. Peers re-pushing a leaf we already have is a
+// no-op upsert, and used to still write a NEW_PROOF event each time.
+func TestUniverseStatsProofCount(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	db := NewTestDB(t)
+	testClock := clock.NewTestClock(time.Now())
+	statsDB, _ := newUniverseStatsWithDB(db.BaseDB, testClock)
+	multiverse, _ := newTestMultiverseWithDb(t, db.BaseDB)
+
+	const (
+		numLeaves = 10
+		numRounds = 5
+	)
+
+	items := make([]*universe.Item, numLeaves)
+	for idx := range items {
+		items[idx] = genRandomAsset(t)
+	}
+
+	// We register the same set of leaves over and over, logging an event
+	// for each leaf that was actually new, the same way the universe
+	// archive does.
+	for i := 0; i < numRounds; i++ {
+		newItems, err := multiverse.UpsertProofLeafBatch(ctx, items)
+		require.NoError(t, err)
+
+		// Only the very first round should produce new leaves.
+		if i == 0 {
+			require.Len(t, newItems, numLeaves)
+		} else {
+			require.Empty(t, newItems)
+		}
+
+		ids := fn.Map(
+			newItems, func(i *universe.Item) universe.Identifier {
+				return i.ID
+			},
+		)
+		if len(ids) == 0 {
+			continue
+		}
+
+		require.NoError(t, statsDB.LogNewProofEvents(ctx, ids...))
+	}
+
+	// The stats should report the number of leaves we hold, not the number
+	// of registration attempts.
+	stats, err := statsDB.AggregateSyncStats(ctx)
+	require.NoError(t, err)
+	require.EqualValues(t, numLeaves, stats.NumTotalProofs)
+}
+
 // TestUniverseStatsEvents tests that we're able to properly insert, and also
 // fetch information related to universe sync related events.
 func TestUniverseStatsEvents(t *testing.T) {

--- a/tapdb/universe_test.go
+++ b/tapdb/universe_test.go
@@ -1100,7 +1100,7 @@ func TestMultiverseRootSum(t *testing.T) {
 					prevID.OutPoint.Hash = [32]byte{1}
 				}
 
-				_, err := multiverse.UpsertProofLeaf(
+				_, _, err := multiverse.UpsertProofLeaf(
 					ctx, id, targetKey, &leaf, nil,
 				)
 				require.NoError(t, err)
@@ -1110,7 +1110,7 @@ func TestMultiverseRootSum(t *testing.T) {
 				if tc.doubleUp {
 					targetKey = randLeafKey(t)
 
-					_, err := multiverse.UpsertProofLeaf(
+					_, _, err := multiverse.UpsertProofLeaf(
 						ctx, id, targetKey, &leaf, nil,
 					)
 					require.NoError(t, err)
@@ -1198,7 +1198,7 @@ func TestDeleteLastUniverseCleansMultiverseRoot(t *testing.T) {
 	leaf.Amt = 100
 
 	targetKey := randLeafKey(t)
-	_, err := multiverse.UpsertProofLeaf(
+	_, _, err := multiverse.UpsertProofLeaf(
 		ctx, id, targetKey, &leaf, nil,
 	)
 	require.NoError(t, err)
@@ -1632,9 +1632,9 @@ func TestDeleteProofLeaf(t *testing.T) {
 	key2 := randLeafKey(t)
 	leaf2 := randMintingLeaf(t, assetGen, id.GroupKey)
 
-	_, err := multiverse.UpsertProofLeaf(ctx, id, key1, &leaf1, nil)
+	_, _, err := multiverse.UpsertProofLeaf(ctx, id, key1, &leaf1, nil)
 	require.NoError(t, err)
-	_, err = multiverse.UpsertProofLeaf(ctx, id, key2, &leaf2, nil)
+	_, _, err = multiverse.UpsertProofLeaf(ctx, id, key2, &leaf2, nil)
 	require.NoError(t, err)
 
 	// Verify both leaves exist.
@@ -1731,11 +1731,11 @@ func TestDeleteProofLeafMultiUniverse(t *testing.T) {
 	key2 := randLeafKey(t)
 	leaf2 := randMintingLeaf(t, assetGen2, id2.GroupKey)
 
-	_, err := multiverse.UpsertProofLeaf(
+	_, _, err := multiverse.UpsertProofLeaf(
 		ctx, id1, key1, &leaf1, nil,
 	)
 	require.NoError(t, err)
-	_, err = multiverse.UpsertProofLeaf(
+	_, _, err = multiverse.UpsertProofLeaf(
 		ctx, id2, key2, &leaf2, nil,
 	)
 	require.NoError(t, err)
@@ -1812,11 +1812,11 @@ func TestDeleteProofLeafBothProofTypes(t *testing.T) {
 		t, assetGen, transferID.GroupKey,
 	)
 
-	_, err := multiverse.UpsertProofLeaf(
+	_, _, err := multiverse.UpsertProofLeaf(
 		ctx, issuanceID, key, &issuanceLeaf, nil,
 	)
 	require.NoError(t, err)
-	_, err = multiverse.UpsertProofLeaf(
+	_, _, err = multiverse.UpsertProofLeaf(
 		ctx, transferID, key, &transferLeaf, nil,
 	)
 	require.NoError(t, err)
@@ -1900,7 +1900,7 @@ func TestProofCacheInvalidatesOnSiblingInsert(t *testing.T) {
 	// back through the multiverse store.
 	keyA := randLeafKey(t)
 	leafA := randMintingLeaf(t, assetGen, id.GroupKey)
-	_, err := multiverse.UpsertProofLeaf(ctx, id, keyA, &leafA, nil)
+	_, _, err := multiverse.UpsertProofLeaf(ctx, id, keyA, &leafA, nil)
 	require.NoError(t, err)
 
 	primed, err := multiverse.FetchProofLeaf(ctx, id, keyA)
@@ -1920,7 +1920,7 @@ func TestProofCacheInvalidatesOnSiblingInsert(t *testing.T) {
 	// must change, since every leaf contributes its sum to the root.
 	keyB := randLeafKey(t)
 	leafB := randMintingLeaf(t, assetGen, id.GroupKey)
-	_, err = multiverse.UpsertProofLeaf(ctx, id, keyB, &leafB, nil)
+	_, _, err = multiverse.UpsertProofLeaf(ctx, id, keyB, &leafB, nil)
 	require.NoError(t, err)
 
 	rootAfterB, _, err := baseUniverse.RootNode(ctx)
@@ -2011,7 +2011,7 @@ func TestUpsertProofLeafBatchMultiverseRoot(t *testing.T) {
 	require.NoError(t, err)
 
 	for _, item := range items {
-		_, err := serialStore.UpsertProofLeaf(
+		_, _, err := serialStore.UpsertProofLeaf(
 			ctx, item.ID, item.Key, item.Leaf, item.MetaReveal,
 		)
 		require.NoError(t, err)

--- a/tapdb/universe_test.go
+++ b/tapdb/universe_test.go
@@ -263,6 +263,65 @@ type leafWithKey struct {
 	universe.Leaf
 }
 
+// TestMultiverseUpsertProofLeafBatchNewLeaves tests that a batch upsert only
+// reports back the leaves that were actually new to the multiverse. Callers
+// use that to avoid counting a re-registration of a leaf we already hold as a
+// new proof in the universe stats.
+func TestMultiverseUpsertProofLeafBatchNewLeaves(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	multiverse, _ := newTestMultiverse(t)
+
+	const numItems = 5
+	items := make([]*universe.Item, numItems)
+	for idx := range items {
+		items[idx] = genRandomAsset(t)
+	}
+
+	// The first insertion is entirely new, so we expect all items back.
+	newItems, err := multiverse.UpsertProofLeafBatch(ctx, items)
+	require.NoError(t, err)
+	require.Equal(t, items, newItems)
+
+	// Inserting the exact same batch again is a no-op upsert, so nothing
+	// should be reported as new.
+	newItems, err = multiverse.UpsertProofLeafBatch(ctx, items)
+	require.NoError(t, err)
+	require.Empty(t, newItems)
+
+	// A mixed batch should only report the items we didn't hold yet.
+	freshItems := []*universe.Item{genRandomAsset(t), genRandomAsset(t)}
+	mixedBatch := append(items[:2:2], freshItems...)
+	newItems, err = multiverse.UpsertProofLeafBatch(ctx, mixedBatch)
+	require.NoError(t, err)
+	require.Equal(t, freshItems, newItems)
+
+	// Replacing the proof of a leaf we already hold (which is what happens
+	// when the anchor transaction is re-organized out of the chain) is an
+	// update of that leaf, not a new one.
+	updatedItem := *items[0]
+	updatedLeaf := randMintingLeaf(
+		t, items[0].Leaf.Genesis, items[0].ID.GroupKey,
+	)
+	updatedItem.Leaf = &updatedLeaf
+
+	newItems, err = multiverse.UpsertProofLeafBatch(
+		ctx, []*universe.Item{&updatedItem},
+	)
+	require.NoError(t, err)
+	require.Empty(t, newItems)
+
+	// A leaf that shows up twice within the same batch is only new the
+	// first time round.
+	dupItem := genRandomAsset(t)
+	newItems, err = multiverse.UpsertProofLeafBatch(
+		ctx, []*universe.Item{dupItem, dupItem},
+	)
+	require.NoError(t, err)
+	require.Equal(t, []*universe.Item{dupItem}, newItems)
+}
+
 // TestUniverseIssuanceProofs tests that we're able to insert issuance proofs
 // for a given asset ID, and then retrieve them all with proper inclusion
 // proofs.
@@ -1948,7 +2007,7 @@ func TestUpsertProofLeafBatchMultiverseRoot(t *testing.T) {
 		})
 	}
 
-	err := batchStore.UpsertProofLeafBatch(ctx, items)
+	_, err := batchStore.UpsertProofLeafBatch(ctx, items)
 	require.NoError(t, err)
 
 	for _, item := range items {

--- a/universe/archive.go
+++ b/universe/archive.go
@@ -294,15 +294,10 @@ func (a *Archive) UpsertProofLeaf(ctx context.Context, id Identifier,
 
 	// We'll first check to see if we already know of this leaf within the
 	// multiverse. If so, then we'll return the existing issuance proof.
-	//
-	// We also remember whether the leaf was already known, so we don't
-	// count a re-registration as a new proof in the universe stats below.
-	var leafKnown bool
 	issuanceProofs, err := a.cfg.Multiverse.FetchProofLeaf(ctx, id, key)
 	switch {
 	case err == nil && len(issuanceProofs) > 0:
 		issuanceProof := issuanceProofs[0]
-		leafKnown = true
 
 		var existingProof proof.Proof
 		if err := existingProof.Decode(bytes.NewReader(
@@ -353,7 +348,7 @@ func (a *Archive) UpsertProofLeaf(ctx context.Context, id Identifier,
 
 	// Now that we know the proof is valid, we'll insert it into the base
 	// multiverse backend, and return the new issuance proof.
-	issuanceProof, err := a.cfg.Multiverse.UpsertProofLeaf(
+	issuanceProof, leafInserted, err := a.cfg.Multiverse.UpsertProofLeaf(
 		ctx, id, key, leaf, assetSnapshot.MetaReveal,
 	)
 	if err != nil && !errors.Is(err, ErrMultiversePending) {
@@ -369,7 +364,9 @@ func (a *Archive) UpsertProofLeaf(ctx context.Context, id Identifier,
 	//
 	// We skip it if we already held the leaf, since then the upsert only
 	// replaced the proof of a leaf that's already counted in the stats.
-	if !leafKnown {
+	// The multiverse decides that inside its write transaction, so two
+	// clients racing to register the same new leaf log exactly one event.
+	if leafInserted {
 		go func() {
 			err := a.cfg.UniverseStats.LogNewProofEvent(
 				context.Background(), id, key,

--- a/universe/archive.go
+++ b/universe/archive.go
@@ -294,10 +294,15 @@ func (a *Archive) UpsertProofLeaf(ctx context.Context, id Identifier,
 
 	// We'll first check to see if we already know of this leaf within the
 	// multiverse. If so, then we'll return the existing issuance proof.
+	//
+	// We also remember whether the leaf was already known, so we don't
+	// count a re-registration as a new proof in the universe stats below.
+	var leafKnown bool
 	issuanceProofs, err := a.cfg.Multiverse.FetchProofLeaf(ctx, id, key)
 	switch {
 	case err == nil && len(issuanceProofs) > 0:
 		issuanceProof := issuanceProofs[0]
+		leafKnown = true
 
 		var existingProof proof.Proof
 		if err := existingProof.Decode(bytes.NewReader(
@@ -361,15 +366,20 @@ func (a *Archive) UpsertProofLeaf(ctx context.Context, id Identifier,
 	// async goroutine. This runs for the pending case too: the universe
 	// leaf is durably stored, only its multiverse entry is still
 	// outstanding.
-	go func() {
-		err := a.cfg.UniverseStats.LogNewProofEvent(
-			context.Background(), id, key,
-		)
-		if err != nil {
-			log.Warnf("unable to log new proof event (id=%v): %v",
-				id.StringForLog(), err)
-		}
-	}()
+	//
+	// We skip it if we already held the leaf, since then the upsert only
+	// replaced the proof of a leaf that's already counted in the stats.
+	if !leafKnown {
+		go func() {
+			err := a.cfg.UniverseStats.LogNewProofEvent(
+				context.Background(), id, key,
+			)
+			if err != nil {
+				log.Warnf("unable to log new proof event "+
+					"(id=%v): %v", id.StringForLog(), err)
+			}
+		}()
+	}
 
 	// With the proof stored but its multiverse update outstanding, no
 	// composing receipt exists to return; surface the typed error to
@@ -457,8 +467,8 @@ func extractBatchDeps(batch []*Item) map[UniverseKey]*asset.Asset {
 }
 
 // UpsertProofLeafBatch inserts a batch of proof leaves within the target
-// universe tree. We assume the proofs within the batch have already been
-// checked that they don't yet exist in the local database.
+// universe tree. Leaves that we already hold are upserted as well, but they
+// don't count towards the new proof events we log for the universe stats.
 func (a *Archive) UpsertProofLeafBatch(ctx context.Context,
 	items []*Item) error {
 
@@ -573,7 +583,9 @@ func (a *Archive) UpsertProofLeafBatch(ctx context.Context,
 
 	log.InfoS(ctx, "Inserting verified group anchor proofs into Universe",
 		"count", len(anchorItems))
-	_, err = a.cfg.Multiverse.UpsertProofLeafBatch(ctx, anchorItems)
+	newAnchorItems, err := a.cfg.Multiverse.UpsertProofLeafBatch(
+		ctx, anchorItems,
+	)
 	switch {
 	case errors.Is(err, ErrMultiversePending):
 		upsertErr = fmt.Errorf("upsert group anchor proof leaf "+
@@ -591,7 +603,9 @@ func (a *Archive) UpsertProofLeafBatch(ctx context.Context,
 
 	log.InfoS(ctx, "Inserting verified proofs into Universe",
 		"count", len(nonAnchorItems))
-	_, err = a.cfg.Multiverse.UpsertProofLeafBatch(ctx, nonAnchorItems)
+	newNonAnchorItems, err := a.cfg.Multiverse.UpsertProofLeafBatch(
+		ctx, nonAnchorItems,
+	)
 	switch {
 	case errors.Is(err, ErrMultiversePending):
 		upsertErr = fmt.Errorf("upsert proof leaf batch "+
@@ -602,11 +616,23 @@ func (a *Archive) UpsertProofLeafBatch(ctx context.Context,
 			len(nonAnchorItems), err)
 	}
 
-	// Log a sync event for the newly inserted leaf in the background as an
-	// async goroutine. This runs for the pending case too: the universe
-	// leaves are durably stored, only their multiverse entries are still
-	// outstanding.
-	ids := fn.Map(items, func(item *Item) Identifier {
+	// Log a sync event for each leaf that was actually new to us, in the
+	// background as an async goroutine. This runs for the pending case
+	// too: the universe leaves are durably stored, only their multiverse
+	// entries are still outstanding.
+	//
+	// Items we already held are no-op upserts, and counting them would
+	// inflate the total proof count reported by the universe stats.
+	numNew := len(newAnchorItems) + len(newNonAnchorItems)
+	if numNew == 0 {
+		return upsertErr
+	}
+
+	newItems := make([]*Item, 0, numNew)
+	newItems = append(newItems, newAnchorItems...)
+	newItems = append(newItems, newNonAnchorItems...)
+
+	ids := fn.Map(newItems, func(item *Item) Identifier {
 		return item.ID
 	})
 	go func() {

--- a/universe/archive.go
+++ b/universe/archive.go
@@ -573,7 +573,7 @@ func (a *Archive) UpsertProofLeafBatch(ctx context.Context,
 
 	log.InfoS(ctx, "Inserting verified group anchor proofs into Universe",
 		"count", len(anchorItems))
-	err = a.cfg.Multiverse.UpsertProofLeafBatch(ctx, anchorItems)
+	_, err = a.cfg.Multiverse.UpsertProofLeafBatch(ctx, anchorItems)
 	switch {
 	case errors.Is(err, ErrMultiversePending):
 		upsertErr = fmt.Errorf("upsert group anchor proof leaf "+
@@ -591,7 +591,7 @@ func (a *Archive) UpsertProofLeafBatch(ctx context.Context,
 
 	log.InfoS(ctx, "Inserting verified proofs into Universe",
 		"count", len(nonAnchorItems))
-	err = a.cfg.Multiverse.UpsertProofLeafBatch(ctx, nonAnchorItems)
+	_, err = a.cfg.Multiverse.UpsertProofLeafBatch(ctx, nonAnchorItems)
 	switch {
 	case errors.Is(err, ErrMultiversePending):
 		upsertErr = fmt.Errorf("upsert proof leaf batch "+

--- a/universe/archive_test.go
+++ b/universe/archive_test.go
@@ -3,10 +3,19 @@ package universe
 import (
 	"context"
 	"math/rand"
+	"sync"
 	"testing"
+	"time"
 
+	"github.com/btcsuite/btcd/blockchain"
+	"github.com/btcsuite/btcd/btcutil/v2"
+	"github.com/btcsuite/btcd/chaincfg/v2"
+	"github.com/btcsuite/btcd/txscript/v2"
+	"github.com/btcsuite/btcd/wire/v2"
 	"github.com/lightninglabs/taproot-assets/asset"
+	"github.com/lightninglabs/taproot-assets/commitment"
 	"github.com/lightninglabs/taproot-assets/fn"
+	"github.com/lightninglabs/taproot-assets/internal/test"
 	"github.com/lightninglabs/taproot-assets/mssmt"
 	"github.com/lightninglabs/taproot-assets/proof"
 	"github.com/stretchr/testify/require"
@@ -16,6 +25,15 @@ import (
 // ErrNoUniverseRoot for any unknown universe.
 type mockMultiverse struct {
 	knownRoots map[IdentifierKey]Root
+
+	// newItems is what UpsertProofLeafBatch reports as newly inserted. If
+	// nil, every item handed in is reported as new.
+	newItems []*Item
+
+	// leafInserted is what UpsertProofLeaf reports for the single-leaf
+	// path, and upsertProof the receipt it hands back.
+	leafInserted bool
+	upsertProof  *Proof
 }
 
 func (m *mockMultiverse) UniverseRootNode(_ context.Context,
@@ -39,13 +57,23 @@ func (m *mockMultiverse) UpsertProofLeaf(context.Context,
 	Identifier, LeafKey, *Leaf,
 	*proof.MetaReveal) (*Proof, bool, error) {
 
-	return nil, true, nil
+	return m.upsertProof, m.leafInserted, nil
 }
 
 func (m *mockMultiverse) UpsertProofLeafBatch(_ context.Context,
 	items []*Item) ([]*Item, error) {
 
-	return items, nil
+	if m.newItems == nil {
+		return items, nil
+	}
+
+	// Report back only those configured items that are in this sub-batch,
+	// the way the real store reports per call.
+	return fn.Filter(m.newItems, func(n *Item) bool {
+		return fn.Any(items, func(i *Item) bool {
+			return i == n
+		})
+	}), nil
 }
 
 func (m *mockMultiverse) FetchProofLeaf(context.Context,
@@ -155,6 +183,24 @@ func newTestArchive(
 	return a, &newTreeCalls
 }
 
+// newTestArchiveWithStats creates an Archive wired to the given multiverse and
+// telemetry, with the mock verifiers that RandProof-free minted proofs expect.
+func newTestArchiveWithStats(mv *mockMultiverse,
+	stats Telemetry) *Archive {
+
+	return NewArchive(ArchiveConfig{
+		NewBaseTree: func(Identifier) StorageBackend {
+			return &mockStorageBackend{}
+		},
+		Multiverse:           mv,
+		UniverseStats:        stats,
+		HeaderVerifier:       proof.MockHeaderVerifier,
+		MerkleVerifier:       proof.MockMerkleVerifier,
+		GroupVerifier:        proof.MockGroupVerifier,
+		ChainLookupGenerator: proof.MockChainLookup,
+	})
+}
+
 func randIdentifier() Identifier {
 	var id asset.ID
 	//nolint:gosec
@@ -218,4 +264,337 @@ func TestFetchLeavesExistingUniverse(t *testing.T) {
 	_, err = archive.FetchLeaves(ctx, id, FetchLeavesQuery{})
 	require.NoError(t, err)
 	require.Equal(t, 1, *newTreeCalls)
+}
+
+// mockTelemetry implements Telemetry, recording the universe ids handed to the
+// new-proof logging calls.
+type mockTelemetry struct {
+	mu sync.Mutex
+
+	loggedProofs []Identifier
+}
+
+func (m *mockTelemetry) AggregateSyncStats(
+	context.Context) (AggregateStats, error) {
+
+	return AggregateStats{}, nil
+}
+
+func (m *mockTelemetry) LogSyncEvent(context.Context, Identifier,
+	LeafKey) error {
+
+	return nil
+}
+
+func (m *mockTelemetry) LogSyncEvents(context.Context, ...Identifier) error {
+	return nil
+}
+
+func (m *mockTelemetry) LogNewProofEvent(_ context.Context, uniID Identifier,
+	_ LeafKey) error {
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.loggedProofs = append(m.loggedProofs, uniID)
+
+	return nil
+}
+
+func (m *mockTelemetry) LogNewProofEvents(_ context.Context,
+	uniIDs ...Identifier) error {
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.loggedProofs = append(m.loggedProofs, uniIDs...)
+
+	return nil
+}
+
+func (m *mockTelemetry) QuerySyncStats(context.Context,
+	SyncStatsQuery) (*AssetSyncStats, error) {
+
+	return nil, nil
+}
+
+func (m *mockTelemetry) QueryAssetStatsPerDay(context.Context,
+	GroupedStatsQuery) ([]*GroupedStats, error) {
+
+	return nil, nil
+}
+
+// logged returns the ids logged so far.
+func (m *mockTelemetry) logged() []Identifier {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	return append([]Identifier(nil), m.loggedProofs...)
+}
+
+// mintTestAsset builds a genesis proof that passes full proof verification, so
+// that a test can drive the archive's real ingest path rather than stopping at
+// the verify step. It returns the universe item the proof belongs in.
+func mintTestAsset(t *testing.T, grouped bool) *Item {
+	t.Helper()
+
+	genesisPrivKey := test.RandPrivKey()
+	genesisScriptKey := test.PubToKeyDesc(genesisPrivKey.PubKey())
+
+	var metaBlob [100]byte
+	//nolint:gosec
+	_, err := rand.Read(metaBlob[:])
+	require.NoError(t, err)
+	metaReveal := &proof.MetaReveal{
+		Data: metaBlob[:],
+	}
+
+	assetGenesis := asset.RandGenesis(t, asset.Collectible)
+	assetGenesis.MetaHash = metaReveal.MetaHash()
+	assetGenesis.OutputIndex = 0
+
+	// A group anchor carries a group key reveal in its proof, which is what
+	// the archive partitions the batch on.
+	var groupKey *asset.GroupKey
+	if grouped {
+		protoAsset := asset.NewAssetNoErr(
+			t, assetGenesis, 1, 0, 0,
+			asset.NewScriptKeyBip86(genesisScriptKey), nil,
+		)
+		groupKey = asset.RandGroupKey(t, assetGenesis, protoAsset)
+	}
+
+	tapCommitment, mintedAssets, err := commitment.Mint(
+		nil, assetGenesis, groupKey, &commitment.AssetDetails{
+			Type:      asset.Collectible,
+			ScriptKey: genesisScriptKey,
+		},
+	)
+	require.NoError(t, err)
+	require.Len(t, mintedAssets, 1)
+
+	internalKey := test.SchnorrPubKey(t, genesisPrivKey)
+	tapscriptRoot := tapCommitment.TapscriptRoot(nil)
+	taprootKey := txscript.ComputeTaprootOutputKey(
+		internalKey, tapscriptRoot[:],
+	)
+
+	changeInternalKey := test.RandPrivKey().PubKey()
+	changeTaprootKey := txscript.ComputeTaprootKeyNoScript(
+		changeInternalKey,
+	)
+
+	genesisTx := &wire.MsgTx{
+		Version: 2,
+		TxIn: []*wire.TxIn{{
+			PreviousOutPoint: assetGenesis.FirstPrevOut,
+		}},
+		TxOut: []*wire.TxOut{{
+			PkScript: test.ComputeTaprootScript(t, taprootKey),
+			Value:    330,
+		}, {
+			PkScript: test.ComputeTaprootScript(
+				t, changeTaprootKey,
+			),
+			Value: 333,
+		}},
+	}
+
+	merkleTree := blockchain.BuildMerkleTreeStore(
+		[]*btcutil.Tx{btcutil.NewTx(genesisTx)}, false,
+	)
+	merkleRoot := merkleTree[len(merkleTree)-1]
+	blockHeader := wire.NewBlockHeader(
+		0, chaincfg.MainNetParams.GenesisHash, merkleRoot, 0, 0,
+	)
+
+	scriptKeyForMeta := asset.NewScriptKeyBip86(genesisScriptKey)
+	metaReveals := map[asset.SerializedKey]*proof.MetaReveal{
+		asset.ToSerialized(scriptKeyForMeta.PubKey): metaReveal,
+	}
+
+	// NewMintingBlobs verifies the proofs it builds, so a proof coming out
+	// of here is one the archive will accept.
+	proofs, err := proof.NewMintingBlobs(&proof.MintParams{
+		BaseProofParams: proof.BaseProofParams{
+			Block: &wire.MsgBlock{
+				Header:       *blockHeader,
+				Transactions: []*wire.MsgTx{genesisTx},
+			},
+			Tx:               genesisTx,
+			TxIndex:          0,
+			OutputIndex:      0,
+			InternalKey:      internalKey,
+			TaprootAssetRoot: tapCommitment,
+			ExclusionProofs: []proof.TaprootProof{{
+				OutputIndex: 1,
+				InternalKey: changeInternalKey,
+				TapscriptProof: &proof.TapscriptProof{
+					Bip86: true,
+				},
+			}},
+		},
+		GenesisPoint: genesisTx.TxIn[0].PreviousOutPoint,
+	}, proof.MockVerifierCtx, proof.WithAssetMetaReveals(metaReveals))
+	require.NoError(t, err)
+	require.Len(t, proofs, 1)
+
+	mintedAsset := mintedAssets[0]
+	assetProof, ok := proofs[asset.ToSerialized(
+		mintedAsset.ScriptKey.PubKey,
+	)]
+	require.True(t, ok)
+
+	rawProof, err := assetProof.Bytes()
+	require.NoError(t, err)
+
+	scriptKey := asset.NewScriptKey(mintedAsset.ScriptKey.PubKey)
+
+	return &Item{
+		ID: Identifier{
+			AssetID:   assetGenesis.ID(),
+			ProofType: ProofTypeIssuance,
+		},
+		Key: BaseLeafKey{
+			OutPoint:  assetGenesis.FirstPrevOut,
+			ScriptKey: &scriptKey,
+		},
+		Leaf: &Leaf{
+			GenesisWithGroup: GenesisWithGroup{
+				Genesis:  assetGenesis,
+				GroupKey: assetProof.Asset.GroupKey,
+			},
+			RawProof: rawProof,
+			Asset:    &assetProof.Asset,
+			Amt:      mintedAsset.Amount,
+		},
+	}
+}
+
+// TestUpsertProofLeafBatchLogsOnlyNewLeaves tests that the archive logs a new
+// proof event for exactly the leaves the multiverse reported as new, and none
+// of the ones it already held.
+func TestUpsertProofLeafBatchLogsOnlyNewLeaves(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	const numItems = 4
+	// A mix of group anchors and plain issuances, so the batch is split
+	// across both of the archive's sub-batches.
+	items := make([]*Item, numItems)
+	for idx := range items {
+		items[idx] = mintTestAsset(t, idx%2 == 0)
+	}
+
+	// The multiverse reports one anchor and one non-anchor item as new,
+	// standing in for a peer re-pushing the other two.
+	newItems := []*Item{items[0], items[1]}
+	mv := &mockMultiverse{
+		knownRoots: make(map[IdentifierKey]Root),
+		newItems:   newItems,
+	}
+	stats := &mockTelemetry{}
+	archive := newTestArchiveWithStats(mv, stats)
+
+	err := archive.UpsertProofLeafBatch(ctx, items)
+	require.NoError(t, err)
+
+	expectedIDs := fn.Map(newItems, func(i *Item) Identifier {
+		return i.ID
+	})
+	require.Eventually(t, func() bool {
+		return len(stats.logged()) == len(expectedIDs)
+	}, time.Second, 10*time.Millisecond)
+	require.ElementsMatch(t, expectedIDs, stats.logged())
+}
+
+// TestUpsertProofLeafBatchNoNewLeaves tests that a batch consisting entirely of
+// leaves we already hold logs no new proof events at all.
+func TestUpsertProofLeafBatchNoNewLeaves(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	items := []*Item{mintTestAsset(t, true), mintTestAsset(t, false)}
+
+	mv := &mockMultiverse{
+		knownRoots: make(map[IdentifierKey]Root),
+		newItems:   []*Item{},
+	}
+	stats := &mockTelemetry{}
+	archive := newTestArchiveWithStats(mv, stats)
+
+	err := archive.UpsertProofLeafBatch(ctx, items)
+	require.NoError(t, err)
+
+	// Nothing was new, so nothing may be logged. Give the async logging
+	// goroutine a chance to run before concluding that.
+	require.Never(t, func() bool {
+		return len(stats.logged()) > 0
+	}, 200*time.Millisecond, 20*time.Millisecond)
+}
+
+// TestUpsertProofLeafLogsOnlyNewLeaf tests that the single-leaf path takes the
+// new/existing answer from the multiverse's write transaction rather than
+// re-deriving it, so a leaf the multiverse reports as already held logs no
+// event even when the archive's earlier read didn't see it.
+func TestUpsertProofLeafLogsOnlyNewLeaf(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	testCases := []struct {
+		name        string
+		multiverse  bool
+		expectEvent bool
+	}{{
+		name:        "new leaf is logged",
+		multiverse:  true,
+		expectEvent: true,
+	}, {
+		// This is the race the read-then-write derivation used to get
+		// wrong: our own FetchProofLeaf missed, so we verified and
+		// wrote, but a concurrent insert of the same leaf won and ours
+		// was a no-op upsert.
+		name:        "leaf lost the insert race is not logged",
+		multiverse:  false,
+		expectEvent: false,
+	}}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			item := mintTestAsset(t, false)
+			mv := &mockMultiverse{
+				knownRoots:   make(map[IdentifierKey]Root),
+				leafInserted: tc.multiverse,
+				upsertProof:  &Proof{Leaf: item.Leaf},
+			}
+			stats := &mockTelemetry{}
+			archive := newTestArchiveWithStats(mv, stats)
+
+			_, err := archive.UpsertProofLeaf(
+				ctx, item.ID, item.Key, item.Leaf,
+			)
+			require.NoError(t, err)
+
+			if tc.expectEvent {
+				require.Eventually(t, func() bool {
+					return len(stats.logged()) == 1
+				}, time.Second, 10*time.Millisecond)
+				require.Equal(
+					t, []Identifier{item.ID},
+					stats.logged(),
+				)
+
+				return
+			}
+
+			require.Never(t, func() bool {
+				return len(stats.logged()) > 0
+			}, 200*time.Millisecond, 20*time.Millisecond)
+		})
+	}
 }

--- a/universe/archive_test.go
+++ b/universe/archive_test.go
@@ -37,9 +37,9 @@ func (m *mockMultiverse) RootNodes(context.Context,
 
 func (m *mockMultiverse) UpsertProofLeaf(context.Context,
 	Identifier, LeafKey, *Leaf,
-	*proof.MetaReveal) (*Proof, error) {
+	*proof.MetaReveal) (*Proof, bool, error) {
 
-	return nil, nil
+	return nil, true, nil
 }
 
 func (m *mockMultiverse) UpsertProofLeafBatch(_ context.Context,

--- a/universe/archive_test.go
+++ b/universe/archive_test.go
@@ -42,10 +42,10 @@ func (m *mockMultiverse) UpsertProofLeaf(context.Context,
 	return nil, nil
 }
 
-func (m *mockMultiverse) UpsertProofLeafBatch(context.Context,
-	[]*Item) error {
+func (m *mockMultiverse) UpsertProofLeafBatch(_ context.Context,
+	items []*Item) ([]*Item, error) {
 
-	return nil
+	return items, nil
 }
 
 func (m *mockMultiverse) FetchProofLeaf(context.Context,

--- a/universe/interface.go
+++ b/universe/interface.go
@@ -653,7 +653,12 @@ type MultiverseArchive interface {
 	// durably stored while their multiverse updates are still
 	// outstanding, to be repaired in the background or at the next
 	// startup.
-	UpsertProofLeafBatch(ctx context.Context, items []*Item) error
+	//
+	// The returned slice holds the subset of items that resulted in a new
+	// universe leaf; items the universe already held are left out. It is
+	// populated in the pending case too, as the leaves are committed.
+	UpsertProofLeafBatch(ctx context.Context,
+		items []*Item) ([]*Item, error)
 
 	// FetchProofLeaf returns a proof leaf for the target key. If the key
 	// doesn't have a script key specified, then all the proof leafs for the

--- a/universe/interface.go
+++ b/universe/interface.go
@@ -641,9 +641,13 @@ type MultiverseArchive interface {
 	// outstanding; the archive repairs the gap in the background, or
 	// at the next startup. On success the returned proof composes:
 	// its multiverse inclusion proof commits to its universe root.
+	//
+	// The returned boolean reports whether the upsert created a new
+	// universe leaf, as opposed to replacing the proof of one we already
+	// held. It is set in the pending case too, as the leaf is committed.
 	UpsertProofLeaf(ctx context.Context, id Identifier, key LeafKey,
 		leaf *Leaf,
-		metaReveal *proof.MetaReveal) (*Proof, error)
+		metaReveal *proof.MetaReveal) (*Proof, bool, error)
 
 	// UpsertProofLeafBatch upserts a proof leaf batch within the multiverse
 	// tree and the universe tree that corresponds to the given key(s).


### PR DESCRIPTION
`Archive.UpsertProofLeafBatch` logged a `NEW_PROOF` event for every item it was
handed, not for the leaves that were actually new. Re-registering a leaf we
already hold is a no-op upsert, but it still wrote an event row.

`universe_stats.total_asset_proofs` was a `COUNT(*)` over those rows, so
`num_total_proofs` reported insert attempts rather than proofs held, and
`universe_events` grew with sync traffic instead of with universe size. On the
node from #2253 that meant 1.3M event rows for 11k leaves, a reported count of
1,324,096, and the stats view taking 437ms per read on postgres where counting
the real leaves takes 0.34ms.

Two halves:

**Stop writing the duplicate events.** The universe leaf upsert now reports
whether it created a leaf or just replaced the proof of one we already had, and
both the batch and the single-leaf path take that answer from inside the write
transaction. Only new leaves get an event. Determining it in the write tx also
closes a race the read-then-write version would have kept: two clients
registering the same new leaf could both miss on their own read, both verify,
and both log, while only one write actually created the leaf.

**Stop deriving the count from the events.** Migration 66 redefines
`universe_stats` to count `universe_leaves` instead, so the figure means what
its name says and is correct on databases that already accumulated duplicate
events. No event rows are deleted: `QueryAssetStatsPerDay` still reads them.

The supply commitment sub-trees keep their leaves in the same table but were
never counted here, having never produced a NEW_PROOF event, so the new count
filters on proof type to keep them out. Verified against a supply tree: 6
leaves across burn, ignore and mint_supply, 0 events.

The added existence lookup is a single hit on an existing unique index and
doesn't move insert timings on either backend.

Behaviour changes, both in the release notes:

- `num_total_proofs` can now decrease when a proof leaf is deleted from a
  universe that still holds others. The event rows previously kept it flat.
- `new_proof_events` in `QueryEvents` is fed by the event rows and now counts
  leaves acquired per day rather than registration attempts per day, so on a
  long-running node the series steps down. `sync_events` is unchanged and still
  carries traffic volume.

Nothing here crosses the wire: no proto, no proof encoding, and the
remote-facing `Registrar` interface is untouched. `universe_events` and the
stats view are local bookkeeping, and no sync or federation path reads them, so
a patched node and an unpatched one interoperate exactly as before.

Fixes #2253