### PR TITLE
rpcserver: reject negative invoice expiry

### DIFF
--- a/docs/release-notes/release-notes-0.9.0.md
+++ b/docs/release-notes/release-notes-0.9.0.md
@@ -113,6 +113,13 @@
   long-running node the series steps down. The per-day `sync_events`
   series is unchanged and still reflects sync traffic volume.
 
+* [PR#2267](https://github.com/lightninglabs/taproot-assets/pull/2267)
+  rejects a negative `expiry` when adding a Taproot Asset channel
+  invoice. A negative expiry previously skipped the default and was
+  passed through to lnd, which treated it as unset and applied its own
+  86400 second default instead of returning an error. Fixes
+  [#2261](https://github.com/lightninglabs/taproot-assets/issues/2261).
+
 # New Features
 
 ## Functional Enhancements
@@ -237,3 +244,5 @@
 ## Tooling and Documentation
 
 # Contributors (Alphabetical Order)
+
+* Vandit Singh

--- a/rpcserver/invoiceexpiry_test.go
+++ b/rpcserver/invoiceexpiry_test.go
@@ -1,0 +1,23 @@
+package rpcserver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestValidateInvoiceExpiry checks that a negative invoice expiry is rejected
+// while a zero (default) or positive expiry is accepted.
+func TestValidateInvoiceExpiry(t *testing.T) {
+	t.Parallel()
+
+	// A negative expiry is meaningless and must be rejected.
+	err := validateInvoiceExpiry(-1)
+	require.ErrorContains(t, err, "must not be negative")
+
+	// A zero expiry is allowed; it is later replaced with the default.
+	require.NoError(t, validateInvoiceExpiry(0))
+
+	// A positive expiry is used as-is.
+	require.NoError(t, validateInvoiceExpiry(3600))
+}

--- a/rpcserver/rpcserver.go
+++ b/rpcserver/rpcserver.go
@@ -10598,6 +10598,10 @@ func (r *RPCServer) AddInvoice(ctx context.Context,
 	}
 	iReq := req.InvoiceRequest
 
+	if err := validateInvoiceExpiry(iReq.Expiry); err != nil {
+		return nil, err
+	}
+
 	existingQuotes := iReq.RouteHints != nil
 
 	if existingQuotes && !tapchannel.IsAssetInvoice(
@@ -11694,6 +11698,18 @@ func notifyUserForPaymentQuotes(
 			},
 		},
 	})
+}
+
+// validateInvoiceExpiry checks that the requested invoice expiry is not
+// negative. A zero expiry is allowed and later replaced with the default, but a
+// negative value is meaningless and, if passed through, is treated by lnd as
+// "unset" and silently replaced with lnd's own default expiry.
+func validateInvoiceExpiry(expiry int64) error {
+	if expiry < 0 {
+		return fmt.Errorf("invoice expiry must not be negative")
+	}
+
+	return nil
 }
 
 // validateInvoiceAmount validates the quote against the invoice we're trying to


### PR DESCRIPTION
### Fixes #2261

`AddInvoice` only defaulted an invoice expiry of exactly zero:

```go
expirySeconds := iReq.Expiry
if expirySeconds == 0 {
    expirySeconds = int64(rfq.DefaultInvoiceExpiry.Seconds())
}
```

A negative `expiry` (e.g. `-1`) skips that check, so the raw negative value is passed through to lnd's `AddInvoice`, which treats a non-positive expiry as unset and stamps its own 86400s default. That is why the reporter saw a 24h invoice rather than an error (`rfq.DefaultInvoiceExpiry` is only 300s, so the 86400 comes from lnd).

This rejects a negative expiry at the RPC boundary, before any RFQ work, so the caller gets a clear error instead of a silently mangled invoice. A zero expiry still means "use the default" and positive values are unchanged.

### Testing

Added a unit test for the new `validateInvoiceExpiry` helper covering the negative, zero and positive cases. Verified it fails without the guard and passes with it.
