### PR TITLE
tapcli+address: decode send address using its own network

### DIFF
--- a/address/address.go
+++ b/address/address.go
@@ -634,9 +634,9 @@ func IsUnknownVersion(v Version) bool {
 	}
 }
 
-// DecodeAddress parses a bech32m encoded Taproot Asset address string and
-// returns the HRP and address TLV.
-func DecodeAddress(addr string, net *ChainParams) (*Tap, error) {
+// extractHRP returns the human-readable prefix of a bech32m encoded Taproot
+// Asset address, after validating that it is a prefix for a known network.
+func extractHRP(addr string) (string, error) {
 	// Bech32m encoded Taproot Asset addresses start with a human-readable
 	// part (hrp) followed by '1'. For Bitcoin mainnet the hrp is "tap",
 	// and for testnet it is "tapt". If the address string has a prefix
@@ -644,16 +644,43 @@ func DecodeAddress(addr string, net *ChainParams) (*Tap, error) {
 	// decode it as a Taproot Asset address.
 	oneIndex := strings.LastIndexByte(addr, '1')
 	if oneIndex <= 0 {
-		return nil, ErrInvalidBech32m
+		return "", ErrInvalidBech32m
 	}
 
 	prefix := addr[:oneIndex+1]
 	if !IsBech32MTapPrefix(prefix) {
-		return nil, ErrUnsupportedHRP
+		return "", ErrUnsupportedHRP
 	}
 
 	// The HRP is everything before the found '1'.
-	hrp := prefix[:len(prefix)-1]
+	return prefix[:len(prefix)-1], nil
+}
+
+// DecodeAddressAnyNet decodes a bech32m encoded Taproot Asset address using the
+// network taken from the address' own HRP, rather than a caller-supplied one.
+// Callers that must not impose their own network, such as tapcli where the
+// daemon is authoritative, should use this instead of DecodeAddress.
+func DecodeAddressAnyNet(addr string) (*Tap, error) {
+	hrp, err := extractHRP(addr)
+	if err != nil {
+		return nil, err
+	}
+
+	net, err := Net(hrp)
+	if err != nil {
+		return nil, err
+	}
+
+	return DecodeAddress(addr, net)
+}
+
+// DecodeAddress parses a bech32m encoded Taproot Asset address string and
+// returns the HRP and address TLV.
+func DecodeAddress(addr string, net *ChainParams) (*Tap, error) {
+	hrp, err := extractHRP(addr)
+	if err != nil {
+		return nil, err
+	}
 
 	// Ensure that the hrp we decoded matches the network we're trying to
 	// use the address on.

--- a/address/address_test.go
+++ b/address/address_test.go
@@ -722,3 +722,52 @@ func TestAddressUnknownOddType(t *testing.T) {
 		},
 	)
 }
+
+// TestDecodeAddressAnyNet checks that DecodeAddressAnyNet decodes an address
+// using the network taken from its own prefix, without the caller passing the
+// network. This is what tapcli's `assets send` relies on so that it accepts an
+// address for whichever network the daemon runs on, regardless of the global
+// --network flag (which defaults to testnet). See issue #2272.
+func TestDecodeAddressAnyNet(t *testing.T) {
+	t.Parallel()
+
+	nets := []*ChainParams{
+		&MainNetTap, &TestNet3Tap, &TestNet4Tap,
+		&RegressionNetTap, &SigNetTap,
+	}
+	for _, net := range nets {
+		net := net
+		t.Run(net.TapHRP, func(t *testing.T) {
+			t.Parallel()
+
+			original, encoded, err := randEncodedAddress(
+				t, net, false, false, asset.Normal,
+			)
+			require.NoError(t, err)
+
+			decoded, err := DecodeAddressAnyNet(encoded)
+			require.NoError(t, err)
+			require.Equal(
+				t, net.TapHRP, decoded.ChainParams.TapHRP,
+			)
+			assertAddressEqual(t, original, decoded)
+		})
+	}
+
+	// A bech32m string whose prefix is not a known Taproot Asset HRP is
+	// rejected, rather than silently decoded against the wrong network.
+	t.Run("unknown hrp", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := DecodeAddressAnyNet("bc1qxyz")
+		require.ErrorIs(t, err, ErrUnsupportedHRP)
+	})
+
+	// A string that is not bech32m at all is rejected too.
+	t.Run("not bech32m", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := DecodeAddressAnyNet("not-an-address")
+		require.ErrorIs(t, err, ErrInvalidBech32m)
+	})
+}

--- a/cmd/commands/assets.go
+++ b/cmd/commands/assets.go
@@ -1111,13 +1111,13 @@ func sendAssets(ctx *cli.Context) error {
 		return err
 	}
 
-	var (
-		network     = ctx.GlobalString("network")
-		chainParams = address.ParamsForChain(network)
-		rpcAddrs    []*taprpc.AddressWithAmount
-	)
+	var rpcAddrs []*taprpc.AddressWithAmount
 	for _, addrStr := range addrs {
-		addr, err := address.DecodeAddress(addrStr, &chainParams)
+		// The address carries its own network in its prefix, and the
+		// daemon is authoritative for the network, so we decode using
+		// the address' own network rather than the global --network
+		// flag (which defaults to testnet).
+		addr, err := address.DecodeAddressAnyNet(addrStr)
 		if err != nil {
 			return fmt.Errorf("unable to decode address %s: %w",
 				addrStr, err)
@@ -1143,7 +1143,7 @@ func sendAssets(ctx *cli.Context) error {
 				"amount: %s, expected a valid uint64", parts[1])
 		}
 
-		addr, err := address.DecodeAddress(addrStr, &chainParams)
+		addr, err := address.DecodeAddressAnyNet(addrStr)
 		if err != nil {
 			return fmt.Errorf("unable to decode address %s: %w",
 				addrStr, err)

--- a/docs/release-notes/release-notes-0.9.0.md
+++ b/docs/release-notes/release-notes-0.9.0.md
@@ -120,6 +120,13 @@
   86400 second default instead of returning an error. Fixes
   [#2261](https://github.com/lightninglabs/taproot-assets/issues/2261).
 
+* [PR#2275](https://github.com/lightninglabs/taproot-assets/pull/2275)
+  makes `tapcli assets send` accept an address for whichever network the
+  daemon runs on, instead of decoding it against the global `--network`
+  flag (which defaults to testnet) and rejecting a mainnet address with a
+  network mismatch. Fixes
+  [#2272](https://github.com/lightninglabs/taproot-assets/issues/2272).
+
 # New Features
 
 ## Functional Enhancements


### PR DESCRIPTION
`tapcli assets send` decodes the destination address on the client, building chain params from the global `--network` flag (default `testnet`, `cmd/commands/commands.go`). So a mainnet `tapbc1...` address is rejected with `address: network mismatch` unless the user also passes `--network=mainnet`:

```
# works: forwarded to the daemon, decoded with its params
tapcli addrs decode --addr tapbc1...
# fails: decoded client-side against testnet
tapcli assets send --addr tapbc1... --sat_per_vbyte 4
```

`addrs decode` forwards the raw string to the daemon (`cmd/commands/addrs.go`), so it works regardless of `--network`. In `sendAssets` the client-side decode only reads the amount and version; the raw address is sent to the daemon anyway, and the daemon owns the network. This regressed in v0.7.0-rc1 and hits anyone who connects via `--rpcserver`/`--tlscertpath`/`--macaroonpath` without setting `--network`.

Fix: decode against the network in the address' own HRP. `DecodeAddress` already parses the HRP, so I split that into `extractHRP` and added `DecodeAddressAnyNet`, which resolves the network via the existing `Net(hrp)`. `sendAssets` uses it for both address forms. No RPC, proto, or daemon change, and it fixes every network at once.

`TestDecodeAddressAnyNet` decodes mainnet, testnet3/4, regtest and signet addresses without being told the network, plus the unknown-HRP and non-bech32m paths. It fails on the mainnet and regtest cases when the network is not inferred.

Fixes #2272.
