### PR TITLE
tapdb: restrict pinned coin queries by anchor

### DIFF
--- a/docs/release-notes/release-notes-0.8.0.md
+++ b/docs/release-notes/release-notes-0.8.0.md
@@ -399,6 +399,12 @@
   `universe.mbox-cleanup-check-timeout` to configure periodic cleanup of
   auth mailbox messages whose claimed outpoints have been spent on chain.
 
+## Performance Improvements
+
+- [PR#2264](https://github.com/lightninglabs/taproot-assets/pull/2264)
+  bounds pinned input coin selection to the requested anchor UTXOs instead of
+  materializing all eligible wallet assets.
+
 # Tooling and Documentation
 
 - [PR#1962](https://github.com/lightninglabs/taproot-assets/pull/1962)
@@ -411,4 +417,3 @@
 - [PR#2056](https://github.com/lightninglabs/taproot-assets/pull/2056)
   expands the example portfolio pilot with constraint enforcement,
   configurable fill caps, and live CoinGecko pricing.
-

--- a/docs/release-notes/release-notes-0.8.0.md
+++ b/docs/release-notes/release-notes-0.8.0.md
@@ -399,12 +399,6 @@
   `universe.mbox-cleanup-check-timeout` to configure periodic cleanup of
   auth mailbox messages whose claimed outpoints have been spent on chain.
 
-## Performance Improvements
-
-- [PR#2264](https://github.com/lightninglabs/taproot-assets/pull/2264)
-  bounds pinned input coin selection to the requested anchor UTXOs instead of
-  materializing all eligible wallet assets.
-
 # Tooling and Documentation
 
 - [PR#1962](https://github.com/lightninglabs/taproot-assets/pull/1962)

--- a/docs/release-notes/release-notes-0.9.0.md
+++ b/docs/release-notes/release-notes-0.9.0.md
@@ -276,6 +276,10 @@
   repeated unbounded before reporting insufficient funds, so that a coin
   the paged listing may have missed can't be mistaken for missing funds.
 
+* [PR#2264](https://github.com/lightninglabs/taproot-assets/pull/2264)
+  bounds pinned input coin selection to the requested anchor UTXOs
+  instead of materializing all eligible wallet assets.
+
 ## Deprecations
 
 # Technical and Architectural Updates

--- a/tapdb/assets_store.go
+++ b/tapdb/assets_store.go
@@ -991,6 +991,29 @@ func (a *AssetStore) constraintsToDbFilter(
 		query.SortDirection.WhenSome(func(dir SortDirection) {
 			assetFilter.SortDirection = sqlInt32(int32(dir))
 		})
+
+		if len(query.PrevIDs) > 0 {
+			assetFilter.UsePrevIDFilter = 1
+			assetFilter.PrevIDAnchorPoints = make(
+				[][]byte, 0, len(query.PrevIDs),
+			)
+			for _, prevID := range query.PrevIDs {
+				anchorPoint, err := encodeOutpoint(
+					prevID.OutPoint,
+				)
+				if err != nil {
+					return QueryAssetFilters{}, fmt.Errorf(
+						"unable to encode previous ID "+
+							"outpoint: %w", err,
+					)
+				}
+
+				assetFilter.PrevIDAnchorPoints = append(
+					assetFilter.PrevIDAnchorPoints,
+					anchorPoint,
+				)
+			}
+		}
 	} else {
 		// Even when query is nil, use all non-channel script key
 		// types.
@@ -2409,9 +2432,9 @@ func (a *AssetStore) ListEligibleCoins(ctx context.Context,
 		return nil, fmt.Errorf("min amount overflow")
 	}
 
-	// The prev ID filter is applied after the query, so a bounded listing
-	// could return a page that holds none of the requested inputs. The two
-	// can't be combined.
+	// The exact prev ID filter is applied after the query, so a bounded
+	// listing could return a page containing only other assets from the
+	// requested anchors. The two can't be combined.
 	if constraints.CoinLimit > 0 && len(constraints.PrevIDs) > 0 {
 		return nil, fmt.Errorf("coin limit cannot be combined with " +
 			"specific prev IDs")
@@ -2455,7 +2478,9 @@ func (a *AssetStore) ListEligibleCoins(ctx context.Context,
 		return nil, fmt.Errorf("unable to query commitments: %w", err)
 	}
 
-	// If we want to restrict on specific inputs, we do the filtering now.
+	// The database limits the result to the requested anchor points.
+	// Apply the asset ID and script key components here to match the full
+	// prev ID.
 	if len(constraints.PrevIDs) > 0 {
 		selectedCommitments = filterCommitmentsByPrevIDs(
 			selectedCommitments, constraints.PrevIDs,

--- a/tapdb/assets_store_test.go
+++ b/tapdb/assets_store_test.go
@@ -1962,6 +1962,70 @@ func TestListEligibleCoinsBounded(t *testing.T) {
 	require.ErrorContains(t, err, "cannot be combined")
 }
 
+// TestListEligibleCoinsPinnedInputQuery verifies that a pinned-input listing
+// materializes only assets anchored at the requested UTXOs.
+func TestListEligibleCoinsPinnedInputQuery(t *testing.T) {
+	t.Parallel()
+
+	const numAssets = 64
+
+	db := NewTestDB(t)
+	_, assetsStore := newAssetStoreFromDB(db.BaseDB)
+	assetGen := newAssetGenerator(t, numAssets, 1)
+	descs := make([]assetDesc, numAssets)
+	for i := range descs {
+		descs[i] = assetDesc{
+			assetGen:    assetGen.assetGens[i],
+			anchorPoint: assetGen.anchorPoints[i],
+			amt:         uint64(i + 1),
+			noGroupKey:  true,
+		}
+	}
+	assetGen.genAssets(t, assetsStore, descs)
+
+	ctx := context.Background()
+	allCoins, err := assetsStore.ListEligibleCoins(
+		ctx, tapfreighter.CommitmentConstraints{MinAmt: 1},
+	)
+	require.NoError(t, err)
+	require.Len(t, allCoins, numAssets)
+
+	pinned := allCoins[numAssets/2]
+	anchorPoint, err := encodeOutpoint(pinned.AnchorPoint)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, `
+		DELETE FROM asset_proofs
+		WHERE asset_id NOT IN (
+			SELECT assets.asset_id
+			FROM assets
+			JOIN managed_utxos utxos
+				ON assets.anchor_utxo_id = utxos.utxo_id
+			WHERE utxos.outpoint = $1
+		)`, anchorPoint,
+	)
+	require.NoError(t, err)
+
+	coins, err := assetsStore.ListEligibleCoins(
+		ctx, tapfreighter.CommitmentConstraints{
+			MinAmt:  1,
+			PrevIDs: []asset.PrevID{pinned.PrevID()},
+		},
+	)
+	require.NoError(t, err)
+	require.Len(t, coins, 1)
+	require.Equal(t, pinned.PrevID(), coins[0].PrevID())
+
+	unknownPrevID := pinned.PrevID()
+	unknownPrevID.ScriptKey[0] ^= 1
+	_, err = assetsStore.ListEligibleCoins(
+		ctx, tapfreighter.CommitmentConstraints{
+			MinAmt:  1,
+			PrevIDs: []asset.PrevID{unknownPrevID},
+		},
+	)
+	require.ErrorIs(t, err, tapfreighter.ErrMatchingAssetsNotFound)
+}
+
 // TestListEligibleCoinsBoundedEqualAmounts tests that paging through a bounded
 // eligible coin listing neither repeats nor skips coins when all the coins hold
 // the same amount, which is the case where the amount ordering alone doesn't

--- a/tapdb/sqlc/assets.sql.go
+++ b/tapdb/sqlc/assets.sql.go
@@ -2747,10 +2747,17 @@ WHERE (
     $15 >= 0 AND
     COALESCE($16, 0) >= 0 AND
     COALESCE($17, 0) >= 0 AND
+    COALESCE($18, 0) >= 0 AND
     -- The script_key_type argument must NEVER be an empty slice, otherwise this
     -- query will return no results.
     COALESCE(script_keys.key_type, 0) IN
-      (/*SLICE:script_key_type*/?)
+      (/*SLICE:script_key_type*/?) AND
+    (
+        COALESCE($18, 0) = 0 OR
+        utxos.outpoint IN (
+            /*SLICE:prev_id_anchor_points*/?
+        )
+    )
 )
 ORDER BY
     CASE WHEN COALESCE($17, 0) = 1 THEN assets.amount END DESC,
@@ -2760,24 +2767,26 @@ LIMIT $14 OFFSET $15
 `
 
 type QueryAssetsParams struct {
-	AssetIDFilter    []byte
-	TweakedScriptKey []byte
-	AnchorPoint      []byte
-	Leased           interface{}
-	Now              sql.NullTime
-	MinAnchorHeight  sql.NullInt32
-	MinAmt           sql.NullInt64
-	MaxAmt           sql.NullInt64
-	Spent            sql.NullBool
-	KeyGroupFilter   []byte
-	AnchorUtxoID     sql.NullInt64
-	GenesisID        sql.NullInt64
-	ScriptKeyID      sql.NullInt64
-	NumLimit         int32
-	NumOffset        int32
-	SortDirection    interface{}
-	OrderByAmount    interface{}
-	ScriptKeyType    []sql.NullInt16
+	AssetIDFilter      []byte
+	TweakedScriptKey   []byte
+	AnchorPoint        []byte
+	Leased             interface{}
+	Now                sql.NullTime
+	MinAnchorHeight    sql.NullInt32
+	MinAmt             sql.NullInt64
+	MaxAmt             sql.NullInt64
+	Spent              sql.NullBool
+	KeyGroupFilter     []byte
+	AnchorUtxoID       sql.NullInt64
+	GenesisID          sql.NullInt64
+	ScriptKeyID        sql.NullInt64
+	NumLimit           int32
+	NumOffset          int32
+	SortDirection      interface{}
+	OrderByAmount      interface{}
+	UsePrevIDFilter    interface{}
+	ScriptKeyType      []sql.NullInt16
+	PrevIDAnchorPoints [][]byte
 }
 
 type QueryAssetsRow struct {
@@ -2851,6 +2860,7 @@ func (q *Queries) QueryAssets(ctx context.Context, arg QueryAssetsParams) ([]Que
 	queryParams = append(queryParams, arg.NumOffset)
 	queryParams = append(queryParams, arg.SortDirection)
 	queryParams = append(queryParams, arg.OrderByAmount)
+	queryParams = append(queryParams, arg.UsePrevIDFilter)
 	if len(arg.ScriptKeyType) > 0 {
 		for _, v := range arg.ScriptKeyType {
 			queryParams = append(queryParams, v)
@@ -2858,6 +2868,14 @@ func (q *Queries) QueryAssets(ctx context.Context, arg QueryAssetsParams) ([]Que
 		query = strings.Replace(query, "/*SLICE:script_key_type*/?", makeQueryParams(len(queryParams), len(arg.ScriptKeyType)), 1)
 	} else {
 		query = strings.Replace(query, "/*SLICE:script_key_type*/?", "NULL", 1)
+	}
+	if len(arg.PrevIDAnchorPoints) > 0 {
+		for _, v := range arg.PrevIDAnchorPoints {
+			queryParams = append(queryParams, v)
+		}
+		query = strings.Replace(query, "/*SLICE:prev_id_anchor_points*/?", makeQueryParams(len(queryParams), len(arg.PrevIDAnchorPoints)), 1)
+	} else {
+		query = strings.Replace(query, "/*SLICE:prev_id_anchor_points*/?", "NULL", 1)
 	}
 	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {

--- a/tapdb/sqlc/queries/assets.sql
+++ b/tapdb/sqlc/queries/assets.sql
@@ -533,10 +533,17 @@ WHERE (
     @num_offset >= 0 AND
     COALESCE(sqlc.narg('sort_direction'), 0) >= 0 AND
     COALESCE(sqlc.narg('order_by_amount'), 0) >= 0 AND
+    COALESCE(sqlc.narg('use_prev_id_filter'), 0) >= 0 AND
     -- The script_key_type argument must NEVER be an empty slice, otherwise this
     -- query will return no results.
     COALESCE(script_keys.key_type, 0) IN
-      (sqlc.slice('script_key_type')/*SLICE:script_key_type*/)
+      (sqlc.slice('script_key_type')/*SLICE:script_key_type*/) AND
+    (
+        COALESCE(sqlc.narg('use_prev_id_filter'), 0) = 0 OR
+        utxos.outpoint IN (
+            sqlc.slice('prev_id_anchor_points')/*SLICE:prev_id_anchor_points*/
+        )
+    )
 )
 -- The trailing sort by asset_id is what makes this a total order, which the
 -- paging of a bounded listing relies on: without it, rows that compare equal

--- a/tapfreighter/coin_select.go
+++ b/tapfreighter/coin_select.go
@@ -73,9 +73,10 @@ func (s *CoinSelect) SelectCoins(ctx context.Context,
 
 	// We list the eligible coins in pages of descending amounts, so we can
 	// stop listing as soon as the accumulated amount covers the target,
-	// instead of loading every coin the node holds. If specific inputs are
-	// requested, we can't bound the listing, as those are filtered out of
-	// the full listing.
+	// instead of loading every coin the node holds. Specific inputs are
+	// already bounded by their anchor points at the database layer, but the
+	// full previous ID is filtered afterward, so that listing stays
+	// unpaged.
 	pageSize := int32(eligibleCoinsPageSize)
 	if len(constraints.PrevIDs) > 0 {
 		pageSize = 0

--- a/tapfreighter/interface.go
+++ b/tapfreighter/interface.go
@@ -67,9 +67,10 @@ type CommitmentConstraints struct {
 	// eligible coins are returned first. A value of 0 means no limit, in
 	// which case no specific order is guaranteed.
 	//
-	// This cannot be combined with PrevIDs, as those are filtered for
-	// after the listing, so a bounded listing could return a page that
-	// holds none of the requested inputs.
+	// This cannot be combined with PrevIDs, as their asset ID and script
+	// key components are filtered after the listing. A bounded listing
+	// could return a page holding only other assets from the requested
+	// anchors.
 	CoinLimit int32
 
 	// CoinOffset is the number of coins to skip in a bounded listing. This


### PR DESCRIPTION
Fixes #2257.

Pinned coin selection currently materializes every eligible coin before filtering requested PrevIDs. This change maps the requested PrevIDs to anchor outpoints and restricts QueryAssets to those anchors. Exact asset ID and script key matching remains in Go. Pagination with PrevIDs remains prohibited.

The regression test creates 64 assets and retains a proof only for the pinned anchor. The old path fails while materializing an unrelated asset. The bounded query succeeds for the pinned input, and rejects an altered script key.

Tests:
* go build ./...
* make lint-source
* go test ./...
* custom channel immediate close, force close, breach, and coop checks