### PR TITLE
tapgarden: release funding leases on batch cancellation

### DIFF
--- a/docs/release-notes/release-notes-0.9.0.md
+++ b/docs/release-notes/release-notes-0.9.0.md
@@ -113,6 +113,13 @@
   long-running node the series steps down. The per-day `sync_events`
   series is unchanged and still reflects sync traffic volume.
 
+* [PR#2262](https://github.com/lightninglabs/taproot-assets/pull/2262)
+  fixes a bug in which cancelling a minting batch left the leases on
+  the batch's funded wallet inputs in place, keeping those inputs
+  unusable until the lease TTL expired. The leases are now released
+  whenever a batch is cancelled, including batches cancelled during
+  startup recovery.
+
 * [PR#2267](https://github.com/lightninglabs/taproot-assets/pull/2267)
   rejects a negative `expiry` when adding a Taproot Asset channel
   invoice. A negative expiry previously skipped the default and was

--- a/tapgarden/cultivator.go
+++ b/tapgarden/cultivator.go
@@ -263,6 +263,14 @@ func (b *Cultivator) Cancel(respCh chan<- CancelResp) error {
 			)
 		}
 
+		// The batch is now cancelled on disk, so any wallet inputs
+		// leased when it was funded can be released.
+		if err == nil {
+			releaseBatchFundingInputs(
+				ctx, b.cfg.Wallet, b.cfg.Batch,
+			)
+		}
+
 		b.publishMintEvent(BatchStateSeedlingCancelled)
 
 		cancelResp = CancelResp{true, err}
@@ -279,6 +287,14 @@ func (b *Cultivator) Cancel(respCh chan<- CancelResp) error {
 
 			b.publishMintErrorEvent(
 				err, BatchStateSproutCancelled,
+			)
+		}
+
+		// The batch is now cancelled on disk, so any wallet inputs
+		// leased when it was funded can be released.
+		if err == nil {
+			releaseBatchFundingInputs(
+				ctx, b.cfg.Wallet, b.cfg.Batch,
 			)
 		}
 

--- a/tapgarden/planter.go
+++ b/tapgarden/planter.go
@@ -578,6 +578,15 @@ func (c *ChainPlanter) Start() error {
 					log.Warnf("Unable to cancel batch (%x)",
 						batchKey)
 				}
+
+				// The batch is now cancelled on disk, so any
+				// wallet inputs leased when it was funded can
+				// be released.
+				if err == nil {
+					releaseBatchFundingInputs(
+						ctx, c.cfg.Wallet, batch,
+					)
+				}
 			}
 
 			// TODO(jhb): Log manual fee rates?
@@ -1860,6 +1869,10 @@ func (c *ChainPlanter) cancelMintingBatch(ctx context.Context,
 		return fmt.Errorf("unable to cancel minting batch: %w", err)
 	}
 
+	// The batch is now cancelled on disk, so any wallet inputs leased
+	// when it was funded can be released.
+	releaseBatchFundingInputs(ctx, c.cfg.Wallet, c.pendingBatch)
+
 	return nil
 }
 
@@ -1897,6 +1910,10 @@ func (c *ChainPlanter) cancelFailedBatch(batch *MintingBatch) error {
 		return fmt.Errorf("unable to cancel failed batch (%x): %w",
 			batchKeySerial[:], err)
 	}
+
+	// The batch is now cancelled on disk, so any wallet inputs leased
+	// when it was funded can be released.
+	releaseBatchFundingInputs(ctx, c.cfg.Wallet, batch)
 
 	return nil
 }
@@ -2066,21 +2083,32 @@ type fundingPrep struct {
 }
 
 // releaseFundingInputs releases every wallet input leased while funding a
-// PSBT. A fresh planter-scoped context is used so a cancelled request context
-// does not prevent cleanup.
-func (c *ChainPlanter) releaseFundingInputs(
+// PSBT. The leased outpoints are read from LockedUTXOs when present. That
+// field is never persisted, so a packet reloaded from disk carries none;
+// in that case the outpoints are derived from the unsigned transaction's
+// inputs instead. Every input of a mint anchor was leased by the wallet
+// during funding, so the two sets coincide.
+func releaseFundingInputs(ctx context.Context, wallet tapnode.WalletAnchor,
 	funded *tapsend.FundedPsbt) error {
 
-	if funded == nil || len(funded.LockedUTXOs) == 0 {
+	if funded == nil {
 		return nil
 	}
 
-	ctx, cancel := c.WithCtxQuit()
-	defer cancel()
+	outpoints := funded.LockedUTXOs
+	if len(outpoints) == 0 && funded.Pkt != nil &&
+		funded.Pkt.UnsignedTx != nil {
+
+		txIns := funded.Pkt.UnsignedTx.TxIn
+		outpoints = make([]wire.OutPoint, 0, len(txIns))
+		for _, txIn := range txIns {
+			outpoints = append(outpoints, txIn.PreviousOutPoint)
+		}
+	}
 
 	var unlockErrs []error
-	for _, outpoint := range funded.LockedUTXOs {
-		if err := c.cfg.Wallet.UnlockInput(ctx, outpoint); err != nil {
+	for _, outpoint := range outpoints {
+		if err := wallet.UnlockInput(ctx, outpoint); err != nil {
 			unlockErrs = append(unlockErrs, fmt.Errorf(
 				"unable to unlock input %v: %w", outpoint, err,
 			))
@@ -2090,12 +2118,41 @@ func (c *ChainPlanter) releaseFundingInputs(
 	return errors.Join(unlockErrs...)
 }
 
+// releaseBatchFundingInputs releases the wallet inputs leased for a
+// batch's genesis packet after the batch has been cancelled on disk. A
+// batch that was never funded has no genesis packet and nothing to
+// release. Unlock failures are only logged, never returned: the
+// cancellation itself has already been written, and a stale lease
+// expires on its own once the wallet's lease TTL passes (for the same
+// reason, an input may already be reported as not leased).
+func releaseBatchFundingInputs(ctx context.Context,
+	wallet tapnode.WalletAnchor, batch *MintingBatch) {
+
+	if batch.GenesisPacket == nil {
+		return
+	}
+
+	err := releaseFundingInputs(
+		ctx, wallet, &batch.GenesisPacket.FundedPsbt,
+	)
+	if err != nil {
+		batchKeySerial := asset.ToSerialized(batch.BatchKey.PubKey)
+		log.Warnf("Unable to release funding inputs of cancelled "+
+			"batch (%x): %v", batchKeySerial[:], err)
+	}
+}
+
 // fundingError releases a funded PSBT's wallet leases and preserves both the
-// original failure and any cleanup failure for the caller.
+// original failure and any cleanup failure for the caller. A fresh
+// planter-scoped context is used so a cancelled request context does not
+// prevent cleanup.
 func (c *ChainPlanter) fundingError(funded *tapsend.FundedPsbt,
 	cause error) error {
 
-	unlockErr := c.releaseFundingInputs(funded)
+	ctx, cancel := c.WithCtxQuit()
+	defer cancel()
+
+	unlockErr := releaseFundingInputs(ctx, c.cfg.Wallet, funded)
 	if unlockErr == nil {
 		return cause
 	}

--- a/tapgarden/planter_test.go
+++ b/tapgarden/planter_test.go
@@ -1918,6 +1918,227 @@ func testFundFailureReleasesWalletLeases(t *mintingTestHarness) {
 	require.Equal(t, funded.LockedUTXOs[0], *unlocked)
 }
 
+// testCancelFundedBatchReleasesLeases verifies that cancelling a funded
+// batch releases every wallet input leased during funding.
+func testCancelFundedBatchReleasesLeases(t *mintingTestHarness) {
+	t.refreshChainPlanter()
+
+	_ = t.queueInitialBatch(2)
+
+	var (
+		wg       sync.WaitGroup
+		respChan = make(chan *FundBatchResp, 1)
+	)
+	t.fundBatch(&wg, respChan, nil)
+	funded := t.assertGenesisTxFunded(nil)
+	fundedBatch := t.assertFundBatch(&wg, respChan, "")
+	require.True(t, fundedBatch.IsFunded())
+
+	// Cancelling the funded batch must release the leased inputs.
+	batchKey := t.cancelMintingBatch(false)
+	t.assertBatchState(
+		batchKey, tapgarden.BatchStateSeedlingCancelled,
+	)
+
+	require.Len(t, funded.LockedUTXOs, 1)
+	unlocked, err := fn.RecvOrTimeout(
+		t.wallet.UnlockInputSignal, defaultTimeout,
+	)
+	require.NoError(t, err)
+	require.Equal(t, funded.LockedUTXOs[0], *unlocked)
+}
+
+// testCancelUnfundedBatchNoLeaseRelease verifies that cancelling a batch
+// that was never funded does not release any wallet inputs.
+func testCancelUnfundedBatchNoLeaseRelease(t *mintingTestHarness) {
+	t.refreshChainPlanter()
+
+	_ = t.queueInitialBatch(2)
+
+	batchKey := t.cancelMintingBatch(false)
+	t.assertBatchState(
+		batchKey, tapgarden.BatchStateSeedlingCancelled,
+	)
+
+	select {
+	case outpoint := <-t.wallet.UnlockInputSignal:
+		t.Fatalf("unexpected input unlock: %v", outpoint)
+	default:
+	}
+}
+
+// testFailedBroadcastKeepsLeases verifies that a batch retained at
+// Committed after a broadcast-path failure keeps its wallet leases, so
+// the same inputs are still reserved when the batch is retried on
+// restart.
+func testFailedBroadcastKeepsLeases(t *mintingTestHarness) {
+	t.refreshChainPlanter()
+
+	_ = t.queueInitialBatch(2)
+
+	var (
+		wg       sync.WaitGroup
+		respChan = make(chan *FinalizeBatchResp, 1)
+	)
+
+	// Arm the wallet so signing the genesis TX fails after the
+	// batch has been committed.
+	t.wallet.FailSignPsbtOnce()
+	t.finalizeBatch(&wg, respChan, nil)
+
+	_ = t.assertGenesisTxFunded(nil)
+	t.assertFinalizeBatch(&wg, respChan, "unable to sign psbt")
+
+	// The batch stays committed for a restart to retry, so its
+	// funding leases must not be released.
+	t.assertNumCultivatorsActive(0)
+	t.assertNoPendingBatch()
+	t.assertLastBatchState(1, tapgarden.BatchStateCommitted)
+
+	select {
+	case outpoint := <-t.wallet.UnlockInputSignal:
+		t.Fatalf("unexpected input unlock: %v", outpoint)
+	default:
+	}
+}
+
+// testCaretakerResumeFailureReleasesLeases verifies that a batch
+// cancelled after its resumed cultivator fails pre-broadcast still
+// releases its funding inputs. A batch reloaded from disk carries no
+// LockedUTXOs (the field is never persisted), so the outpoints must be
+// derived from the funded PSBT's inputs instead.
+func testCaretakerResumeFailureReleasesLeases(t *mintingTestHarness) {
+	t.refreshChainPlanter()
+
+	const numSeedlings = 5
+	seedlings := t.newRandSeedlings(numSeedlings)
+	t.queueSeedlingsInBatch(false, seedlings...)
+
+	// Fund the batch with a tapscript sibling, so the resumed
+	// cultivator must load the tapscript tree before it can commit
+	// the batch.
+	sigLockKey := test.RandPubKey(t)
+	hashLockWitness := []byte("foobar")
+	hashLockLeaf := test.ScriptHashLock(t, hashLockWitness)
+	sigLeaf := test.ScriptSchnorrSig(t, sigLockKey)
+	tapTreePreimage, err := asset.TapTreeNodesFromLeaves(
+		[]txscript.TapLeaf{hashLockLeaf, sigLeaf},
+	)
+	require.NoError(t, err)
+
+	var (
+		wg       sync.WaitGroup
+		respChan = make(chan *FundBatchResp, 1)
+	)
+
+	fundReq := tapgarden.FundParams{
+		SiblingTapTree: fn.Some(*tapTreePreimage),
+	}
+	t.fundBatch(&wg, respChan, &fundReq)
+	funded := t.assertGenesisTxFunded(nil)
+	t.assertFundBatch(&wg, respChan, "")
+
+	// Force tapscript tree loading to fail, then restart the
+	// planter. The resumed cultivator fails before broadcast and
+	// the planter cancels the batch in the background.
+	t.treeStore.FailLoad = true
+	t.refreshChainPlanter()
+
+	err = wait.NoError(func() error {
+		batches, err := t.store.FetchAllBatches(
+			context.Background(),
+		)
+		if err != nil {
+			return err
+		}
+		if len(batches) != 1 {
+			return fmt.Errorf("expected 1 batch, found %d",
+				len(batches))
+		}
+
+		batchState := batches[0].State()
+		if batchState != tapgarden.BatchStateSeedlingCancelled {
+			return fmt.Errorf("batch not cancelled, state %v",
+				batchState)
+		}
+
+		return nil
+	}, defaultTimeout)
+	require.NoError(t, err)
+
+	// The reloaded batch has no LockedUTXOs, so the released
+	// outpoints must have been derived from the funded PSBT's
+	// inputs.
+	require.Len(t, funded.LockedUTXOs, 1)
+	unlocked, err := fn.RecvOrTimeout(
+		t.wallet.UnlockInputSignal, defaultTimeout,
+	)
+	require.NoError(t, err)
+	require.Equal(t, funded.LockedUTXOs[0], *unlocked)
+}
+
+// testResumeSealFailureReleasesLeases verifies that a funded batch that
+// fails to seal while being resumed at startup, and is therefore
+// cancelled by the resume loop itself, releases its funding inputs. As
+// on the other resume paths, the reloaded batch carries no LockedUTXOs,
+// so the outpoints must be derived from the funded PSBT's inputs.
+func testResumeSealFailureReleasesLeases(t *mintingTestHarness) {
+	t.refreshChainPlanter()
+
+	// Create a batch with a grouped seedling, so sealing must
+	// create an asset group witness.
+	const numSeedlings = 2
+	seedlings := t.newRandSeedlings(numSeedlings)
+	seedlings[0].EnableEmission = true
+	seedlings[0].GroupInternalKey = nil
+	seedlings[1].EnableEmission = false
+	t.queueSeedlingsInBatch(false, seedlings...)
+
+	var (
+		wg       sync.WaitGroup
+		respChan = make(chan *FundBatchResp, 1)
+	)
+	t.fundBatch(&wg, respChan, nil)
+	funded := t.assertGenesisTxFunded(nil)
+	t.assertFundBatch(&wg, respChan, "")
+
+	// Set group key signing to fail, then restart the planter. The
+	// resume loop skips funding (the batch is already funded), fails
+	// to seal the batch, and cancels it before any cultivator is
+	// launched.
+	t.genSigner.FailSigningOnce()
+	t.refreshChainPlanter()
+
+	err := wait.NoError(func() error {
+		batches, err := t.store.FetchAllBatches(
+			context.Background(),
+		)
+		if err != nil {
+			return err
+		}
+		if len(batches) != 1 {
+			return fmt.Errorf("expected 1 batch, found %d",
+				len(batches))
+		}
+
+		batchState := batches[0].State()
+		if batchState != tapgarden.BatchStateSeedlingCancelled {
+			return fmt.Errorf("batch not cancelled, state %v",
+				batchState)
+		}
+
+		return nil
+	}, defaultTimeout)
+	require.NoError(t, err)
+
+	require.Len(t, funded.LockedUTXOs, 1)
+	unlocked, err := fn.RecvOrTimeout(
+		t.wallet.UnlockInputSignal, defaultTimeout,
+	)
+	require.NoError(t, err)
+	require.Equal(t, funded.LockedUTXOs[0], *unlocked)
+}
+
 // testFundBatchChecksDurableSingleton verifies that FundBatch checks the
 // durable singleton before it asks the wallet to lease inputs.
 func testFundBatchChecksDurableSingleton(t *mintingTestHarness) {
@@ -2917,6 +3138,26 @@ var testCases = []mintingStoreTestCase{
 	{
 		name:     "fund_failure_releases_wallet_leases",
 		testFunc: testFundFailureReleasesWalletLeases,
+	},
+	{
+		name:     "cancel_funded_batch_releases_leases",
+		testFunc: testCancelFundedBatchReleasesLeases,
+	},
+	{
+		name:     "cancel_unfunded_batch_no_lease_release",
+		testFunc: testCancelUnfundedBatchNoLeaseRelease,
+	},
+	{
+		name:     "failed_broadcast_keeps_leases",
+		testFunc: testFailedBroadcastKeepsLeases,
+	},
+	{
+		name:     "caretaker_resume_failure_releases_leases",
+		testFunc: testCaretakerResumeFailureReleasesLeases,
+	},
+	{
+		name:     "resume_seal_failure_releases_leases",
+		testFunc: testResumeSealFailureReleasesLeases,
 	},
 	{
 		name:     "fund_batch_checks_durable_singleton",

--- a/tapgarden/planter_test.go
+++ b/tapgarden/planter_test.go
@@ -2139,6 +2139,101 @@ func testResumeSealFailureReleasesLeases(t *mintingTestHarness) {
 	require.Equal(t, funded.LockedUTXOs[0], *unlocked)
 }
 
+// cancelBatchWithCultivator loads the given batch from disk, hands it
+// to a cultivator built over the harness stores, and cancels it,
+// asserting that the batch reaches cancelledState and that the wallet
+// input leased during funding is released. Cancel is invoked directly
+// because a cancel routed through a running cultivator is only read
+// between state steps, a window no mock can hold open
+// deterministically.
+func (t *mintingTestHarness) cancelBatchWithCultivator(
+	batchKey *btcec.PublicKey, funded *tapsend.FundedPsbt,
+	cancelledState tapgarden.BatchState) {
+
+	t.Helper()
+
+	cultivator := tapgarden.NewCultivator(&tapgarden.CultivatorConfig{
+		Batch: t.fetchSingleBatch(batchKey),
+		GardenKit: &tapgarden.GardenKit{
+			Wallet:     t.wallet,
+			BatchStore: t.store,
+		},
+		PublishMintEvent: func(event fn.Event) {},
+	})
+
+	respCh := make(chan tapgarden.CancelResp, 1)
+	require.NoError(t, cultivator.Cancel(respCh))
+
+	t.assertBatchState(batchKey, cancelledState)
+
+	// The reloaded batch carries no LockedUTXOs, so the released
+	// outpoints must have been derived from the funded PSBT's
+	// inputs.
+	require.Len(t, funded.LockedUTXOs, 1)
+	unlocked, err := fn.RecvOrTimeout(
+		t.wallet.UnlockInputSignal, defaultTimeout,
+	)
+	require.NoError(t, err)
+	require.Equal(t, funded.LockedUTXOs[0], *unlocked)
+}
+
+// testCultivatorCancelReleasesLeases verifies that both cancel branches
+// of the cultivator release the wallet inputs leased during funding: a
+// batch cancelled at BatchStateFrozen (to SeedlingCancelled) and one
+// cancelled at BatchStateCommitted (to SproutCancelled).
+func testCultivatorCancelReleasesLeases(t *mintingTestHarness) {
+	t.refreshChainPlanter()
+
+	// First, cancel a funded batch at BatchStateFrozen. The batch is
+	// frozen manually; freezing normally happens inside batch
+	// finalization, which would also hand the batch to a live
+	// cultivator.
+	_ = t.queueInitialBatch(2)
+
+	var (
+		wg       sync.WaitGroup
+		fundResp = make(chan *FundBatchResp, 1)
+	)
+	t.fundBatch(&wg, fundResp, nil)
+	funded := t.assertGenesisTxFunded(nil)
+	fundedBatch := t.assertFundBatch(&wg, fundResp, "")
+
+	frozenKey := fundedBatch.BatchKey.PubKey
+	require.NoError(t, t.store.UpdateBatchState(
+		context.Background(), t.fetchSingleBatch(frozenKey),
+		tapgarden.BatchStateFrozen,
+	))
+
+	t.cancelBatchWithCultivator(
+		frozenKey, funded, tapgarden.BatchStateSeedlingCancelled,
+	)
+
+	// Next, cancel a batch at BatchStateCommitted. Finalize a second
+	// batch with signing armed to fail: the cultivator commits the
+	// batch's sprouts to disk, fails to sign the genesis TX, and the
+	// planter retains the batch at Committed with its leases intact.
+	t.refreshChainPlanter()
+	_ = t.queueInitialBatch(2)
+
+	finalizeResp := make(chan *FinalizeBatchResp, 1)
+	t.wallet.FailSignPsbtOnce()
+	t.finalizeBatch(&wg, finalizeResp, nil)
+
+	funded = t.assertGenesisTxFunded(nil)
+	t.assertFinalizeBatch(&wg, finalizeResp, "unable to sign psbt")
+	t.assertNumCultivatorsActive(0)
+
+	committedBatch := t.fetchLastBatch()
+	require.Equal(
+		t, tapgarden.BatchStateCommitted, committedBatch.State(),
+	)
+
+	t.cancelBatchWithCultivator(
+		committedBatch.BatchKey.PubKey, funded,
+		tapgarden.BatchStateSproutCancelled,
+	)
+}
+
 // testFundBatchChecksDurableSingleton verifies that FundBatch checks the
 // durable singleton before it asks the wallet to lease inputs.
 func testFundBatchChecksDurableSingleton(t *mintingTestHarness) {
@@ -3158,6 +3253,10 @@ var testCases = []mintingStoreTestCase{
 	{
 		name:     "resume_seal_failure_releases_leases",
 		testFunc: testResumeSealFailureReleasesLeases,
+	},
+	{
+		name:     "cultivator_cancel_releases_leases",
+		testFunc: testCultivatorCancelReleasesLeases,
 	},
 	{
 		name:     "fund_batch_checks_durable_singleton",


### PR DESCRIPTION
Addresses an item left.. uh, unaddressed in #2259. Simply ensures that we release leases immediately when cancelling a minting batch.

Fable's summary, from the commit message:

> Funding a minting batch leases the selected wallet inputs, and the leased outpoints are recorded only in memory on the batch's genesis packet (FundedPsbt.LockedUTXOs). Cancelling a batch wrote the cancelled state to disk but never called Wallet.UnlockInput, so the inputs stayed unusable until lnd's lease TTL expired.
> 
> Release the leases at every point a batch is cancelled into a dead state: the cultivator's Cancel branches (SeedlingCancelled and SproutCancelled), the planter's no-cultivator cancel of the pending batch, cancelFailedBatch on the pre-broadcast failure path, and the startup resume loop's cancellation of batches that fail to fund or seal. Committed batches retained for a broadcast retry keep their leases.
> 
> The release happens only after the cancelled state has been written, and unlock failures are logged rather than returned, so a lease cleanup problem can never un-cancel a batch.
> 
> Since LockedUTXOs is never persisted, a batch reloaded from disk carries an empty set even though its funded PSBT survives. In that case the outpoints are derived from the unsigned transaction's inputs; every input of a mint anchor was leased by the wallet during funding, so the two sets coincide.

