### PR TITLE
tapdb: query orphan UTXO candidates in one pass

### DIFF
--- a/docs/release-notes/release-notes-0.8.0.md
+++ b/docs/release-notes/release-notes-0.8.0.md
@@ -399,12 +399,6 @@
   `universe.mbox-cleanup-check-timeout` to configure periodic cleanup of
   auth mailbox messages whose claimed outpoints have been spent on chain.
 
-## Performance Improvements
-
-- [PR#2265](https://github.com/lightninglabs/taproot-assets/pull/2265)
-  reduces orphan UTXO scan work by filtering normal funded anchors in a single
-  database query instead of materializing assets once per managed UTXO.
-
 # Tooling and Documentation
 
 - [PR#1962](https://github.com/lightninglabs/taproot-assets/pull/1962)

--- a/docs/release-notes/release-notes-0.8.0.md
+++ b/docs/release-notes/release-notes-0.8.0.md
@@ -399,6 +399,12 @@
   `universe.mbox-cleanup-check-timeout` to configure periodic cleanup of
   auth mailbox messages whose claimed outpoints have been spent on chain.
 
+## Performance Improvements
+
+- [PR#2265](https://github.com/lightninglabs/taproot-assets/pull/2265)
+  reduces orphan UTXO scan work by filtering normal funded anchors in a single
+  database query instead of materializing assets once per managed UTXO.
+
 # Tooling and Documentation
 
 - [PR#1962](https://github.com/lightninglabs/taproot-assets/pull/1962)

--- a/docs/release-notes/release-notes-0.9.0.md
+++ b/docs/release-notes/release-notes-0.9.0.md
@@ -290,6 +290,11 @@
   bounds pinned input coin selection to the requested anchor UTXOs
   instead of materializing all eligible wallet assets.
 
+* [PR#2265](https://github.com/lightninglabs/taproot-assets/pull/2265)
+  reduces orphan UTXO scan work by filtering normal funded anchors in a
+  single database query instead of materializing assets once per managed
+  UTXO.
+
 ## Deprecations
 
 # Technical and Architectural Updates

--- a/tapdb/assets_store.go
+++ b/tapdb/assets_store.go
@@ -1532,6 +1532,7 @@ func (a *AssetStore) FetchOrphanUTXOs(ctx context.Context) (
 				TombstoneKeyType: sqlInt16(
 					asset.ScriptKeyTombstone,
 				),
+				NumsKey: asset.NUMSCompressedKey[:],
 			},
 		)
 		if err != nil {

--- a/tapdb/assets_store.go
+++ b/tapdb/assets_store.go
@@ -298,6 +298,12 @@ type ActiveAssetsStore interface {
 	// FetchManagedUTXOs fetches all managed UTXOs.
 	FetchManagedUTXOs(context.Context) ([]ManagedUTXORow, error)
 
+	// FetchOrphanManagedUTXOs fetches candidate managed UTXOs that contain
+	// only tombstone, burn or unclassified assets.
+	FetchOrphanManagedUTXOs(context.Context,
+		sqlc.FetchOrphanManagedUTXOsParams) (
+		[]sqlc.FetchOrphanManagedUTXOsRow, error)
+
 	// ApplyPendingOutput applies a transfer output (new amount and script
 	// key) based on the existing script key of an asset.
 	ApplyPendingOutput(ctx context.Context, arg ApplyPendingOutput) (int64,
@@ -1511,20 +1517,25 @@ func (a *AssetStore) FetchManagedUTXOs(ctx context.Context) (
 func (a *AssetStore) FetchOrphanUTXOs(ctx context.Context) (
 	[]*tapfreighter.ZeroValueInput, error) {
 
-	// Strategy: fetch all managed UTXOs and filter in-memory.
-	//  A UTXO is a "zero-value anchor" if all assets are either tombstones
-	// (NUMS key with amount 0) or burns.
-	// We exclude leased and spent UTXOs.
-
 	var results []*tapfreighter.ZeroValueInput
 
 	readOpts := NewAssetStoreReadTx()
 	now := a.clock.Now().UTC()
 
 	dbErr := a.db.ExecTx(ctx, &readOpts, func(q ActiveAssetsStore) error {
-		utxos, err := q.FetchManagedUTXOs(ctx)
+		utxos, err := q.FetchOrphanManagedUTXOs(
+			ctx, sqlc.FetchOrphanManagedUTXOsParams{
+				UnknownKeyType: sqlInt16(
+					asset.ScriptKeyUnknown,
+				),
+				BurnKeyType: sqlInt16(asset.ScriptKeyBurn),
+				TombstoneKeyType: sqlInt16(
+					asset.ScriptKeyTombstone,
+				),
+			},
+		)
 		if err != nil {
-			return fmt.Errorf("failed to fetch managed "+
+			return fmt.Errorf("failed to fetch orphan managed "+
 				"utxos: %w", err)
 		}
 
@@ -1566,40 +1577,33 @@ func (a *AssetStore) FetchOrphanUTXOs(ctx context.Context) (
 					"outpoint: %w", err)
 			}
 
-			// Query all assets anchored at this outpoint.
-			// We include spent assets here because tombstones are
-			// marked as spent when created.
-			_, assetsAtAnchor, err := a.queryChainAssets(
-				ctx, q, QueryAssetFilters{
-					AnchorPoint: u.Outpoint,
-					Now:         sqlTime(now),
-				},
-			)
-			if err != nil {
-				return fmt.Errorf("failed to query chain "+
-					"assets at anchor: %w", err)
-			}
-
-			if len(assetsAtAnchor) == 0 {
-				continue
-			}
-
-			// Determine if all assets are tombstones or burns.
-			// A tombstone asset is marked as "spent" at the asset
-			// level but its anchor UTXO may still be unspent
-			// on-chain and available for sweeping.
-			allZeroValue := true
-			for _, chainAsset := range assetsAtAnchor {
-				aAsset := chainAsset.Asset
-
-				if !aAsset.IsTombstone() && !aAsset.IsBurn() {
-					allZeroValue = false
-					break
+			if u.NeedsAssetValidation {
+				_, assetsAtAnchor, err := a.queryChainAssets(
+					ctx, q, QueryAssetFilters{
+						AnchorPoint: u.Outpoint,
+						Now:         sqlTime(now),
+					},
+				)
+				if err != nil {
+					return fmt.Errorf(
+						"failed to query chain "+
+							"assets at anchor: %w",
+						err,
+					)
 				}
-			}
 
-			if !allZeroValue {
-				continue
+				allZeroValue := len(assetsAtAnchor) > 0
+				for _, chainAsset := range assetsAtAnchor {
+					if !chainAsset.Asset.IsTombstone() &&
+						!chainAsset.Asset.IsBurn() {
+
+						allZeroValue = false
+						break
+					}
+				}
+				if !allZeroValue {
+					continue
+				}
 			}
 
 			log.DebugS(ctx, "adding orphan utxo to sweep list",

--- a/tapdb/assets_store_test.go
+++ b/tapdb/assets_store_test.go
@@ -4191,6 +4191,82 @@ func TestFetchOrphanUTXOsSkipsFundedAnchors(t *testing.T) {
 	require.Empty(t, orphans)
 }
 
+// TestFetchOrphanUTXOsRejectsMisclassifiedBurn verifies that a script key's
+// burn classification alone cannot make a funded asset eligible for sweeping.
+func TestFetchOrphanUTXOsRejectsMisclassifiedBurn(t *testing.T) {
+	t.Parallel()
+
+	db := NewTestDB(t)
+	_, assetsStore := newAssetStoreFromDB(db.BaseDB)
+	assetGen := newAssetGenerator(t, 1, 1)
+	assetGen.genAssets(t, assetsStore, []assetDesc{{
+		assetGen:    assetGen.assetGens[0],
+		anchorPoint: assetGen.anchorPoints[0],
+		amt:         1,
+		noGroupKey:  true,
+	}})
+
+	ctx := context.Background()
+	_, err := db.ExecContext(ctx, `
+		UPDATE internal_keys
+		SET key_family = 1, key_index = 1
+		WHERE key_id IN (
+			SELECT internal_key_id FROM managed_utxos
+		)`,
+	)
+	require.NoError(t, err)
+
+	_, err = db.ExecContext(
+		ctx, `
+			UPDATE script_keys
+			SET key_type = $1
+			WHERE script_key_id IN (
+				SELECT script_key_id FROM assets
+			)`,
+		sqlInt16(asset.ScriptKeyBurn),
+	)
+	require.NoError(t, err)
+
+	orphans, err := assetsStore.FetchOrphanUTXOs(ctx)
+	require.NoError(t, err)
+	require.Empty(t, orphans)
+}
+
+// TestFetchOrphanUTXOsRejectsMisclassifiedTombstone verifies that a
+// tombstone-classified asset must also use the NUMS script key.
+func TestFetchOrphanUTXOsRejectsMisclassifiedTombstone(t *testing.T) {
+	t.Parallel()
+
+	db := NewTestDB(t)
+	_, assetsStore := newAssetStoreFromDB(db.BaseDB)
+	ctx := context.Background()
+	outpoint := insertOrphanUTXO(
+		t, ctx, db, assetsStore, 1, 1, false,
+	)
+	outpointBytes, err := encodeOutpoint(outpoint)
+	require.NoError(t, err)
+
+	_, err = db.ExecContext(
+		ctx, `
+			UPDATE script_keys
+			SET tweaked_script_key = $1
+			WHERE script_key_id IN (
+				SELECT assets.script_key_id
+				FROM assets
+				JOIN managed_utxos
+					ON assets.anchor_utxo_id =
+						managed_utxos.utxo_id
+				WHERE managed_utxos.outpoint = $2
+			)`,
+		test.RandPubKey(t).SerializeCompressed(), outpointBytes,
+	)
+	require.NoError(t, err)
+
+	orphans, err := assetsStore.FetchOrphanUTXOs(ctx)
+	require.NoError(t, err)
+	require.Empty(t, orphans)
+}
+
 // insertOrphanUTXO inserts a managed UTXO with a tombstone asset and the
 // specified KeyFamily and KeyIndex values for the internal key.
 func insertOrphanUTXO(t *testing.T, ctx context.Context, db sqlc.Querier,

--- a/tapdb/assets_store_test.go
+++ b/tapdb/assets_store_test.go
@@ -3991,14 +3991,16 @@ func TestFetchOrphanUTXOs(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {
-		name          string
-		utxosToInsert [][2]int32
-		expectedCount int
-		checkFunc     func(t *testing.T,
+		name           string
+		utxosToInsert  [][2]int32
+		unknownKeyType bool
+		expectedCount  int
+		checkFunc      func(t *testing.T,
 			orphans []*tapfreighter.ZeroValueInput)
 	}{
 		{
-			name: "filters missing signing info",
+			name:           "filters missing signing info",
+			unknownKeyType: true,
 			utxosToInsert: [][2]int32{
 				{212, 5}, // Valid signing info.
 				{0, 0},   // Missing signing info.
@@ -4125,6 +4127,7 @@ func TestFetchOrphanUTXOs(t *testing.T) {
 				insertOrphanUTXO(
 					t, ctx, db, assetsStore,
 					keyInfo[0], keyInfo[1],
+					tc.unknownKeyType,
 				)
 			}
 
@@ -4141,10 +4144,58 @@ func TestFetchOrphanUTXOs(t *testing.T) {
 	}
 }
 
+// TestFetchOrphanUTXOsSkipsFundedAnchors verifies that funded anchors are
+// filtered before their assets are materialized.
+func TestFetchOrphanUTXOsSkipsFundedAnchors(t *testing.T) {
+	t.Parallel()
+
+	const numAssets = 64
+
+	db := NewTestDB(t)
+	_, assetsStore := newAssetStoreFromDB(db.BaseDB)
+	assetGen := newAssetGenerator(t, numAssets, 1)
+	descs := make([]assetDesc, numAssets)
+	for i := range descs {
+		descs[i] = assetDesc{
+			assetGen:    assetGen.assetGens[i],
+			anchorPoint: assetGen.anchorPoints[i],
+			amt:         1,
+			noGroupKey:  true,
+		}
+	}
+	assetGen.genAssets(t, assetsStore, descs)
+
+	ctx := context.Background()
+	_, err := db.ExecContext(ctx, `
+		UPDATE internal_keys
+		SET key_family = 1, key_index = 1
+		WHERE key_id IN (
+			SELECT internal_key_id FROM managed_utxos
+		)`,
+	)
+	require.NoError(t, err)
+
+	_, err = db.ExecContext(
+		ctx, `
+			UPDATE script_keys
+			SET tweaked_script_key = $1
+			WHERE script_key_id = (
+				SELECT MIN(script_key_id) FROM script_keys
+			)`,
+		make([]byte, 33),
+	)
+	require.NoError(t, err)
+
+	orphans, err := assetsStore.FetchOrphanUTXOs(ctx)
+	require.NoError(t, err)
+	require.Empty(t, orphans)
+}
+
 // insertOrphanUTXO inserts a managed UTXO with a tombstone asset and the
 // specified KeyFamily and KeyIndex values for the internal key.
 func insertOrphanUTXO(t *testing.T, ctx context.Context, db sqlc.Querier,
-	assetsStore *AssetStore, keyFamily, keyIndex int32) wire.OutPoint {
+	assetsStore *AssetStore, keyFamily, keyIndex int32,
+	unknownKeyType bool) wire.OutPoint {
 
 	internalKey := test.RandPubKey(t)
 
@@ -4239,6 +4290,20 @@ func insertOrphanUTXO(t *testing.T, ctx context.Context, db sqlc.Querier,
 		},
 	)
 	require.NoError(t, err)
+
+	if !unknownKeyType {
+		dbKey, err := db.FetchScriptKeyByTweakedKey(
+			ctx, asset.NUMSCompressedKey[:],
+		)
+		require.NoError(t, err)
+
+		_, err = db.UpsertScriptKey(ctx, sqlc.UpsertScriptKeyParams{
+			InternalKeyID:    dbKey.ScriptKey.InternalKeyID,
+			TweakedScriptKey: asset.NUMSCompressedKey[:],
+			KeyType:          sqlInt16(asset.ScriptKeyTombstone),
+		})
+		require.NoError(t, err)
+	}
 
 	return outpoint
 }

--- a/tapdb/sqlc/assets.sql.go
+++ b/tapdb/sqlc/assets.sql.go
@@ -1918,6 +1918,100 @@ func (q *Queries) FetchMintingBatchesByInverseState(ctx context.Context, batchSt
 	return items, nil
 }
 
+const FetchOrphanManagedUTXOs = `-- name: FetchOrphanManagedUTXOs :many
+SELECT
+    utxos.utxo_id, utxos.outpoint, utxos.amt_sats, utxos.internal_key_id, utxos.taproot_asset_root, utxos.tapscript_sibling, utxos.merkle_root, utxos.txn_id, utxos.lease_owner, utxos.lease_expiry, utxos.root_version, utxos.swept_txn_id,
+    keys.key_id, keys.raw_key, keys.key_family, keys.key_index,
+    MAX(CASE
+        WHEN COALESCE(script_keys.key_type, 0) = $1
+        THEN 1 ELSE 0
+    END) = 1 AS needs_asset_validation
+FROM managed_utxos utxos
+JOIN internal_keys keys
+    ON utxos.internal_key_id = keys.key_id
+JOIN assets
+    ON assets.anchor_utxo_id = utxos.utxo_id
+JOIN script_keys
+    ON assets.script_key_id = script_keys.script_key_id
+GROUP BY utxos.utxo_id, keys.key_id
+HAVING SUM(CASE
+    WHEN COALESCE(script_keys.key_type, 0) = $1
+        OR script_keys.key_type = $2
+        OR (
+            script_keys.key_type = $3
+            AND assets.amount = 0
+        )
+    THEN 0 ELSE 1
+END) = 0
+`
+
+type FetchOrphanManagedUTXOsParams struct {
+	UnknownKeyType   sql.NullInt16
+	BurnKeyType      sql.NullInt16
+	TombstoneKeyType sql.NullInt16
+}
+
+type FetchOrphanManagedUTXOsRow struct {
+	UtxoID               int64
+	Outpoint             []byte
+	AmtSats              int64
+	InternalKeyID        int64
+	TaprootAssetRoot     []byte
+	TapscriptSibling     []byte
+	MerkleRoot           []byte
+	TxnID                int64
+	LeaseOwner           []byte
+	LeaseExpiry          sql.NullTime
+	RootVersion          sql.NullInt16
+	SweptTxnID           sql.NullInt64
+	KeyID                int64
+	RawKey               []byte
+	KeyFamily            int32
+	KeyIndex             int32
+	NeedsAssetValidation bool
+}
+
+func (q *Queries) FetchOrphanManagedUTXOs(ctx context.Context, arg FetchOrphanManagedUTXOsParams) ([]FetchOrphanManagedUTXOsRow, error) {
+	rows, err := q.db.QueryContext(ctx, FetchOrphanManagedUTXOs, arg.UnknownKeyType, arg.BurnKeyType, arg.TombstoneKeyType)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []FetchOrphanManagedUTXOsRow
+	for rows.Next() {
+		var i FetchOrphanManagedUTXOsRow
+		if err := rows.Scan(
+			&i.UtxoID,
+			&i.Outpoint,
+			&i.AmtSats,
+			&i.InternalKeyID,
+			&i.TaprootAssetRoot,
+			&i.TapscriptSibling,
+			&i.MerkleRoot,
+			&i.TxnID,
+			&i.LeaseOwner,
+			&i.LeaseExpiry,
+			&i.RootVersion,
+			&i.SweptTxnID,
+			&i.KeyID,
+			&i.RawKey,
+			&i.KeyFamily,
+			&i.KeyIndex,
+			&i.NeedsAssetValidation,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const FetchScriptKeyByTweakedKey = `-- name: FetchScriptKeyByTweakedKey :one
 SELECT script_keys.script_key_id, script_keys.internal_key_id, script_keys.tweaked_script_key, script_keys.tweak, script_keys.key_type, internal_keys.key_id, internal_keys.raw_key, internal_keys.key_family, internal_keys.key_index
 FROM script_keys

--- a/tapdb/sqlc/assets.sql.go
+++ b/tapdb/sqlc/assets.sql.go
@@ -1924,6 +1924,7 @@ SELECT
     keys.key_id, keys.raw_key, keys.key_family, keys.key_index,
     MAX(CASE
         WHEN COALESCE(script_keys.key_type, 0) = $1
+            OR script_keys.key_type = $2
         THEN 1 ELSE 0
     END) = 1 AS needs_asset_validation
 FROM managed_utxos utxos
@@ -1939,6 +1940,7 @@ HAVING SUM(CASE
         OR script_keys.key_type = $2
         OR (
             script_keys.key_type = $3
+            AND script_keys.tweaked_script_key = $4
             AND assets.amount = 0
         )
     THEN 0 ELSE 1
@@ -1949,6 +1951,7 @@ type FetchOrphanManagedUTXOsParams struct {
 	UnknownKeyType   sql.NullInt16
 	BurnKeyType      sql.NullInt16
 	TombstoneKeyType sql.NullInt16
+	NumsKey          []byte
 }
 
 type FetchOrphanManagedUTXOsRow struct {
@@ -1972,7 +1975,12 @@ type FetchOrphanManagedUTXOsRow struct {
 }
 
 func (q *Queries) FetchOrphanManagedUTXOs(ctx context.Context, arg FetchOrphanManagedUTXOsParams) ([]FetchOrphanManagedUTXOsRow, error) {
-	rows, err := q.db.QueryContext(ctx, FetchOrphanManagedUTXOs, arg.UnknownKeyType, arg.BurnKeyType, arg.TombstoneKeyType)
+	rows, err := q.db.QueryContext(ctx, FetchOrphanManagedUTXOs,
+		arg.UnknownKeyType,
+		arg.BurnKeyType,
+		arg.TombstoneKeyType,
+		arg.NumsKey,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/tapdb/sqlc/querier.go
+++ b/tapdb/sqlc/querier.go
@@ -162,6 +162,7 @@ type Querier interface {
 	// timestamp reaches the same row as the migration.
 	FetchMintingBatchesByInverseState(ctx context.Context, batchState int16) ([]FetchMintingBatchesByInverseStateRow, error)
 	FetchMultiverseRoot(ctx context.Context, namespaceRoot string) (FetchMultiverseRootRow, error)
+	FetchOrphanManagedUTXOs(ctx context.Context, arg FetchOrphanManagedUTXOsParams) ([]FetchOrphanManagedUTXOsRow, error)
 	FetchPeerAcceptedBuyPeerByScid(ctx context.Context, scid int64) ([]byte, error)
 	FetchReorgAnchoring(ctx context.Context, id int64) (ReorgAnchoring, error)
 	FetchReorgCandidateSpends(ctx context.Context, anchoringID int64) ([]ReorgCandidateSpend, error)

--- a/tapdb/sqlc/queries/assets.sql
+++ b/tapdb/sqlc/queries/assets.sql
@@ -685,6 +685,32 @@ FROM managed_utxos utxos
 JOIN internal_keys keys
     ON utxos.internal_key_id = keys.key_id;
 
+-- name: FetchOrphanManagedUTXOs :many
+SELECT
+    utxos.*,
+    keys.*,
+    MAX(CASE
+        WHEN COALESCE(script_keys.key_type, 0) = @unknown_key_type
+        THEN 1 ELSE 0
+    END) = 1 AS needs_asset_validation
+FROM managed_utxos utxos
+JOIN internal_keys keys
+    ON utxos.internal_key_id = keys.key_id
+JOIN assets
+    ON assets.anchor_utxo_id = utxos.utxo_id
+JOIN script_keys
+    ON assets.script_key_id = script_keys.script_key_id
+GROUP BY utxos.utxo_id, keys.key_id
+HAVING SUM(CASE
+    WHEN COALESCE(script_keys.key_type, 0) = @unknown_key_type
+        OR script_keys.key_type = @burn_key_type
+        OR (
+            script_keys.key_type = @tombstone_key_type
+            AND assets.amount = 0
+        )
+    THEN 0 ELSE 1
+END) = 0;
+
 -- name: AnchorPendingAssets :exec
 WITH assets_to_update AS (
     SELECT script_key_id

--- a/tapdb/sqlc/queries/assets.sql
+++ b/tapdb/sqlc/queries/assets.sql
@@ -691,6 +691,7 @@ SELECT
     keys.*,
     MAX(CASE
         WHEN COALESCE(script_keys.key_type, 0) = @unknown_key_type
+            OR script_keys.key_type = @burn_key_type
         THEN 1 ELSE 0
     END) = 1 AS needs_asset_validation
 FROM managed_utxos utxos
@@ -706,6 +707,7 @@ HAVING SUM(CASE
         OR script_keys.key_type = @burn_key_type
         OR (
             script_keys.key_type = @tombstone_key_type
+            AND script_keys.tweaked_script_key = @nums_key
             AND assets.amount = 0
         )
     THEN 0 ELSE 1


### PR DESCRIPTION
Fixes #2256.

The orphan scan currently materializes assets once per managed UTXO. This change adds a grouped SQL candidate query that filters normal funded anchors in one pass. Unknown script key types keep the existing full validation fallback. Lease, sweep, signing, chain transaction, and output checks are unchanged.

The regression test creates 64 funded anchors and proves they are excluded before asset materialization. It fails on the old path after an unrelated funded anchor is made unmaterializable and passes with the candidate query.

Tests:
* go build ./...
* make lint-source
* go test ./...
* custom channel immediate close, force close, breach, and coop checks