### PR TITLE
tapcli+universe: filter universe roots by proof type

### DIFF
--- a/cmd/commands/universe.go
+++ b/cmd/commands/universe.go
@@ -220,13 +220,24 @@ func universeRoots(ctx *cli.Context) error {
 	// If neither an asset ID or group key is specified, then we'll query
 	// for all the known universe roots.
 	if universeID == nil {
-		universeRoots, err := client.AssetRoots(
-			ctxc, &unirpc.AssetRootRequest{
-				WithAmountsById: !ctx.Bool(skipAmountsByIdName),
-				Offset:          int32(ctx.Uint64(offsetName)),
-				Limit:           int32(ctx.Uint64(limitName)),
-			},
-		)
+		rootReq := &unirpc.AssetRootRequest{
+			WithAmountsById: !ctx.Bool(skipAmountsByIdName),
+			Offset:          int32(ctx.Uint64(offsetName)),
+			Limit:           int32(ctx.Uint64(limitName)),
+		}
+
+		// Only filter by proof type if the user explicitly set the
+		// flag, so that by default all known roots are returned.
+		if ctx.IsSet(proofTypeName) {
+			rpcProofType, err := parseProofType(ctx)
+			if err != nil {
+				return err
+			}
+
+			rootReq.ProofType = *rpcProofType
+		}
+
+		universeRoots, err := client.AssetRoots(ctxc, rootReq)
 		if err != nil {
 			return err
 		}

--- a/docs/release-notes/release-notes-0.9.0.md
+++ b/docs/release-notes/release-notes-0.9.0.md
@@ -120,6 +120,13 @@
   86400 second default instead of returning an error. Fixes
   [#2261](https://github.com/lightninglabs/taproot-assets/issues/2261).
 
+* [PR#2260](https://github.com/lightninglabs/taproot-assets/pull/2260):
+  `tapcli universe roots --proof_type` no longer ignores the filter when
+  no asset ID or group key is given. The `AssetRoots` RPC gains an
+  optional `proof_type` field, so callers can list only issuance or only
+  transfer roots. Fixes
+  [#1762](https://github.com/lightninglabs/taproot-assets/issues/1762).
+
 # New Features
 
 ## Functional Enhancements

--- a/itest/test_list_on_test.go
+++ b/itest/test_list_on_test.go
@@ -330,6 +330,10 @@ var allTestCases = []*testCase{
 		test: testUniverseSync,
 	},
 	{
+		name: "universe roots proof type filter",
+		test: testUniverseRootsProofTypeFilter,
+	},
+	{
 		name: "universe delete leaf",
 		test: testUniverseDeleteLeaf,
 	},

--- a/itest/universe_roots_proof_type_test.go
+++ b/itest/universe_roots_proof_type_test.go
@@ -1,0 +1,118 @@
+package itest
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/lightninglabs/taproot-assets/taprpc"
+	"github.com/lightninglabs/taproot-assets/taprpc/mintrpc"
+	unirpc "github.com/lightninglabs/taproot-assets/taprpc/universerpc"
+	"github.com/lightningnetwork/lnd/lntest/wait"
+	"github.com/stretchr/testify/require"
+)
+
+// countRootProofTypes counts how many of the given universe roots are of the
+// issuance and transfer proof types respectively.
+func countRootProofTypes(resp *unirpc.AssetRootResponse) (int, int) {
+	var issuance, transfer int
+	for _, root := range resp.UniverseRoots {
+		switch root.Id.ProofType {
+		case unirpc.ProofType_PROOF_TYPE_ISSUANCE:
+			issuance++
+		case unirpc.ProofType_PROOF_TYPE_TRANSFER:
+			transfer++
+
+		// Any other proof type is not counted.
+		default:
+		}
+	}
+
+	return issuance, transfer
+}
+
+// testUniverseRootsProofTypeFilter tests that the AssetRoots RPC only returns
+// roots of the requested proof type when a proof type filter is set, and all
+// roots when it is left unspecified.
+func testUniverseRootsProofTypeFilter(t *harnessTest) {
+	ctx := context.Background()
+	miner := t.lndHarness.Miner()
+
+	// Mint an issuable asset so that the sending node has an issuance
+	// universe root.
+	rpcAssets := MintAssetsConfirmBatch(
+		t.t, miner, t.tapd,
+		[]*mintrpc.MintAssetRequest{issuableAssets[0]},
+	)
+	require.Len(t.t, rpcAssets, 1)
+	mintedAsset := rpcAssets[0]
+
+	// Set up a second node to receive a send. Sending an asset creates a
+	// transfer universe root on the sending node, so afterwards our main
+	// node holds both an issuance and a transfer root.
+	bobLnd := t.lndHarness.NewNodeWithCoins("Bob", nil)
+	bob := setupTapdHarness(t.t, t, bobLnd, t.universeServer)
+	defer func() {
+		require.NoError(t.t, bob.stop(!*noDelete))
+	}()
+
+	addr, events := NewAddrWithEventStream(
+		t.t, bob, &taprpc.NewAddrRequest{
+			AssetId: mintedAsset.AssetGenesis.AssetId,
+			Amt:     mintedAsset.Amount - 1,
+		},
+	)
+	AssertAddrCreated(t.t, bob, mintedAsset, addr)
+
+	_, sendEvents := sendAssetsToAddr(t, t.tapd, addr)
+	AssertAddrEvent(t.t, bob, addr, 1, statusDetected)
+	MineBlocks(t.t, miner, 1, 1)
+	AssertAddrEvent(t.t, bob, addr, 1, statusConfirmed)
+	AssertNonInteractiveRecvComplete(t.t, bob, 1)
+	AssertSendEventsComplete(t.t, addr.ScriptKey, sendEvents)
+	AssertReceiveEvents(t.t, addr, events)
+
+	// The universe server receives the issuance root via federation from
+	// the minting node and the transfer root via the proof courier, so it
+	// holds both proof types. We run all root queries against it.
+	uniServer := t.universeServer.service
+
+	// Wait until the universe server holds both an issuance and a transfer
+	// root.
+	var issuanceRoots, transferRoots int
+	err := wait.NoError(func() error {
+		roots, err := uniServer.AssetRoots(
+			ctx, &unirpc.AssetRootRequest{},
+		)
+		require.NoError(t.t, err)
+
+		issuanceRoots, transferRoots = countRootProofTypes(roots)
+		if issuanceRoots == 0 || transferRoots == 0 {
+			return fmt.Errorf("expected both proof types, got "+
+				"issuance=%d transfer=%d", issuanceRoots,
+				transferRoots)
+		}
+
+		return nil
+	}, defaultWaitTimeout)
+	require.NoError(t.t, err)
+
+	// Filtering by issuance must return only the issuance roots.
+	issuanceOnly, err := uniServer.AssetRoots(ctx, &unirpc.AssetRootRequest{
+		ProofType: unirpc.ProofType_PROOF_TYPE_ISSUANCE,
+	})
+	require.NoError(t.t, err)
+
+	gotIssuance, gotTransfer := countRootProofTypes(issuanceOnly)
+	require.Equal(t.t, issuanceRoots, gotIssuance)
+	require.Zero(t.t, gotTransfer)
+
+	// Filtering by transfer must return only the transfer roots.
+	transferOnly, err := uniServer.AssetRoots(ctx, &unirpc.AssetRootRequest{
+		ProofType: unirpc.ProofType_PROOF_TYPE_TRANSFER,
+	})
+	require.NoError(t.t, err)
+
+	gotIssuance, gotTransfer = countRootProofTypes(transferOnly)
+	require.Zero(t.t, gotIssuance)
+	require.Equal(t.t, transferRoots, gotTransfer)
+}

--- a/rpcserver/rpcserver.go
+++ b/rpcserver/rpcserver.go
@@ -6787,6 +6787,11 @@ func (r *RPCServer) AssetRoots(ctx context.Context,
 		limit = universe.RequestPageSize
 	}
 
+	proofType, err := UnmarshalUniProofType(req.ProofType)
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse proof type: %w", err)
+	}
+
 	// First, we'll retrieve the full set of known asset Universe roots.
 	sortDir := unmarshalUniSortDirection(req.Direction)
 	assetRoots, err := r.cfg.UniverseArchive.RootNodes(
@@ -6795,6 +6800,7 @@ func (r *RPCServer) AssetRoots(ctx context.Context,
 			SortDirection:   sortDir,
 			Offset:          req.Offset,
 			Limit:           limit + 1,
+			ProofType:       proofType,
 		},
 	)
 	if err != nil {

--- a/tapdb/multiverse.go
+++ b/tapdb/multiverse.go
@@ -569,6 +569,14 @@ func (b *MultiverseStore) RootNodes(ctx context.Context,
 			return q.Limit
 		}(),
 	}
+
+	// If a proof type filter was specified, only the roots of that proof
+	// type are returned. Otherwise the null value leaves the query
+	// unfiltered.
+	if q.ProofType != universe.ProofTypeUnspecified {
+		params.ProofType = sqlStr(q.ProofType.String())
+	}
+
 	uniRoots, err := b.queryRootNodes(ctx, params, q.WithAmountsById)
 	if err != nil {
 		return nil, err

--- a/tapdb/multiverse_cache.go
+++ b/tapdb/multiverse_cache.go
@@ -336,6 +336,7 @@ func (p *universeProofCache) RemoveLeafKeyProofs(id universe.Identifier,
 // roots, but with pagination parameters.
 type rootPageQueryKey struct {
 	withAmountsById bool
+	proofType       universe.ProofType
 	leafQueryKey
 }
 
@@ -343,6 +344,7 @@ type rootPageQueryKey struct {
 func newRootPageQuery(q universe.RootNodesQuery) rootPageQueryKey {
 	return rootPageQueryKey{
 		withAmountsById: q.WithAmountsById,
+		proofType:       q.ProofType,
 		leafQueryKey: leafQueryKey{
 			sortDirection: q.SortDirection,
 			offset:        q.Offset,
@@ -490,6 +492,12 @@ func newSyncerRootNodeCache(enabled bool,
 // database.
 func isQueryForSyncerCache(q universe.RootNodesQuery) bool {
 	if q.WithAmountsById || q.SortDirection != universe.SortAscending {
+		return false
+	}
+
+	// The syncer cache holds the complete, unfiltered set of roots, so a
+	// query that filters by proof type can't be served from it.
+	if q.ProofType != universe.ProofTypeUnspecified {
 		return false
 	}
 

--- a/tapdb/sqlc/queries/universe.sql
+++ b/tapdb/sqlc/queries/universe.sql
@@ -165,11 +165,13 @@ FROM universe_roots
 JOIN mssmt_roots
     ON universe_roots.namespace_root = mssmt_roots.namespace
 JOIN mssmt_nodes
-    ON mssmt_nodes.hash_key = mssmt_roots.root_hash 
+    ON mssmt_nodes.hash_key = mssmt_roots.root_hash
        AND mssmt_nodes.namespace = mssmt_roots.namespace
 JOIN genesis_assets
     ON genesis_assets.asset_id = universe_roots.asset_id
-ORDER BY 
+WHERE (universe_roots.proof_type = sqlc.narg('proof_type')
+           OR sqlc.narg('proof_type') IS NULL)
+ORDER BY
     CASE WHEN sqlc.narg('sort_direction') = 0 THEN universe_roots.id END ASC,
     CASE WHEN sqlc.narg('sort_direction') = 1 THEN universe_roots.id END DESC
 LIMIT @num_limit OFFSET @num_offset;

--- a/tapdb/sqlc/universe.sql.go
+++ b/tapdb/sqlc/universe.sql.go
@@ -1280,17 +1280,20 @@ FROM universe_roots
 JOIN mssmt_roots
     ON universe_roots.namespace_root = mssmt_roots.namespace
 JOIN mssmt_nodes
-    ON mssmt_nodes.hash_key = mssmt_roots.root_hash 
+    ON mssmt_nodes.hash_key = mssmt_roots.root_hash
        AND mssmt_nodes.namespace = mssmt_roots.namespace
 JOIN genesis_assets
     ON genesis_assets.asset_id = universe_roots.asset_id
-ORDER BY 
-    CASE WHEN $1 = 0 THEN universe_roots.id END ASC,
-    CASE WHEN $1 = 1 THEN universe_roots.id END DESC
-LIMIT $3 OFFSET $2
+WHERE (universe_roots.proof_type = $1
+           OR $1 IS NULL)
+ORDER BY
+    CASE WHEN $2 = 0 THEN universe_roots.id END ASC,
+    CASE WHEN $2 = 1 THEN universe_roots.id END DESC
+LIMIT $4 OFFSET $3
 `
 
 type UniverseRootsParams struct {
+	ProofType     sql.NullString
 	SortDirection interface{}
 	NumOffset     int32
 	NumLimit      int32
@@ -1306,7 +1309,12 @@ type UniverseRootsRow struct {
 }
 
 func (q *Queries) UniverseRoots(ctx context.Context, arg UniverseRootsParams) ([]UniverseRootsRow, error) {
-	rows, err := q.db.QueryContext(ctx, UniverseRoots, arg.SortDirection, arg.NumOffset, arg.NumLimit)
+	rows, err := q.db.QueryContext(ctx, UniverseRoots,
+		arg.ProofType,
+		arg.SortDirection,
+		arg.NumOffset,
+		arg.NumLimit,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/taprpc/universerpc/universe.pb.go
+++ b/taprpc/universerpc/universe.pb.go
@@ -346,7 +346,10 @@ type AssetRootRequest struct {
 	// The length limit for the page.
 	Limit int32 `protobuf:"varint,3,opt,name=limit,proto3" json:"limit,omitempty"`
 	// The direction of the page.
-	Direction     taprpc.SortDirection `protobuf:"varint,4,opt,name=direction,proto3,enum=taprpc.SortDirection" json:"direction,omitempty"`
+	Direction taprpc.SortDirection `protobuf:"varint,4,opt,name=direction,proto3,enum=taprpc.SortDirection" json:"direction,omitempty"`
+	// An optional filter to only return roots of the given proof type. If left
+	// unspecified, roots of all proof types are returned.
+	ProofType     ProofType `protobuf:"varint,5,opt,name=proof_type,json=proofType,proto3,enum=universerpc.ProofType" json:"proof_type,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -407,6 +410,13 @@ func (x *AssetRootRequest) GetDirection() taprpc.SortDirection {
 		return x.Direction
 	}
 	return taprpc.SortDirection(0)
+}
+
+func (x *AssetRootRequest) GetProofType() ProofType {
+	if x != nil {
+		return x.ProofType
+	}
+	return ProofType_PROOF_TYPE_UNSPECIFIED
 }
 
 type MerkleSumNode struct {
@@ -5115,12 +5125,14 @@ const file_universerpc_universe_proto_rawDesc = "" +
 	"proof_type\x18\x01 \x01(\x0e2\x16.universerpc.ProofTypeR\tproofType\x122\n" +
 	"\fspecific_ids\x18\x02 \x03(\v2\x0f.universerpc.IDR\vspecificIds\"]\n" +
 	"\x16MultiverseRootResponse\x12C\n" +
-	"\x0fmultiverse_root\x18\x01 \x01(\v2\x1a.universerpc.MerkleSumNodeR\x0emultiverseRoot\"\xa2\x01\n" +
+	"\x0fmultiverse_root\x18\x01 \x01(\v2\x1a.universerpc.MerkleSumNodeR\x0emultiverseRoot\"\xd9\x01\n" +
 	"\x10AssetRootRequest\x12+\n" +
 	"\x12with_amounts_by_id\x18\x01 \x01(\bR\x0fwithAmountsById\x12\x16\n" +
 	"\x06offset\x18\x02 \x01(\x05R\x06offset\x12\x14\n" +
 	"\x05limit\x18\x03 \x01(\x05R\x05limit\x123\n" +
-	"\tdirection\x18\x04 \x01(\x0e2\x15.taprpc.SortDirectionR\tdirection\"G\n" +
+	"\tdirection\x18\x04 \x01(\x0e2\x15.taprpc.SortDirectionR\tdirection\x125\n" +
+	"\n" +
+	"proof_type\x18\x05 \x01(\x0e2\x16.universerpc.ProofTypeR\tproofType\"G\n" +
 	"\rMerkleSumNode\x12\x1b\n" +
 	"\troot_hash\x18\x01 \x01(\fR\brootHash\x12\x19\n" +
 	"\broot_sum\x18\x02 \x01(\x03R\arootSum\"\xc7\x01\n" +
@@ -5600,157 +5612,158 @@ var file_universerpc_universe_proto_depIdxs = []int32{
 	8,   // 1: universerpc.MultiverseRootRequest.specific_ids:type_name -> universerpc.ID
 	7,   // 2: universerpc.MultiverseRootResponse.multiverse_root:type_name -> universerpc.MerkleSumNode
 	81,  // 3: universerpc.AssetRootRequest.direction:type_name -> taprpc.SortDirection
-	0,   // 4: universerpc.ID.proof_type:type_name -> universerpc.ProofType
-	8,   // 5: universerpc.UniverseRoot.id:type_name -> universerpc.ID
-	7,   // 6: universerpc.UniverseRoot.mssmt_root:type_name -> universerpc.MerkleSumNode
-	77,  // 7: universerpc.UniverseRoot.amounts_by_asset_id:type_name -> universerpc.UniverseRoot.AmountsByAssetIdEntry
-	78,  // 8: universerpc.AssetRootResponse.universe_roots:type_name -> universerpc.AssetRootResponse.UniverseRootsEntry
-	8,   // 9: universerpc.AssetRootQuery.id:type_name -> universerpc.ID
-	9,   // 10: universerpc.QueryRootResponse.issuance_root:type_name -> universerpc.UniverseRoot
-	9,   // 11: universerpc.QueryRootResponse.transfer_root:type_name -> universerpc.UniverseRoot
-	8,   // 12: universerpc.DeleteRootQuery.id:type_name -> universerpc.ID
-	25,  // 13: universerpc.DeleteAssetLeafRequest.key:type_name -> universerpc.UniverseKey
-	17,  // 14: universerpc.AssetKey.op:type_name -> universerpc.Outpoint
-	8,   // 15: universerpc.AssetLeafKeysRequest.id:type_name -> universerpc.ID
-	81,  // 16: universerpc.AssetLeafKeysRequest.direction:type_name -> taprpc.SortDirection
-	8,   // 17: universerpc.AssetLeavesRequest.id:type_name -> universerpc.ID
-	81,  // 18: universerpc.AssetLeavesRequest.direction:type_name -> taprpc.SortDirection
-	18,  // 19: universerpc.AssetLeafEntry.asset_key:type_name -> universerpc.AssetKey
-	18,  // 20: universerpc.AssetLeafKeyResponse.asset_keys:type_name -> universerpc.AssetKey
-	21,  // 21: universerpc.AssetLeafKeyResponse.entries:type_name -> universerpc.AssetLeafEntry
-	82,  // 22: universerpc.AssetLeaf.asset:type_name -> taprpc.Asset
-	23,  // 23: universerpc.AssetLeafResponse.leaves:type_name -> universerpc.AssetLeaf
-	8,   // 24: universerpc.UniverseKey.id:type_name -> universerpc.ID
-	18,  // 25: universerpc.UniverseKey.leaf_key:type_name -> universerpc.AssetKey
-	25,  // 26: universerpc.AssetProofResponse.req:type_name -> universerpc.UniverseKey
-	9,   // 27: universerpc.AssetProofResponse.universe_root:type_name -> universerpc.UniverseRoot
-	23,  // 28: universerpc.AssetProofResponse.asset_leaf:type_name -> universerpc.AssetLeaf
-	7,   // 29: universerpc.AssetProofResponse.multiverse_root:type_name -> universerpc.MerkleSumNode
-	27,  // 30: universerpc.AssetProofResponse.issuance_data:type_name -> universerpc.IssuanceData
-	83,  // 31: universerpc.IssuanceData.meta_reveal:type_name -> taprpc.AssetMeta
-	84,  // 32: universerpc.IssuanceData.genesis_reveal:type_name -> taprpc.GenesisReveal
-	85,  // 33: universerpc.IssuanceData.group_key_reveal:type_name -> taprpc.GroupKeyReveal
-	25,  // 34: universerpc.AssetProof.key:type_name -> universerpc.UniverseKey
-	23,  // 35: universerpc.AssetProof.asset_leaf:type_name -> universerpc.AssetLeaf
-	25,  // 36: universerpc.PushProofRequest.key:type_name -> universerpc.UniverseKey
-	41,  // 37: universerpc.PushProofRequest.server:type_name -> universerpc.UniverseFederationServer
-	25,  // 38: universerpc.PushProofResponse.key:type_name -> universerpc.UniverseKey
-	8,   // 39: universerpc.SyncTarget.id:type_name -> universerpc.ID
-	1,   // 40: universerpc.SyncRequest.sync_mode:type_name -> universerpc.UniverseSyncMode
-	33,  // 41: universerpc.SyncRequest.sync_targets:type_name -> universerpc.SyncTarget
-	9,   // 42: universerpc.SyncedUniverse.old_asset_root:type_name -> universerpc.UniverseRoot
-	9,   // 43: universerpc.SyncedUniverse.new_asset_root:type_name -> universerpc.UniverseRoot
-	23,  // 44: universerpc.SyncedUniverse.new_asset_leaves:type_name -> universerpc.AssetLeaf
-	35,  // 45: universerpc.SyncResponse.synced_universes:type_name -> universerpc.SyncedUniverse
-	8,   // 46: universerpc.SyncDeltaItem.universe_id:type_name -> universerpc.ID
-	18,  // 47: universerpc.SyncDeltaItem.key:type_name -> universerpc.AssetKey
-	23,  // 48: universerpc.SyncDeltaItem.leaf:type_name -> universerpc.AssetLeaf
-	39,  // 49: universerpc.SyncDeltaResponse.items:type_name -> universerpc.SyncDeltaItem
-	9,   // 50: universerpc.SyncDeltaResponse.universe_roots:type_name -> universerpc.UniverseRoot
-	41,  // 51: universerpc.ListFederationServersResponse.servers:type_name -> universerpc.UniverseFederationServer
-	41,  // 52: universerpc.AddFederationServerRequest.servers:type_name -> universerpc.UniverseFederationServer
-	41,  // 53: universerpc.DeleteFederationServerRequest.servers:type_name -> universerpc.UniverseFederationServer
-	3,   // 54: universerpc.AssetStatsQuery.asset_type_filter:type_name -> universerpc.AssetTypeFilter
-	2,   // 55: universerpc.AssetStatsQuery.sort_by:type_name -> universerpc.AssetQuerySort
-	81,  // 56: universerpc.AssetStatsQuery.direction:type_name -> taprpc.SortDirection
-	51,  // 57: universerpc.AssetStatsSnapshot.group_anchor:type_name -> universerpc.AssetStatsAsset
-	51,  // 58: universerpc.AssetStatsSnapshot.asset:type_name -> universerpc.AssetStatsAsset
-	86,  // 59: universerpc.AssetStatsAsset.asset_type:type_name -> taprpc.AssetType
-	50,  // 60: universerpc.UniverseAssetStats.asset_stats:type_name -> universerpc.AssetStatsSnapshot
-	55,  // 61: universerpc.QueryEventsResponse.events:type_name -> universerpc.GroupedUniverseEvents
-	58,  // 62: universerpc.SetFederationSyncConfigRequest.global_sync_configs:type_name -> universerpc.GlobalFederationSyncConfig
-	59,  // 63: universerpc.SetFederationSyncConfigRequest.asset_sync_configs:type_name -> universerpc.AssetFederationSyncConfig
-	0,   // 64: universerpc.GlobalFederationSyncConfig.proof_type:type_name -> universerpc.ProofType
-	8,   // 65: universerpc.AssetFederationSyncConfig.id:type_name -> universerpc.ID
-	8,   // 66: universerpc.QueryFederationSyncConfigRequest.id:type_name -> universerpc.ID
-	58,  // 67: universerpc.QueryFederationSyncConfigResponse.global_sync_configs:type_name -> universerpc.GlobalFederationSyncConfig
-	59,  // 68: universerpc.QueryFederationSyncConfigResponse.asset_sync_configs:type_name -> universerpc.AssetFederationSyncConfig
-	87,  // 69: universerpc.IgnoreAssetOutPointRequest.asset_out_point:type_name -> taprpc.AssetOutPoint
-	7,   // 70: universerpc.IgnoreAssetOutPointResponse.leaf:type_name -> universerpc.MerkleSumNode
-	88,  // 71: universerpc.FetchSupplyCommitRequest.commit_outpoint:type_name -> taprpc.OutPoint
-	88,  // 72: universerpc.FetchSupplyCommitRequest.spent_commit_outpoint:type_name -> taprpc.OutPoint
-	7,   // 73: universerpc.SupplyCommitSubtreeRoot.root_node:type_name -> universerpc.MerkleSumNode
-	74,  // 74: universerpc.FetchSupplyCommitResponse.chain_data:type_name -> universerpc.SupplyCommitChainData
-	67,  // 75: universerpc.FetchSupplyCommitResponse.issuance_subtree_root:type_name -> universerpc.SupplyCommitSubtreeRoot
-	67,  // 76: universerpc.FetchSupplyCommitResponse.burn_subtree_root:type_name -> universerpc.SupplyCommitSubtreeRoot
-	67,  // 77: universerpc.FetchSupplyCommitResponse.ignore_subtree_root:type_name -> universerpc.SupplyCommitSubtreeRoot
-	71,  // 78: universerpc.FetchSupplyCommitResponse.issuance_leaves:type_name -> universerpc.SupplyLeafEntry
-	71,  // 79: universerpc.FetchSupplyCommitResponse.burn_leaves:type_name -> universerpc.SupplyLeafEntry
-	71,  // 80: universerpc.FetchSupplyCommitResponse.ignore_leaves:type_name -> universerpc.SupplyLeafEntry
-	88,  // 81: universerpc.FetchSupplyCommitResponse.spent_commitment_outpoint:type_name -> taprpc.OutPoint
-	79,  // 82: universerpc.FetchSupplyCommitResponse.block_headers:type_name -> universerpc.FetchSupplyCommitResponse.BlockHeadersEntry
-	17,  // 83: universerpc.SupplyLeafKey.outpoint:type_name -> universerpc.Outpoint
-	70,  // 84: universerpc.SupplyLeafEntry.leaf_key:type_name -> universerpc.SupplyLeafKey
-	7,   // 85: universerpc.SupplyLeafEntry.leaf_node:type_name -> universerpc.MerkleSumNode
-	71,  // 86: universerpc.FetchSupplyLeavesResponse.issuance_leaves:type_name -> universerpc.SupplyLeafEntry
-	71,  // 87: universerpc.FetchSupplyLeavesResponse.burn_leaves:type_name -> universerpc.SupplyLeafEntry
-	71,  // 88: universerpc.FetchSupplyLeavesResponse.ignore_leaves:type_name -> universerpc.SupplyLeafEntry
-	80,  // 89: universerpc.FetchSupplyLeavesResponse.block_headers:type_name -> universerpc.FetchSupplyLeavesResponse.BlockHeadersEntry
-	74,  // 90: universerpc.InsertSupplyCommitRequest.chain_data:type_name -> universerpc.SupplyCommitChainData
-	88,  // 91: universerpc.InsertSupplyCommitRequest.spent_commitment_outpoint:type_name -> taprpc.OutPoint
-	71,  // 92: universerpc.InsertSupplyCommitRequest.issuance_leaves:type_name -> universerpc.SupplyLeafEntry
-	71,  // 93: universerpc.InsertSupplyCommitRequest.burn_leaves:type_name -> universerpc.SupplyLeafEntry
-	71,  // 94: universerpc.InsertSupplyCommitRequest.ignore_leaves:type_name -> universerpc.SupplyLeafEntry
-	9,   // 95: universerpc.AssetRootResponse.UniverseRootsEntry.value:type_name -> universerpc.UniverseRoot
-	72,  // 96: universerpc.FetchSupplyCommitResponse.BlockHeadersEntry.value:type_name -> universerpc.SupplyLeafBlockHeader
-	72,  // 97: universerpc.FetchSupplyLeavesResponse.BlockHeadersEntry.value:type_name -> universerpc.SupplyLeafBlockHeader
-	4,   // 98: universerpc.Universe.MultiverseRoot:input_type -> universerpc.MultiverseRootRequest
-	6,   // 99: universerpc.Universe.AssetRoots:input_type -> universerpc.AssetRootRequest
-	11,  // 100: universerpc.Universe.QueryAssetRoots:input_type -> universerpc.AssetRootQuery
-	13,  // 101: universerpc.Universe.DeleteAssetRoot:input_type -> universerpc.DeleteRootQuery
-	15,  // 102: universerpc.Universe.DeleteAssetLeaf:input_type -> universerpc.DeleteAssetLeafRequest
-	19,  // 103: universerpc.Universe.AssetLeafKeys:input_type -> universerpc.AssetLeafKeysRequest
-	20,  // 104: universerpc.Universe.AssetLeaves:input_type -> universerpc.AssetLeavesRequest
-	25,  // 105: universerpc.Universe.QueryProof:input_type -> universerpc.UniverseKey
-	28,  // 106: universerpc.Universe.InsertProof:input_type -> universerpc.AssetProof
-	29,  // 107: universerpc.Universe.PushProof:input_type -> universerpc.PushProofRequest
-	31,  // 108: universerpc.Universe.Info:input_type -> universerpc.InfoRequest
-	34,  // 109: universerpc.Universe.SyncUniverse:input_type -> universerpc.SyncRequest
-	38,  // 110: universerpc.Universe.SyncDelta:input_type -> universerpc.SyncDeltaRequest
-	42,  // 111: universerpc.Universe.ListFederationServers:input_type -> universerpc.ListFederationServersRequest
-	44,  // 112: universerpc.Universe.AddFederationServer:input_type -> universerpc.AddFederationServerRequest
-	46,  // 113: universerpc.Universe.DeleteFederationServer:input_type -> universerpc.DeleteFederationServerRequest
-	36,  // 114: universerpc.Universe.UniverseStats:input_type -> universerpc.StatsRequest
-	49,  // 115: universerpc.Universe.QueryAssetStats:input_type -> universerpc.AssetStatsQuery
-	53,  // 116: universerpc.Universe.QueryEvents:input_type -> universerpc.QueryEventsRequest
-	56,  // 117: universerpc.Universe.SetFederationSyncConfig:input_type -> universerpc.SetFederationSyncConfigRequest
-	60,  // 118: universerpc.Universe.QueryFederationSyncConfig:input_type -> universerpc.QueryFederationSyncConfigRequest
-	62,  // 119: universerpc.Universe.IgnoreAssetOutPoint:input_type -> universerpc.IgnoreAssetOutPointRequest
-	64,  // 120: universerpc.Universe.UpdateSupplyCommit:input_type -> universerpc.UpdateSupplyCommitRequest
-	66,  // 121: universerpc.Universe.FetchSupplyCommit:input_type -> universerpc.FetchSupplyCommitRequest
-	69,  // 122: universerpc.Universe.FetchSupplyLeaves:input_type -> universerpc.FetchSupplyLeavesRequest
-	75,  // 123: universerpc.Universe.InsertSupplyCommit:input_type -> universerpc.InsertSupplyCommitRequest
-	5,   // 124: universerpc.Universe.MultiverseRoot:output_type -> universerpc.MultiverseRootResponse
-	10,  // 125: universerpc.Universe.AssetRoots:output_type -> universerpc.AssetRootResponse
-	12,  // 126: universerpc.Universe.QueryAssetRoots:output_type -> universerpc.QueryRootResponse
-	14,  // 127: universerpc.Universe.DeleteAssetRoot:output_type -> universerpc.DeleteRootResponse
-	16,  // 128: universerpc.Universe.DeleteAssetLeaf:output_type -> universerpc.DeleteAssetLeafResponse
-	22,  // 129: universerpc.Universe.AssetLeafKeys:output_type -> universerpc.AssetLeafKeyResponse
-	24,  // 130: universerpc.Universe.AssetLeaves:output_type -> universerpc.AssetLeafResponse
-	26,  // 131: universerpc.Universe.QueryProof:output_type -> universerpc.AssetProofResponse
-	26,  // 132: universerpc.Universe.InsertProof:output_type -> universerpc.AssetProofResponse
-	30,  // 133: universerpc.Universe.PushProof:output_type -> universerpc.PushProofResponse
-	32,  // 134: universerpc.Universe.Info:output_type -> universerpc.InfoResponse
-	37,  // 135: universerpc.Universe.SyncUniverse:output_type -> universerpc.SyncResponse
-	40,  // 136: universerpc.Universe.SyncDelta:output_type -> universerpc.SyncDeltaResponse
-	43,  // 137: universerpc.Universe.ListFederationServers:output_type -> universerpc.ListFederationServersResponse
-	45,  // 138: universerpc.Universe.AddFederationServer:output_type -> universerpc.AddFederationServerResponse
-	47,  // 139: universerpc.Universe.DeleteFederationServer:output_type -> universerpc.DeleteFederationServerResponse
-	48,  // 140: universerpc.Universe.UniverseStats:output_type -> universerpc.StatsResponse
-	52,  // 141: universerpc.Universe.QueryAssetStats:output_type -> universerpc.UniverseAssetStats
-	54,  // 142: universerpc.Universe.QueryEvents:output_type -> universerpc.QueryEventsResponse
-	57,  // 143: universerpc.Universe.SetFederationSyncConfig:output_type -> universerpc.SetFederationSyncConfigResponse
-	61,  // 144: universerpc.Universe.QueryFederationSyncConfig:output_type -> universerpc.QueryFederationSyncConfigResponse
-	63,  // 145: universerpc.Universe.IgnoreAssetOutPoint:output_type -> universerpc.IgnoreAssetOutPointResponse
-	65,  // 146: universerpc.Universe.UpdateSupplyCommit:output_type -> universerpc.UpdateSupplyCommitResponse
-	68,  // 147: universerpc.Universe.FetchSupplyCommit:output_type -> universerpc.FetchSupplyCommitResponse
-	73,  // 148: universerpc.Universe.FetchSupplyLeaves:output_type -> universerpc.FetchSupplyLeavesResponse
-	76,  // 149: universerpc.Universe.InsertSupplyCommit:output_type -> universerpc.InsertSupplyCommitResponse
-	124, // [124:150] is the sub-list for method output_type
-	98,  // [98:124] is the sub-list for method input_type
-	98,  // [98:98] is the sub-list for extension type_name
-	98,  // [98:98] is the sub-list for extension extendee
-	0,   // [0:98] is the sub-list for field type_name
+	0,   // 4: universerpc.AssetRootRequest.proof_type:type_name -> universerpc.ProofType
+	0,   // 5: universerpc.ID.proof_type:type_name -> universerpc.ProofType
+	8,   // 6: universerpc.UniverseRoot.id:type_name -> universerpc.ID
+	7,   // 7: universerpc.UniverseRoot.mssmt_root:type_name -> universerpc.MerkleSumNode
+	77,  // 8: universerpc.UniverseRoot.amounts_by_asset_id:type_name -> universerpc.UniverseRoot.AmountsByAssetIdEntry
+	78,  // 9: universerpc.AssetRootResponse.universe_roots:type_name -> universerpc.AssetRootResponse.UniverseRootsEntry
+	8,   // 10: universerpc.AssetRootQuery.id:type_name -> universerpc.ID
+	9,   // 11: universerpc.QueryRootResponse.issuance_root:type_name -> universerpc.UniverseRoot
+	9,   // 12: universerpc.QueryRootResponse.transfer_root:type_name -> universerpc.UniverseRoot
+	8,   // 13: universerpc.DeleteRootQuery.id:type_name -> universerpc.ID
+	25,  // 14: universerpc.DeleteAssetLeafRequest.key:type_name -> universerpc.UniverseKey
+	17,  // 15: universerpc.AssetKey.op:type_name -> universerpc.Outpoint
+	8,   // 16: universerpc.AssetLeafKeysRequest.id:type_name -> universerpc.ID
+	81,  // 17: universerpc.AssetLeafKeysRequest.direction:type_name -> taprpc.SortDirection
+	8,   // 18: universerpc.AssetLeavesRequest.id:type_name -> universerpc.ID
+	81,  // 19: universerpc.AssetLeavesRequest.direction:type_name -> taprpc.SortDirection
+	18,  // 20: universerpc.AssetLeafEntry.asset_key:type_name -> universerpc.AssetKey
+	18,  // 21: universerpc.AssetLeafKeyResponse.asset_keys:type_name -> universerpc.AssetKey
+	21,  // 22: universerpc.AssetLeafKeyResponse.entries:type_name -> universerpc.AssetLeafEntry
+	82,  // 23: universerpc.AssetLeaf.asset:type_name -> taprpc.Asset
+	23,  // 24: universerpc.AssetLeafResponse.leaves:type_name -> universerpc.AssetLeaf
+	8,   // 25: universerpc.UniverseKey.id:type_name -> universerpc.ID
+	18,  // 26: universerpc.UniverseKey.leaf_key:type_name -> universerpc.AssetKey
+	25,  // 27: universerpc.AssetProofResponse.req:type_name -> universerpc.UniverseKey
+	9,   // 28: universerpc.AssetProofResponse.universe_root:type_name -> universerpc.UniverseRoot
+	23,  // 29: universerpc.AssetProofResponse.asset_leaf:type_name -> universerpc.AssetLeaf
+	7,   // 30: universerpc.AssetProofResponse.multiverse_root:type_name -> universerpc.MerkleSumNode
+	27,  // 31: universerpc.AssetProofResponse.issuance_data:type_name -> universerpc.IssuanceData
+	83,  // 32: universerpc.IssuanceData.meta_reveal:type_name -> taprpc.AssetMeta
+	84,  // 33: universerpc.IssuanceData.genesis_reveal:type_name -> taprpc.GenesisReveal
+	85,  // 34: universerpc.IssuanceData.group_key_reveal:type_name -> taprpc.GroupKeyReveal
+	25,  // 35: universerpc.AssetProof.key:type_name -> universerpc.UniverseKey
+	23,  // 36: universerpc.AssetProof.asset_leaf:type_name -> universerpc.AssetLeaf
+	25,  // 37: universerpc.PushProofRequest.key:type_name -> universerpc.UniverseKey
+	41,  // 38: universerpc.PushProofRequest.server:type_name -> universerpc.UniverseFederationServer
+	25,  // 39: universerpc.PushProofResponse.key:type_name -> universerpc.UniverseKey
+	8,   // 40: universerpc.SyncTarget.id:type_name -> universerpc.ID
+	1,   // 41: universerpc.SyncRequest.sync_mode:type_name -> universerpc.UniverseSyncMode
+	33,  // 42: universerpc.SyncRequest.sync_targets:type_name -> universerpc.SyncTarget
+	9,   // 43: universerpc.SyncedUniverse.old_asset_root:type_name -> universerpc.UniverseRoot
+	9,   // 44: universerpc.SyncedUniverse.new_asset_root:type_name -> universerpc.UniverseRoot
+	23,  // 45: universerpc.SyncedUniverse.new_asset_leaves:type_name -> universerpc.AssetLeaf
+	35,  // 46: universerpc.SyncResponse.synced_universes:type_name -> universerpc.SyncedUniverse
+	8,   // 47: universerpc.SyncDeltaItem.universe_id:type_name -> universerpc.ID
+	18,  // 48: universerpc.SyncDeltaItem.key:type_name -> universerpc.AssetKey
+	23,  // 49: universerpc.SyncDeltaItem.leaf:type_name -> universerpc.AssetLeaf
+	39,  // 50: universerpc.SyncDeltaResponse.items:type_name -> universerpc.SyncDeltaItem
+	9,   // 51: universerpc.SyncDeltaResponse.universe_roots:type_name -> universerpc.UniverseRoot
+	41,  // 52: universerpc.ListFederationServersResponse.servers:type_name -> universerpc.UniverseFederationServer
+	41,  // 53: universerpc.AddFederationServerRequest.servers:type_name -> universerpc.UniverseFederationServer
+	41,  // 54: universerpc.DeleteFederationServerRequest.servers:type_name -> universerpc.UniverseFederationServer
+	3,   // 55: universerpc.AssetStatsQuery.asset_type_filter:type_name -> universerpc.AssetTypeFilter
+	2,   // 56: universerpc.AssetStatsQuery.sort_by:type_name -> universerpc.AssetQuerySort
+	81,  // 57: universerpc.AssetStatsQuery.direction:type_name -> taprpc.SortDirection
+	51,  // 58: universerpc.AssetStatsSnapshot.group_anchor:type_name -> universerpc.AssetStatsAsset
+	51,  // 59: universerpc.AssetStatsSnapshot.asset:type_name -> universerpc.AssetStatsAsset
+	86,  // 60: universerpc.AssetStatsAsset.asset_type:type_name -> taprpc.AssetType
+	50,  // 61: universerpc.UniverseAssetStats.asset_stats:type_name -> universerpc.AssetStatsSnapshot
+	55,  // 62: universerpc.QueryEventsResponse.events:type_name -> universerpc.GroupedUniverseEvents
+	58,  // 63: universerpc.SetFederationSyncConfigRequest.global_sync_configs:type_name -> universerpc.GlobalFederationSyncConfig
+	59,  // 64: universerpc.SetFederationSyncConfigRequest.asset_sync_configs:type_name -> universerpc.AssetFederationSyncConfig
+	0,   // 65: universerpc.GlobalFederationSyncConfig.proof_type:type_name -> universerpc.ProofType
+	8,   // 66: universerpc.AssetFederationSyncConfig.id:type_name -> universerpc.ID
+	8,   // 67: universerpc.QueryFederationSyncConfigRequest.id:type_name -> universerpc.ID
+	58,  // 68: universerpc.QueryFederationSyncConfigResponse.global_sync_configs:type_name -> universerpc.GlobalFederationSyncConfig
+	59,  // 69: universerpc.QueryFederationSyncConfigResponse.asset_sync_configs:type_name -> universerpc.AssetFederationSyncConfig
+	87,  // 70: universerpc.IgnoreAssetOutPointRequest.asset_out_point:type_name -> taprpc.AssetOutPoint
+	7,   // 71: universerpc.IgnoreAssetOutPointResponse.leaf:type_name -> universerpc.MerkleSumNode
+	88,  // 72: universerpc.FetchSupplyCommitRequest.commit_outpoint:type_name -> taprpc.OutPoint
+	88,  // 73: universerpc.FetchSupplyCommitRequest.spent_commit_outpoint:type_name -> taprpc.OutPoint
+	7,   // 74: universerpc.SupplyCommitSubtreeRoot.root_node:type_name -> universerpc.MerkleSumNode
+	74,  // 75: universerpc.FetchSupplyCommitResponse.chain_data:type_name -> universerpc.SupplyCommitChainData
+	67,  // 76: universerpc.FetchSupplyCommitResponse.issuance_subtree_root:type_name -> universerpc.SupplyCommitSubtreeRoot
+	67,  // 77: universerpc.FetchSupplyCommitResponse.burn_subtree_root:type_name -> universerpc.SupplyCommitSubtreeRoot
+	67,  // 78: universerpc.FetchSupplyCommitResponse.ignore_subtree_root:type_name -> universerpc.SupplyCommitSubtreeRoot
+	71,  // 79: universerpc.FetchSupplyCommitResponse.issuance_leaves:type_name -> universerpc.SupplyLeafEntry
+	71,  // 80: universerpc.FetchSupplyCommitResponse.burn_leaves:type_name -> universerpc.SupplyLeafEntry
+	71,  // 81: universerpc.FetchSupplyCommitResponse.ignore_leaves:type_name -> universerpc.SupplyLeafEntry
+	88,  // 82: universerpc.FetchSupplyCommitResponse.spent_commitment_outpoint:type_name -> taprpc.OutPoint
+	79,  // 83: universerpc.FetchSupplyCommitResponse.block_headers:type_name -> universerpc.FetchSupplyCommitResponse.BlockHeadersEntry
+	17,  // 84: universerpc.SupplyLeafKey.outpoint:type_name -> universerpc.Outpoint
+	70,  // 85: universerpc.SupplyLeafEntry.leaf_key:type_name -> universerpc.SupplyLeafKey
+	7,   // 86: universerpc.SupplyLeafEntry.leaf_node:type_name -> universerpc.MerkleSumNode
+	71,  // 87: universerpc.FetchSupplyLeavesResponse.issuance_leaves:type_name -> universerpc.SupplyLeafEntry
+	71,  // 88: universerpc.FetchSupplyLeavesResponse.burn_leaves:type_name -> universerpc.SupplyLeafEntry
+	71,  // 89: universerpc.FetchSupplyLeavesResponse.ignore_leaves:type_name -> universerpc.SupplyLeafEntry
+	80,  // 90: universerpc.FetchSupplyLeavesResponse.block_headers:type_name -> universerpc.FetchSupplyLeavesResponse.BlockHeadersEntry
+	74,  // 91: universerpc.InsertSupplyCommitRequest.chain_data:type_name -> universerpc.SupplyCommitChainData
+	88,  // 92: universerpc.InsertSupplyCommitRequest.spent_commitment_outpoint:type_name -> taprpc.OutPoint
+	71,  // 93: universerpc.InsertSupplyCommitRequest.issuance_leaves:type_name -> universerpc.SupplyLeafEntry
+	71,  // 94: universerpc.InsertSupplyCommitRequest.burn_leaves:type_name -> universerpc.SupplyLeafEntry
+	71,  // 95: universerpc.InsertSupplyCommitRequest.ignore_leaves:type_name -> universerpc.SupplyLeafEntry
+	9,   // 96: universerpc.AssetRootResponse.UniverseRootsEntry.value:type_name -> universerpc.UniverseRoot
+	72,  // 97: universerpc.FetchSupplyCommitResponse.BlockHeadersEntry.value:type_name -> universerpc.SupplyLeafBlockHeader
+	72,  // 98: universerpc.FetchSupplyLeavesResponse.BlockHeadersEntry.value:type_name -> universerpc.SupplyLeafBlockHeader
+	4,   // 99: universerpc.Universe.MultiverseRoot:input_type -> universerpc.MultiverseRootRequest
+	6,   // 100: universerpc.Universe.AssetRoots:input_type -> universerpc.AssetRootRequest
+	11,  // 101: universerpc.Universe.QueryAssetRoots:input_type -> universerpc.AssetRootQuery
+	13,  // 102: universerpc.Universe.DeleteAssetRoot:input_type -> universerpc.DeleteRootQuery
+	15,  // 103: universerpc.Universe.DeleteAssetLeaf:input_type -> universerpc.DeleteAssetLeafRequest
+	19,  // 104: universerpc.Universe.AssetLeafKeys:input_type -> universerpc.AssetLeafKeysRequest
+	20,  // 105: universerpc.Universe.AssetLeaves:input_type -> universerpc.AssetLeavesRequest
+	25,  // 106: universerpc.Universe.QueryProof:input_type -> universerpc.UniverseKey
+	28,  // 107: universerpc.Universe.InsertProof:input_type -> universerpc.AssetProof
+	29,  // 108: universerpc.Universe.PushProof:input_type -> universerpc.PushProofRequest
+	31,  // 109: universerpc.Universe.Info:input_type -> universerpc.InfoRequest
+	34,  // 110: universerpc.Universe.SyncUniverse:input_type -> universerpc.SyncRequest
+	38,  // 111: universerpc.Universe.SyncDelta:input_type -> universerpc.SyncDeltaRequest
+	42,  // 112: universerpc.Universe.ListFederationServers:input_type -> universerpc.ListFederationServersRequest
+	44,  // 113: universerpc.Universe.AddFederationServer:input_type -> universerpc.AddFederationServerRequest
+	46,  // 114: universerpc.Universe.DeleteFederationServer:input_type -> universerpc.DeleteFederationServerRequest
+	36,  // 115: universerpc.Universe.UniverseStats:input_type -> universerpc.StatsRequest
+	49,  // 116: universerpc.Universe.QueryAssetStats:input_type -> universerpc.AssetStatsQuery
+	53,  // 117: universerpc.Universe.QueryEvents:input_type -> universerpc.QueryEventsRequest
+	56,  // 118: universerpc.Universe.SetFederationSyncConfig:input_type -> universerpc.SetFederationSyncConfigRequest
+	60,  // 119: universerpc.Universe.QueryFederationSyncConfig:input_type -> universerpc.QueryFederationSyncConfigRequest
+	62,  // 120: universerpc.Universe.IgnoreAssetOutPoint:input_type -> universerpc.IgnoreAssetOutPointRequest
+	64,  // 121: universerpc.Universe.UpdateSupplyCommit:input_type -> universerpc.UpdateSupplyCommitRequest
+	66,  // 122: universerpc.Universe.FetchSupplyCommit:input_type -> universerpc.FetchSupplyCommitRequest
+	69,  // 123: universerpc.Universe.FetchSupplyLeaves:input_type -> universerpc.FetchSupplyLeavesRequest
+	75,  // 124: universerpc.Universe.InsertSupplyCommit:input_type -> universerpc.InsertSupplyCommitRequest
+	5,   // 125: universerpc.Universe.MultiverseRoot:output_type -> universerpc.MultiverseRootResponse
+	10,  // 126: universerpc.Universe.AssetRoots:output_type -> universerpc.AssetRootResponse
+	12,  // 127: universerpc.Universe.QueryAssetRoots:output_type -> universerpc.QueryRootResponse
+	14,  // 128: universerpc.Universe.DeleteAssetRoot:output_type -> universerpc.DeleteRootResponse
+	16,  // 129: universerpc.Universe.DeleteAssetLeaf:output_type -> universerpc.DeleteAssetLeafResponse
+	22,  // 130: universerpc.Universe.AssetLeafKeys:output_type -> universerpc.AssetLeafKeyResponse
+	24,  // 131: universerpc.Universe.AssetLeaves:output_type -> universerpc.AssetLeafResponse
+	26,  // 132: universerpc.Universe.QueryProof:output_type -> universerpc.AssetProofResponse
+	26,  // 133: universerpc.Universe.InsertProof:output_type -> universerpc.AssetProofResponse
+	30,  // 134: universerpc.Universe.PushProof:output_type -> universerpc.PushProofResponse
+	32,  // 135: universerpc.Universe.Info:output_type -> universerpc.InfoResponse
+	37,  // 136: universerpc.Universe.SyncUniverse:output_type -> universerpc.SyncResponse
+	40,  // 137: universerpc.Universe.SyncDelta:output_type -> universerpc.SyncDeltaResponse
+	43,  // 138: universerpc.Universe.ListFederationServers:output_type -> universerpc.ListFederationServersResponse
+	45,  // 139: universerpc.Universe.AddFederationServer:output_type -> universerpc.AddFederationServerResponse
+	47,  // 140: universerpc.Universe.DeleteFederationServer:output_type -> universerpc.DeleteFederationServerResponse
+	48,  // 141: universerpc.Universe.UniverseStats:output_type -> universerpc.StatsResponse
+	52,  // 142: universerpc.Universe.QueryAssetStats:output_type -> universerpc.UniverseAssetStats
+	54,  // 143: universerpc.Universe.QueryEvents:output_type -> universerpc.QueryEventsResponse
+	57,  // 144: universerpc.Universe.SetFederationSyncConfig:output_type -> universerpc.SetFederationSyncConfigResponse
+	61,  // 145: universerpc.Universe.QueryFederationSyncConfig:output_type -> universerpc.QueryFederationSyncConfigResponse
+	63,  // 146: universerpc.Universe.IgnoreAssetOutPoint:output_type -> universerpc.IgnoreAssetOutPointResponse
+	65,  // 147: universerpc.Universe.UpdateSupplyCommit:output_type -> universerpc.UpdateSupplyCommitResponse
+	68,  // 148: universerpc.Universe.FetchSupplyCommit:output_type -> universerpc.FetchSupplyCommitResponse
+	73,  // 149: universerpc.Universe.FetchSupplyLeaves:output_type -> universerpc.FetchSupplyLeavesResponse
+	76,  // 150: universerpc.Universe.InsertSupplyCommit:output_type -> universerpc.InsertSupplyCommitResponse
+	125, // [125:151] is the sub-list for method output_type
+	99,  // [99:125] is the sub-list for method input_type
+	99,  // [99:99] is the sub-list for extension type_name
+	99,  // [99:99] is the sub-list for extension extendee
+	0,   // [0:99] is the sub-list for field type_name
 }
 
 func init() { file_universerpc_universe_proto_init() }

--- a/taprpc/universerpc/universe.proto
+++ b/taprpc/universerpc/universe.proto
@@ -245,6 +245,10 @@ message AssetRootRequest {
     // The direction of the page.
     taprpc.SortDirection direction = 4;
 
+    // An optional filter to only return roots of the given proof type. If left
+    // unspecified, roots of all proof types are returned.
+    ProofType proof_type = 5;
+
     // TODO(roasbeef): filter by asset ID, etc?
 }
 

--- a/taprpc/universerpc/universe.swagger.json
+++ b/taprpc/universerpc/universe.swagger.json
@@ -1194,6 +1194,19 @@
               "SORT_DIRECTION_ASC"
             ],
             "default": "SORT_DIRECTION_DESC"
+          },
+          {
+            "name": "proof_type",
+            "description": "An optional filter to only return roots of the given proof type. If left\nunspecified, roots of all proof types are returned.",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "PROOF_TYPE_UNSPECIFIED",
+              "PROOF_TYPE_ISSUANCE",
+              "PROOF_TYPE_TRANSFER"
+            ],
+            "default": "PROOF_TYPE_UNSPECIFIED"
           }
         ],
         "tags": [

--- a/universe/archive.go
+++ b/universe/archive.go
@@ -174,6 +174,11 @@ type RootNodesQuery struct {
 	// Limit is the maximum number of root nodes to return. If this is
 	// zero, then the default limit will be used.
 	Limit int32
+
+	// ProofType is an optional filter for the proof type of the returned
+	// root nodes. If set to ProofTypeUnspecified, root nodes of all proof
+	// types are returned.
+	ProofType ProofType
 }
 
 // RootNodes returns the set of root nodes for all known base universes assets.


### PR DESCRIPTION
`tapcli universe roots --proof_type issuance` returned transfer roots too. When no asset ID or group key is given, the CLI dropped the proof type and `AssetRoots` had no way to filter, so every root came back regardless of the flag. Fixes #1762.

**Fix**

- `AssetRootRequest` gains an optional `proof_type` field. Unspecified returns all roots, so existing callers are unaffected.
- The `UniverseRoots` SQL query filters by proof type when set, so pagination stays correct.
- `RootNodesQuery` carries the proof type; the root page cache key includes it, and the syncer cache (which holds the complete set) is bypassed when a filter is set.
- The `AssetRoots` handler passes the filter through.
- `tapcli universe roots` sends the flag only when the user sets it, so a bare call still lists all roots.

The `UniverseRootsAfterID` query used by universe reconciliation is intentionally left unfiltered; it is a separate path unrelated to this RPC.

**Testing**

New itest `universe roots proof type filter` mints an issuable asset and sends it so the universe server holds both an issuance and a transfer root, then checks that each proof-type filter returns only its own type. It passes with the fix and fails without it (an issuance-filtered query returns a transfer root).
