### PR TITLE
rfq+rfqmsg: harden asset amount handling

### DIFF
--- a/rfq/order.go
+++ b/rfq/order.go
@@ -745,10 +745,21 @@ func (c *AssetPurchasePolicy) GenerateInterceptorResponse(
 	// amount. Due to rounding errors, we may slightly underreport the
 	// incoming value of the asset. So we increase it by exactly one asset
 	// unit to ensure that the fee logic in lnd does not reject the HTLC.
-	const roundingCorrection = 1
-	htlcAssetAmount := htlcRecord.Amounts.Val.Sum() + roundingCorrection
+	//
+	// The sum of the asset balances may exceed the uint64 range, so we
+	// accumulate them using big integer arithmetic.
+	htlcAssetAmount := rfqmath.NewBigIntFromUint64(0)
+	for idx := range htlcRecord.Amounts.Val.Balances {
+		balanceAmt := rfqmath.NewBigIntFromUint64(
+			htlcRecord.Amounts.Val.Balances[idx].Amount.Val,
+		)
+		htlcAssetAmount = htlcAssetAmount.Add(balanceAmt)
+	}
 
-	assetAmt := rfqmath.NewBigIntFixedPoint(htlcAssetAmount, 0)
+	roundingCorrection := rfqmath.NewBigIntFromUint64(1)
+	htlcAssetAmount = htlcAssetAmount.Add(roundingCorrection)
+
+	assetAmt := new(rfqmath.BigIntFixedPoint).SetIntValue(htlcAssetAmount)
 	incomingHtlcMsats, err := rfqmath.UnitsToMilliSatoshi(
 		assetAmt, c.BidAssetRate,
 	)

--- a/rfq/order_test.go
+++ b/rfq/order_test.go
@@ -2,6 +2,7 @@ package rfq
 
 import (
 	"context"
+	"math"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -413,4 +414,107 @@ func TestAssetPurchasePolicyConcurrentHtlcCap(t *testing.T) {
 	// that never tracks accepted HTLCs would leave the total at zero.
 	require.EqualValues(t, 1, accepted.Load())
 	require.Equal(t, policy.PaymentMaxAmt, policy.CurrentAmountMsat)
+}
+
+// TestGenerateInterceptorResponseOverflow tests that
+// GenerateInterceptorResponse handles HTLC asset balances whose sum
+// approaches or exceeds the uint64 limit without overflowing.
+func TestGenerateInterceptorResponseOverflow(t *testing.T) {
+	t.Parallel()
+
+	specifier := asset.NewSpecifierFromId(asset.ID{0x01})
+	peer := route.Vertex{0x0A}
+
+	// Use a high units-per-BTC rate so that the resulting milli-satoshi
+	// amounts still fit in a uint64.
+	rate := rfqmsg.NewAssetRate(
+		rfqmath.NewBigIntFixedPoint(1_000_000_000_000, 0),
+		time.Now().Add(time.Hour),
+	)
+
+	sellReq := &rfqmsg.SellRequest{
+		Peer:           peer,
+		AssetSpecifier: specifier,
+		PaymentMaxAmt:  1000,
+	}
+
+	accept := rfqmsg.SellAccept{
+		Peer:      peer,
+		Request:   *sellReq,
+		AssetRate: rate,
+	}
+
+	policy := NewAssetPurchasePolicy(accept)
+
+	testCases := []struct {
+		name     string
+		balances []uint64
+	}{
+		{
+			name:     "sum wraps to zero with rounding correction",
+			balances: []uint64{math.MaxUint64},
+		},
+		{
+			// A multi-balance sum beyond the uint64 limit is
+			// already rejected when the wire record is decoded,
+			// so this case sits exactly at the limit and lets
+			// the rounding correction push it over.
+			name:     "sum at limit wraps with rounding correction",
+			balances: []uint64{math.MaxUint64 - 1, 1},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			assetBalances := make(
+				[]*rfqmsg.AssetBalance, len(tc.balances),
+			)
+			for i, amt := range tc.balances {
+				assetBalances[i] = rfqmsg.NewAssetBalance(
+					asset.ID{0x01}, amt,
+				)
+			}
+
+			htlcRecord := rfqmsg.NewHtlc(
+				assetBalances, fn.None[rfqmsg.ID](),
+				fn.None[[]rfqmsg.ID](),
+			)
+
+			customRecords, err := htlcRecord.ToCustomRecords()
+			require.NoError(t, err)
+
+			resp, err := policy.GenerateInterceptorResponse(
+				lndclient.InterceptedHtlc{
+					InWireCustomRecords: customRecords,
+				},
+			)
+			require.NoError(t, err)
+
+			// Compute the expected incoming amount using big
+			// integer arithmetic, including the rounding
+			// correction of one asset unit.
+			expectedAmt := rfqmath.NewBigIntFromUint64(0)
+			for _, amt := range tc.balances {
+				expectedAmt = expectedAmt.Add(
+					rfqmath.NewBigIntFromUint64(amt),
+				)
+			}
+			expectedAmt = expectedAmt.Add(
+				rfqmath.NewBigIntFromUint64(1),
+			)
+
+			expectedFp := new(rfqmath.BigIntFixedPoint).SetIntValue(
+				expectedAmt,
+			)
+			expectedMsat, err := rfqmath.UnitsToMilliSatoshi(
+				expectedFp, policy.BidAssetRate,
+			)
+			require.NoError(t, err)
+
+			require.Equal(t, expectedMsat, resp.IncomingAmount)
+			require.NotZero(t, resp.IncomingAmount)
+		})
+	}
 }

--- a/rfqmsg/records.go
+++ b/rfqmsg/records.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 
 	"github.com/lightninglabs/taproot-assets/asset"
 	"github.com/lightninglabs/taproot-assets/fn"
@@ -474,11 +475,21 @@ func (a *AssetBalance) Decode(r io.Reader) error {
 }
 
 // Sum returns the sum of the amounts of all the asset Balances in the list.
+// If the sum would overflow a uint64, it saturates at the maximum uint64
+// value instead of wrapping around.
 func Sum(balances []*AssetBalance) uint64 {
 	var sum uint64
 	for _, balance := range balances {
-		sum += balance.Amount.Val
+		newSum := sum + balance.Amount.Val
+		if newSum < sum {
+			// The sum overflowed, saturate at the maximum uint64
+			// value.
+			return math.MaxUint64
+		}
+
+		sum = newSum
 	}
+
 	return sum
 }
 

--- a/rfqmsg/records.go
+++ b/rfqmsg/records.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/lightninglabs/taproot-assets/asset"
 	"github.com/lightninglabs/taproot-assets/fn"
+	"github.com/lightninglabs/taproot-assets/mssmt/arith"
 	"github.com/lightninglabs/taproot-assets/rfqmath"
 	"github.com/lightningnetwork/lnd/lnwallet"
 	"github.com/lightningnetwork/lnd/lnwire"
@@ -615,6 +616,7 @@ func dAssetBalanceList(r io.Reader, val interface{}, buf *[8]byte,
 		}
 
 		outputs := make([]*AssetBalance, numBalances)
+		var totalAmount uint64
 		for i := uint64(0); i < numBalances; i++ {
 			var outputBytes []byte
 			err := asset.InlineVarBytesDecoder(
@@ -628,6 +630,16 @@ func dAssetBalanceList(r io.Reader, val interface{}, buf *[8]byte,
 			if err != nil {
 				return err
 			}
+
+			// Reject the record if the cumulative sum of the
+			// balance amounts would overflow a uint64. A wrapping
+			// balance list must never decode as valid.
+			err = arith.CheckAdd(totalAmount, outputs[i].Amount.Val)
+			if err != nil {
+				return fmt.Errorf("%w: balance amounts sum "+
+					"overflows uint64", ErrListInvalid)
+			}
+			totalAmount += outputs[i].Amount.Val
 		}
 		*typ = outputs
 		return nil

--- a/rfqmsg/records_test.go
+++ b/rfqmsg/records_test.go
@@ -231,3 +231,41 @@ func TestSumOverflow(t *testing.T) {
 	// An empty list should sum to zero.
 	require.Equal(t, uint64(0), Sum(nil))
 }
+
+// TestAssetBalanceListDecodeOverflow tests that decoding an asset balance
+// list whose amounts sum past the maximum uint64 value fails, while a list
+// summing to exactly the maximum uint64 value still decodes.
+func TestAssetBalanceListDecodeOverflow(t *testing.T) {
+	t.Parallel()
+
+	// Two balances of 2^63 each sum to 2^64, which overflows a uint64.
+	// Decoding such a list must fail.
+	overflowList := &AssetBalanceListRecord{
+		Balances: []*AssetBalance{
+			NewAssetBalance([32]byte{1}, 1<<63),
+			NewAssetBalance([32]byte{1}, 1<<63),
+		},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, overflowList.Encode(&buf))
+
+	var decoded AssetBalanceListRecord
+	err := decoded.Decode(&buf)
+	require.ErrorIs(t, err, ErrListInvalid)
+
+	// A list summing to exactly the maximum uint64 value must still
+	// decode.
+	maxList := &AssetBalanceListRecord{
+		Balances: []*AssetBalance{
+			NewAssetBalance([32]byte{1}, math.MaxUint64-1),
+			NewAssetBalance([32]byte{1}, 1),
+		},
+	}
+
+	buf.Reset()
+	require.NoError(t, maxList.Encode(&buf))
+
+	require.NoError(t, decoded.Decode(&buf))
+	require.Equal(t, uint64(math.MaxUint64), decoded.Sum())
+}

--- a/rfqmsg/records_test.go
+++ b/rfqmsg/records_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"math"
 	"testing"
 
 	"github.com/lightninglabs/taproot-assets/asset"
@@ -198,4 +199,35 @@ func TestHtlc(t *testing.T) {
 			assetHtlcTestCase(t, tc)
 		})
 	}
+}
+
+// TestSumOverflow ensures that summing asset balances does not silently
+// overflow the uint64 sum. A peer can craft a balance list with amounts that
+// wrap around to zero (e.g. [2^63, 2^63]), which would make a value-carrying
+// HTLC appear worthless to downstream consumers of the sum.
+func TestSumOverflow(t *testing.T) {
+	t.Parallel()
+
+	// Two balances of 2^63 each sum to 2^64, which overflows a uint64.
+	// The sum must saturate at the maximum uint64 value instead of
+	// wrapping around to zero.
+	balances := []*AssetBalance{
+		NewAssetBalance([32]byte{1}, 1<<63),
+		NewAssetBalance([32]byte{1}, 1<<63),
+	}
+
+	require.Equal(t, uint64(math.MaxUint64), Sum(balances))
+
+	list := &AssetBalanceListRecord{Balances: balances}
+	require.Equal(t, uint64(math.MaxUint64), list.Sum())
+
+	// A sum that doesn't overflow should be unaffected.
+	normal := []*AssetBalance{
+		NewAssetBalance([32]byte{1}, 1000),
+		NewAssetBalance([32]byte{2}, 2000),
+	}
+	require.Equal(t, uint64(3000), Sum(normal))
+
+	// An empty list should sum to zero.
+	require.Equal(t, uint64(0), Sum(nil))
 }

--- a/tapchannel/commitment.go
+++ b/tapchannel/commitment.go
@@ -255,10 +255,14 @@ func ComputeView(ourBalance, theirBalance uint64,
 			AuxHtlcDescriptor: entry,
 			AssetBalances:     assetHtlc.Balances(),
 		}
-		local, remote = processAddEntry(
+		local, remote, err = processAddEntry(
 			decodedEntry, local, remote, whoseCommit, false,
 			nextHeight,
 		)
+		if err != nil {
+			return 0, 0, nil, nil, fmt.Errorf("unable to process "+
+				"add entry: %w", err)
+		}
 
 		newView.OurUpdates = append(newView.OurUpdates, decodedEntry)
 	}
@@ -297,10 +301,14 @@ func ComputeView(ourBalance, theirBalance uint64,
 			AuxHtlcDescriptor: entry,
 			AssetBalances:     assetHtlc.Balances(),
 		}
-		local, remote = processAddEntry(
+		local, remote, err = processAddEntry(
 			decodedEntry, local, remote, whoseCommit, true,
 			nextHeight,
 		)
+		if err != nil {
+			return 0, 0, nil, nil, fmt.Errorf("unable to process "+
+				"add entry: %w", err)
+		}
 
 		newView.TheirUpdates = append(
 			newView.TheirUpdates, decodedEntry,
@@ -360,12 +368,12 @@ func processRemoveEntry(htlc *DecodedDescriptor, ourBalance,
 // transaction. It returns the updated balances for both parties.
 func processAddEntry(htlc *DecodedDescriptor, ourBalance, theirBalance uint64,
 	whoseCommit lntypes.ChannelParty, isIncoming bool,
-	nextHeight uint64) (uint64, uint64) {
+	nextHeight uint64) (uint64, uint64, error) {
 
 	// Ignore any add entries which have already been processed.
 	addHeight := htlc.AddHeight(whoseCommit)
 	if addHeight != nextHeight {
-		return ourBalance, theirBalance
+		return ourBalance, theirBalance, nil
 	}
 
 	var amount = rfqmsg.Sum(htlc.AssetBalances)
@@ -373,14 +381,26 @@ func processAddEntry(htlc *DecodedDescriptor, ourBalance, theirBalance uint64,
 		// If this is a new incoming (un-committed) HTLC, then we need
 		// to update their balance accordingly by subtracting the
 		// amount of the HTLC that are funds pending.
+		if amount > theirBalance {
+			return 0, 0, fmt.Errorf("incoming HTLC asset amount "+
+				"%d exceeds their balance %d", amount,
+				theirBalance)
+		}
+
 		theirBalance -= amount
 	} else {
 		// Similarly, we need to debit our balance if this is an
 		// outgoing HTLC to reflect the pending balance.
+		if amount > ourBalance {
+			return 0, 0, fmt.Errorf("outgoing HTLC asset amount "+
+				"%d exceeds our balance %d", amount,
+				ourBalance)
+		}
+
 		ourBalance -= amount
 	}
 
-	return ourBalance, theirBalance
+	return ourBalance, theirBalance, nil
 }
 
 // SanityCheckAmounts makes sure that any output that carries an asset has a

--- a/tapchannel/commitment_test.go
+++ b/tapchannel/commitment_test.go
@@ -710,6 +710,46 @@ func TestComputeView(t *testing.T) {
 			expectedOurUpdates:   1,
 			expectedTheirUpdates: 1,
 		},
+		{
+			name: "outgoing htlc exceeds our balance" +
+				" (error)",
+			ourBalance:   100000,
+			theirBalance: 100000,
+			whoseCommit:  lntypes.Remote,
+			viewConfig: viewConfig{
+				nextHeight: 50,
+				localHtlcs: []assetHtlc{
+					// Being committed NOW
+					{
+						amount:          100001,
+						htlcIndex:       10,
+						entryType:       htlcNoOpAdd,
+						addHeightRemote: 50,
+					},
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "incoming htlc exceeds their balance" +
+				" (error)",
+			ourBalance:   100000,
+			theirBalance: 100000,
+			whoseCommit:  lntypes.Remote,
+			viewConfig: viewConfig{
+				nextHeight: 50,
+				remoteHtlcs: []assetHtlc{
+					// Being committed NOW
+					{
+						amount:          100001,
+						htlcIndex:       20,
+						entryType:       htlcNoOpAdd,
+						addHeightRemote: 50,
+					},
+				},
+			},
+			expectError: true,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
## Description

Hardens asset amount handling in the RFQ layer. Balance list sums are range-checked at decode and aggregation time, the interceptor response computation uses big integer arithmetic, and channel commitment balance updates are bounds-checked. 

Covered by unit tests in `rfqmsg`, `rfq`, and `tapchannel`.