### PR TITLE
rpcserver: reject unspecified proof type in AssetLeaves

### DIFF
--- a/docs/release-notes/release-notes-0.9.0.md
+++ b/docs/release-notes/release-notes-0.9.0.md
@@ -120,6 +120,11 @@
   86400 second default instead of returning an error. Fixes
   [#2261](https://github.com/lightninglabs/taproot-assets/issues/2261).
 
+* [PR#2274](https://github.com/lightninglabs/taproot-assets/pull/2274)
+  makes `AssetLeaves` reject an unspecified proof type with an error
+  instead of returning an empty leaf list. Fixes
+  [#701](https://github.com/lightninglabs/taproot-assets/issues/701).
+
 # New Features
 
 ## Functional Enhancements

--- a/rpcserver/rpcserver.go
+++ b/rpcserver/rpcserver.go
@@ -7381,6 +7381,14 @@ func (r *RPCServer) AssetLeaves(ctx context.Context,
 			"universe id: %w", err)
 	}
 
+	// A leaf lookup targets a single universe, so the proof type must be
+	// specified. An unspecified proof type resolves to a universe that does
+	// not exist, which would return an empty result instead of an error.
+	if universeID.ProofType == universe.ProofTypeUnspecified {
+		return nil, status.Errorf(codes.InvalidArgument, "proof type "+
+			"must be specified")
+	}
+
 	if err = validatePage(req.Offset, req.Limit); err != nil {
 		return nil, fmt.Errorf("invalid page "+
 			"(offset=%d, limit=%d): %w", req.Offset, req.Limit,

--- a/rpcserver/validation_test.go
+++ b/rpcserver/validation_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/lightninglabs/taproot-assets/tapconfig"
 	"github.com/lightninglabs/taproot-assets/taprpc"
 	wrpc "github.com/lightninglabs/taproot-assets/taprpc/assetwalletrpc"
+	unirpc "github.com/lightninglabs/taproot-assets/taprpc/universerpc"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -297,4 +298,26 @@ func TestExportProofValidation(t *testing.T) {
 			assertCode(t, err, tc.wantCode)
 		})
 	}
+}
+
+// TestAssetLeavesValidation tests that AssetLeaves rejects an unspecified
+// proof type with InvalidArgument. An unspecified proof type resolves to a
+// universe that does not exist, so without this check the RPC returns an
+// empty leaf list instead of an error.
+func TestAssetLeavesValidation(t *testing.T) {
+	t.Parallel()
+
+	server := newTestServer()
+	unspecified := unirpc.ProofType_PROOF_TYPE_UNSPECIFIED
+	_, err := server.AssetLeaves(
+		context.Background(), &unirpc.AssetLeavesRequest{
+			Id: &unirpc.ID{
+				Id: &unirpc.ID_AssetId{
+					AssetId: make([]byte, 32),
+				},
+				ProofType: unspecified,
+			},
+		},
+	)
+	assertCode(t, err, codes.InvalidArgument)
 }


### PR DESCRIPTION
Fixes #701.

`AssetLeaves` returns an empty list instead of an error when the proof type is left unspecified. `UnmarshalUniID` (rpcserver.go:6893) maps `PROOF_TYPE_UNSPECIFIED` to `universe.ProofTypeUnspecified` without complaint, and the handler then queries a universe that does not exist. A caller that omits the proof type gets a silent empty result.

I add a guard in `AssetLeaves` that rejects an unspecified proof type with `InvalidArgument`, matching the validation style in `validation_test.go`. I put it in the handler rather than in `UnmarshalUniID`, since `DeleteAssetRoot` (rpcserver.go:7141) relies on unspecified meaning "both roots".

The issue also asked for a check in `universe.Archive.MintingLeaves`. That method is gone; the leaf query now runs through `UniverseArchive.FetchLeaves` from this handler, so the one guard covers it.

While here, I noticed `AssetLeafKeys` (rpcserver.go:7246) already has the same guard but returns a plain error (gRPC `Unknown`) rather than `InvalidArgument`. I left it alone to keep this focused on #701, happy to align it in a follow-up if you want.

`TestAssetLeavesValidation` panics on a nil deref past the missing guard before the fix, and passes after.
