### PR TITLE
universe: pre-decode transfer block heights before sorting

### DIFF
--- a/docs/release-notes/release-notes-0.9.0.md
+++ b/docs/release-notes/release-notes-0.9.0.md
@@ -289,6 +289,9 @@
 * [PR#2264](https://github.com/lightninglabs/taproot-assets/pull/2264)
   bounds pinned input coin selection to the requested anchor UTXOs
   instead of materializing all eligible wallet assets.
+* [PR#2273](https://github.com/lightninglabs/taproot-assets/pull/2273)
+  pre-decodes transfer block heights before sorting universe transfer leaves,
+  avoiding repeated proof decoding during sort comparisons.
 
 ## Deprecations
 

--- a/universe/syncer.go
+++ b/universe/syncer.go
@@ -575,9 +575,7 @@ func (s *SimpleSyncer) syncRoot(ctx context.Context, remoteRoot Root,
 		for _, item := range transferLeaves {
 			var blockHeight uint32
 			record := proof.BlockHeightRecord(&blockHeight)
-			if err := proof.SparseDecode(bytes.NewReader(item.Leaf.RawProof), record); err != nil {
-				return fmt.Errorf("failed to decode block height for sorting: %w", err)
-			}
+			_ = proof.SparseDecode(bytes.NewReader(item.Leaf.RawProof), record)
 			leavesWithHeight = append(leavesWithHeight, leafWithHeight{
 				leaf:        item,
 				blockHeight: blockHeight,

--- a/universe/syncer.go
+++ b/universe/syncer.go
@@ -571,18 +571,26 @@ func (s *SimpleSyncer) syncRoot(ctx context.Context, remoteRoot Root,
 			leaf        *Item
 			blockHeight uint32
 		}
-		leavesWithHeight := make([]leafWithHeight, 0, len(transferLeaves))
+		leavesWithHeight := make(
+			[]leafWithHeight, 0, len(transferLeaves),
+		)
 		for _, item := range transferLeaves {
 			var blockHeight uint32
 			record := proof.BlockHeightRecord(&blockHeight)
-			_ = proof.SparseDecode(bytes.NewReader(item.Leaf.RawProof), record)
-			leavesWithHeight = append(leavesWithHeight, leafWithHeight{
-				leaf:        item,
-				blockHeight: blockHeight,
-			})
+			_ = proof.SparseDecode(
+				bytes.NewReader(item.Leaf.RawProof),
+				record,
+			)
+			leavesWithHeight = append(
+				leavesWithHeight, leafWithHeight{
+					leaf:        item,
+					blockHeight: blockHeight,
+				},
+			)
 		}
 		sort.Slice(leavesWithHeight, func(i, j int) bool {
-			return leavesWithHeight[i].blockHeight < leavesWithHeight[j].blockHeight
+			return leavesWithHeight[i].blockHeight <
+				leavesWithHeight[j].blockHeight
 		})
 		for i, item := range leavesWithHeight {
 			transferLeaves[i] = item.leaf

--- a/universe/syncer.go
+++ b/universe/syncer.go
@@ -568,7 +568,7 @@ func (s *SimpleSyncer) syncRoot(ctx context.Context, remoteRoot Root,
 	if !isIssuanceTree {
 		transferLeaves := fn.Collect(transferLeafProofs)
 		type leafWithHeight struct {
-			leaf        ItemProof
+			leaf        *Item
 			blockHeight uint32
 		}
 		leavesWithHeight := make([]leafWithHeight, 0, len(transferLeaves))

--- a/universe/syncer.go
+++ b/universe/syncer.go
@@ -567,28 +567,28 @@ func (s *SimpleSyncer) syncRoot(ctx context.Context, remoteRoot Root,
 	// need to sort them to ensure we can validate them in dep order.
 	if !isIssuanceTree {
 		transferLeaves := fn.Collect(transferLeafProofs)
-		sort.Slice(transferLeaves, func(i, j int) bool {
-			// We'll need to decode the block heights from the
-			// proof, so we'll make a record to do so.
-			var iBlockHeight, jBlockHeight uint32
-
-			iRecord := proof.BlockHeightRecord(&iBlockHeight)
-			jRecord := proof.BlockHeightRecord(&jBlockHeight)
-
-			_ = proof.SparseDecode(
-				//nolint:lll
-				bytes.NewReader(transferLeaves[i].Leaf.RawProof),
-				iRecord,
-			)
-
-			_ = proof.SparseDecode(
-				//nolint:lll
-				bytes.NewReader(transferLeaves[j].Leaf.RawProof),
-				jRecord,
-			)
-
-			return iBlockHeight < jBlockHeight
+		type leafWithHeight struct {
+			leaf        ItemProof
+			blockHeight uint32
+		}
+		leavesWithHeight := make([]leafWithHeight, 0, len(transferLeaves))
+		for _, item := range transferLeaves {
+			var blockHeight uint32
+			record := proof.BlockHeightRecord(&blockHeight)
+			if err := proof.SparseDecode(bytes.NewReader(item.Leaf.RawProof), record); err != nil {
+				return fmt.Errorf("failed to decode block height for sorting: %w", err)
+			}
+			leavesWithHeight = append(leavesWithHeight, leafWithHeight{
+				leaf:        item,
+				blockHeight: blockHeight,
+			})
+		}
+		sort.Slice(leavesWithHeight, func(i, j int) bool {
+			return leavesWithHeight[i].blockHeight < leavesWithHeight[j].blockHeight
 		})
+		for i, item := range leavesWithHeight {
+			transferLeaves[i] = item.leaf
+		}
 
 		fn.SendAll(fetchedLeaves, transferLeaves...)
 	}


### PR DESCRIPTION
In universe/syncer.go, sorting transferLeaves previously executed SparseDecode inside the sort.Slice comparison closure. Doing so performed redundant O(N log N) proof decoding allocations during slice sorting.

This PR pre-decodes block heights into a slice before invoking sort.Slice, reducing proof decoding allocations to O(N) while preserving existing best-effort fallback semantics for mock and non-standard leaves.