### PR TITLE
itest: sandbox aperture sqlite database in temp dir

### DIFF
--- a/itest/aperture_harness.go
+++ b/itest/aperture_harness.go
@@ -35,6 +35,14 @@ func NewApertureHarness(t *testing.T, port int) *ApertureHarness {
 
 	listenAddr := fmt.Sprintf("127.0.0.1:%d", port)
 
+	// DefaultSqliteConfig points the database file at a fixed, global
+	// path, so override it to keep the sqlite file inside the per-test
+	// temp directory. Otherwise every hashmail-courier itest shares one
+	// database outside the sandbox, which leaks state between runs and
+	// can fail on a stale schema left by another aperture version.
+	sqliteCfg := aperture.DefaultSqliteConfig()
+	sqliteCfg.DatabaseFileName = filepath.Join(baseDir, "aperture.db")
+
 	cfg := &aperture.Config{
 		Insecure:   false,
 		DebugLevel: "debug",
@@ -43,7 +51,7 @@ func NewApertureHarness(t *testing.T, port int) *ApertureHarness {
 			Disable: true,
 		},
 		DatabaseBackend: "sqlite",
-		Sqlite:          aperture.DefaultSqliteConfig(),
+		Sqlite:          sqliteCfg,
 		HashMail: &aperture.HashMailConfig{
 			Enabled:               true,
 			MessageRate:           time.Millisecond,


### PR DESCRIPTION
Fixes #2233.

`NewApertureHarness` sandboxes `BaseDir` in `t.TempDir()` but configured the sqlite backend with `aperture.DefaultSqliteConfig()`, whose `DatabaseFileName` resolves to a fixed, machine-global path (`~/.aperture/aperture.db` on Linux, `~/Library/Application Support/Aperture/aperture.db` on macOS). So every `*_hashmail_courier` itest read and wrote one shared database outside the test sandbox.

Consequences:
- Not hermetic: results depend on whatever aperture last touched the developer's home directory.
- Shared across the parallel tranches, since several hashmail tests run at once in `make itest-parallel`.
- Leaks rows between runs; the file is never cleaned by `clean-itest-logs`.
- On a machine where a newer aperture had created that file, all five hashmail tests fail at harness startup with `no migration found for version 7`, before any tapd logic runs.

The fix overrides `DatabaseFileName` to sit under the temp dir the harness already creates. `DefaultSqliteConfig` returns a pointer, so this needs no new import and leaves `SkipMigrations` at its default.

Verified locally: `basic_send_unidirectional_hashmail_courier` passes, and the machine-global aperture DB is no longer created by the run.

Test-infra only, no user-facing change, so this should carry the `no-changelog` label.
