### PR TITLE
backup: keep a live encrypted asset wallet backup file on disk

### DIFF
--- a/backup/backup.go
+++ b/backup/backup.go
@@ -187,7 +187,7 @@ func createAssetBackup(ctx context.Context,
 // will not be populated (only the public keys will be included).
 func collectAssetBackups(ctx context.Context,
 	assets []*asset.ChainAsset,
-	proofArchive proof.Archiver,
+	proofArchive proof.Exporter,
 	keyLookup KeyLocatorLookup) ([]*AssetBackup, error) {
 
 	backups := make([]*AssetBackup, 0, len(assets))

--- a/backup/backup.go
+++ b/backup/backup.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/lightninglabs/taproot-assets/address"
 	"github.com/lightninglabs/taproot-assets/asset"
 	"github.com/lightninglabs/taproot-assets/proof"
 	"github.com/lightningnetwork/lnd/keychain"
@@ -100,6 +101,14 @@ type ScriptKeyBackup struct {
 	// Tweak is the tweak applied to derive the final script key.
 	// If nil, a BIP-0086 tweak is assumed.
 	Tweak []byte
+
+	// Type is the script key type as known by the exporting wallet. It
+	// decides how the wallet treats the key after a restore, for example
+	// whether the asset shows up in default listings and coin selection.
+	// A tweaked key alone does not reveal the type: unique Pedersen keys
+	// carry a tweak too but are spent like BIP-0086 keys. Unknown if the
+	// backup predates this field.
+	Type asset.ScriptKeyType
 }
 
 // KeyDescriptorBackup contains the key derivation info for an internal key.
@@ -153,10 +162,12 @@ func createAssetBackup(ctx context.Context,
 
 	// Extract script key info if available.
 	if chainAsset.ScriptKey.TweakedScriptKey != nil {
+		assetID := chainAsset.ID()
 		backup.ScriptKeyInfo = &ScriptKeyBackup{
 			PubKey: chainAsset.ScriptKey.PubKey,
 			RawKey: chainAsset.ScriptKey.TweakedScriptKey.RawKey,
 			Tweak:  chainAsset.ScriptKey.TweakedScriptKey.Tweak,
+			Type:   chainAsset.ScriptKey.DetermineType(&assetID),
 		}
 	}
 
@@ -166,16 +177,27 @@ func createAssetBackup(ctx context.Context,
 			PubKey: chainAsset.AnchorInternalKey,
 		}
 
-		// Try to look up the key locator for full derivation info.
+		// Look up the key locator for full derivation info. A key the
+		// wallet does not know, for example the aggregated key of a
+		// channel funding output, has no locator and is stored with
+		// the public key only. Any other failure is transient and must
+		// not produce an entry with a wrong locator, since a restored
+		// anchor with a zero locator cannot be spent.
 		if keyLookup != nil {
 			keyLoc, err := keyLookup.FetchInternalKeyLocator(
 				ctx, chainAsset.AnchorInternalKey,
 			)
-			if err == nil {
+			switch {
+			case err == nil:
 				backup.AnchorInternalKeyInfo.KeyLocator = keyLoc
+
+			case errors.Is(err, ErrKeyLocatorNotFound),
+				errors.Is(err, address.ErrInternalKeyNotFound):
+
+			default:
+				return nil, fmt.Errorf("unable to look up "+
+					"anchor key locator: %w", err)
 			}
-			// If lookup fails, we still have the public key which
-			// may be sufficient for some recovery scenarios.
 		}
 	}
 

--- a/backup/encoding.go
+++ b/backup/encoding.go
@@ -109,6 +109,10 @@ const (
 	ScriptKeyIndexType     tlv.Type = 2
 	ScriptKeyRawPubKeyType tlv.Type = 3
 	ScriptKeyTweakType     tlv.Type = 4
+
+	// ScriptKeyTypeType is the TLV type for the script key type. Odd so
+	// older decoders skip it.
+	ScriptKeyTypeType tlv.Type = 5
 )
 
 // TLV type constants for KeyDescriptorBackup fields.
@@ -590,6 +594,13 @@ func (sk *ScriptKeyBackup) Encode(w io.Writer) error {
 			ScriptKeyTweakType, &sk.Tweak))
 	}
 
+	// Add the script key type if known.
+	if sk.Type != asset.ScriptKeyUnknown {
+		keyType := uint8(sk.Type)
+		records = append(records, tlv.MakePrimitiveRecord(
+			ScriptKeyTypeType, &keyType))
+	}
+
 	stream, err := tlv.NewStream(records...)
 	if err != nil {
 		return err
@@ -606,6 +617,7 @@ func (sk *ScriptKeyBackup) Decode(r io.Reader) error {
 		family         uint32
 		index          uint32
 		tweak          []byte
+		keyType        uint8
 	)
 
 	// Records must be in ascending type order.
@@ -617,6 +629,7 @@ func (sk *ScriptKeyBackup) Decode(r io.Reader) error {
 			ScriptKeyRawPubKeyType, &rawPubKeyBytes,
 		),
 		tlv.MakePrimitiveRecord(ScriptKeyTweakType, &tweak),
+		tlv.MakePrimitiveRecord(ScriptKeyTypeType, &keyType),
 	}
 
 	stream, err := tlv.NewStream(records...)
@@ -656,6 +669,17 @@ func (sk *ScriptKeyBackup) Decode(r io.Reader) error {
 	// Decode tweak if present.
 	if _, ok := parsedTypes[ScriptKeyTweakType]; ok {
 		sk.Tweak = tweak
+	}
+
+	// Decode the script key type if present. A value this decoder does
+	// not know, from a newer exporter or a damaged blob, is treated as
+	// unknown so the importer classifies the key from its material
+	// instead of registering a type no filter will ever match.
+	if _, ok := parsedTypes[ScriptKeyTypeType]; ok {
+		decodedType := asset.ScriptKeyType(keyType)
+		if decodedType <= asset.ScriptKeyUniquePedersen {
+			sk.Type = decodedType
+		}
 	}
 
 	return nil

--- a/backup/encrypt.go
+++ b/backup/encrypt.go
@@ -1,0 +1,181 @@
+package backup
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+
+	"github.com/lightningnetwork/lnd/keychain"
+	"github.com/lightningnetwork/lnd/lnencrypt"
+)
+
+const (
+	// encryptedMagicBytes are the magic bytes that identify an encrypted
+	// backup blob. They are distinct from the plaintext magic so a decoder
+	// can tell the two apart before attempting to decrypt.
+	encryptedMagicBytes = "TAPENC"
+
+	// EncryptedBackupVersion is the current version of the encrypted
+	// backup container format.
+	EncryptedBackupVersion uint32 = 1
+
+	// encryptedHeaderSize is the size of the encrypted container header:
+	// magic bytes followed by a big endian uint32 version.
+	encryptedHeaderSize = len(encryptedMagicBytes) + 4
+)
+
+var (
+	// ErrNotEncrypted is returned when a blob does not carry the encrypted
+	// container header.
+	ErrNotEncrypted = errors.New("backup is not encrypted")
+
+	// ErrNoKeyDeriver is returned when an encrypted backup is presented
+	// but no key deriver is available to decrypt it.
+	ErrNoKeyDeriver = errors.New("encrypted backup but no key deriver " +
+		"configured")
+
+	// errDeriveNextKeyUnsupported is returned by the key ring adapter for
+	// the DeriveNextKey method, which the encrypter never calls.
+	errDeriveNextKeyUnsupported = errors.New("DeriveNextKey is not " +
+		"supported by the backup key ring adapter")
+)
+
+// KeyDeriver is the minimal interface needed to derive the backup encryption
+// key from the lnd wallet. It is satisfied by lndclient's WalletKitClient.
+type KeyDeriver interface {
+	// DeriveKey derives the key described by the given locator.
+	DeriveKey(ctx context.Context,
+		locator *keychain.KeyLocator) (*keychain.KeyDescriptor, error)
+}
+
+// keyRingAdapter adapts a context aware KeyDeriver to lnd's keychain.KeyRing
+// interface so that lnencrypt.KeyRingEncrypter can be reused as is.
+type keyRingAdapter struct {
+	ctx     context.Context //nolint:containedctx
+	deriver KeyDeriver
+}
+
+// DeriveNextKey is part of the keychain.KeyRing interface. The encrypter
+// never calls it, so it is not supported.
+func (k *keyRingAdapter) DeriveNextKey(
+	keychain.KeyFamily) (keychain.KeyDescriptor, error) {
+
+	return keychain.KeyDescriptor{}, errDeriveNextKeyUnsupported
+}
+
+// DeriveKey derives the key described by the given locator through the
+// wrapped KeyDeriver.
+func (k *keyRingAdapter) DeriveKey(
+	keyLoc keychain.KeyLocator) (keychain.KeyDescriptor, error) {
+
+	desc, err := k.deriver.DeriveKey(k.ctx, &keyLoc)
+	if err != nil {
+		return keychain.KeyDescriptor{}, err
+	}
+	if desc == nil || desc.PubKey == nil {
+		return keychain.KeyDescriptor{}, fmt.Errorf("derived key " +
+			"descriptor is empty")
+	}
+
+	return *desc, nil
+}
+
+// A compile time assertion to ensure keyRingAdapter meets the
+// keychain.KeyRing interface.
+var _ keychain.KeyRing = (*keyRingAdapter)(nil)
+
+// NewKeyRingEncrypter derives the backup encryption key from the lnd wallet
+// and returns an encrypter/decrypter that uses it. The key is derived the
+// same way lnd derives the key for its static channel backup file, so a
+// backup encrypted by tapd can be decrypted by any tapd connected to an lnd
+// with the same seed.
+func NewKeyRingEncrypter(ctx context.Context,
+	deriver KeyDeriver) (lnencrypt.EncrypterDecrypter, error) {
+
+	if deriver == nil {
+		return nil, ErrNoKeyDeriver
+	}
+
+	encrypter, err := lnencrypt.KeyRingEncrypter(&keyRingAdapter{
+		ctx:     ctx,
+		deriver: deriver,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("unable to derive backup encryption "+
+			"key: %w", err)
+	}
+
+	return encrypter, nil
+}
+
+// IsEncryptedBackup returns true if the given blob carries the encrypted
+// backup container header.
+func IsEncryptedBackup(data []byte) bool {
+	if len(data) < encryptedHeaderSize {
+		return false
+	}
+
+	return bytes.Equal(
+		data[:len(encryptedMagicBytes)], []byte(encryptedMagicBytes),
+	)
+}
+
+// EncryptBackup wraps an encoded (plaintext) wallet backup into the encrypted
+// container format: magic bytes, a version and the AEAD sealed payload.
+func EncryptBackup(encrypter lnencrypt.EncrypterDecrypter,
+	plaintext []byte) ([]byte, error) {
+
+	if encrypter == nil {
+		return nil, ErrNoKeyDeriver
+	}
+	if len(plaintext) == 0 {
+		return nil, fmt.Errorf("backup data is empty")
+	}
+
+	var buf bytes.Buffer
+	buf.WriteString(encryptedMagicBytes)
+
+	var versionBuf [4]byte
+	binary.BigEndian.PutUint32(versionBuf[:], EncryptedBackupVersion)
+	buf.Write(versionBuf[:])
+
+	err := encrypter.EncryptPayloadToWriter(plaintext, &buf)
+	if err != nil {
+		return nil, fmt.Errorf("unable to encrypt backup: %w", err)
+	}
+
+	return buf.Bytes(), nil
+}
+
+// DecryptBackup unwraps an encrypted backup container and returns the encoded
+// plaintext wallet backup. ErrNotEncrypted is returned if the blob does not
+// carry the encrypted header.
+func DecryptBackup(encrypter lnencrypt.EncrypterDecrypter,
+	data []byte) ([]byte, error) {
+
+	if !IsEncryptedBackup(data) {
+		return nil, ErrNotEncrypted
+	}
+	if encrypter == nil {
+		return nil, ErrNoKeyDeriver
+	}
+
+	version := binary.BigEndian.Uint32(
+		data[len(encryptedMagicBytes):encryptedHeaderSize],
+	)
+	if version != EncryptedBackupVersion {
+		return nil, fmt.Errorf("unsupported encrypted backup "+
+			"version %d", version)
+	}
+
+	plaintext, err := encrypter.DecryptPayloadFromReader(
+		bytes.NewReader(data[encryptedHeaderSize:]),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("unable to decrypt backup: %w", err)
+	}
+
+	return plaintext, nil
+}

--- a/backup/encrypt_test.go
+++ b/backup/encrypt_test.go
@@ -1,0 +1,220 @@
+package backup
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/lightningnetwork/lnd/keychain"
+	"github.com/lightningnetwork/lnd/lnencrypt"
+	"github.com/stretchr/testify/require"
+)
+
+// mockKeyDeriver is a KeyDeriver that always returns the public key of a
+// fixed private key, regardless of the requested locator. It records the
+// locators it was asked for.
+type mockKeyDeriver struct {
+	privKey  *btcec.PrivateKey
+	err      error
+	locators []keychain.KeyLocator
+	nilDesc  bool
+}
+
+func newMockKeyDeriver(t *testing.T) *mockKeyDeriver {
+	privKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	return &mockKeyDeriver{privKey: privKey}
+}
+
+func (m *mockKeyDeriver) DeriveKey(_ context.Context,
+	locator *keychain.KeyLocator) (*keychain.KeyDescriptor, error) {
+
+	m.locators = append(m.locators, *locator)
+
+	if m.err != nil {
+		return nil, m.err
+	}
+	if m.nilDesc {
+		return &keychain.KeyDescriptor{}, nil
+	}
+
+	return &keychain.KeyDescriptor{
+		KeyLocator: *locator,
+		PubKey:     m.privKey.PubKey(),
+	}, nil
+}
+
+// newTestEncrypter returns an encrypter derived from the given mock deriver.
+func newTestEncrypter(t *testing.T,
+	deriver KeyDeriver) lnencrypt.EncrypterDecrypter {
+
+	encrypter, err := NewKeyRingEncrypter(context.Background(), deriver)
+	require.NoError(t, err)
+
+	return encrypter
+}
+
+// TestNewKeyRingEncrypter asserts the key derivation contract: the key is
+// derived from the base encryption family, and deriver failures propagate.
+func TestNewKeyRingEncrypter(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	t.Run("nil deriver", func(t *testing.T) {
+		_, err := NewKeyRingEncrypter(ctx, nil)
+		require.ErrorIs(t, err, ErrNoKeyDeriver)
+	})
+
+	t.Run("uses base encryption key locator", func(t *testing.T) {
+		deriver := newMockKeyDeriver(t)
+		_, err := NewKeyRingEncrypter(ctx, deriver)
+		require.NoError(t, err)
+
+		require.Len(t, deriver.locators, 1)
+		require.Equal(t, keychain.KeyLocator{
+			Family: keychain.KeyFamilyBaseEncryption,
+			Index:  0,
+		}, deriver.locators[0])
+	})
+
+	t.Run("deriver error propagates", func(t *testing.T) {
+		deriver := newMockKeyDeriver(t)
+		deriver.err = errors.New("lnd unavailable")
+
+		_, err := NewKeyRingEncrypter(ctx, deriver)
+		require.ErrorContains(t, err, "lnd unavailable")
+	})
+
+	t.Run("empty descriptor rejected", func(t *testing.T) {
+		deriver := newMockKeyDeriver(t)
+		deriver.nilDesc = true
+
+		_, err := NewKeyRingEncrypter(ctx, deriver)
+		require.ErrorContains(t, err, "empty")
+	})
+
+	t.Run("adapter rejects DeriveNextKey", func(t *testing.T) {
+		adapter := &keyRingAdapter{
+			ctx:     ctx,
+			deriver: newMockKeyDeriver(t),
+		}
+		_, err := adapter.DeriveNextKey(
+			keychain.KeyFamilyBaseEncryption,
+		)
+		require.ErrorIs(t, err, errDeriveNextKeyUnsupported)
+	})
+}
+
+// TestEncryptDecryptBackup covers the encrypted container round trip and the
+// ways decryption must fail.
+func TestEncryptDecryptBackup(t *testing.T) {
+	t.Parallel()
+
+	deriver := newMockKeyDeriver(t)
+	encrypter := newTestEncrypter(t, deriver)
+
+	plaintext, err := EncodeWalletBackup(&WalletBackup{
+		Version: BackupVersionStripped,
+		Assets:  []*AssetBackup{newTestAssetBackupV2(t)},
+	})
+	require.NoError(t, err)
+	require.False(t, IsEncryptedBackup(plaintext))
+
+	packed, err := EncryptBackup(encrypter, plaintext)
+	require.NoError(t, err)
+	require.True(t, IsEncryptedBackup(packed))
+	require.NotEqual(t, plaintext, packed)
+
+	t.Run("round trip", func(t *testing.T) {
+		got, err := DecryptBackup(encrypter, packed)
+		require.NoError(t, err)
+		require.Equal(t, plaintext, got)
+
+		// The decrypted payload is a regular backup.
+		decoded, err := DecodeWalletBackup(got)
+		require.NoError(t, err)
+		require.Len(t, decoded.Assets, 1)
+	})
+
+	t.Run("fresh nonce per encryption", func(t *testing.T) {
+		packed2, err := EncryptBackup(encrypter, plaintext)
+		require.NoError(t, err)
+		require.NotEqual(t, packed, packed2)
+	})
+
+	t.Run("wrong key", func(t *testing.T) {
+		other := newTestEncrypter(t, newMockKeyDeriver(t))
+		_, err := DecryptBackup(other, packed)
+		require.ErrorContains(t, err, "unable to decrypt")
+	})
+
+	t.Run("same seed decrypts", func(t *testing.T) {
+		// A second encrypter derived from the same wallet key must
+		// be able to read the file, this is the restore scenario.
+		same := newTestEncrypter(t, &mockKeyDeriver{
+			privKey: deriver.privKey,
+		})
+		got, err := DecryptBackup(same, packed)
+		require.NoError(t, err)
+		require.Equal(t, plaintext, got)
+	})
+
+	t.Run("tampered ciphertext", func(t *testing.T) {
+		tampered := append([]byte{}, packed...)
+		tampered[len(tampered)-1] ^= 0xff
+
+		_, err := DecryptBackup(encrypter, tampered)
+		require.ErrorContains(t, err, "unable to decrypt")
+	})
+
+	t.Run("truncated ciphertext", func(t *testing.T) {
+		truncated := packed[:encryptedHeaderSize+5]
+		_, err := DecryptBackup(encrypter, truncated)
+		require.Error(t, err)
+	})
+
+	t.Run("unsupported version", func(t *testing.T) {
+		bad := append([]byte{}, packed...)
+		binary.BigEndian.PutUint32(
+			bad[len(encryptedMagicBytes):encryptedHeaderSize], 99,
+		)
+
+		_, err := DecryptBackup(encrypter, bad)
+		require.ErrorContains(t, err, "unsupported encrypted backup "+
+			"version 99")
+	})
+
+	t.Run("plaintext is not encrypted", func(t *testing.T) {
+		_, err := DecryptBackup(encrypter, plaintext)
+		require.ErrorIs(t, err, ErrNotEncrypted)
+	})
+
+	t.Run("nil encrypter", func(t *testing.T) {
+		_, err := DecryptBackup(nil, packed)
+		require.ErrorIs(t, err, ErrNoKeyDeriver)
+
+		_, err = EncryptBackup(nil, plaintext)
+		require.ErrorIs(t, err, ErrNoKeyDeriver)
+	})
+
+	t.Run("empty plaintext", func(t *testing.T) {
+		_, err := EncryptBackup(encrypter, nil)
+		require.ErrorContains(t, err, "empty")
+	})
+}
+
+// TestIsEncryptedBackup checks the header detection edge cases.
+func TestIsEncryptedBackup(t *testing.T) {
+	t.Parallel()
+
+	require.False(t, IsEncryptedBackup(nil))
+	require.False(t, IsEncryptedBackup([]byte(encryptedMagicBytes)))
+	require.False(t, IsEncryptedBackup([]byte(backupMagicBytes+"0000")))
+
+	header := append([]byte(encryptedMagicBytes), 0, 0, 0, 1)
+	require.True(t, IsEncryptedBackup(header))
+}

--- a/backup/export.go
+++ b/backup/export.go
@@ -14,92 +14,15 @@ import (
 // ExportModeOptimistic, no proofs are included and federationURLs must be
 // non-empty.
 func ExportBackup(ctx context.Context, mode ExportMode,
-	assets []*asset.ChainAsset, proofArchive proof.Archiver,
+	assets []*asset.ChainAsset, proofArchive proof.Exporter,
 	keyLookup KeyLocatorLookup,
 	federationURLs []string) ([]byte, error) {
 
-	var (
-		assetBackups  []*AssetBackup
-		backupVersion uint32
-		err           error
+	assetBackups, backupVersion, err := CollectBackups(
+		ctx, mode, assets, proofArchive, keyLookup, federationURLs,
 	)
-
-	switch mode {
-	case ExportModeOptimistic:
-		// Validate federation URLs before collecting backups to
-		// avoid wasted work.
-		if len(federationURLs) == 0 {
-			return nil, fmt.Errorf("no federation servers " +
-				"configured; optimistic backup requires " +
-				"at least one universe server")
-		}
-
-		// v3: Collect asset backups without fetching proofs.
-		assetBackups, err = collectAssetBackupsOptimistic(
-			ctx, assets, keyLookup,
-		)
-		if err != nil {
-			return nil, fmt.Errorf("failed to collect "+
-				"optimistic asset backups: %w", err)
-		}
-
-		backupVersion = BackupVersionOptimistic
-
-	case ExportModeCompact:
-		// v2: Collect backups with proofs, then strip them.
-		assetBackups, err = collectAssetBackups(
-			ctx, assets, proofArchive, keyLookup,
-		)
-		if err != nil {
-			return nil, fmt.Errorf("failed to collect "+
-				"asset backups: %w", err)
-		}
-
-		for i, ab := range assetBackups {
-			if len(ab.ProofFileBlob) == 0 {
-				continue
-			}
-
-			strippedBlob, hints, err := StripProofFile(
-				ab.ProofFileBlob,
-			)
-			if err != nil {
-				return nil, fmt.Errorf("failed to strip "+
-					"proof for asset %d: %w", i, err)
-			}
-
-			var hintsBuf bytes.Buffer
-			err = EncodeFileHints(&hintsBuf, hints)
-			if err != nil {
-				return nil, fmt.Errorf("failed to encode "+
-					"hints for asset %d: %w",
-					i, err)
-			}
-
-			log.Debugf("Asset %d: proof %d -> %d bytes "+
-				"(stripped %d bytes)", i,
-				len(ab.ProofFileBlob),
-				len(strippedBlob),
-				len(ab.ProofFileBlob)-len(strippedBlob))
-
-			ab.StrippedProofFileBlob = strippedBlob
-			ab.RehydrationHintsBlob = hintsBuf.Bytes()
-			ab.ProofFileBlob = nil
-		}
-
-		backupVersion = BackupVersionStripped
-
-	default:
-		// v1 (RAW): Full backup with complete proof data.
-		assetBackups, err = collectAssetBackups(
-			ctx, assets, proofArchive, keyLookup,
-		)
-		if err != nil {
-			return nil, fmt.Errorf("failed to collect "+
-				"asset backups: %w", err)
-		}
-
-		backupVersion = BackupVersionOriginal
+	if err != nil {
+		return nil, err
 	}
 
 	log.Infof("Collected backup data for %d assets (mode=%v)",
@@ -121,4 +44,104 @@ func ExportBackup(ctx context.Context, mode ExportMode,
 	log.Infof("Encoded wallet backup: %d bytes", len(backupBytes))
 
 	return backupBytes, nil
+}
+
+// CollectBackups builds the per-asset backup entries for the given assets in
+// the requested mode and returns them together with the backup format version
+// they must be encoded with.
+func CollectBackups(ctx context.Context, mode ExportMode,
+	assets []*asset.ChainAsset, proofArchive proof.Exporter,
+	keyLookup KeyLocatorLookup,
+	federationURLs []string) ([]*AssetBackup, uint32, error) {
+
+	var (
+		assetBackups  []*AssetBackup
+		backupVersion uint32
+		err           error
+	)
+
+	switch mode {
+	case ExportModeOptimistic:
+		// Validate federation URLs before collecting backups to
+		// avoid wasted work.
+		if len(federationURLs) == 0 {
+			return nil, 0, fmt.Errorf("no federation servers " +
+				"configured; optimistic backup requires " +
+				"at least one universe server")
+		}
+
+		// v3: Collect asset backups without fetching proofs.
+		assetBackups, err = collectAssetBackupsOptimistic(
+			ctx, assets, keyLookup,
+		)
+		if err != nil {
+			return nil, 0, fmt.Errorf("failed to collect "+
+				"optimistic asset backups: %w", err)
+		}
+
+		backupVersion = BackupVersionOptimistic
+
+	case ExportModeCompact:
+		// v2: Collect backups with proofs, then strip them.
+		assetBackups, err = collectAssetBackups(
+			ctx, assets, proofArchive, keyLookup,
+		)
+		if err != nil {
+			return nil, 0, fmt.Errorf("failed to collect "+
+				"asset backups: %w", err)
+		}
+
+		for i, ab := range assetBackups {
+			if err := stripAssetBackup(ab); err != nil {
+				return nil, 0, fmt.Errorf("asset %d: %w", i,
+					err)
+			}
+		}
+
+		backupVersion = BackupVersionStripped
+
+	default:
+		// v1 (RAW): Full backup with complete proof data.
+		assetBackups, err = collectAssetBackups(
+			ctx, assets, proofArchive, keyLookup,
+		)
+		if err != nil {
+			return nil, 0, fmt.Errorf("failed to collect "+
+				"asset backups: %w", err)
+		}
+
+		backupVersion = BackupVersionOriginal
+	}
+
+	return assetBackups, backupVersion, nil
+}
+
+// stripAssetBackup converts a raw (v1) asset backup entry into a compact (v2)
+// one by stripping the proof file of blockchain-derivable fields and storing
+// the rehydration hints alongside it. Entries without a proof blob are left
+// untouched.
+func stripAssetBackup(ab *AssetBackup) error {
+	if len(ab.ProofFileBlob) == 0 {
+		return nil
+	}
+
+	strippedBlob, hints, err := StripProofFile(ab.ProofFileBlob)
+	if err != nil {
+		return fmt.Errorf("failed to strip proof: %w", err)
+	}
+
+	var hintsBuf bytes.Buffer
+	if err := EncodeFileHints(&hintsBuf, hints); err != nil {
+		return fmt.Errorf("failed to encode hints: %w", err)
+	}
+
+	log.Debugf("Stripped proof %d -> %d bytes (saved %d bytes)",
+		len(ab.ProofFileBlob), len(strippedBlob),
+		len(ab.ProofFileBlob)-len(strippedBlob))
+
+	ab.StrippedProofFileBlob = strippedBlob
+	ab.RehydrationHintsBlob = hintsBuf.Bytes()
+	ab.ProofFileBlob = nil
+
+	return nil
 }

--- a/backup/file.go
+++ b/backup/file.go
@@ -1,0 +1,187 @@
+package backup
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+const (
+	// DefaultBackupFileName is the default name of the on-disk asset
+	// wallet backup file that is kept up to date by the Updater.
+	DefaultBackupFileName = "assets.backup"
+
+	// DefaultTempBackupFileName is the name of the temporary file the
+	// Updater writes to before atomically renaming it over the main
+	// backup file.
+	DefaultTempBackupFileName = "temp-dont-use-assets.backup"
+)
+
+var (
+	// ErrNoBackupFile is returned when no backup file path is configured
+	// or the file does not exist on disk yet.
+	ErrNoBackupFile = errors.New("backup file does not exist")
+)
+
+// Swapper is an interface that allows the Updater to atomically replace the
+// persisted backup with a new version and to read back what is currently
+// persisted.
+type Swapper interface {
+	// UpdateAndSwap atomically replaces the persisted backup with the
+	// given packed (encoded and encrypted) bytes.
+	UpdateAndSwap(packed []byte) error
+
+	// Extract returns the currently persisted packed backup bytes.
+	// ErrNoBackupFile is returned if nothing has been persisted yet.
+	Extract() ([]byte, error)
+}
+
+// File is a Swapper implementation backed by a single file on disk. Updates
+// are written to a temporary sibling file first, synced, and then renamed
+// over the main file so a crash can never leave a half written backup.
+type File struct {
+	fileName string
+}
+
+// NewFile creates a new File swapper for the given path.
+func NewFile(fileName string) *File {
+	return &File{fileName: fileName}
+}
+
+// Path returns the path of the main backup file.
+func (f *File) Path() string {
+	return f.fileName
+}
+
+// target returns the path the backup is actually written to. A symlink at the
+// configured path is followed, so the operator's link to another volume is
+// kept and the file behind it is replaced.
+func (f *File) target() string {
+	resolved, err := filepath.EvalSymlinks(f.fileName)
+	if err != nil {
+		return f.fileName
+	}
+
+	return resolved
+}
+
+// UpdateAndSwap writes the packed backup to a temporary file, syncs it and
+// then atomically renames it over the main backup file.
+func (f *File) UpdateAndSwap(packed []byte) error {
+	if f.fileName == "" {
+		return ErrNoBackupFile
+	}
+	if len(packed) == 0 {
+		return fmt.Errorf("refusing to write empty backup file")
+	}
+
+	target := f.target()
+	tempFileName := filepath.Join(
+		filepath.Dir(target), DefaultTempBackupFileName,
+	)
+
+	// A custom path may point into a directory that does not exist yet.
+	dir := filepath.Dir(target)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("unable to create backup directory: %w", err)
+	}
+
+	// A stale temp file from a crashed previous attempt is discarded.
+	if _, err := os.Stat(tempFileName); err == nil {
+		log.Infof("Found stale temp backup file %v, removing",
+			tempFileName)
+
+		if err := os.Remove(tempFileName); err != nil {
+			return fmt.Errorf("unable to remove stale temp "+
+				"backup file: %w", err)
+		}
+	}
+
+	if err := writeTemp(tempFileName, packed); err != nil {
+		_ = os.Remove(tempFileName)
+		return err
+	}
+
+	log.Debugf("Swapping backup file %v -> %v", tempFileName, target)
+
+	if err := os.Rename(tempFileName, target); err != nil {
+		_ = os.Remove(tempFileName)
+		return fmt.Errorf("unable to rename temp backup file: %w",
+			err)
+	}
+
+	// Sync the containing directory so the rename itself is durable. Not
+	// every platform or file system supports this, and the data itself is
+	// already synced, so a failure here is not fatal. Windows cannot open
+	// directories for syncing at all, so skip it there.
+	if runtime.GOOS != "windows" {
+		if err := syncDir(dir); err != nil {
+			log.Warnf("Unable to sync backup directory %v: %v",
+				dir, err)
+		}
+	}
+
+	return nil
+}
+
+// writeTemp creates the temp file, writes the payload, syncs and closes it.
+func writeTemp(tempFileName string, packed []byte) error {
+	tempFile, err := os.OpenFile(
+		tempFileName, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600,
+	)
+	if err != nil {
+		return fmt.Errorf("unable to create temp backup file: %w",
+			err)
+	}
+
+	if _, err := tempFile.Write(packed); err != nil {
+		_ = tempFile.Close()
+		return fmt.Errorf("unable to write temp backup file: %w",
+			err)
+	}
+	if err := tempFile.Sync(); err != nil {
+		_ = tempFile.Close()
+		return fmt.Errorf("unable to sync temp backup file: %w", err)
+	}
+	if err := tempFile.Close(); err != nil {
+		return fmt.Errorf("unable to close temp backup file: %w",
+			err)
+	}
+
+	return nil
+}
+
+// Extract reads the currently persisted backup file. ErrNoBackupFile is
+// returned if no path is configured or the file does not exist.
+func (f *File) Extract() ([]byte, error) {
+	if f.fileName == "" {
+		return nil, ErrNoBackupFile
+	}
+
+	data, err := os.ReadFile(f.fileName)
+	switch {
+	case errors.Is(err, os.ErrNotExist):
+		return nil, ErrNoBackupFile
+
+	case err != nil:
+		return nil, fmt.Errorf("unable to read backup file: %w", err)
+	}
+
+	return data, nil
+}
+
+// syncDir fsyncs a directory so that a preceding rename in it is durable.
+func syncDir(dir string) error {
+	d, err := os.Open(dir)
+	if err != nil {
+		return err
+	}
+	defer d.Close()
+
+	return d.Sync()
+}
+
+// A compile time assertion to ensure File meets the Swapper interface.
+var _ Swapper = (*File)(nil)

--- a/backup/file_test.go
+++ b/backup/file_test.go
@@ -1,0 +1,172 @@
+package backup
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestFileNoPath asserts that a File without a path refuses to do anything.
+func TestFileNoPath(t *testing.T) {
+	t.Parallel()
+
+	f := NewFile("")
+
+	require.ErrorIs(t, f.UpdateAndSwap([]byte("x")), ErrNoBackupFile)
+
+	_, err := f.Extract()
+	require.ErrorIs(t, err, ErrNoBackupFile)
+}
+
+// TestFileUpdateAndSwap covers the write, replace and read back cycle of the
+// on-disk swapper.
+func TestFileUpdateAndSwap(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, DefaultBackupFileName)
+	tempPath := filepath.Join(dir, DefaultTempBackupFileName)
+	f := NewFile(path)
+
+	require.Equal(t, path, f.Path())
+
+	// Nothing written yet.
+	_, err := f.Extract()
+	require.ErrorIs(t, err, ErrNoBackupFile)
+
+	// Empty payloads are refused so a bug can never truncate the backup.
+	require.ErrorContains(t, f.UpdateAndSwap(nil), "empty")
+	require.NoFileExists(t, path)
+
+	// First write.
+	first := []byte("first backup")
+	require.NoError(t, f.UpdateAndSwap(first))
+
+	got, err := f.Extract()
+	require.NoError(t, err)
+	require.Equal(t, first, got)
+
+	// The temp file must not linger and the file is private.
+	require.NoFileExists(t, tempPath)
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+
+	// Second write replaces the content.
+	second := []byte("second, longer backup payload")
+	require.NoError(t, f.UpdateAndSwap(second))
+
+	got, err = f.Extract()
+	require.NoError(t, err)
+	require.Equal(t, second, got)
+	require.NoFileExists(t, tempPath)
+
+	// Shorter content must fully replace, not overlay.
+	third := []byte("3")
+	require.NoError(t, f.UpdateAndSwap(third))
+
+	got, err = f.Extract()
+	require.NoError(t, err)
+	require.Equal(t, third, got)
+}
+
+// TestFileStaleTempRemoved asserts that a leftover temp file from a crashed
+// attempt is discarded and does not leak into the new backup.
+func TestFileStaleTempRemoved(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, DefaultBackupFileName)
+	tempPath := filepath.Join(dir, DefaultTempBackupFileName)
+	f := NewFile(path)
+
+	require.NoError(t, os.WriteFile(tempPath, []byte("stale"), 0o600))
+
+	payload := []byte("fresh")
+	require.NoError(t, f.UpdateAndSwap(payload))
+
+	got, err := f.Extract()
+	require.NoError(t, err)
+	require.Equal(t, payload, got)
+	require.NoFileExists(t, tempPath)
+}
+
+// TestFileMissingDirectory asserts that a write into a directory that does not
+// exist yet creates it, as a custom --backup.filepath may point anywhere.
+func TestFileMissingDirectory(t *testing.T) {
+	t.Parallel()
+
+	dir := filepath.Join(t.TempDir(), "missing", "nested")
+	path := filepath.Join(dir, DefaultBackupFileName)
+	f := NewFile(path)
+
+	require.NoError(t, f.UpdateAndSwap([]byte("x")))
+	require.FileExists(t, path)
+
+	info, err := os.Stat(dir)
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0o700), info.Mode().Perm())
+}
+
+// TestFileDirectoryIsFile asserts that a path whose parent is a regular file
+// fails cleanly without leaving anything behind.
+func TestFileDirectoryIsFile(t *testing.T) {
+	t.Parallel()
+
+	parent := filepath.Join(t.TempDir(), "not-a-dir")
+	require.NoError(t, os.WriteFile(parent, []byte("x"), 0o600))
+
+	path := filepath.Join(parent, DefaultBackupFileName)
+	require.ErrorContains(t, NewFile(path).UpdateAndSwap([]byte("x")),
+		"unable to create backup directory")
+	require.NoFileExists(t, path)
+}
+
+// TestFileExtractUnreadable asserts that read errors other than a missing
+// file are surfaced rather than treated as an empty backup.
+func TestFileExtractUnreadable(t *testing.T) {
+	t.Parallel()
+
+	if os.Geteuid() == 0 {
+		t.Skip("root ignores file permissions")
+	}
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, DefaultBackupFileName)
+	require.NoError(t, os.WriteFile(path, []byte("x"), 0o000))
+
+	_, err := NewFile(path).Extract()
+	require.Error(t, err)
+	require.NotErrorIs(t, err, ErrNoBackupFile)
+}
+
+// TestFileSymlinkFollowed asserts that a symlink at the backup path is
+// followed, so the operator's link stays and the file behind it is replaced.
+func TestFileSymlinkFollowed(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	real := filepath.Join(dir, "volume", DefaultBackupFileName)
+	require.NoError(t, os.MkdirAll(filepath.Dir(real), 0o700))
+	require.NoError(t, os.WriteFile(real, []byte("old"), 0o600))
+
+	link := filepath.Join(dir, DefaultBackupFileName)
+	require.NoError(t, os.Symlink(real, link))
+
+	f := NewFile(link)
+	require.NoError(t, f.UpdateAndSwap([]byte("new")))
+
+	info, err := os.Lstat(link)
+	require.NoError(t, err)
+	require.NotZero(t, info.Mode()&os.ModeSymlink, "link was replaced")
+
+	got, err := os.ReadFile(real)
+	require.NoError(t, err)
+	require.Equal(t, []byte("new"), got)
+
+	got, err = f.Extract()
+	require.NoError(t, err)
+	require.Equal(t, []byte("new"), got)
+}

--- a/backup/import.go
+++ b/backup/import.go
@@ -75,6 +75,107 @@ type ImportConfig struct {
 	// ProofVerifier provides the verification context for imported
 	// proofs.
 	ProofVerifier proof.VerifierCtx
+
+	// KeyDeriver derives the backup encryption key from the lnd wallet.
+	// It is only needed to import encrypted backups such as the file
+	// written by the Updater. If nil, encrypted backups are rejected.
+	KeyDeriver KeyDeriver
+
+	// WalletProofs is the database backed proof store that decides
+	// whether an asset is already part of the wallet. It must not fall
+	// back to proof files on disk: a node whose database was wiped but
+	// whose proofs directory survived would otherwise skip every asset.
+	// If nil, ProofArchive is used.
+	WalletProofs proof.Exporter
+}
+
+// keyMaterialComplete reports whether the key info of an entry carries the
+// public keys the import needs to register it.
+func keyMaterialComplete(ab *AssetBackup) bool {
+	if info := ab.AnchorInternalKeyInfo; info != nil && info.PubKey == nil {
+		return false
+	}
+
+	if info := ab.ScriptKeyInfo; info != nil {
+		if info.PubKey == nil || info.RawKey.PubKey == nil {
+			return false
+		}
+	}
+
+	return true
+}
+
+// scriptKeyTypeForImport returns the type a restored script key is registered
+// with. A type recorded by the exporting wallet wins. Backups that predate the
+// type field are classified from the key material: tombstones by the NUMS
+// key, burns from the first witness, BIP-0086 and unique Pedersen keys by
+// re-deriving them. The Pedersen case matters because such a key carries a
+// tweak yet must stay visible and spendable like a BIP-0086 key. Any other
+// tweaked key is an external script path key.
+func scriptKeyTypeForImport(sk asset.ScriptKey,
+	a *asset.Asset) asset.ScriptKeyType {
+
+	tweaked := sk.TweakedScriptKey
+	if tweaked == nil || sk.PubKey == nil || a == nil {
+		return asset.ScriptKeyUnknown
+	}
+	if tweaked.Type != asset.ScriptKeyUnknown {
+		return tweaked.Type
+	}
+
+	if sk.PubKey.IsEqual(asset.NUMSPubKey) {
+		return asset.ScriptKeyTombstone
+	}
+
+	if len(a.PrevWitnesses) > 0 &&
+		asset.IsBurnKey(sk.PubKey, a.PrevWitnesses[0]) {
+
+		return asset.ScriptKeyBurn
+	}
+
+	if tweaked.RawKey.PubKey != nil {
+		bip86 := asset.NewScriptKeyBip86(tweaked.RawKey)
+		if bip86.PubKey.IsEqual(sk.PubKey) {
+			return asset.ScriptKeyBip86
+		}
+
+		pedersen, err := asset.DeriveUniqueScriptKey(
+			*tweaked.RawKey.PubKey, a.ID(),
+			asset.ScriptKeyDerivationUniquePedersen,
+		)
+		if err == nil && pedersen.PubKey.IsEqual(sk.PubKey) {
+			return asset.ScriptKeyUniquePedersen
+		}
+	}
+
+	if len(tweaked.Tweak) > 0 {
+		return asset.ScriptKeyScriptPathExternal
+	}
+
+	return asset.ScriptKeyBip86
+}
+
+// assetExists reports whether the wallet database already holds a proof for
+// the given locator.
+func assetExists(ctx context.Context, cfg *ImportConfig,
+	locator proof.Locator) (bool, error) {
+
+	var store proof.Exporter = cfg.ProofArchive
+	if cfg.WalletProofs != nil {
+		store = cfg.WalletProofs
+	}
+
+	_, err := store.FetchProof(ctx, locator)
+	switch {
+	case err == nil:
+		return true, nil
+
+	case errors.Is(err, proof.ErrProofNotFound):
+		return false, nil
+
+	default:
+		return false, err
+	}
 }
 
 // extractGroupKeys extracts group public keys from genesis proofs
@@ -160,6 +261,26 @@ func ImportBackup(ctx context.Context, backupBlob []byte,
 
 	log.Infof("Importing assets from backup (%d bytes)",
 		len(backupBlob))
+
+	// The on-disk backup file is encrypted with a key derived from the
+	// lnd wallet. Plaintext exports are accepted as before.
+	if IsEncryptedBackup(backupBlob) {
+		if cfg.KeyDeriver == nil {
+			return 0, 0, ErrNoKeyDeriver
+		}
+
+		encrypter, err := NewKeyRingEncrypter(ctx, cfg.KeyDeriver)
+		if err != nil {
+			return 0, 0, err
+		}
+
+		backupBlob, err = DecryptBackup(encrypter, backupBlob)
+		if err != nil {
+			return 0, 0, err
+		}
+
+		log.Infof("Decrypted backup (%d bytes)", len(backupBlob))
+	}
 
 	// Decode and verify the backup.
 	walletBackup, err := DecodeWalletBackup(backupBlob)
@@ -293,16 +414,16 @@ func ImportBackup(ctx context.Context, backupBlob []byte,
 			OutPoint:  &assetBackup.AnchorOutpoint,
 		}
 
-		_, err := cfg.ProofArchive.FetchProof(ctx, locator)
-		if err == nil {
-			log.Debugf("Asset %d already exists, "+
-				"skipping", i)
-			continue
-		}
-		if !errors.Is(err, proof.ErrProofNotFound) {
+		exists, err := assetExists(ctx, cfg, locator)
+		if err != nil {
 			return numImported, numSkipped,
 				fmt.Errorf("error checking existing "+
 					"asset %d: %w", i, err)
+		}
+		if exists {
+			log.Debugf("Asset %d already exists, "+
+				"skipping", i)
+			continue
 		}
 
 		// For v2+ backups, rehydrate the stripped proof by
@@ -394,10 +515,29 @@ func ImportBackup(ctx context.Context, backupBlob []byte,
 		// Key registration errors are fatal since they
 		// indicate DB/infrastructure problems.
 
+		// Entries without the public keys they claim to describe
+		// cannot be registered and would not be spendable, so they
+		// count as data errors rather than crash the import.
+		if !keyMaterialComplete(assetBackup) {
+			log.Warnf("Skipping asset %d (id=%x): incomplete "+
+				"key material", i, assetID[:])
+			numSkipped++
+			continue
+		}
+
 		// Register the anchor internal key so LND can sign
-		// for the anchor output when spending.
-		if assetBackup.AnchorInternalKeyInfo != nil {
-			info := assetBackup.AnchorInternalKeyInfo
+		// for the anchor output when spending. An entry without
+		// a locator describes a key the exporting wallet did not
+		// own, registering it would only record a derivation
+		// path of zero that lnd cannot use.
+		info := assetBackup.AnchorInternalKeyInfo
+		if info != nil && info.KeyLocator == (keychain.KeyLocator{}) {
+			log.Debugf("Asset %d: anchor key %x has no "+
+				"locator, not registering it", i,
+				info.PubKey.SerializeCompressed())
+			info = nil
+		}
+		if info != nil {
 			anchorKey := keychain.KeyDescriptor{
 				PubKey:     info.PubKey,
 				KeyLocator: info.KeyLocator,
@@ -425,14 +565,14 @@ func ImportBackup(ctx context.Context, backupBlob []byte,
 				TweakedScriptKey: &asset.TweakedScriptKey{
 					RawKey: skInfo.RawKey,
 					Tweak:  skInfo.Tweak,
+					Type:   skInfo.Type,
 				},
 			}
 
-			scriptKeyType := asset.ScriptKeyBip86
-			if len(skInfo.Tweak) > 0 {
-				scriptKeyType =
-					asset.ScriptKeyScriptPathExternal
-			}
+			scriptKeyType := scriptKeyTypeForImport(
+				scriptKey, assetBackup.Asset,
+			)
+			scriptKey.TweakedScriptKey.Type = scriptKeyType
 
 			err = cfg.KeyRegistrar.InsertScriptKey(
 				ctx, scriptKey, scriptKeyType,

--- a/backup/import_test.go
+++ b/backup/import_test.go
@@ -1,0 +1,431 @@
+package backup
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/lightninglabs/taproot-assets/address"
+	"github.com/lightninglabs/taproot-assets/asset"
+	"github.com/lightninglabs/taproot-assets/internal/test"
+	"github.com/lightninglabs/taproot-assets/proof"
+	"github.com/lightningnetwork/lnd/keychain"
+	"github.com/stretchr/testify/require"
+)
+
+// TestScriptKeyTypeForImport asserts how restored script keys are classified.
+// The important case is a unique Pedersen key from a V2 address receive: it
+// carries a tweak, so a tweak based guess would file it as an external script
+// path key and hide the asset from default listings and coin selection.
+func TestScriptKeyTypeForImport(t *testing.T) {
+	t.Parallel()
+
+	rawKey := keychain.KeyDescriptor{
+		PubKey:     test.RandPubKey(t),
+		KeyLocator: keychain.KeyLocator{Family: 212, Index: 3},
+	}
+	untyped := func(sk asset.ScriptKey) asset.ScriptKey {
+		sk.TweakedScriptKey.Type = asset.ScriptKeyUnknown
+		return sk
+	}
+
+	// The classifier only reads the ID and the first witness from the
+	// asset.
+	testAsset := newTestAsset(t)
+	assetID := testAsset.ID()
+
+	t.Run("declared type wins", func(t *testing.T) {
+		sk := asset.NewScriptKeyBip86(rawKey)
+		sk.TweakedScriptKey.Type = asset.ScriptKeyScriptPathChannel
+		require.Equal(t, asset.ScriptKeyScriptPathChannel,
+			scriptKeyTypeForImport(sk, testAsset))
+	})
+
+	t.Run("bip86 derived", func(t *testing.T) {
+		sk := untyped(asset.NewScriptKeyBip86(rawKey))
+		require.Equal(t, asset.ScriptKeyBip86,
+			scriptKeyTypeForImport(sk, testAsset))
+	})
+
+	t.Run("tombstone by NUMS key", func(t *testing.T) {
+		sk := asset.ScriptKey{
+			PubKey:           asset.NUMSPubKey,
+			TweakedScriptKey: &asset.TweakedScriptKey{},
+		}
+		require.Equal(t, asset.ScriptKeyTombstone,
+			scriptKeyTypeForImport(sk, testAsset))
+
+		// Even with a raw key attached, NUMS is a tombstone, never
+		// BIP-86. All tombstones share one script key row, so a
+		// wrong classification would leak into every tombstone.
+		sk.TweakedScriptKey.RawKey = rawKey
+		require.Equal(t, asset.ScriptKeyTombstone,
+			scriptKeyTypeForImport(sk, testAsset))
+	})
+
+	t.Run("burn key from first witness", func(t *testing.T) {
+		burnAsset := *testAsset
+		prevID := asset.PrevID{
+			OutPoint:  wire.OutPoint{Index: 7},
+			ID:        asset.ID{3},
+			ScriptKey: asset.ToSerialized(test.RandPubKey(t)),
+		}
+		burnAsset.PrevWitnesses = []asset.Witness{{PrevID: &prevID}}
+		sk := asset.ScriptKey{
+			PubKey:           asset.DeriveBurnKey(prevID),
+			TweakedScriptKey: &asset.TweakedScriptKey{},
+		}
+		require.Equal(t, asset.ScriptKeyBurn,
+			scriptKeyTypeForImport(sk, &burnAsset))
+	})
+
+	t.Run("unique pedersen derived", func(t *testing.T) {
+		sk, err := asset.DeriveUniqueScriptKey(
+			*rawKey.PubKey, assetID,
+			asset.ScriptKeyDerivationUniquePedersen,
+		)
+		require.NoError(t, err)
+		require.NotEmpty(t, sk.TweakedScriptKey.Tweak)
+		sk.TweakedScriptKey.RawKey = rawKey
+
+		require.Equal(t, asset.ScriptKeyUniquePedersen,
+			scriptKeyTypeForImport(untyped(sk), testAsset))
+
+		// A different asset does not derive the same key, so it
+		// falls through to the tweaked classification.
+		other := newTestAsset(t)
+		other.Genesis.Tag = "other"
+		require.NotEqual(t, assetID, other.ID())
+		require.Equal(t, asset.ScriptKeyScriptPathExternal,
+			scriptKeyTypeForImport(untyped(sk), other))
+	})
+
+	t.Run("other tweak is external script path", func(t *testing.T) {
+		sk := asset.ScriptKey{
+			PubKey: test.RandPubKey(t),
+			TweakedScriptKey: &asset.TweakedScriptKey{
+				RawKey: rawKey,
+				Tweak:  []byte("some tapscript root"),
+			},
+		}
+		require.Equal(t, asset.ScriptKeyScriptPathExternal,
+			scriptKeyTypeForImport(sk, testAsset))
+	})
+
+	t.Run("no raw key and no tweak", func(t *testing.T) {
+		sk := asset.ScriptKey{
+			PubKey:           test.RandPubKey(t),
+			TweakedScriptKey: &asset.TweakedScriptKey{},
+		}
+		require.Equal(t, asset.ScriptKeyBip86,
+			scriptKeyTypeForImport(sk, testAsset))
+	})
+
+	t.Run("missing material", func(t *testing.T) {
+		require.Equal(t, asset.ScriptKeyUnknown,
+			scriptKeyTypeForImport(asset.ScriptKey{}, testAsset))
+		require.Equal(t, asset.ScriptKeyUnknown,
+			scriptKeyTypeForImport(
+				asset.NewScriptKeyBip86(rawKey), nil,
+			))
+	})
+}
+
+// TestKeyMaterialComplete asserts that entries missing the public keys they
+// describe are recognised, so the import skips them instead of crashing.
+func TestKeyMaterialComplete(t *testing.T) {
+	t.Parallel()
+
+	complete := newTestAssetBackupV2(t)
+	require.True(t, keyMaterialComplete(complete))
+
+	noKeys := newTestAssetBackupV2(t)
+	noKeys.ScriptKeyInfo = nil
+	noKeys.AnchorInternalKeyInfo = nil
+	require.True(t, keyMaterialComplete(noKeys))
+
+	noScriptPub := newTestAssetBackupV2(t)
+	noScriptPub.ScriptKeyInfo.PubKey = nil
+	require.False(t, keyMaterialComplete(noScriptPub))
+
+	noRawPub := newTestAssetBackupV2(t)
+	noRawPub.ScriptKeyInfo.RawKey.PubKey = nil
+	require.False(t, keyMaterialComplete(noRawPub))
+
+	noAnchorPub := newTestAssetBackupV2(t)
+	noAnchorPub.AnchorInternalKeyInfo.PubKey = nil
+	require.False(t, keyMaterialComplete(noAnchorPub))
+}
+
+// lookupErr is a KeyLocatorLookup that always fails with the given error.
+type lookupErr struct {
+	err error
+}
+
+func (l lookupErr) FetchInternalKeyLocator(context.Context,
+	*btcec.PublicKey) (keychain.KeyLocator, error) {
+
+	return keychain.KeyLocator{}, l.err
+}
+
+// TestCreateAssetBackupKeyLookupErrors asserts that an unknown anchor key
+// yields an entry with the public key only, while any other lookup failure
+// fails the entry instead of recording a zero locator.
+func TestCreateAssetBackupKeyLookupErrors(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	chainAsset := &asset.ChainAsset{
+		Asset:             newTestAsset(t),
+		AnchorInternalKey: test.RandPubKey(t),
+	}
+
+	for _, notFound := range []error{
+		ErrKeyLocatorNotFound, address.ErrInternalKeyNotFound,
+	} {
+		ab, err := createAssetBackup(
+			ctx, chainAsset, nil, lookupErr{err: notFound},
+		)
+		require.NoError(t, err)
+		require.True(t, chainAsset.AnchorInternalKey.IsEqual(
+			ab.AnchorInternalKeyInfo.PubKey,
+		))
+		require.Equal(t, keychain.KeyLocator{},
+			ab.AnchorInternalKeyInfo.KeyLocator)
+	}
+
+	_, err := createAssetBackup(
+		ctx, chainAsset, nil, lookupErr{err: errors.New("db locked")},
+	)
+	require.ErrorContains(t, err, "db locked")
+}
+
+// TestCreateAssetBackupRecordsType asserts the export records the script key
+// type, taking the stored type and otherwise deriving it.
+func TestCreateAssetBackupRecordsType(t *testing.T) {
+	t.Parallel()
+
+	rawKey := keychain.KeyDescriptor{
+		PubKey:     test.RandPubKey(t),
+		KeyLocator: keychain.KeyLocator{Family: 212, Index: 1},
+	}
+
+	// Stored type wins.
+	a := newTestAsset(t)
+	a.ScriptKey = asset.NewScriptKeyBip86(rawKey)
+	a.ScriptKey.TweakedScriptKey.Type = asset.ScriptKeyUniquePedersen
+	ab, err := createAssetBackup(
+		context.Background(), &asset.ChainAsset{Asset: a}, nil, nil,
+	)
+	require.NoError(t, err)
+	require.Equal(t, asset.ScriptKeyUniquePedersen, ab.ScriptKeyInfo.Type)
+
+	// Unknown stored type is derived from the key material.
+	a.ScriptKey.TweakedScriptKey.Type = asset.ScriptKeyUnknown
+	ab, err = createAssetBackup(
+		context.Background(), &asset.ChainAsset{Asset: a}, nil, nil,
+	)
+	require.NoError(t, err)
+	require.Equal(t, asset.ScriptKeyBip86, ab.ScriptKeyInfo.Type)
+}
+
+// TestScriptKeyBackupTypeEncoding asserts the type round trips and that a
+// backup written without it decodes to an unknown type.
+func TestScriptKeyBackupTypeEncoding(t *testing.T) {
+	t.Parallel()
+
+	sk := newTestScriptKeyBackup(t)
+	sk.Type = asset.ScriptKeyUniquePedersen
+
+	var buf bytes.Buffer
+	require.NoError(t, sk.Encode(&buf))
+
+	var decoded ScriptKeyBackup
+	require.NoError(t, decoded.Decode(&buf))
+	require.Equal(t, asset.ScriptKeyUniquePedersen, decoded.Type)
+
+	// A type this decoder does not know reads back as unknown, so the
+	// importer classifies from the key material instead of registering
+	// a type no filter matches.
+	sk.Type = asset.ScriptKeyType(200)
+	buf.Reset()
+	require.NoError(t, sk.Encode(&buf))
+	var future ScriptKeyBackup
+	require.NoError(t, future.Decode(&buf))
+	require.Equal(t, asset.ScriptKeyUnknown, future.Type)
+
+	// Without a type nothing is written for it and it reads back as
+	// unknown, which the import then classifies from the key material.
+	sk.Type = asset.ScriptKeyUnknown
+	buf.Reset()
+	require.NoError(t, sk.Encode(&buf))
+
+	var legacy ScriptKeyBackup
+	require.NoError(t, legacy.Decode(&buf))
+	require.Equal(t, asset.ScriptKeyUnknown, legacy.Type)
+}
+
+// staticExporter is a proof.Exporter that answers every lookup the same way.
+type staticExporter struct {
+	err error
+}
+
+func (s *staticExporter) FetchProof(context.Context,
+	proof.Locator) (proof.Blob, error) {
+
+	if s.err != nil {
+		return nil, s.err
+	}
+
+	return proof.Blob("found"), nil
+}
+
+// TestAssetExists asserts that the existence check consults the wallet
+// database store when one is configured, and only falls back to the full
+// archive without it. A proof file left on disk must not make an asset look
+// like it is already part of a wiped wallet.
+func TestAssetExists(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	found := &staticExporter{}
+	missing := &staticExporter{err: proof.ErrProofNotFound}
+	broken := &staticExporter{err: errors.New("db locked")}
+
+	t.Run("wallet store wins over archive", func(t *testing.T) {
+		exists, err := assetExists(ctx, &ImportConfig{
+			ProofArchive: proof.NewMockProofArchive(),
+			WalletProofs: missing,
+		}, proof.Locator{})
+		require.NoError(t, err)
+		require.False(t, exists)
+
+		exists, err = assetExists(ctx, &ImportConfig{
+			ProofArchive: proof.NewMockProofArchive(),
+			WalletProofs: found,
+		}, proof.Locator{})
+		require.NoError(t, err)
+		require.True(t, exists)
+	})
+
+	t.Run("archive fallback", func(t *testing.T) {
+		exists, err := assetExists(ctx, &ImportConfig{
+			ProofArchive: proof.NewMockProofArchive(),
+		}, proof.Locator{})
+		require.NoError(t, err)
+		require.False(t, exists)
+	})
+
+	t.Run("store error is fatal", func(t *testing.T) {
+		_, err := assetExists(ctx, &ImportConfig{
+			ProofArchive: proof.NewMockProofArchive(),
+			WalletProofs: broken,
+		}, proof.Locator{})
+		require.ErrorContains(t, err, "db locked")
+	})
+}
+
+// TestImportBackupEncrypted covers the decryption gate at the start of
+// ImportBackup. The config deliberately carries only a key deriver: any path
+// that reaches the chain or archive would dereference nil and panic, which
+// proves the encrypted cases are decided before any other dependency is used.
+func TestImportBackupEncrypted(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	deriver := newMockKeyDeriver(t)
+	encrypter := newTestEncrypter(t, deriver)
+
+	// An empty wallet backup needs no chain access to import, so the
+	// happy path can run end to end with an otherwise empty config.
+	plaintext, err := EncodeWalletBackup(&WalletBackup{
+		Version: BackupVersionStripped,
+	})
+	require.NoError(t, err)
+
+	packed, err := EncryptBackup(encrypter, plaintext)
+	require.NoError(t, err)
+
+	t.Run("no key deriver", func(t *testing.T) {
+		_, _, err := ImportBackup(ctx, packed, &ImportConfig{})
+		require.ErrorIs(t, err, ErrNoKeyDeriver)
+	})
+
+	t.Run("wrong key", func(t *testing.T) {
+		_, _, err := ImportBackup(ctx, packed, &ImportConfig{
+			KeyDeriver: newMockKeyDeriver(t),
+		})
+		require.ErrorContains(t, err, "unable to decrypt")
+	})
+
+	t.Run("key derivation fails", func(t *testing.T) {
+		bad := newMockKeyDeriver(t)
+		bad.err = context.DeadlineExceeded
+
+		_, _, err := ImportBackup(ctx, packed, &ImportConfig{
+			KeyDeriver: bad,
+		})
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+	})
+
+	t.Run("correct key", func(t *testing.T) {
+		imported, skipped, err := ImportBackup(ctx, packed,
+			&ImportConfig{KeyDeriver: deriver})
+		require.NoError(t, err)
+		require.Zero(t, imported)
+		require.Zero(t, skipped)
+	})
+
+	t.Run("encrypted v1 and v3 payloads", func(t *testing.T) {
+		for _, version := range []uint32{
+			BackupVersionOriginal, BackupVersionOptimistic,
+		} {
+			wb := &WalletBackup{Version: version}
+			if version == BackupVersionOptimistic {
+				wb.FederationURLs = []string{"u:1"}
+			}
+			plain, err := EncodeWalletBackup(wb)
+			require.NoError(t, err)
+			enc, err := EncryptBackup(encrypter, plain)
+			require.NoError(t, err)
+
+			imported, skipped, err := ImportBackup(ctx, enc,
+				&ImportConfig{KeyDeriver: deriver})
+			require.NoError(t, err)
+			require.Zero(t, imported)
+			require.Zero(t, skipped)
+		}
+	})
+
+	t.Run("garbage plaintext", func(t *testing.T) {
+		enc, err := EncryptBackup(encrypter, []byte("not a backup"))
+		require.NoError(t, err)
+
+		_, _, err = ImportBackup(ctx, enc, &ImportConfig{
+			KeyDeriver: deriver,
+		})
+		require.ErrorContains(t, err, "failed to decode backup")
+	})
+
+	t.Run("plaintext still accepted", func(t *testing.T) {
+		imported, skipped, err := ImportBackup(
+			ctx, plaintext, &ImportConfig{},
+		)
+		require.NoError(t, err)
+		require.Zero(t, imported)
+		require.Zero(t, skipped)
+	})
+
+	t.Run("tampered ciphertext", func(t *testing.T) {
+		tampered := append([]byte{}, packed...)
+		tampered[len(tampered)-1] ^= 0x01
+
+		_, _, err := ImportBackup(ctx, tampered, &ImportConfig{
+			KeyDeriver: deriver,
+		})
+		require.ErrorContains(t, err, "unable to decrypt")
+	})
+}

--- a/backup/updater.go
+++ b/backup/updater.go
@@ -1,0 +1,761 @@
+package backup
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"slices"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/lightninglabs/taproot-assets/asset"
+	"github.com/lightninglabs/taproot-assets/fn"
+	"github.com/lightninglabs/taproot-assets/proof"
+	"github.com/lightningnetwork/lnd/lnencrypt"
+)
+
+const (
+	// DefaultDebounce is the default amount of time the Updater waits
+	// after the first wallet change notification before it reconciles
+	// and rewrites the backup file. A single on-chain confirmation can
+	// emit many proof notifications (active outputs, change, passive
+	// assets), so coalescing them avoids one rewrite per notification.
+	DefaultDebounce = time.Second
+
+	// DefaultRetryInterval is the default amount of time the Updater waits
+	// before retrying after a reconcile that failed or could not back up
+	// every asset.
+	DefaultRetryInterval = 30 * time.Second
+
+	// startupTimeout bounds the key derivation and the check of the
+	// existing file that happen synchronously in Start.
+	startupTimeout = 2 * time.Minute
+
+	// shutdownSyncTimeout bounds the final reconcile that happens in Stop.
+	shutdownSyncTimeout = 30 * time.Second
+)
+
+var (
+	// ErrUpdaterNotActive is returned when a manual sync is requested
+	// while the Updater is not running.
+	ErrUpdaterNotActive = errors.New("backup updater is not active")
+)
+
+// AssetFetcher returns the current set of unspent wallet assets that should
+// be part of the backup. Filtering of unconfirmed assets is done by the
+// Updater.
+type AssetFetcher func(ctx context.Context) ([]*asset.ChainAsset, error)
+
+// SpentLookup reports whether the wallet database knows the leaf identified
+// by script key and anchor outpoint and has it marked as spent. It is used to
+// prune leaves from the file that were spent while the Updater was not
+// running. Leaves the database does not know at all are not spent.
+type SpentLookup func(ctx context.Context, scriptKey *btcec.PublicKey,
+	anchorPoint wire.OutPoint) (bool, error)
+
+// ProofNotifier is the event publisher the Updater subscribes to in order to
+// learn about received, transferred and re-anchored assets. Every new or
+// replaced asset proof in the local asset store is published on it.
+type ProofNotifier = fn.EventPublisher[proof.Blob, []*proof.Locator]
+
+// EventNotifier is a generic event publisher the Updater subscribes to in
+// addition to the proof notifier. Two wallet changes leave no trace in the
+// proof notifications: a mint stores its proof file before it writes the
+// confirmed asset, so the proof notification alone would race the database
+// write, and a full value send without change or tombstone output creates no
+// local proof at all. The planter and the chain porter publish state change
+// events for both, after the database write.
+type EventNotifier = fn.EventPublisher[fn.Event, bool]
+
+// UpdaterConfig holds the dependencies of the Updater.
+type UpdaterConfig struct {
+	// FetchAssets returns the current set of unspent wallet assets.
+	FetchAssets AssetFetcher
+
+	// LookupSpent reports whether the database knows a leaf as spent. It
+	// is consulted for entries that are only found on disk, so a leaf
+	// spent while the Updater was down does not stay in the file forever.
+	// Optional, without it disk-only entries are always retained.
+	LookupSpent SpentLookup
+
+	// ProofArchive is used to fetch the proof file of each asset.
+	ProofArchive proof.Exporter
+
+	// KeyLookup is used to resolve anchor internal key locators.
+	KeyLookup KeyLocatorLookup
+
+	// ProofNotifier publishes proof import events that signal wallet
+	// state changes.
+	ProofNotifier ProofNotifier
+
+	// EventNotifiers publish state changes of the subsystems that modify
+	// the wallet without necessarily importing a proof: the planter (mints)
+	// and the chain porter (sends). Optional.
+	EventNotifiers []EventNotifier
+
+	// KeyDeriver derives the backup encryption key from the lnd wallet.
+	KeyDeriver KeyDeriver
+
+	// Swapper persists the packed backup.
+	Swapper Swapper
+
+	// Debounce is how long to wait after the first change notification
+	// before reconciling. Zero selects DefaultDebounce.
+	Debounce time.Duration
+
+	// RetryInterval is how long to wait before retrying a failed
+	// reconcile. Zero selects DefaultRetryInterval.
+	RetryInterval time.Duration
+}
+
+// entryKey uniquely identifies an asset leaf within the backup.
+type entryKey struct {
+	assetID   asset.ID
+	scriptKey asset.SerializedKey
+	outpoint  wire.OutPoint
+}
+
+// bytes returns a fixed layout serialization of the key that is used for
+// deterministic ordering of the backup entries.
+func (k entryKey) bytes() []byte {
+	var buf bytes.Buffer
+	buf.Write(k.assetID[:])
+	buf.Write(k.scriptKey[:])
+	buf.Write(k.outpoint.Hash[:])
+
+	var idx [4]byte
+	binary.BigEndian.PutUint32(idx[:], k.outpoint.Index)
+	buf.Write(idx[:])
+
+	return buf.Bytes()
+}
+
+// keyForChainAsset returns the entry key for a chain asset.
+func keyForChainAsset(a *asset.ChainAsset) entryKey {
+	return entryKey{
+		assetID:   a.ID(),
+		scriptKey: asset.ToSerialized(a.ScriptKey.PubKey),
+		outpoint:  a.AnchorOutpoint,
+	}
+}
+
+// keyForBackup returns the entry key for a backup entry. The boolean is false
+// if the entry is missing the fields needed to identify it.
+func keyForBackup(ab *AssetBackup) (entryKey, bool) {
+	if ab == nil || ab.Asset == nil || ab.Asset.ScriptKey.PubKey == nil {
+		return entryKey{}, false
+	}
+
+	return entryKey{
+		assetID:   ab.Asset.ID(),
+		scriptKey: asset.ToSerialized(ab.Asset.ScriptKey.PubKey),
+		outpoint:  ab.AnchorOutpoint,
+	}, true
+}
+
+// trackedEntry is an in-memory backup entry together with the anchor block
+// hash it was built from, so a re-org that re-anchors the same leaf in a
+// different block is detected and the entry rebuilt.
+type trackedEntry struct {
+	backup    *AssetBackup
+	blockHash chainhash.Hash
+}
+
+// syncRequest is a request to reconcile immediately and report the result.
+type syncRequest struct {
+	errChan chan error
+}
+
+// Updater keeps an encrypted asset wallet backup file on disk in sync with the
+// wallet state. It mirrors lnd's chanbackup.SubSwapper: it holds the current
+// set of backup entries in memory, subscribes to wallet change notifications,
+// and on every change reconciles the in-memory set against the database and
+// atomically rewrites the file. Entries found on disk that the database does
+// not know about are retained, entries for spent leaves are removed.
+type Updater struct {
+	startOnce sync.Once
+	stopOnce  sync.Once
+
+	cfg *UpdaterConfig
+
+	encrypter lnencrypt.EncrypterDecrypter
+
+	receiver       *fn.EventReceiver[proof.Blob]
+	eventReceivers []*fn.EventReceiver[fn.Event]
+
+	// entries is the in-memory backup state. It is only accessed from
+	// Start (before the main loop runs) and from the main loop itself.
+	entries map[entryKey]trackedEntry
+
+	// pendingRemovals holds the keys of leaves that were removed from the
+	// in-memory state but whose removal has not yet been persisted. They
+	// are dropped from the disk union on the next successful write.
+	pendingRemovals map[entryKey]struct{}
+
+	// dirty is true if the in-memory state has changes that have not been
+	// persisted yet. It is cleared by a successful write only, so a failed
+	// write is retried even if no further change happens.
+	dirty bool
+
+	syncReqs chan syncRequest
+
+	isActive atomic.Bool
+
+	ctx    context.Context //nolint:containedctx
+	cancel context.CancelFunc
+
+	quit chan struct{}
+	wg   sync.WaitGroup
+}
+
+// NewUpdater creates a new Updater from the given config.
+func NewUpdater(cfg *UpdaterConfig) (*Updater, error) {
+	switch {
+	case cfg == nil:
+		return nil, fmt.Errorf("updater config is nil")
+	case cfg.FetchAssets == nil:
+		return nil, fmt.Errorf("updater requires an asset fetcher")
+	case cfg.ProofArchive == nil:
+		return nil, fmt.Errorf("updater requires a proof archive")
+	case cfg.ProofNotifier == nil:
+		return nil, fmt.Errorf("updater requires a proof notifier")
+	case cfg.KeyDeriver == nil:
+		return nil, fmt.Errorf("updater requires a key deriver")
+	case cfg.Swapper == nil:
+		return nil, fmt.Errorf("updater requires a swapper")
+	}
+
+	if cfg.Debounce <= 0 {
+		cfg.Debounce = DefaultDebounce
+	}
+	if cfg.RetryInterval <= 0 {
+		cfg.RetryInterval = DefaultRetryInterval
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	return &Updater{
+		cfg:             cfg,
+		entries:         make(map[entryKey]trackedEntry),
+		pendingRemovals: make(map[entryKey]struct{}),
+		syncReqs:        make(chan syncRequest),
+		ctx:             ctx,
+		cancel:          cancel,
+		quit:            make(chan struct{}),
+	}, nil
+}
+
+// Start derives the encryption key, checks that any existing backup file can
+// be read with it, subscribes to wallet changes and starts the background
+// loop, which immediately reconciles the file against the database. An
+// existing backup file that cannot be decrypted with the wallet's key is a
+// fatal error, since it most likely belongs to a different seed.
+func (u *Updater) Start() error {
+	var startErr error
+	u.startOnce.Do(func() {
+		log.Infof("Starting asset wallet backup file updater")
+
+		ctx, cancel := context.WithTimeout(u.ctx, startupTimeout)
+		defer cancel()
+
+		encrypter, err := NewKeyRingEncrypter(ctx, u.cfg.KeyDeriver)
+		if err != nil {
+			startErr = err
+			return
+		}
+		u.encrypter = encrypter
+
+		// Make sure we can read what is already there before we
+		// commit to rewriting it.
+		if _, err := u.readDisk(); err != nil {
+			startErr = err
+			return
+		}
+
+		// Subscribe before the initial reconcile so no change that
+		// lands in between is missed.
+		u.receiver = fn.NewEventReceiver[proof.Blob](
+			fn.DefaultQueueSize,
+		)
+		err = u.cfg.ProofNotifier.RegisterSubscriber(
+			u.receiver, false, nil,
+		)
+		if err != nil {
+			u.receiver.Stop()
+			u.receiver = nil
+			startErr = fmt.Errorf("unable to subscribe to proof "+
+				"events: %w", err)
+			return
+		}
+
+		for _, notifier := range u.cfg.EventNotifiers {
+			eventReceiver := fn.NewEventReceiver[fn.Event](
+				fn.DefaultQueueSize,
+			)
+			err = notifier.RegisterSubscriber(
+				eventReceiver, false, false,
+			)
+			if err != nil {
+				eventReceiver.Stop()
+				u.unsubscribe()
+				startErr = fmt.Errorf("unable to subscribe to "+
+					"wallet events: %w", err)
+				return
+			}
+			u.eventReceivers = append(
+				u.eventReceivers, eventReceiver,
+			)
+		}
+
+		u.isActive.Store(true)
+
+		u.wg.Add(1)
+		go u.mainLoop()
+	})
+
+	return startErr
+}
+
+// Stop performs a final reconcile so the file reflects the latest wallet
+// state, then shuts the background loop down. The loop is always shut down,
+// but a failed final reconcile is returned so the shutdown does not look
+// clean while the file is stale.
+func (u *Updater) Stop() error {
+	var stopErr error
+	u.stopOnce.Do(func() {
+		log.Infof("Stopping asset wallet backup file updater")
+
+		if u.isActive.Load() {
+			ctx, cancel := context.WithTimeout(
+				context.Background(), shutdownSyncTimeout,
+			)
+			err := u.Sync(ctx)
+			cancel()
+			if err != nil {
+				log.Errorf("Final backup file sync failed: %v",
+					err)
+				stopErr = fmt.Errorf("final backup file "+
+					"sync failed: %w", err)
+			}
+		}
+
+		u.isActive.Store(false)
+		u.cancel()
+		close(u.quit)
+		u.wg.Wait()
+
+		u.unsubscribe()
+	})
+
+	return stopErr
+}
+
+// unsubscribe removes the change subscriptions that were registered in Start.
+func (u *Updater) unsubscribe() {
+	// The publishers may already have shut down and dropped their
+	// subscribers, in which case removal reports the subscriber as
+	// unknown. That is expected on shutdown, so it is not worth a warning.
+	if u.receiver != nil {
+		err := u.cfg.ProofNotifier.RemoveSubscriber(u.receiver)
+		if err != nil {
+			log.Debugf("Unable to remove proof subscriber: %v", err)
+		}
+		u.receiver = nil
+	}
+
+	// The receivers were registered in config order, so they pair up
+	// with the notifiers by index.
+	for idx, eventReceiver := range u.eventReceivers {
+		err := u.cfg.EventNotifiers[idx].RemoveSubscriber(eventReceiver)
+		if err != nil {
+			log.Debugf("Unable to remove event subscriber: %v", err)
+		}
+	}
+	u.eventReceivers = nil
+}
+
+// Sync forces an immediate reconcile and blocks until the file has been
+// rewritten or the context expires. An error is returned if the write failed
+// or if any asset could not be backed up.
+func (u *Updater) Sync(ctx context.Context) error {
+	if !u.isActive.Load() {
+		return ErrUpdaterNotActive
+	}
+
+	req := syncRequest{errChan: make(chan error, 1)}
+
+	select {
+	case u.syncReqs <- req:
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-u.quit:
+		return ErrUpdaterNotActive
+	}
+
+	select {
+	case err := <-req.errChan:
+		return err
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-u.quit:
+		return ErrUpdaterNotActive
+	}
+}
+
+// mainLoop writes the initial state, then waits for change notifications,
+// debounces them and reconciles.
+func (u *Updater) mainLoop() {
+	defer u.wg.Done()
+
+	var (
+		timer   *time.Timer
+		timerCh <-chan time.Time
+
+		// retrying is true while the armed timer is a retry after a
+		// failure rather than a debounce of fresh changes.
+		retrying bool
+	)
+	arm := func(d time.Duration, retry bool) {
+		if timer != nil {
+			timer.Stop()
+		}
+		timer = time.NewTimer(d)
+		timerCh = timer.C
+		retrying = retry
+	}
+	disarm := func() {
+		if timer != nil {
+			timer.Stop()
+		}
+		timer = nil
+		timerCh = nil
+		retrying = false
+	}
+	defer disarm()
+
+	// handleResult logs the outcome of a reconcile and arms the retry
+	// timer if anything is left to do.
+	handleResult := func(failed int, err error) {
+		switch {
+		case err != nil:
+			log.Errorf("Unable to update backup file: %v, "+
+				"retrying in %v", err, u.cfg.RetryInterval)
+			arm(u.cfg.RetryInterval, true)
+
+		case failed > 0:
+			log.Warnf("%d asset(s) could not be backed up, "+
+				"retrying in %v", failed, u.cfg.RetryInterval)
+			arm(u.cfg.RetryInterval, true)
+		}
+	}
+
+	// The initial write always happens, so the file reflects the database
+	// state even if nothing changes for a long time after startup.
+	handleResult(u.reconcile(u.ctx, true))
+
+	// Only arm the debounce timer for the first notification of a burst,
+	// later ones fold into it. A change that arrives while a retry is
+	// pending pulls the retry forward to the debounce delay, so a fresh
+	// change is not held back by an earlier failure.
+	onChange := func() {
+		if timerCh == nil || retrying {
+			arm(u.cfg.Debounce, false)
+		}
+	}
+
+	// Fan all generic event receivers into one channel so the loop below
+	// can select on a fixed set of cases.
+	events := make(chan struct{}, 1)
+	for _, eventReceiver := range u.eventReceivers {
+		u.wg.Add(1)
+		go func(in <-chan fn.Event) {
+			defer u.wg.Done()
+
+			for {
+				select {
+				case <-in:
+					select {
+					case events <- struct{}{}:
+					case <-u.quit:
+						return
+					}
+
+				case <-u.quit:
+					return
+				}
+			}
+		}(eventReceiver.NewItemCreated.ChanOut())
+	}
+
+	for {
+		select {
+		case <-u.receiver.NewItemCreated.ChanOut():
+			onChange()
+
+		case <-events:
+			onChange()
+
+		case <-timerCh:
+			disarm()
+			handleResult(u.reconcile(u.ctx, false))
+
+		case req := <-u.syncReqs:
+			disarm()
+
+			failed, err := u.reconcile(u.ctx, false)
+			if err == nil && failed > 0 {
+				err = fmt.Errorf("%d asset(s) could not be "+
+					"backed up", failed)
+			}
+			if err != nil {
+				arm(u.cfg.RetryInterval, true)
+			}
+			req.errChan <- err
+
+		case <-u.quit:
+			return
+		}
+	}
+}
+
+// reconcile fetches the current wallet state, updates the in-memory entry set
+// and, if anything changed (or force is set), rewrites the backup file. It
+// returns the number of assets that could not be turned into backup entries;
+// those are retried on the next reconcile. The error is only non-nil for
+// failures that affect the whole file.
+func (u *Updater) reconcile(ctx context.Context, force bool) (int, error) {
+	assets, err := u.cfg.FetchAssets(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("unable to fetch assets: %w", err)
+	}
+
+	current := make(map[entryKey]*asset.ChainAsset, len(assets))
+	for _, a := range assets {
+		if a == nil || a.Asset == nil || a.ScriptKey.PubKey == nil {
+			continue
+		}
+
+		// Unconfirmed leaves have no anchor block yet, they enter
+		// the backup once their anchor transaction confirms.
+		if a.AnchorBlockHeight == 0 {
+			continue
+		}
+
+		current[keyForChainAsset(a)] = a
+	}
+
+	// Leaves that are no longer part of the unspent set were spent, drop
+	// them from memory and remember to drop them from disk too.
+	numRemoved := 0
+	for key := range u.entries {
+		if _, ok := current[key]; ok {
+			continue
+		}
+
+		delete(u.entries, key)
+		u.pendingRemovals[key] = struct{}{}
+		numRemoved++
+	}
+
+	// New leaves, and leaves whose anchor block changed because of a
+	// re-org, need a fresh backup entry built from their proof.
+	var numAdded, numFailed int
+	for key, chainAsset := range current {
+		existing, ok := u.entries[key]
+		if ok && existing.blockHash == chainAsset.AnchorBlockHash {
+			continue
+		}
+
+		backups, _, err := CollectBackups(
+			ctx, ExportModeCompact,
+			[]*asset.ChainAsset{chainAsset}, u.cfg.ProofArchive,
+			u.cfg.KeyLookup, nil,
+		)
+		if err != nil || len(backups) != 1 {
+			log.Warnf("Unable to build backup entry for asset "+
+				"%x at %v: %v", key.assetID[:], key.outpoint,
+				err)
+			numFailed++
+			continue
+		}
+
+		u.entries[key] = trackedEntry{
+			backup:    backups[0],
+			blockHash: chainAsset.AnchorBlockHash,
+		}
+		delete(u.pendingRemovals, key)
+		numAdded++
+	}
+
+	u.dirty = u.dirty || force || numAdded > 0 ||
+		len(u.pendingRemovals) > 0
+	if !u.dirty {
+		return numFailed, nil
+	}
+
+	log.Infof("Updating backup file: %d wallet entries (%d added, %d "+
+		"removed, %d failed)", len(u.entries), numAdded, numRemoved,
+		numFailed)
+
+	if err := u.updateFile(); err != nil {
+		return numFailed, err
+	}
+
+	return numFailed, nil
+}
+
+// updateFile merges what is currently on disk with the in-memory state (the
+// in-memory state wins on conflicts), drops pending removals, and atomically
+// swaps the encrypted result into place.
+func (u *Updater) updateFile() error {
+	combined := make(map[entryKey]*AssetBackup)
+
+	diskBackup, err := u.readDisk()
+	if err != nil {
+		return err
+	}
+	if diskBackup != nil {
+		for _, ab := range diskBackup.Assets {
+			key, ok := keyForBackup(ab)
+			if !ok {
+				continue
+			}
+			combined[key] = ab
+		}
+	}
+
+	// Entries only found on disk are retained, unless the database knows
+	// them as spent: that happens when a spend confirmed while the
+	// Updater was not running. Leaves the database does not know at all
+	// stay, they may come from a file the operator placed here.
+	for key, ab := range combined {
+		if _, inMemory := u.entries[key]; inMemory {
+			continue
+		}
+		if _, pending := u.pendingRemovals[key]; pending {
+			continue
+		}
+
+		spent, err := u.knownSpent(ab)
+		if err != nil {
+			return err
+		}
+		if spent {
+			log.Infof("Dropping spent leaf %x at %v from backup "+
+				"file", key.assetID[:], key.outpoint)
+			delete(combined, key)
+		}
+	}
+
+	for key, entry := range u.entries {
+		combined[key] = entry.backup
+	}
+	for key := range u.pendingRemovals {
+		delete(combined, key)
+	}
+
+	keys := make([]entryKey, 0, len(combined))
+	for key := range combined {
+		keys = append(keys, key)
+	}
+	slices.SortFunc(keys, func(a, b entryKey) int {
+		return bytes.Compare(a.bytes(), b.bytes())
+	})
+
+	walletBackup := &WalletBackup{
+		Version: BackupVersionStripped,
+		Assets:  make([]*AssetBackup, 0, len(keys)),
+	}
+	for _, key := range keys {
+		walletBackup.Assets = append(walletBackup.Assets, combined[key])
+	}
+
+	plaintext, err := EncodeWalletBackup(walletBackup)
+	if err != nil {
+		return fmt.Errorf("unable to encode backup: %w", err)
+	}
+
+	packed, err := EncryptBackup(u.encrypter, plaintext)
+	if err != nil {
+		return err
+	}
+
+	if err := u.cfg.Swapper.UpdateAndSwap(packed); err != nil {
+		return fmt.Errorf("unable to swap backup file: %w", err)
+	}
+
+	// The in-memory state is now reflected on disk.
+	u.pendingRemovals = make(map[entryKey]struct{})
+	u.dirty = false
+
+	log.Infof("Wrote backup file with %d entries (%d bytes)", len(keys),
+		len(packed))
+
+	return nil
+}
+
+// knownSpent reports whether the database knows the leaf of a disk-only
+// entry as spent.
+func (u *Updater) knownSpent(ab *AssetBackup) (bool, error) {
+	if u.cfg.LookupSpent == nil {
+		return false, nil
+	}
+
+	spent, err := u.cfg.LookupSpent(
+		u.ctx, ab.Asset.ScriptKey.PubKey, ab.AnchorOutpoint,
+	)
+	if err != nil {
+		return false, fmt.Errorf("unable to look up spent state of "+
+			"disk entry: %w", err)
+	}
+
+	return spent, nil
+}
+
+// readDisk reads and decodes the currently persisted backup. It returns nil
+// if nothing is persisted yet. Both encrypted and plaintext files are
+// accepted, so a plaintext export placed at the backup path is picked up and
+// re-written encrypted on the next update. Optimistic (v3) exports are
+// refused, their entries carry no proof data and would be useless once
+// re-written into the compact file.
+func (u *Updater) readDisk() (*WalletBackup, error) {
+	packed, err := u.cfg.Swapper.Extract()
+	switch {
+	case errors.Is(err, ErrNoBackupFile):
+		return nil, nil
+
+	case err != nil:
+		return nil, fmt.Errorf("unable to read existing backup "+
+			"file: %w", err)
+	}
+
+	plaintext := packed
+	if IsEncryptedBackup(packed) {
+		plaintext, err = DecryptBackup(u.encrypter, packed)
+		if err != nil {
+			return nil, fmt.Errorf("existing backup file cannot "+
+				"be decrypted with the wallet key: %w", err)
+		}
+	}
+
+	walletBackup, err := DecodeWalletBackup(plaintext)
+	if err != nil {
+		return nil, fmt.Errorf("existing backup file cannot be "+
+			"decoded: %w", err)
+	}
+
+	if walletBackup.Version == BackupVersionOptimistic {
+		return nil, fmt.Errorf("existing backup file is an " +
+			"optimistic (v3) export without proof data, it " +
+			"cannot be maintained as the backup file; move it " +
+			"away or import it and delete it")
+	}
+
+	return walletBackup, nil
+}

--- a/backup/updater_test.go
+++ b/backup/updater_test.go
@@ -1,0 +1,1375 @@
+package backup
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/lightninglabs/taproot-assets/address"
+	"github.com/lightninglabs/taproot-assets/asset"
+	"github.com/lightninglabs/taproot-assets/fn"
+	"github.com/lightninglabs/taproot-assets/internal/test"
+	"github.com/lightninglabs/taproot-assets/proof"
+	"github.com/lightningnetwork/lnd/keychain"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	// testDebounce is the debounce used in tests, short enough to keep
+	// the tests fast but long enough to observe coalescing.
+	testDebounce = 50 * time.Millisecond
+
+	// testRetry is the retry interval used in tests.
+	testRetry = 100 * time.Millisecond
+
+	// testTimeout is how long tests wait for an expected write.
+	testTimeout = 5 * time.Second
+
+	// testQuiet is how long tests wait to assert that no write happens.
+	testQuiet = 10 * testDebounce
+)
+
+// mockSwapper is an in-memory Swapper that records every write and can be
+// told to fail.
+type mockSwapper struct {
+	mu         sync.Mutex
+	data       []byte
+	fail       bool
+	extractErr error
+	writes     chan []byte
+}
+
+func newMockSwapper() *mockSwapper {
+	return &mockSwapper{writes: make(chan []byte, 100)}
+}
+
+func (m *mockSwapper) UpdateAndSwap(packed []byte) error {
+	m.mu.Lock()
+	if m.fail {
+		m.mu.Unlock()
+		return errors.New("disk full")
+	}
+
+	m.data = append([]byte{}, packed...)
+	data := m.data
+	m.mu.Unlock()
+
+	// Deliver outside the lock so a slow test cannot block Extract.
+	m.writes <- data
+
+	return nil
+}
+
+func (m *mockSwapper) Extract() ([]byte, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.extractErr != nil {
+		return nil, m.extractErr
+	}
+	if m.data == nil {
+		return nil, ErrNoBackupFile
+	}
+
+	return append([]byte{}, m.data...), nil
+}
+
+func (m *mockSwapper) setExtractErr(err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.extractErr = err
+}
+
+func (m *mockSwapper) setFail(fail bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.fail = fail
+}
+
+func (m *mockSwapper) seed(data []byte) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.data = data
+}
+
+// mockNotifier is a ProofNotifier that hands out the registered receiver so
+// tests can push notifications.
+type mockNotifier struct {
+	mu          sync.Mutex
+	receiver    *fn.EventReceiver[proof.Blob]
+	registerErr error
+	removed     bool
+}
+
+func (m *mockNotifier) RegisterSubscriber(
+	receiver *fn.EventReceiver[proof.Blob], _ bool,
+	_ []*proof.Locator) error {
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.registerErr != nil {
+		return m.registerErr
+	}
+	m.receiver = receiver
+
+	return nil
+}
+
+func (m *mockNotifier) RemoveSubscriber(
+	receiver *fn.EventReceiver[proof.Blob]) error {
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.receiver != receiver {
+		return errors.New("unknown subscriber")
+	}
+	m.removed = true
+	m.receiver.Stop()
+
+	return nil
+}
+
+func (m *mockNotifier) notify(t *testing.T) {
+	m.mu.Lock()
+	receiver := m.receiver
+	m.mu.Unlock()
+
+	require.NotNil(t, receiver)
+	receiver.NewItemCreated.ChanIn() <- proof.Blob("irrelevant")
+}
+
+// mockMintNotifier is an EventNotifier that hands out the registered receiver
+// so tests can push events.
+type mockMintNotifier struct {
+	mu          sync.Mutex
+	receiver    *fn.EventReceiver[fn.Event]
+	registerErr error
+	removed     bool
+}
+
+func (m *mockMintNotifier) RegisterSubscriber(
+	receiver *fn.EventReceiver[fn.Event], _, _ bool) error {
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.registerErr != nil {
+		return m.registerErr
+	}
+	m.receiver = receiver
+
+	return nil
+}
+
+func (m *mockMintNotifier) RemoveSubscriber(
+	receiver *fn.EventReceiver[fn.Event]) error {
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.receiver != receiver {
+		return errors.New("unknown subscriber")
+	}
+	m.removed = true
+	m.receiver.Stop()
+
+	return nil
+}
+
+// mintEvent is a minimal fn.Event.
+type mintEvent struct{}
+
+func (mintEvent) Timestamp() time.Time {
+	return time.Now()
+}
+
+func (m *mockMintNotifier) notify(t *testing.T) {
+	m.mu.Lock()
+	receiver := m.receiver
+	m.mu.Unlock()
+
+	require.NotNil(t, receiver)
+	receiver.NewItemCreated.ChanIn() <- mintEvent{}
+}
+
+// mockKeyLookup resolves every internal key to a fixed locator.
+type mockKeyLookup struct {
+	mu  sync.Mutex
+	err error
+}
+
+func (m *mockKeyLookup) FetchInternalKeyLocator(_ context.Context,
+	_ *btcec.PublicKey) (keychain.KeyLocator, error) {
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.err != nil {
+		return keychain.KeyLocator{}, m.err
+	}
+
+	return keychain.KeyLocator{Family: 212, Index: 7}, nil
+}
+
+// assetSource is a mutable in-memory stand-in for the asset database.
+type assetSource struct {
+	mu      sync.Mutex
+	assets  map[entryKey]*asset.ChainAsset
+	err     error
+	fetches int
+
+	// spent records leaves the source knows as spent, by key.
+	spent map[entryKey]struct{}
+
+	// spentErr, if set, is returned by lookupSpent.
+	spentErr error
+}
+
+func newAssetSource() *assetSource {
+	return &assetSource{
+		assets: make(map[entryKey]*asset.ChainAsset),
+		spent:  make(map[entryKey]struct{}),
+	}
+}
+
+func (s *assetSource) fetch(_ context.Context) ([]*asset.ChainAsset, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.fetches++
+	if s.err != nil {
+		return nil, s.err
+	}
+
+	assets := make([]*asset.ChainAsset, 0, len(s.assets))
+	for _, a := range s.assets {
+		assets = append(assets, a)
+	}
+
+	return assets, nil
+}
+
+func (s *assetSource) add(a *asset.ChainAsset) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.assets[keyForChainAsset(a)] = a
+}
+
+func (s *assetSource) remove(a *asset.ChainAsset) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	delete(s.assets, keyForChainAsset(a))
+}
+
+// spend removes the leaf from the unspent set and records it as spent.
+func (s *assetSource) spend(a *asset.ChainAsset) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	key := keyForChainAsset(a)
+	delete(s.assets, key)
+	s.spent[key] = struct{}{}
+}
+
+func (s *assetSource) numFetches() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.fetches
+}
+
+func (s *assetSource) lookupSpent(_ context.Context,
+	scriptKey *btcec.PublicKey, anchorPoint wire.OutPoint) (bool, error) {
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.spentErr != nil {
+		return false, s.spentErr
+	}
+
+	for key := range s.spent {
+		if key.scriptKey == asset.ToSerialized(scriptKey) &&
+			key.outpoint == anchorPoint {
+
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+// testChainAsset is a chain asset together with the proof file it was built
+// from.
+type testChainAsset struct {
+	*asset.ChainAsset
+	proofBlob proof.Blob
+}
+
+// newTestChainAsset builds a confirmed chain asset backed by a valid proof
+// file and, unless skipArchive is set, stores the proof in the archive under
+// the locator the Updater will use.
+func newTestChainAsset(t *testing.T, archive *proof.MockProofArchive,
+	skipArchive bool) *testChainAsset {
+
+	proofBlob, block, height := makeTestProofFile(t)
+
+	f, err := proof.Blob(proofBlob).AsFile()
+	require.NoError(t, err)
+	p, err := f.LastProof()
+	require.NoError(t, err)
+
+	chainAsset := &asset.ChainAsset{
+		Asset:             &p.Asset,
+		AnchorTx:          &p.AnchorTx,
+		AnchorBlockHash:   block.BlockHash(),
+		AnchorBlockHeight: height,
+		AnchorOutpoint:    p.OutPoint(),
+		AnchorInternalKey: p.InclusionProof.InternalKey,
+	}
+
+	tca := &testChainAsset{ChainAsset: chainAsset, proofBlob: proofBlob}
+	if !skipArchive {
+		tca.storeProof(t, archive)
+	}
+
+	return tca
+}
+
+func (a *testChainAsset) storeProof(t *testing.T,
+	archive *proof.MockProofArchive) {
+
+	assetID := a.ID()
+	err := archive.ImportProofs(
+		context.Background(), proof.VerifierCtx{}, false,
+		&proof.AnnotatedProof{
+			Locator: proof.Locator{
+				AssetID:   &assetID,
+				ScriptKey: *a.ScriptKey.PubKey,
+				OutPoint:  &a.AnchorOutpoint,
+			},
+			Blob: a.proofBlob,
+		},
+	)
+	require.NoError(t, err)
+}
+
+func (a *testChainAsset) key() entryKey {
+	return keyForChainAsset(a.ChainAsset)
+}
+
+// updaterHarness wires an Updater to all mocks.
+type updaterHarness struct {
+	t        *testing.T
+	updater  *Updater
+	source   *assetSource
+	archive  *proof.MockProofArchive
+	notifier *mockNotifier
+	minter   *mockMintNotifier
+	porter   *mockMintNotifier
+	swapper  *mockSwapper
+	deriver  *mockKeyDeriver
+	lookup   *mockKeyLookup
+}
+
+func newUpdaterHarness(t *testing.T) *updaterHarness {
+	h := &updaterHarness{
+		t:        t,
+		source:   newAssetSource(),
+		archive:  proof.NewMockProofArchive(),
+		notifier: &mockNotifier{},
+		minter:   &mockMintNotifier{},
+		porter:   &mockMintNotifier{},
+		swapper:  newMockSwapper(),
+		deriver:  newMockKeyDeriver(t),
+		lookup:   &mockKeyLookup{},
+	}
+
+	updater, err := NewUpdater(h.config())
+	require.NoError(t, err)
+	h.updater = updater
+
+	return h
+}
+
+func (h *updaterHarness) config() *UpdaterConfig {
+	return &UpdaterConfig{
+		FetchAssets:   h.source.fetch,
+		LookupSpent:   h.source.lookupSpent,
+		ProofArchive:  h.archive,
+		KeyLookup:     h.lookup,
+		ProofNotifier: h.notifier,
+		EventNotifiers: []EventNotifier{
+			h.minter, h.porter,
+		},
+		KeyDeriver:    h.deriver,
+		Swapper:       h.swapper,
+		Debounce:      testDebounce,
+		RetryInterval: testRetry,
+	}
+}
+
+func (h *updaterHarness) newAsset() *testChainAsset {
+	return newTestChainAsset(h.t, h.archive, false)
+}
+
+func (h *updaterHarness) start() {
+	require.NoError(h.t, h.updater.Start())
+	h.t.Cleanup(func() {
+		require.NoError(h.t, h.updater.Stop())
+	})
+}
+
+// waitWrite blocks until the swapper records a write and returns the decoded
+// backup.
+func (h *updaterHarness) waitWrite() *WalletBackup {
+	select {
+	case packed := <-h.swapper.writes:
+		return h.decode(packed)
+
+	case <-time.After(testTimeout):
+		h.t.Fatalf("timeout waiting for backup file write")
+		return nil
+	}
+}
+
+// assertNoWrite asserts that no write happens within the quiet period.
+func (h *updaterHarness) assertNoWrite() {
+	select {
+	case <-h.swapper.writes:
+		h.t.Fatalf("unexpected backup file write")
+
+	case <-time.After(testQuiet):
+	}
+}
+
+// decode decrypts and decodes a packed backup with the harness key.
+func (h *updaterHarness) decode(packed []byte) *WalletBackup {
+	require.True(h.t, IsEncryptedBackup(packed))
+
+	plaintext, err := DecryptBackup(
+		newTestEncrypter(h.t, h.deriver), packed,
+	)
+	require.NoError(h.t, err)
+
+	wb, err := DecodeWalletBackup(plaintext)
+	require.NoError(h.t, err)
+
+	return wb
+}
+
+// onDisk returns the decoded backup currently held by the swapper.
+func (h *updaterHarness) onDisk() *WalletBackup {
+	packed, err := h.swapper.Extract()
+	require.NoError(h.t, err)
+
+	return h.decode(packed)
+}
+
+// keys returns the set of entry keys in a backup.
+func keys(t *testing.T, wb *WalletBackup) map[entryKey]*AssetBackup {
+	result := make(map[entryKey]*AssetBackup, len(wb.Assets))
+	for _, ab := range wb.Assets {
+		key, ok := keyForBackup(ab)
+		require.True(t, ok)
+		result[key] = ab
+	}
+
+	return result
+}
+
+// assertEntries asserts that the backup holds exactly the given assets.
+func assertEntries(t *testing.T, wb *WalletBackup, assets ...*testChainAsset) {
+	got := keys(t, wb)
+	require.Len(t, got, len(assets))
+	for _, a := range assets {
+		require.Contains(t, got, a.key())
+	}
+}
+
+// encodePlain encodes a plaintext backup holding the given assets as raw v1
+// entries.
+func encodePlain(t *testing.T, assets ...*testChainAsset) []byte {
+	wb := &WalletBackup{Version: BackupVersionOriginal}
+	for _, a := range assets {
+		wb.Assets = append(wb.Assets, &AssetBackup{
+			Asset:             a.Asset,
+			AnchorOutpoint:    a.AnchorOutpoint,
+			AnchorBlockHeight: a.AnchorBlockHeight,
+			ProofFileBlob:     a.proofBlob,
+		})
+	}
+
+	data, err := EncodeWalletBackup(wb)
+	require.NoError(t, err)
+
+	return data
+}
+
+// TestNewUpdaterValidation asserts that every dependency is required and that
+// zero durations fall back to the defaults.
+func TestNewUpdaterValidation(t *testing.T) {
+	t.Parallel()
+
+	h := newUpdaterHarness(t)
+
+	_, err := NewUpdater(nil)
+	require.ErrorContains(t, err, "nil")
+
+	mutations := map[string]func(*UpdaterConfig){
+		"asset fetcher": func(c *UpdaterConfig) {
+			c.FetchAssets = nil
+		},
+		"proof archive": func(c *UpdaterConfig) {
+			c.ProofArchive = nil
+		},
+		"proof notifier": func(c *UpdaterConfig) {
+			c.ProofNotifier = nil
+		},
+		"key deriver": func(c *UpdaterConfig) {
+			c.KeyDeriver = nil
+		},
+		"swapper": func(c *UpdaterConfig) {
+			c.Swapper = nil
+		},
+	}
+	for name, mutate := range mutations {
+		cfg := h.config()
+		mutate(cfg)
+
+		_, err := NewUpdater(cfg)
+		require.ErrorContains(t, err, name)
+	}
+
+	cfg := h.config()
+	cfg.Debounce = 0
+	cfg.RetryInterval = -1
+	u, err := NewUpdater(cfg)
+	require.NoError(t, err)
+	require.Equal(t, DefaultDebounce, u.cfg.Debounce)
+	require.Equal(t, DefaultRetryInterval, u.cfg.RetryInterval)
+}
+
+// TestUpdaterInitialWrite asserts that Start writes the full confirmed wallet
+// state as an encrypted compact backup.
+func TestUpdaterInitialWrite(t *testing.T) {
+	t.Parallel()
+
+	h := newUpdaterHarness(t)
+	a1, a2 := h.newAsset(), h.newAsset()
+	h.source.add(a1.ChainAsset)
+	h.source.add(a2.ChainAsset)
+
+	// An unconfirmed leaf must be left out.
+	pending := h.newAsset()
+	pending.AnchorBlockHeight = 0
+	h.source.add(pending.ChainAsset)
+
+	h.start()
+
+	wb := h.waitWrite()
+	require.Equal(t, BackupVersionStripped, wb.Version)
+	assertEntries(t, wb, a1, a2)
+
+	for _, ab := range wb.Assets {
+		// Compact entries carry a stripped proof and hints only.
+		require.Empty(t, ab.ProofFileBlob)
+		require.NotEmpty(t, ab.StrippedProofFileBlob)
+		require.NotEmpty(t, ab.RehydrationHintsBlob)
+
+		require.NotEmpty(t, ab.AnchorOutputPkScript)
+		require.NotNil(t, ab.AnchorInternalKeyInfo)
+		require.Equal(t, keychain.KeyLocator{Family: 212, Index: 7},
+			ab.AnchorInternalKeyInfo.KeyLocator)
+	}
+
+	// The starting state is written exactly once.
+	h.assertNoWrite()
+
+	// Once the pending leaf confirms it is picked up.
+	pending.AnchorBlockHeight = 101
+	h.source.add(pending.ChainAsset)
+	h.notifier.notify(t)
+
+	assertEntries(t, h.waitWrite(), a1, a2, pending)
+}
+
+// TestUpdaterAddAndRemove drives a receive and a spend through the notifier
+// and asserts the file follows.
+func TestUpdaterAddAndRemove(t *testing.T) {
+	t.Parallel()
+
+	h := newUpdaterHarness(t)
+	a1 := h.newAsset()
+	h.source.add(a1.ChainAsset)
+	h.start()
+	assertEntries(t, h.waitWrite(), a1)
+
+	// Receive.
+	a2 := h.newAsset()
+	h.source.add(a2.ChainAsset)
+	h.notifier.notify(t)
+	assertEntries(t, h.waitWrite(), a1, a2)
+
+	// Mint: signalled through the mint notifier instead.
+	a3 := h.newAsset()
+	h.source.add(a3.ChainAsset)
+	h.minter.notify(t)
+	assertEntries(t, h.waitWrite(), a1, a2, a3)
+
+	// Full value send without change: no proof is imported locally, only
+	// the send state machine reports it.
+	h.source.remove(a3.ChainAsset)
+	h.porter.notify(t)
+	assertEntries(t, h.waitWrite(), a1, a2)
+
+	// Spend a1: the leaf leaves the unspent set.
+	h.source.remove(a1.ChainAsset)
+	h.notifier.notify(t)
+	assertEntries(t, h.waitWrite(), a2)
+
+	// A notification that changes nothing does not rewrite the file.
+	h.notifier.notify(t)
+	h.assertNoWrite()
+
+	// Spend the last one, the file is rewritten empty rather than left
+	// stale.
+	h.source.remove(a2.ChainAsset)
+	h.notifier.notify(t)
+	assertEntries(t, h.waitWrite())
+}
+
+// TestUpdaterDebounce asserts that a burst of notifications results in a
+// single rewrite.
+func TestUpdaterDebounce(t *testing.T) {
+	t.Parallel()
+
+	h := newUpdaterHarness(t)
+	h.start()
+	h.waitWrite()
+
+	before := h.source.numFetches()
+
+	a := h.newAsset()
+	h.source.add(a.ChainAsset)
+	for i := 0; i < 20; i++ {
+		h.notifier.notify(t)
+	}
+
+	assertEntries(t, h.waitWrite(), a)
+	h.assertNoWrite()
+
+	// The burst was coalesced into a single reconcile, not one per
+	// notification.
+	require.Equal(t, before+1, h.source.numFetches())
+}
+
+// TestUpdaterDiskOnlyEntriesRetained asserts that entries found on disk that
+// the database does not know about survive rewrites, and that spends of known
+// leaves still get removed.
+func TestUpdaterDiskOnlyEntriesRetained(t *testing.T) {
+	t.Parallel()
+
+	h := newUpdaterHarness(t)
+
+	// Seed the disk with an encrypted backup holding a foreign leaf.
+	foreign := h.newAsset()
+	packed, err := EncryptBackup(
+		newTestEncrypter(t, h.deriver), encodePlain(t, foreign),
+	)
+	require.NoError(t, err)
+	h.swapper.seed(packed)
+
+	local := h.newAsset()
+	h.source.add(local.ChainAsset)
+	h.start()
+
+	assertEntries(t, h.waitWrite(), foreign, local)
+
+	h.source.remove(local.ChainAsset)
+	h.notifier.notify(t)
+	assertEntries(t, h.waitWrite(), foreign)
+}
+
+// TestUpdaterDiskOnlySpentPruned asserts that a leaf spent while the Updater
+// was not running, so only found on disk, is dropped once the database
+// reports it as spent, while leaves the database does not know are kept.
+func TestUpdaterDiskOnlySpentPruned(t *testing.T) {
+	t.Parallel()
+
+	h := newUpdaterHarness(t)
+
+	// The previous run left two leaves in the file. One was spent while
+	// we were down, one belongs to another wallet entirely.
+	spentWhileDown, foreign := h.newAsset(), h.newAsset()
+	packed, err := EncryptBackup(
+		newTestEncrypter(t, h.deriver),
+		encodePlain(t, spentWhileDown, foreign),
+	)
+	require.NoError(t, err)
+	h.swapper.seed(packed)
+	h.source.spend(spentWhileDown.ChainAsset)
+
+	live := h.newAsset()
+	h.source.add(live.ChainAsset)
+	h.start()
+
+	assertEntries(t, h.waitWrite(), foreign, live)
+
+	// A lookup failure is a write failure, the file is left untouched
+	// and the write retried.
+	h.source.mu.Lock()
+	h.source.spentErr = errors.New("db locked")
+	h.source.mu.Unlock()
+
+	live2 := h.newAsset()
+	h.source.add(live2.ChainAsset)
+	h.notifier.notify(t)
+	h.assertNoWrite()
+	assertEntries(t, h.onDisk(), foreign, live)
+
+	h.source.mu.Lock()
+	h.source.spentErr = nil
+	h.source.mu.Unlock()
+	assertEntries(t, h.waitWrite(), foreign, live, live2)
+}
+
+// TestUpdaterRetryPulledForwardByChange asserts that a change arriving while
+// a retry is pending is handled after the debounce, not the retry interval.
+func TestUpdaterRetryPulledForwardByChange(t *testing.T) {
+	t.Parallel()
+
+	h := newUpdaterHarness(t)
+	cfg := h.config()
+	cfg.RetryInterval = 10 * time.Second
+	u, err := NewUpdater(cfg)
+	require.NoError(t, err)
+	h.updater = u
+	h.start()
+	h.waitWrite()
+
+	// Provoke a failure so a long retry is armed.
+	h.swapper.setFail(true)
+	a := h.newAsset()
+	h.source.add(a.ChainAsset)
+	h.notifier.notify(t)
+	h.assertNoWrite()
+
+	// The disk recovers and another change arrives. It must not wait for
+	// the 10s retry.
+	h.swapper.setFail(false)
+	h.notifier.notify(t)
+
+	start := time.Now()
+	assertEntries(t, h.waitWrite(), a)
+	require.Less(t, time.Since(start), 5*time.Second)
+}
+
+// TestUpdaterCorruptFileAtRuntime asserts that a backup file that becomes
+// unreadable while running blocks writes with an error, is retried, and is
+// recovered from once it is readable again.
+func TestUpdaterCorruptFileAtRuntime(t *testing.T) {
+	t.Parallel()
+
+	h := newUpdaterHarness(t)
+	a1 := h.newAsset()
+	h.source.add(a1.ChainAsset)
+	h.start()
+	assertEntries(t, h.waitWrite(), a1)
+
+	h.swapper.setExtractErr(errors.New("I/O error"))
+
+	a2 := h.newAsset()
+	h.source.add(a2.ChainAsset)
+	h.notifier.notify(t)
+	h.assertNoWrite()
+
+	err := h.updater.Sync(context.Background())
+	require.ErrorContains(t, err, "I/O error")
+
+	h.swapper.setExtractErr(nil)
+	assertEntries(t, h.waitWrite(), a1, a2)
+}
+
+// TestUpdaterOptimisticFileRejected asserts that a v3 export at the backup
+// path is refused rather than silently rewritten without its proof data.
+func TestUpdaterOptimisticFileRejected(t *testing.T) {
+	t.Parallel()
+
+	h := newUpdaterHarness(t)
+	plain, err := EncodeWalletBackup(&WalletBackup{
+		Version:        BackupVersionOptimistic,
+		Assets:         []*AssetBackup{newTestAssetBackupV3(t)},
+		FederationURLs: []string{"universe.example:10029"},
+	})
+	require.NoError(t, err)
+	h.swapper.seed(plain)
+
+	require.ErrorContains(t, h.updater.Start(), "optimistic (v3)")
+
+	// Encrypted v3 is refused the same way.
+	packed, err := EncryptBackup(newTestEncrypter(t, h.deriver), plain)
+	require.NoError(t, err)
+	h2 := newUpdaterHarness(t)
+	h2.deriver = h.deriver
+	cfg := h2.config()
+	u, err := NewUpdater(cfg)
+	require.NoError(t, err)
+	h2.swapper.seed(packed)
+	require.ErrorContains(t, u.Start(), "optimistic (v3)")
+}
+
+// TestUpdaterSkipsIncompleteAssets asserts that fetched assets without the
+// fields needed to identify them are ignored rather than crash the loop.
+func TestUpdaterSkipsIncompleteAssets(t *testing.T) {
+	t.Parallel()
+
+	h := newUpdaterHarness(t)
+	a := h.newAsset()
+	h.source.add(a.ChainAsset)
+
+	// A row without an asset and one without a script key.
+	h.source.mu.Lock()
+	h.source.assets[entryKey{assetID: asset.ID{1}}] = &asset.ChainAsset{}
+	broken := *a.ChainAsset
+	brokenAsset := *a.Asset
+	brokenAsset.ScriptKey = asset.ScriptKey{}
+	broken.Asset = &brokenAsset
+	h.source.assets[entryKey{assetID: asset.ID{2}}] = &broken
+	h.source.mu.Unlock()
+
+	h.start()
+	assertEntries(t, h.waitWrite(), a)
+}
+
+// TestUpdaterPlaintextFileAdopted asserts that a plaintext export placed at
+// the backup path is merged and rewritten encrypted.
+func TestUpdaterPlaintextFileAdopted(t *testing.T) {
+	t.Parallel()
+
+	h := newUpdaterHarness(t)
+	seeded := h.newAsset()
+	h.swapper.seed(encodePlain(t, seeded))
+
+	local := h.newAsset()
+	h.source.add(local.ChainAsset)
+	h.start()
+
+	wb := h.waitWrite()
+	assertEntries(t, wb, seeded, local)
+
+	// The seeded raw entry is carried over as is.
+	require.NotEmpty(t, keys(t, wb)[seeded.key()].ProofFileBlob)
+
+	packed, err := h.swapper.Extract()
+	require.NoError(t, err)
+	require.True(t, IsEncryptedBackup(packed))
+}
+
+// TestUpdaterMemoryWinsAndReorg asserts that the in-memory entry replaces the
+// disk entry for the same leaf, and that a re-org changing the anchor block
+// rebuilds the entry.
+func TestUpdaterMemoryWinsAndReorg(t *testing.T) {
+	t.Parallel()
+
+	h := newUpdaterHarness(t)
+
+	// Seed disk with a raw entry for the same leaf the DB knows.
+	a := h.newAsset()
+	h.swapper.seed(encodePlain(t, a))
+	h.source.add(a.ChainAsset)
+	h.start()
+
+	wb := h.waitWrite()
+	assertEntries(t, wb, a)
+	entry := keys(t, wb)[a.key()]
+	require.Empty(t, entry.ProofFileBlob, "disk entry should be replaced")
+	require.NotEmpty(t, entry.StrippedProofFileBlob)
+	require.Equal(t, a.AnchorBlockHeight, entry.AnchorBlockHeight)
+
+	// Same leaf, but now anchored in a different block.
+	reorged := *a.ChainAsset
+	reorged.AnchorBlockHash = chainhash.Hash{0xaa}
+	reorged.AnchorBlockHeight = a.AnchorBlockHeight + 1
+	h.source.add(&reorged)
+	h.notifier.notify(t)
+
+	wb = h.waitWrite()
+	assertEntries(t, wb, a)
+	require.Equal(t, reorged.AnchorBlockHeight,
+		keys(t, wb)[a.key()].AnchorBlockHeight)
+}
+
+// TestUpdaterSwapFailureRetried asserts that a failed write is retried and
+// that removals are not lost across the failure.
+func TestUpdaterSwapFailureRetried(t *testing.T) {
+	t.Parallel()
+
+	h := newUpdaterHarness(t)
+	a1, a2 := h.newAsset(), h.newAsset()
+	h.source.add(a1.ChainAsset)
+	h.source.add(a2.ChainAsset)
+	h.start()
+	assertEntries(t, h.waitWrite(), a1, a2)
+
+	// Disk goes bad, a1 is spent and a3 arrives.
+	h.swapper.setFail(true)
+	a3 := h.newAsset()
+	h.source.remove(a1.ChainAsset)
+	h.source.add(a3.ChainAsset)
+	h.notifier.notify(t)
+	h.assertNoWrite()
+
+	// The file on disk is untouched.
+	assertEntries(t, h.onDisk(), a1, a2)
+
+	// Disk recovers, the retry applies both the add and the removal.
+	h.swapper.setFail(false)
+	assertEntries(t, h.waitWrite(), a2, a3)
+}
+
+// TestUpdaterProofFetchFailureRetried asserts that a leaf whose proof cannot
+// be fetched is skipped and picked up on a later retry.
+func TestUpdaterProofFetchFailureRetried(t *testing.T) {
+	t.Parallel()
+
+	h := newUpdaterHarness(t)
+	a1 := h.newAsset()
+	h.source.add(a1.ChainAsset)
+
+	// a2 is in the DB but its proof is missing from the archive.
+	a2 := newTestChainAsset(t, h.archive, true)
+	h.source.add(a2.ChainAsset)
+
+	h.start()
+	assertEntries(t, h.waitWrite(), a1)
+
+	// Sync reports the failure explicitly.
+	err := h.updater.Sync(context.Background())
+	require.ErrorContains(t, err, "1 asset(s) could not be backed up")
+
+	// The proof shows up, the retry picks it up.
+	a2.storeProof(t, h.archive)
+	assertEntries(t, h.waitWrite(), a1, a2)
+}
+
+// TestUpdaterFetchAssetsFailure asserts that a database error does not touch
+// the file and is retried.
+func TestUpdaterFetchAssetsFailure(t *testing.T) {
+	t.Parallel()
+
+	h := newUpdaterHarness(t)
+	a1 := h.newAsset()
+	h.source.add(a1.ChainAsset)
+	h.start()
+	assertEntries(t, h.waitWrite(), a1)
+
+	h.source.mu.Lock()
+	h.source.err = errors.New("db locked")
+	h.source.mu.Unlock()
+
+	a2 := h.newAsset()
+	h.source.add(a2.ChainAsset)
+	h.notifier.notify(t)
+	h.assertNoWrite()
+
+	err := h.updater.Sync(context.Background())
+	require.ErrorContains(t, err, "db locked")
+
+	h.source.mu.Lock()
+	h.source.err = nil
+	h.source.mu.Unlock()
+
+	assertEntries(t, h.waitWrite(), a1, a2)
+}
+
+// TestUpdaterStartFailures covers the fatal startup conditions.
+func TestUpdaterStartFailures(t *testing.T) {
+	t.Parallel()
+
+	t.Run("undecryptable file", func(t *testing.T) {
+		h := newUpdaterHarness(t)
+
+		other := newTestEncrypter(t, newMockKeyDeriver(t))
+		packed, err := EncryptBackup(other, encodePlain(t))
+		require.NoError(t, err)
+		h.swapper.seed(packed)
+
+		err = h.updater.Start()
+		require.ErrorContains(t, err, "cannot be decrypted")
+		require.False(t, h.updater.isActive.Load())
+
+		// We never subscribed, and Stop is still safe to call.
+		require.Nil(t, h.updater.receiver)
+		require.NoError(t, h.updater.Stop())
+	})
+
+	t.Run("garbage file", func(t *testing.T) {
+		h := newUpdaterHarness(t)
+		h.swapper.seed([]byte("definitely not a backup"))
+
+		err := h.updater.Start()
+		require.ErrorContains(t, err, "cannot be decoded")
+	})
+
+	t.Run("key derivation fails", func(t *testing.T) {
+		h := newUpdaterHarness(t)
+		h.deriver.err = errors.New("lnd down")
+
+		require.ErrorContains(t, h.updater.Start(), "lnd down")
+	})
+
+	t.Run("subscribe fails", func(t *testing.T) {
+		h := newUpdaterHarness(t)
+		h.notifier.registerErr = errors.New("no subscriptions")
+
+		require.ErrorContains(t, h.updater.Start(),
+			"no subscriptions")
+	})
+
+	t.Run("subscribe fails leaves no receiver", func(t *testing.T) {
+		h := newUpdaterHarness(t)
+		h.notifier.registerErr = errors.New("no subscriptions")
+
+		require.Error(t, h.updater.Start())
+		require.Nil(t, h.updater.receiver)
+		require.Empty(t, h.updater.eventReceivers)
+		require.NoError(t, h.updater.Stop())
+	})
+
+	t.Run("event subscribe fails", func(t *testing.T) {
+		h := newUpdaterHarness(t)
+		h.porter.registerErr = errors.New("no send events")
+
+		require.ErrorContains(t, h.updater.Start(), "no send events")
+
+		// The subscriptions that did succeed are rolled back.
+		require.True(t, h.notifier.removed)
+		require.True(t, h.minter.removed)
+		require.Nil(t, h.updater.receiver)
+		require.Empty(t, h.updater.eventReceivers)
+		require.NoError(t, h.updater.Stop())
+	})
+}
+
+// TestUpdaterWithoutEventNotifiers asserts the event notifiers are optional.
+func TestUpdaterWithoutEventNotifiers(t *testing.T) {
+	t.Parallel()
+
+	h := newUpdaterHarness(t)
+	cfg := h.config()
+	cfg.EventNotifiers = nil
+	u, err := NewUpdater(cfg)
+	require.NoError(t, err)
+	h.updater = u
+
+	a := h.newAsset()
+	h.source.add(a.ChainAsset)
+	h.start()
+	assertEntries(t, h.waitWrite(), a)
+
+	h.source.remove(a.ChainAsset)
+	h.notifier.notify(t)
+	assertEntries(t, h.waitWrite())
+}
+
+// TestUpdaterStartupTransientFailuresRetried asserts that database and disk
+// failures during the initial write do not fail startup and are retried.
+func TestUpdaterStartupTransientFailuresRetried(t *testing.T) {
+	t.Parallel()
+
+	t.Run("database fails", func(t *testing.T) {
+		h := newUpdaterHarness(t)
+		a := h.newAsset()
+		h.source.add(a.ChainAsset)
+		h.source.err = errors.New("db locked")
+
+		h.start()
+		h.assertNoWrite()
+
+		h.source.mu.Lock()
+		h.source.err = nil
+		h.source.mu.Unlock()
+
+		assertEntries(t, h.waitWrite(), a)
+	})
+
+	t.Run("swap fails", func(t *testing.T) {
+		h := newUpdaterHarness(t)
+		a := h.newAsset()
+		h.source.add(a.ChainAsset)
+		h.swapper.setFail(true)
+
+		h.start()
+		h.assertNoWrite()
+
+		h.swapper.setFail(false)
+		assertEntries(t, h.waitWrite(), a)
+	})
+}
+
+// TestUpdaterStartupProofFailureNotFatal asserts that a single leaf without a
+// proof does not prevent startup and gets retried.
+func TestUpdaterStartupProofFailureNotFatal(t *testing.T) {
+	t.Parallel()
+
+	h := newUpdaterHarness(t)
+	a1 := h.newAsset()
+	a2 := newTestChainAsset(t, h.archive, true)
+	h.source.add(a1.ChainAsset)
+	h.source.add(a2.ChainAsset)
+
+	h.start()
+	assertEntries(t, h.waitWrite(), a1)
+
+	a2.storeProof(t, h.archive)
+	assertEntries(t, h.waitWrite(), a1, a2)
+}
+
+// TestUpdaterSyncAndStop covers the manual sync path and the final sync on
+// shutdown.
+func TestUpdaterSyncAndStop(t *testing.T) {
+	t.Parallel()
+
+	h := newUpdaterHarness(t)
+
+	// Not started yet.
+	require.ErrorIs(t, h.updater.Sync(context.Background()),
+		ErrUpdaterNotActive)
+
+	require.NoError(t, h.updater.Start())
+	h.waitWrite()
+
+	// Idempotent start.
+	require.NoError(t, h.updater.Start())
+
+	// Sync with nothing changed does not write.
+	require.NoError(t, h.updater.Sync(context.Background()))
+	h.assertNoWrite()
+
+	// Sync with a change writes synchronously.
+	a1 := h.newAsset()
+	h.source.add(a1.ChainAsset)
+	require.NoError(t, h.updater.Sync(context.Background()))
+	assertEntries(t, h.waitWrite(), a1)
+
+	// A change without notification is captured by the final sync on
+	// Stop.
+	a2 := h.newAsset()
+	h.source.add(a2.ChainAsset)
+	require.NoError(t, h.updater.Stop())
+	assertEntries(t, h.waitWrite(), a1, a2)
+
+	require.True(t, h.notifier.removed)
+	require.True(t, h.minter.removed)
+	require.True(t, h.porter.removed)
+	require.ErrorIs(t, h.updater.Sync(context.Background()),
+		ErrUpdaterNotActive)
+
+	// Idempotent stop.
+	require.NoError(t, h.updater.Stop())
+}
+
+// TestUpdaterSyncContext asserts that Sync honours its context.
+func TestUpdaterSyncContext(t *testing.T) {
+	t.Parallel()
+
+	h := newUpdaterHarness(t)
+	h.start()
+	h.waitWrite()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := h.updater.Sync(ctx)
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+// TestUpdaterDeterministicOutput asserts that the same state produces the same
+// plaintext regardless of map iteration order.
+func TestUpdaterDeterministicOutput(t *testing.T) {
+	t.Parallel()
+
+	h := newUpdaterHarness(t)
+	var assets []*testChainAsset
+	for i := 0; i < 5; i++ {
+		a := h.newAsset()
+		assets = append(assets, a)
+		h.source.add(a.ChainAsset)
+	}
+	h.start()
+	first := h.waitWrite()
+
+	// Force a rewrite of identical content by spending and re-adding a
+	// leaf.
+	h.source.remove(assets[0].ChainAsset)
+	require.NoError(t, h.updater.Sync(context.Background()))
+	h.waitWrite()
+	h.source.add(assets[0].ChainAsset)
+	require.NoError(t, h.updater.Sync(context.Background()))
+	second := h.waitWrite()
+
+	firstPlain, err := EncodeWalletBackup(first)
+	require.NoError(t, err)
+	secondPlain, err := EncodeWalletBackup(second)
+	require.NoError(t, err)
+	require.Equal(t, firstPlain, secondPlain)
+}
+
+// TestUpdaterKeyLookupUnknownKeyTolerated asserts that an anchor key the
+// wallet does not know still produces an entry, with the public key only.
+func TestUpdaterKeyLookupUnknownKeyTolerated(t *testing.T) {
+	t.Parallel()
+
+	h := newUpdaterHarness(t)
+	h.lookup.err = fmt.Errorf("%w", address.ErrInternalKeyNotFound)
+	a := h.newAsset()
+	h.source.add(a.ChainAsset)
+	h.start()
+
+	wb := h.waitWrite()
+	assertEntries(t, wb, a)
+
+	info := keys(t, wb)[a.key()].AnchorInternalKeyInfo
+	require.NotNil(t, info)
+	require.True(t, a.AnchorInternalKey.IsEqual(info.PubKey))
+	require.Equal(t, keychain.KeyLocator{}, info.KeyLocator)
+}
+
+// TestUpdaterKeyLookupErrorRetried asserts that a transient key locator
+// lookup failure does not produce an entry with a zero locator. The leaf is
+// left out, reported as failed and picked up once the lookup works again.
+func TestUpdaterKeyLookupErrorRetried(t *testing.T) {
+	t.Parallel()
+
+	h := newUpdaterHarness(t)
+	h.lookup.mu.Lock()
+	h.lookup.err = errors.New("db locked")
+	h.lookup.mu.Unlock()
+	a := h.newAsset()
+	h.source.add(a.ChainAsset)
+	h.start()
+
+	// The initial write happens, without the leaf.
+	assertEntries(t, h.waitWrite())
+
+	err := h.updater.Sync(context.Background())
+	require.ErrorContains(t, err, "1 asset(s) could not be backed up")
+
+	h.lookup.mu.Lock()
+	h.lookup.err = nil
+	h.lookup.mu.Unlock()
+
+	wb := h.waitWrite()
+	assertEntries(t, wb, a)
+	require.Equal(t, keychain.KeyLocator{Family: 212, Index: 7},
+		keys(t, wb)[a.key()].AnchorInternalKeyInfo.KeyLocator)
+}
+
+// TestUpdaterStopReportsFailedFinalSync asserts that Stop shuts the loop down
+// but returns the error of a failed final write, so a graceful shutdown does
+// not look clean while the file is stale.
+func TestUpdaterStopReportsFailedFinalSync(t *testing.T) {
+	t.Parallel()
+
+	h := newUpdaterHarness(t)
+	require.NoError(t, h.updater.Start())
+	h.waitWrite()
+
+	a := h.newAsset()
+	h.source.add(a.ChainAsset)
+	h.swapper.setFail(true)
+
+	err := h.updater.Stop()
+	require.ErrorContains(t, err, "final backup file sync failed")
+	require.ErrorContains(t, err, "disk full")
+
+	// Stopped regardless.
+	require.False(t, h.updater.isActive.Load())
+	require.True(t, h.notifier.removed)
+	require.ErrorIs(t, h.updater.Sync(context.Background()),
+		ErrUpdaterNotActive)
+
+	// A second Stop is a no-op and does not repeat the error.
+	require.NoError(t, h.updater.Stop())
+}
+
+// TestUpdaterFileSwapper runs the updater against the real File swapper to
+// make sure the two compose, including reading back an existing file on a
+// second start.
+func TestUpdaterFileSwapper(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := dir + "/" + DefaultBackupFileName
+
+	h := newUpdaterHarness(t)
+	cfg := h.config()
+	cfg.Swapper = NewFile(path)
+	u, err := NewUpdater(cfg)
+	require.NoError(t, err)
+
+	a1 := h.newAsset()
+	h.source.add(a1.ChainAsset)
+	require.NoError(t, u.Start())
+	require.NoError(t, u.Stop())
+
+	packed, err := NewFile(path).Extract()
+	require.NoError(t, err)
+	assertEntries(t, h.decode(packed), a1)
+
+	// Second run with a different DB state picks the file up and merges.
+	h2 := newUpdaterHarness(t)
+	h2.deriver = h.deriver
+	cfg = h2.config()
+	cfg.Swapper = NewFile(path)
+	u2, err := NewUpdater(cfg)
+	require.NoError(t, err)
+
+	a2 := newTestChainAsset(t, h2.archive, false)
+	h2.source.add(a2.ChainAsset)
+	require.NoError(t, u2.Start())
+	require.NoError(t, u2.Stop())
+
+	packed, err = NewFile(path).Extract()
+	require.NoError(t, err)
+	assertEntries(t, h.decode(packed), a1, a2)
+}
+
+// TestEntryKeyBytes asserts the ordering key distinguishes every component.
+func TestEntryKeyBytes(t *testing.T) {
+	t.Parallel()
+
+	base := entryKey{
+		assetID:   asset.ID{1},
+		scriptKey: asset.ToSerialized(test.RandPubKey(t)),
+	}
+	base.outpoint.Index = 1
+
+	other := base
+	other.outpoint.Index = 2
+	require.NotEqual(t, base.bytes(), other.bytes())
+
+	other = base
+	other.assetID = asset.ID{2}
+	require.NotEqual(t, base.bytes(), other.bytes())
+
+	other = base
+	other.scriptKey = asset.ToSerialized(test.RandPubKey(t))
+	require.NotEqual(t, base.bytes(), other.bytes())
+
+	require.Equal(t, base.bytes(), base.bytes())
+}

--- a/docs/backup-file.md
+++ b/docs/backup-file.md
@@ -1,0 +1,189 @@
+# Asset Wallet Backup File
+
+`tapd` keeps an encrypted backup of every asset the wallet owns in a single
+file on disk and updates that file whenever the wallet state changes. Copying
+this file somewhere safe is the recommended way to protect against the loss of
+the `tapd` database. Together with the `lnd` seed it is enough to recover all
+confirmed, unspent assets.
+
+This guide explains what the file covers, how to keep a copy of it and how to
+restore from it. The binary format and the update mechanism are documented in
+[backup.md](backup.md).
+
+## What the file protects
+
+The file holds one entry per confirmed, unspent asset output the wallet
+controls. Each entry contains the asset itself, the anchor outpoint, the key
+derivation paths for the script key and the anchor internal key, and a compact
+copy of the proof chain. That is everything a fresh `tapd` needs to recognise
+the output as its own, verify its history and spend it.
+
+The file does **not** cover:
+
+- The `lnd` wallet. The seed still has to be backed up separately, all asset
+  keys are derived from it.
+- Lightning channels carrying assets. Leaves that fund asset channels are
+  left out of the file, they are covered by `lnd`'s `channel.backup` and the
+  channel funding state in the `tapd` database.
+- Unconfirmed receives and sends. An output enters the file once its anchor
+  transaction confirms.
+- Addresses, universe and federation state, minting batches that have not
+  confirmed yet, and transfer history.
+
+A regular backup of the `tapd` database (see [safety.md](safety.md)) remains
+the complete backup. The file is the safety net for the case where the
+database is gone.
+
+## Where the file is
+
+By default:
+
+```
+<datadir>/<network>/assets.backup
+```
+
+which on Linux is `~/.tapd/data/mainnet/assets.backup`. The location can be
+changed with the `backup.filepath` option and the file can be turned off with
+`backup.disable`:
+
+```
+[backup]
+backup.filepath=/mnt/secure/assets.backup
+backup.disable=false
+```
+
+If the configured directory does not exist it is created on the first write.
+The path has to name a file, `tapd` refuses to start if it points at a
+directory.
+
+The file is written on startup and after every wallet change, and checked
+once more on shutdown so a change that had not been written yet still lands
+on disk. Writes are atomic: a new version is written next to the file and then
+renamed over it, so a copy taken at any moment is either the previous or the
+new complete version, never a partial one.
+
+## How the file is protected
+
+The file is encrypted with a key derived from the `lnd` wallet, the same key
+`lnd` uses for `channel.backup`. Only a `tapd` connected to an `lnd` that was
+created or restored from the same seed can read it. The file can therefore be
+stored anywhere, including cloud storage, without exposing which outputs the
+wallet owns.
+
+Keep in mind that whoever holds both the seed and the file can see everything
+the wallet owns. Treat the seed as the secret, the file as the data.
+
+## Keeping a copy
+
+The file changes whenever assets are minted, received or sent. Copy it to a
+second location whenever it changes, for example with a file watcher or a
+periodic sync job. An older copy is safe to restore from, it simply does not
+contain outputs received after it was taken, and outputs it lists that have
+since been spent are skipped on import. A spend that `tapd` recorded but did
+not get to write to the file, for example because it was shut down right after
+the spend confirmed, is removed from the file on the next start. A spend
+`tapd` never saw, made by another wallet on the same seed, stays in the file
+and is skipped on import.
+
+To check that a copy can be read, import it into the node that wrote it. This
+is a no-op and reports zero imported assets if the file is readable and up to
+date:
+
+```
+$ tapcli assets backup import --backup_file=/path/to/assets.backup
+{
+    "num_imported": 0,
+    "num_skipped": 0
+}
+```
+
+A copy that was taken from a node with a different seed fails instead:
+
+```
+[tapcli] unable to import backup: ... unable to decrypt backup:
+chacha20poly1305: message authentication failed
+```
+
+## Restoring from the file
+
+Restore is a three step process. It assumes the `lnd` node is already running
+with the wallet restored from the same seed.
+
+1. **Start a fresh `tapd`** against the restored `lnd`. An empty data
+   directory is the clean way to do this. Removing only the database
+   (`tapd.db*`) and leaving the rest of the directory in place works as
+   well, leftover proof files do not affect the import. Either way the node
+   has no assets yet:
+
+   ```
+   $ tapcli assets list
+   {
+       "assets": []
+   }
+   ```
+
+2. **Import the backup file:**
+
+   ```
+   $ tapcli assets backup import --backup_file=/path/to/assets.backup
+   {
+       "num_imported": 3,
+       "num_skipped": 0
+   }
+   ```
+
+   The import checks on chain whether every listed output is still unspent
+   before touching anything, so expect it to take around ten seconds.
+
+   `num_imported` is the number of asset outputs that were recovered.
+   `num_skipped` counts entries that could not be imported because their data
+   did not verify. Entries whose anchor output was already spent are neither
+   imported nor counted as skipped, they are silently left out since they hold
+   no value.
+
+3. **Verify:**
+
+   ```
+   $ tapcli assets list
+   ```
+
+   should now list the recovered assets, and the new node's own backup file
+   picks them up shortly after.
+
+The import registers the recovered keys with the `lnd` wallet so the outputs
+can be spent right away. Importing the same file again is harmless and reports
+zero imported assets.
+
+## Manual exports
+
+The `tapcli assets backup export` command still exists and produces a
+plaintext snapshot in the format of your choice. The file and the manual
+export complement each other:
+
+| | Backup file | Manual export |
+|---|---|---|
+| Kept up to date | automatically | when you run it |
+| Encrypted | yes, wallet key | no |
+| Proof data | compact | raw, compact or optimistic |
+| Import command | `tapcli assets backup import` | `tapcli assets backup import` |
+
+Both are accepted by the same import command, which detects the format from the
+file contents.
+
+## Known limitations
+
+- The import restores the assets but does not advance the `lnd` key family
+  counters. After a restore, `tapd` derives new keys starting from where the
+  restored `lnd` wallet stands, which may reuse indexes that the old node had
+  already handed out. This is being addressed separately.
+- A backup file at the configured path that cannot be decrypted with the
+  wallet key stops `tapd` from starting:
+
+  ```
+  unable to start backup file updater: existing backup file cannot be
+  decrypted with the wallet key: unable to decrypt backup: ...
+  ```
+
+  This protects a file that most likely belongs to another seed from being
+  overwritten. Move the file away or point `backup.filepath` elsewhere to
+  proceed.

--- a/docs/backup.md
+++ b/docs/backup.md
@@ -2,7 +2,8 @@
 
 This document describes the wallet backup system for Taproot Assets (`tapd`),
 covering the binary format, the stripping/rehydration mechanism for compact
-backups, stale-backup detection, and the RPC interface.
+backups, stale-backup detection, the RPC interface and the encrypted backup
+file that `tapd` keeps up to date on disk.
 
 ## Overview
 
@@ -97,6 +98,7 @@ Types 7 and 9 are odd, so a v1-only decoder will safely skip them.
 | 2 | Index | Key index (`uint32`) |
 | 3 | RawPubKey | Pre-tweak internal public key (33 bytes) |
 | 4 | Tweak | Tweak bytes; absent means BIP-86 |
+| 5 | Type | Script key type (`uint8`) as known by the exporting wallet; optional. Without it the importer classifies the key from its material (BIP-86 and unique Pedersen keys by re-derivation, other tweaked keys as external script path) |
 
 ### KeyDescriptorBackup TLV
 
@@ -290,6 +292,119 @@ sequenceDiagram
   immediately after its registration. For very large wallets (tens of
   thousands of assets) the dispatch loop itself adds latency, and early
   goroutines' timeouts may expire before later registrations complete.
+
+---
+
+## Backup File
+
+In addition to the on-demand export RPC, `tapd` keeps an encrypted compact (v2)
+backup of the wallet on disk and updates it whenever the wallet state changes.
+The operator guide for the file is [backup-file.md](backup-file.md), this
+section covers the mechanics.
+This mirrors lnd's `channel.backup` file: the goal is that a copy of the file
+plus the lnd seed is enough to recover every asset the wallet held at the time
+the copy was taken.
+
+### Location and configuration
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `backup.filepath` | `<datadir>/<network>/assets.backup` | Location of the backup file |
+| `backup.disable` | `false` | Turn the on-disk backup file off |
+
+The export and import RPCs work regardless of these settings.
+
+### Encryption
+
+The file is encrypted with XChaCha20-Poly1305. The key is derived from the
+lnd wallet the same way lnd derives the key for `channel.backup`: the public
+key at key family `KeyFamilyBaseEncryption` (8), index 0 is hashed with
+SHA-256. Any `tapd` connected to an lnd with the same seed can decrypt the
+file. Nothing else can, so the file may be copied to untrusted storage.
+
+The encrypted container is:
+
+```
+"TAPENC" (6 bytes) | version (uint32 BE, currently 1) | nonce (24 bytes) | ciphertext
+```
+
+The plaintext inside is a regular v2 backup as produced by
+`ExportAssetWalletBackup` in `COMPACT` mode, including its checksum.
+
+`ImportAssetsFromBackup` accepts both plaintext exports and encrypted files.
+The container header decides which path is taken, so `tapcli assets backup
+import --backup_file=assets.backup` works unchanged.
+
+### Update mechanism
+
+The updater holds the current set of backup entries in memory, keyed by
+`(asset ID, script key, anchor outpoint)`, and subscribes to three event
+sources: the proof import notifications of the asset store (asset received,
+transfer confirmed with local outputs, sweep, re-org re-import), the minting
+batch state events of the planter (mint confirmed) and the send state events
+of the chain porter (a full value send without change or tombstone output
+imports no local proof). Notifications only mark the state as changed, the
+actual content is always read from the database.
+
+On each notification, after a short debounce (1s) so a single confirmation with
+many outputs causes one rewrite:
+
+1. The confirmed, unspent asset set is fetched from the database. Leased
+   leaves are included since they are still owned until their spend confirms.
+   Unconfirmed leaves are skipped and enter the file once they confirm.
+   Leaves that fund asset channels are excluded, they belong to lnd's channel
+   state and `channel.backup` and cannot be used by a tapd restored on its
+   own.
+2. Leaves that disappeared from the set were spent and are dropped. Leaves
+   that appeared, or whose anchor block changed, get a fresh compact entry
+   built from their proof. An anchor key the wallet does not own, such as
+   the aggregated key of a channel funding output, is recorded without a
+   locator. Any other failure while building an entry leaves the leaf out
+   and it is retried, so a transient database error never produces an entry
+   with a wrong derivation path.
+3. The existing file is read and decrypted. Entries known to the database
+   replace their disk copy and spent leaves are removed. Entries found only
+   on disk are checked against the database: a leaf the database knows as
+   spent, which happens when the spend confirmed while tapd was down, is
+   dropped. A leaf the database does not know at all is retained, it may
+   come from a file the operator placed at the path.
+4. The result is encoded, encrypted, written to a temporary sibling file,
+   synced, and renamed over the main file so a crash can never leave a half
+   written backup.
+
+The same reconcile runs right after startup (so the file reflects the
+database after a restart or a manual import) and once more on shutdown.
+Startup itself only derives the key and checks that an existing file can be
+read. Failures to build an entry, for example because a proof is temporarily
+unavailable, are retried every 30 seconds, and a change arriving during that
+wait is handled after the normal debounce. An existing file that cannot be
+decrypted with the wallet key is a startup error, since it most likely
+belongs to a different seed and overwriting it could destroy the only copy.
+A plaintext export placed at the path is adopted and re-written encrypted,
+except an optimistic (v3) export, which carries no proof data and is refused.
+
+### Cost
+
+Every reconcile fetches the full unspent asset set with witnesses from the
+database, the same query the export RPC runs, and rewrites the whole file:
+read, decrypt, decode, encode, encrypt, write. Proof fetching and stripping
+only happens for leaves that are new or re-anchored. The in-memory entry set
+holds one compact entry per leaf, 2 to 10 KB each, for the lifetime of the
+process. The file grows with the length of the provenance chains, since each
+entry carries a stripped proof chain. The debounce of one second keeps a
+confirmation with many outputs to a single rewrite.
+
+### Restore
+
+Point a fresh `tapd`, connected to an lnd restored from the same seed, at the
+file:
+
+```
+tapcli assets backup import --backup_file=/path/to/assets.backup
+```
+
+Import is idempotent and skips leaves whose anchor outpoint has been spent, so
+a copy of the file that is somewhat out of date is safe to import.
 
 ---
 

--- a/docs/release-notes/release-notes-0.9.0.md
+++ b/docs/release-notes/release-notes-0.9.0.md
@@ -21,6 +21,15 @@
 
 # Bug Fixes
 
+- [Importing an asset wallet
+  backup](https://github.com/lightninglabs/taproot-assets/pull/2277) into a
+  node whose database was wiped but whose proofs directory survived no longer
+  skips every asset as already present. The existence check now consults the
+  wallet database only. Backups also record the script key type, so assets
+  received on V2 addresses (unique Pedersen script keys) stay visible and
+  spendable after a restore instead of being filed as external script path
+  keys.
+
 * [PR#2190](https://github.com/lightninglabs/taproot-assets/pull/2190)
   fixes a bug that could cause minted assets to commit to the wrong
   address.
@@ -113,13 +122,6 @@
   long-running node the series steps down. The per-day `sync_events`
   series is unchanged and still reflects sync traffic volume.
 
-* [PR#2262](https://github.com/lightninglabs/taproot-assets/pull/2262)
-  fixes a bug in which cancelling a minting batch left the leases on
-  the batch's funded wallet inputs in place, keeping those inputs
-  unusable until the lease TTL expired. The leases are now released
-  whenever a batch is cancelled, including batches cancelled during
-  startup recovery.
-
 * [PR#2267](https://github.com/lightninglabs/taproot-assets/pull/2267)
   rejects a negative `expiry` when adding a Taproot Asset channel
   invoice. A negative expiry previously skipped the default and was
@@ -140,6 +142,16 @@
   runs alongside the existing re-org watcher; no subsystem registers
   anchorings with it yet, so no existing flow changes behaviour in
   this release.
+
+- [`tapd` now keeps an encrypted asset wallet backup
+  file](https://github.com/lightninglabs/taproot-assets/pull/2277)
+  (`assets.backup`, see [backup-file.md](../backup-file.md)) on disk that is updated
+  whenever the wallet state changes, in the same spirit as lnd's
+  `channel.backup`. The file holds a compact backup of every confirmed,
+  unspent asset and is encrypted with a key derived from the connected lnd
+  wallet. `ImportAssetsFromBackup` accepts the encrypted file directly, so a
+  fresh `tapd` connected to an lnd restored from the same seed can recover
+  its assets with `tapcli assets backup import`.
 
 ## RPC Additions
 
@@ -201,6 +213,11 @@
 ## tapcli Updates
 
 ## Config Changes
+
+- The new [`--backup.filepath`
+  flag](https://github.com/lightninglabs/taproot-assets/pull/2277) sets the
+  location of the encrypted asset wallet backup file (default: `assets.backup` in the network data
+  directory) and `--backup.disable` turns the file off.
 
 - The new `--universe.no-delta-sync` flag forces the federation syncer
   to always use full enumeration sync, serving as a kill switch for

--- a/docs/safety.md
+++ b/docs/safety.md
@@ -11,17 +11,21 @@ and BTC)!**
 
 ## How to avoid loss of funds (short version, tl;dr)
 
-In short, there is no recovery mechanism yet that allows easy asset recovery
-using only the `lnd` seed. If `tapd`'s database is lost or corrupted,
-access to all assets minted or received by that `tapd` **is lost**.
-Additionally, custody the BTC used to carry/anchor the assets would also be
-lost.
+In short, the `lnd` seed alone is not enough to recover assets. If `tapd`'s
+database is lost or corrupted and no backup exists, access to all assets minted
+or received by that `tapd` **is lost**. Additionally, custody of the BTC used
+to carry/anchor the assets would also be lost.
 
 **To avoid loss of funds:**
 1. **make sure the `/home/<user>/.tapd` directory is backed up regularly.**
-   If `tapd` is configured to use Postgres as the database backend, backups this
-   database is sufficient to preserve access to funds.
-2. `lnd`'s seed phrase has been securely backed up, as all `tapd` assets private
+   If `tapd` is configured to use Postgres as the database backend, backing up
+   this database is sufficient to preserve access to funds.
+2. **keep a copy of the asset wallet backup file** `tapd` maintains at
+   `<tapddir>/data/<network>/assets.backup`. It is encrypted with a key derived
+   from the `lnd` seed and, together with the seed, allows recovery of all
+   confirmed unspent assets into a fresh `tapd`. See
+   [backup-file.md](backup-file.md).
+3. `lnd`'s seed phrase has been securely backed up, as all `tapd` assets private
    keys are derived from it.
 
 ## How to avoid loss of funds (extended version)
@@ -59,6 +63,12 @@ users/transactions of a system):
 Optionally, instances of the proof files in `<tapddir>/data/<network>/proofs`
 can be backed up as well, but those are also all contained in the SQLite or
 Postgres database and are only on the filesystem for faster access.
+
+The asset wallet backup file `<tapddir>/data/<network>/assets.backup` is kept
+up to date by `tapd` itself and is safe to copy at any time. It covers the
+confirmed unspent assets only, not addresses, universe state or channel data,
+so it complements rather than replaces the database backup. See
+[backup-file.md](backup-file.md) for how to use it.
 
 ### Where are the private keys for assets stored?
 

--- a/itest/backup_file_test.go
+++ b/itest/backup_file_test.go
@@ -1,0 +1,446 @@
+package itest
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/lightninglabs/lndclient"
+	"github.com/lightninglabs/taproot-assets/asset"
+	"github.com/lightninglabs/taproot-assets/backup"
+	"github.com/lightninglabs/taproot-assets/taprpc"
+	wrpc "github.com/lightninglabs/taproot-assets/taprpc/assetwalletrpc"
+	"github.com/lightninglabs/taproot-assets/taprpc/mintrpc"
+	"github.com/lightningnetwork/lnd/lntest/wait"
+	"github.com/stretchr/testify/require"
+)
+
+// backupFilePath returns the default location of the encrypted asset wallet
+// backup file of the given tapd node.
+func backupFilePath(tapd *tapdHarness) string {
+	return filepath.Join(
+		tapd.cfg.BaseDir, "data", tapd.cfg.NetParams.Name,
+		backup.DefaultBackupFileName,
+	)
+}
+
+// readBackupFile reads, decrypts and decodes the backup file of the given
+// node, using the lnd node it is connected to for the encryption key.
+func readBackupFile(ctx context.Context, tapd *tapdHarness,
+	lnd *lndclient.GrpcLndServices) ([]byte, *backup.WalletBackup, error) {
+
+	raw, err := os.ReadFile(backupFilePath(tapd))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if !backup.IsEncryptedBackup(raw) {
+		return nil, nil, fmt.Errorf("backup file is not encrypted")
+	}
+
+	encrypter, err := backup.NewKeyRingEncrypter(ctx, lnd.WalletKit)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	plaintext, err := backup.DecryptBackup(encrypter, raw)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	wb, err := backup.DecodeWalletBackup(plaintext)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return raw, wb, nil
+}
+
+// waitForBackupFile waits until the backup file of the given node decodes
+// and satisfies the condition, then returns the raw file and decoded backup.
+func waitForBackupFile(t *harnessTest, tapd *tapdHarness,
+	lnd *lndclient.GrpcLndServices,
+	cond func(*backup.WalletBackup) error) ([]byte, *backup.WalletBackup) {
+
+	ctx := context.Background()
+
+	var (
+		raw []byte
+		wb  *backup.WalletBackup
+	)
+	err := wait.NoError(func() error {
+		var err error
+		raw, wb, err = readBackupFile(ctx, tapd, lnd)
+		if err != nil {
+			return err
+		}
+
+		return cond(wb)
+	}, defaultWaitTimeout)
+	require.NoError(t.t, err)
+
+	return raw, wb
+}
+
+// expectEntries returns a backup file condition that requires exactly the
+// given amounts to be present, in any order.
+func expectEntries(amounts ...uint64) func(*backup.WalletBackup) error {
+	return func(wb *backup.WalletBackup) error {
+		if len(wb.Assets) != len(amounts) {
+			return fmt.Errorf("expected %d entries, got %d",
+				len(amounts), len(wb.Assets))
+		}
+
+		remaining := append([]uint64{}, amounts...)
+		for _, ab := range wb.Assets {
+			if ab.Asset == nil {
+				return fmt.Errorf("entry without asset")
+			}
+
+			found := false
+			for i, amt := range remaining {
+				if ab.Asset != nil && ab.Asset.Amount == amt {
+					remaining = append(
+						remaining[:i],
+						remaining[i+1:]...,
+					)
+					found = true
+					break
+				}
+			}
+			if !found {
+				return fmt.Errorf("unexpected entry with "+
+					"amount %d", ab.Asset.Amount)
+			}
+		}
+
+		return nil
+	}
+}
+
+// testBackupFileUpdates asserts that the encrypted asset wallet backup file
+// is written on startup, follows sends and receives, can only be read with the
+// wallet key and can be used to restore a fresh tapd on the same lnd.
+//
+// Flow:
+//  1. Alice mints an asset, her backup file contains the minted leaf.
+//  2. Alice sends part of it to Bob. Alice's file swaps the minted leaf for
+//     the change leaf, Bob's file gains the received leaf. Alice also mints
+//     a grouped asset and sends it to a V2 address of Bob, whose script key
+//     is a unique Pedersen key: tweaked, yet spent like a BIP-86 key.
+//  3. Alice cannot import Bob's file (different wallet key).
+//  4. Bob's tapd is stopped and a fresh tapd on Bob's lnd imports the file,
+//     recovering the leaf.
+//  5. Only Bob's database is wiped, the proofs directory and the file stay.
+//     The restarted tapd imports the file and recovers the leaf again.
+func testBackupFileUpdates(t *harnessTest) {
+	ctxb := context.Background()
+	ctxt, cancel := context.WithTimeout(ctxb, defaultWaitTimeout*6)
+	defer cancel()
+
+	aliceLnd, err := t.newLndClient(t.tapd.cfg.LndNode)
+	require.NoError(t.t, err)
+	defer aliceLnd.Close()
+
+	// A fresh node with no assets still writes an (empty) file on
+	// startup.
+	waitForBackupFile(t, t.tapd, aliceLnd, expectEntries())
+
+	// === Stage 1: Mint on Alice ===
+	rpcAssets := MintAssetsConfirmBatch(
+		t.t, t.lndHarness.Miner(), t.tapd,
+		[]*mintrpc.MintAssetRequest{{
+			Asset: &mintrpc.MintAsset{
+				AssetType: taprpc.AssetType_NORMAL,
+				Name:      "backup-file-asset",
+				AssetMeta: &taprpc.AssetMeta{
+					Data: []byte("backup file test"),
+				},
+				Amount: 1000,
+			},
+		}},
+	)
+	require.Len(t.t, rpcAssets, 1)
+	minted := rpcAssets[0]
+
+	_, aliceBackup := waitForBackupFile(
+		t, t.tapd, aliceLnd, expectEntries(1000),
+	)
+	mintedEntry := aliceBackup.Assets[0]
+	require.Equal(t.t, backup.BackupVersionStripped, aliceBackup.Version)
+
+	mintedID := mintedEntry.Asset.ID()
+	require.Equal(t.t, minted.AssetGenesis.AssetId, mintedID[:])
+	require.Equal(t.t, minted.ScriptKey,
+		mintedEntry.Asset.ScriptKey.PubKey.SerializeCompressed())
+	require.NotEmpty(t.t, mintedEntry.StrippedProofFileBlob)
+	require.Empty(t.t, mintedEntry.ProofFileBlob)
+	require.NotNil(t.t, mintedEntry.AnchorInternalKeyInfo)
+	require.NotZero(
+		t.t, mintedEntry.AnchorInternalKeyInfo.KeyLocator.Family,
+	)
+
+	// === Stage 2: Send part of the asset to Bob ===
+	bobLnd := t.lndHarness.NewNodeWithCoins("Bob", nil)
+	bobTapd := setupTapdHarness(t.t, t, bobLnd, t.universeServer)
+
+	bobLndClient, err := t.newLndClient(bobLnd)
+	require.NoError(t.t, err)
+	defer bobLndClient.Close()
+
+	bobAddr, err := bobTapd.NewAddr(ctxt, &taprpc.NewAddrRequest{
+		AssetId:      minted.AssetGenesis.AssetId,
+		Amt:          300,
+		AssetVersion: minted.Version,
+	})
+	require.NoError(t.t, err)
+	AssertAddrCreated(t.t, bobTapd, minted, bobAddr)
+
+	sendResp, _ := sendAssetsToAddr(t, t.tapd, bobAddr)
+	ConfirmAndAssertOutboundTransfer(
+		t.t, t.lndHarness.Miner(), t.tapd, sendResp,
+		minted.AssetGenesis.AssetId, []uint64{700, 300}, 0, 1,
+	)
+	AssertNonInteractiveRecvComplete(t.t, bobTapd, 1)
+
+	// Alice's file now holds the change leaf only, anchored at a new
+	// outpoint.
+	_, aliceBackup = waitForBackupFile(
+		t, t.tapd, aliceLnd, expectEntries(700),
+	)
+	require.NotEqual(t.t, mintedEntry.AnchorOutpoint,
+		aliceBackup.Assets[0].AnchorOutpoint)
+
+	// Bob's file holds the received leaf.
+	_, bobBackup := waitForBackupFile(
+		t, bobTapd, bobLndClient, expectEntries(300),
+	)
+	bobID := bobBackup.Assets[0].Asset.ID()
+	require.Equal(t.t, minted.AssetGenesis.AssetId, bobID[:])
+
+	// A grouped asset received on a V2 address lands on a unique Pedersen
+	// script key. Its entry must record that type, otherwise a restore
+	// files it as an external script path key and hides it.
+	grouped := MintAssetsConfirmBatch(
+		t.t, t.lndHarness.Miner(), t.tapd,
+		[]*mintrpc.MintAssetRequest{CopyRequest(issuableAssets[0])},
+	)[0]
+	groupAddr, err := bobTapd.NewAddr(ctxt, &taprpc.NewAddrRequest{
+		AddressVersion: taprpc.AddrVersion_ADDR_VERSION_V2,
+		GroupKey:       grouped.AssetGroup.TweakedGroupKey,
+	})
+	require.NoError(t.t, err)
+
+	sendResp, err = t.tapd.SendAsset(ctxt, &taprpc.SendAssetRequest{
+		AddressesWithAmounts: []*taprpc.AddressWithAmount{{
+			TapAddr: groupAddr.Encoded,
+			Amount:  grouped.Amount,
+		}},
+	})
+	require.NoError(t.t, err)
+	AssertAssetOutboundTransferWithOutputs(
+		t.t, t.lndHarness.Miner(), t.tapd, sendResp.Transfer,
+		[][]byte{grouped.AssetGenesis.AssetId},
+		[]uint64{grouped.Amount}, 1, 2, 1, true,
+	)
+	AssertNonInteractiveRecvComplete(t.t, bobTapd, 2)
+
+	bobRaw, bobBackup := waitForBackupFile(
+		t, bobTapd, bobLndClient, expectEntries(300, grouped.Amount),
+	)
+	for _, ab := range bobBackup.Assets {
+		require.NotNil(t.t, ab.ScriptKeyInfo)
+		if ab.Asset.Amount == grouped.Amount {
+			require.Equal(t.t, asset.ScriptKeyUniquePedersen,
+				ab.ScriptKeyInfo.Type)
+			require.NotEmpty(t.t, ab.ScriptKeyInfo.Tweak)
+		} else {
+			require.Equal(t.t, asset.ScriptKeyBip86,
+				ab.ScriptKeyInfo.Type)
+		}
+	}
+
+	// Both leaves are visible with the default listing filter.
+	bobAssets, err := bobTapd.ListAssets(ctxt, &taprpc.ListAssetRequest{})
+	require.NoError(t.t, err)
+	require.Len(t.t, bobAssets.Assets, 2)
+
+	// === Stage 3: Wrong key ===
+	// Alice's wallet key cannot decrypt Bob's file.
+	_, err = t.tapd.ImportAssetsFromBackup(
+		ctxt, &wrpc.ImportAssetsFromBackupRequest{Backup: bobRaw},
+	)
+	require.ErrorContains(t.t, err, "unable to decrypt")
+
+	// === Stage 4: Restore Bob from the file ===
+	// Stop Bob's tapd, dropping its database, and start a fresh tapd on
+	// the same lnd node.
+	require.NoError(t.t, bobTapd.stop(!*noDelete))
+
+	bobTapd2 := setupTapdHarness(t.t, t, bobLnd, t.universeServer)
+
+	bobAssets, err = bobTapd2.ListAssets(ctxt, &taprpc.ListAssetRequest{})
+	require.NoError(t.t, err)
+	require.Empty(t.t, bobAssets.Assets)
+
+	importResp, err := bobTapd2.ImportAssetsFromBackup(
+		ctxt, &wrpc.ImportAssetsFromBackupRequest{Backup: bobRaw},
+	)
+	require.NoError(t.t, err)
+	require.Equal(t.t, uint32(2), importResp.NumImported)
+	require.Equal(t.t, uint32(0), importResp.NumSkipped)
+
+	// Both leaves are back, visible with the default filter, and the
+	// balances see them too. This is what a restore is for.
+	assertRestoredLeaves(t, bobTapd2, minted, grouped)
+
+	// Importing again is a no-op.
+	importResp, err = bobTapd2.ImportAssetsFromBackup(
+		ctxt, &wrpc.ImportAssetsFromBackupRequest{Backup: bobRaw},
+	)
+	require.NoError(t.t, err)
+	require.Equal(t.t, uint32(0), importResp.NumImported)
+
+	// The restored node's own backup file catches up with the imported
+	// leaves.
+	waitForBackupFile(
+		t, bobTapd2, bobLndClient, expectEntries(300, grouped.Amount),
+	)
+
+	// === Stage 5: Wipe only the database ===
+	// A common way to "reset" tapd is to delete tapd.db and keep the rest
+	// of the data directory, including the proof files and the backup
+	// file itself. The import must still recover the leaf: proof files
+	// on disk are not the wallet. With the postgres backend every harness
+	// gets its own database, so reusing the data directory alone produces
+	// the same state: fresh database, old proofs directory.
+	require.NoError(t.t, bobTapd2.stop(false))
+
+	dataDir := filepath.Dir(backupFilePath(bobTapd2))
+	dbFiles, err := filepath.Glob(filepath.Join(dataDir, "tapd.db*"))
+	require.NoError(t.t, err)
+	if *dbbackend == "sqlite" {
+		require.NotEmpty(t.t, dbFiles)
+	}
+	for _, f := range dbFiles {
+		require.NoError(t.t, os.Remove(f))
+	}
+	require.FileExists(t.t, backupFilePath(bobTapd2))
+	require.DirExists(t.t, filepath.Join(dataDir, "proofs"))
+
+	bobTapd3 := setupTapdHarness(
+		t.t, t, bobLnd, t.universeServer,
+		WithBaseDir(bobTapd2.cfg.BaseDir),
+	)
+	defer func() {
+		require.NoError(t.t, bobTapd3.stop(!*noDelete))
+	}()
+
+	bobAssets, err = bobTapd3.ListAssets(ctxt, &taprpc.ListAssetRequest{})
+	require.NoError(t.t, err)
+	require.Empty(t.t, bobAssets.Assets)
+
+	// The file on disk was retained across the restart and is what we
+	// import from.
+	bobRaw, _ = waitForBackupFile(
+		t, bobTapd3, bobLndClient, expectEntries(300, grouped.Amount),
+	)
+	importResp, err = bobTapd3.ImportAssetsFromBackup(
+		ctxt, &wrpc.ImportAssetsFromBackupRequest{Backup: bobRaw},
+	)
+	require.NoError(t.t, err)
+	require.Equal(t.t, uint32(2), importResp.NumImported)
+	require.Equal(t.t, uint32(0), importResp.NumSkipped)
+
+	assertRestoredLeaves(t, bobTapd3, minted, grouped)
+
+	// The restored leaf is spendable: send it back to Alice.
+	aliceAddr, err := t.tapd.NewAddr(ctxt, &taprpc.NewAddrRequest{
+		AssetId:      minted.AssetGenesis.AssetId,
+		Amt:          300,
+		AssetVersion: minted.Version,
+	})
+	require.NoError(t.t, err)
+	AssertAddrCreated(t.t, t.tapd, minted, aliceAddr)
+
+	sendResp, _ = sendAssetsToAddr(t, bobTapd3, aliceAddr)
+	ConfirmAndAssertOutboundTransfer(
+		t.t, t.lndHarness.Miner(), bobTapd3, sendResp,
+		minted.AssetGenesis.AssetId, []uint64{0, 300}, 0, 1,
+	)
+	AssertNonInteractiveRecvComplete(t.t, t.tapd, 1)
+
+	waitForBackupFile(
+		t, bobTapd3, bobLndClient, expectEntries(grouped.Amount),
+	)
+	waitForBackupFile(t, t.tapd, aliceLnd, expectEntries(700, 300))
+
+	// The restored Pedersen leaf is spendable as well: send it back to a
+	// V2 address of Alice.
+	aliceGroupAddr, err := t.tapd.NewAddr(ctxt, &taprpc.NewAddrRequest{
+		AddressVersion: taprpc.AddrVersion_ADDR_VERSION_V2,
+		GroupKey:       grouped.AssetGroup.TweakedGroupKey,
+	})
+	require.NoError(t.t, err)
+
+	sendResp, err = bobTapd3.SendAsset(ctxt, &taprpc.SendAssetRequest{
+		AddressesWithAmounts: []*taprpc.AddressWithAmount{{
+			TapAddr: aliceGroupAddr.Encoded,
+			Amount:  grouped.Amount,
+		}},
+	})
+	require.NoError(t.t, err)
+	AssertAssetOutboundTransferWithOutputs(
+		t.t, t.lndHarness.Miner(), bobTapd3, sendResp.Transfer,
+		[][]byte{grouped.AssetGenesis.AssetId},
+		[]uint64{grouped.Amount}, 1, 2, 1, true,
+	)
+	AssertNonInteractiveRecvComplete(t.t, t.tapd, 2)
+
+	waitForBackupFile(t, bobTapd3, bobLndClient, expectEntries())
+	waitForBackupFile(
+		t, t.tapd, aliceLnd, expectEntries(700, 300, grouped.Amount),
+	)
+}
+
+// assertRestoredLeaves asserts that a restored node lists both the BIP-86
+// leaf of the minted asset and the unique Pedersen leaf of the grouped asset
+// with the default filters, in ListAssets and in ListBalances.
+func assertRestoredLeaves(t *harnessTest, tapd *tapdHarness,
+	minted, grouped *taprpc.Asset) {
+
+	ctxb := context.Background()
+	ctxt, cancel := context.WithTimeout(ctxb, defaultWaitTimeout)
+	defer cancel()
+
+	assets, err := tapd.ListAssets(ctxt, &taprpc.ListAssetRequest{})
+	require.NoError(t.t, err)
+	require.Len(t.t, assets.Assets, 2)
+
+	amounts := make(map[string]uint64)
+	types := make(map[string]taprpc.ScriptKeyType)
+	for _, a := range assets.Assets {
+		id := fmt.Sprintf("%x", a.AssetGenesis.AssetId)
+		amounts[id] = a.Amount
+		types[id] = a.ScriptKeyType
+	}
+	mintedID := fmt.Sprintf("%x", minted.AssetGenesis.AssetId)
+	groupedID := fmt.Sprintf("%x", grouped.AssetGenesis.AssetId)
+	require.Equal(t.t, uint64(300), amounts[mintedID])
+	require.Equal(t.t, grouped.Amount, amounts[groupedID])
+	require.Equal(t.t, taprpc.ScriptKeyType_SCRIPT_KEY_BIP86,
+		types[mintedID])
+	require.Equal(t.t, taprpc.ScriptKeyType_SCRIPT_KEY_UNIQUE_PEDERSEN,
+		types[groupedID])
+
+	balances, err := tapd.ListBalances(ctxt, &taprpc.ListBalancesRequest{
+		GroupBy: &taprpc.ListBalancesRequest_AssetId{AssetId: true},
+	})
+	require.NoError(t.t, err)
+	require.Len(t.t, balances.AssetBalances, 2)
+	require.Equal(t.t, uint64(300),
+		balances.AssetBalances[mintedID].Balance)
+	require.Equal(t.t, grouped.Amount,
+		balances.AssetBalances[groupedID].Balance)
+}

--- a/itest/test_harness.go
+++ b/itest/test_harness.go
@@ -431,6 +431,10 @@ type tapdHarnessParams struct {
 	// sweepOrphanUtxos indicates whether orphan UTXO sweeping should be
 	// enabled (overriding the test default of disabled).
 	sweepOrphanUtxos bool
+
+	// baseDir, if set, is the tapd data directory to use instead of a
+	// fresh temporary one. This restarts a tapd on existing data.
+	baseDir string
 }
 
 // Option is a tapd harness option.
@@ -482,6 +486,14 @@ func WithSweepOrphanUtxos() Option {
 	}
 }
 
+// WithBaseDir makes the tapd harness reuse the given data directory instead
+// of creating a fresh one, so a node can be restarted on existing data.
+func WithBaseDir(dir string) Option {
+	return func(th *tapdHarnessParams) {
+		th.baseDir = dir
+	}
+}
+
 // setupTapdHarness creates a new tapd that connects to the given lnd node
 // and to the given universe server.
 func setupTapdHarness(t *testing.T, ht *harnessTest,
@@ -523,6 +535,7 @@ func setupTapdHarness(t *testing.T, ht *harnessTest,
 	tapdCfg := tapdConfig{
 		NetParams: harnessNetParams,
 		LndNode:   node,
+		BaseDir:   params.baseDir,
 	}
 	tapdHarness, err := newTapdHarness(t, ht, tapdCfg, harnessOpts)
 	require.NoError(t, err)

--- a/itest/test_list_on_test.go
+++ b/itest/test_list_on_test.go
@@ -78,6 +78,10 @@ var allTestCases = []*testCase{
 		test: testBackupRestoreOptimistic,
 	},
 	{
+		name: "backup file updates",
+		test: testBackupFileUpdates,
+	},
+	{
 		name: "addresses",
 		test: testAddresses,
 	},

--- a/rpcserver/rpcserver.go
+++ b/rpcserver/rpcserver.go
@@ -12636,6 +12636,8 @@ func (r *RPCServer) ImportAssetsFromBackup(ctx context.Context,
 		ProofArchive:  r.cfg.ProofArchive,
 		KeyRegistrar:  r.cfg.TapAddrBook,
 		ProofVerifier: r.ProofVerifierCtx(ctx),
+		KeyDeriver:    r.cfg.Lnd.WalletKit,
+		WalletProofs:  r.cfg.AssetStore,
 	}
 
 	numImported, numSkipped, err := backup.ImportBackup(

--- a/sample-tapd.conf
+++ b/sample-tapd.conf
@@ -444,6 +444,18 @@
 ; Sweeping is enabled by default; set to true to disable.
 ; wallet.disable-sweep-orphan-utxos=false
 
+[backup]
+
+; The full path to the encrypted asset wallet backup file that tapd keeps up
+; to date with the wallet state. The file is encrypted with a key derived from
+; the connected lnd wallet and can be imported into a fresh tapd connected to
+; an lnd restored from the same seed.
+; backup.filepath=~/.tapd/data/mainnet/assets.backup
+
+; Disable keeping the asset wallet backup file on disk up to date. The export
+; and import RPCs keep working regardless of this setting.
+; backup.disable=false
+
 [address]
 
 ; If true, tapd will not try to sync issuance proofs for unknown assets when

--- a/scripts/check-sample-tapd-conf.sh
+++ b/scripts/check-sample-tapd-conf.sh
@@ -55,7 +55,7 @@ OPTIONS_NO_CONF="help lnddir configfile version end"
 # set, but there aren't any returned defaults by tapd --help. Defaults have to
 # be included in sample-tapd.conf but no further checks are performed.
 OPTIONS_NO_TAPD_DEFAULT_VALUE_CHECK="tapddir configfile tlscertpath tlskeypath \
-    lnd.macaroonpath sqlite.dbfile" 
+    lnd.macaroonpath sqlite.dbfile backup.filepath"
 
 
 # EXITCODE is returned at the end after all checks are performed and set to 1 

--- a/server.go
+++ b/server.go
@@ -264,6 +264,15 @@ func (s *Server) initialize(interceptorChain *rpcperms.InterceptorChain) error {
 		return fmt.Errorf("unable to start aux sweeper mgr: %w", err)
 	}
 
+	// Start the backup file updater last, so its initial reconcile sees
+	// the state all other subsystems settled into on startup.
+	if s.cfg.BackupUpdater != nil {
+		if err := s.cfg.BackupUpdater.Start(); err != nil {
+			return fmt.Errorf("unable to start backup file "+
+				"updater: %w", err)
+		}
+	}
+
 	// If the server is configured to sync all assets by default, we'll set
 	// the universe federation to allow public access.
 	if s.cfg.UniFedSyncAllAssets {
@@ -910,6 +919,15 @@ func (s *Server) Stop() error {
 	}
 	if err := s.cfg.AuxSweeper.Stop(); err != nil {
 		return err
+	}
+
+	// Every subsystem that changes wallet state has stopped, so the
+	// updater's final sync captures the complete state.
+	if s.cfg.BackupUpdater != nil {
+		if err := s.cfg.BackupUpdater.Stop(); err != nil {
+			return fmt.Errorf("unable to stop backup file "+
+				"updater: %w", err)
+		}
 	}
 
 	if s.macaroonService != nil {

--- a/tapcfg/config.go
+++ b/tapcfg/config.go
@@ -21,6 +21,7 @@ import (
 	"github.com/jessevdk/go-flags"
 	"github.com/lightninglabs/lndclient"
 	tap "github.com/lightninglabs/taproot-assets"
+	"github.com/lightninglabs/taproot-assets/backup"
 	"github.com/lightninglabs/taproot-assets/fn"
 	"github.com/lightninglabs/taproot-assets/internal/lncfg"
 	"github.com/lightninglabs/taproot-assets/lndservices"
@@ -330,6 +331,18 @@ type WalletConfig struct {
 	DisableSweepOrphanUtxos bool `long:"disable-sweep-orphan-utxos" description:"Disable sweeping orphaned UTXOs into anchor transactions created during sends and burns. Sweeping is enabled by default."`
 }
 
+// BackupConfig holds the configuration for the on-disk asset wallet backup
+// file that is kept in sync with the wallet state.
+type BackupConfig struct {
+	// Disable turns off the on-disk backup file entirely. The export and
+	// import RPCs keep working regardless of this setting.
+	Disable bool `long:"disable" description:"Disable keeping the encrypted asset wallet backup file on disk up to date."`
+
+	// FilePath is the location of the backup file. If empty, it defaults
+	// to assets.backup inside the network data directory.
+	FilePath string `long:"filepath" description:"The full path to the encrypted asset wallet backup file that is kept up to date with the wallet state. Defaults to assets.backup in the network data directory."`
+}
+
 // UniverseConfig is the config that houses any Universe related config
 // values.
 type UniverseConfig struct {
@@ -439,6 +452,8 @@ type Config struct {
 	Universe *UniverseConfig `group:"universe" namespace:"universe"`
 
 	Wallet *WalletConfig `group:"wallet" namespace:"wallet"`
+
+	Backup *BackupConfig `group:"backup" namespace:"backup"`
 
 	AddrBook *AddrBookConfig `group:"address" namespace:"address"`
 
@@ -560,6 +575,7 @@ func DefaultConfig() Config {
 		Wallet: &WalletConfig{
 			PsbtMaxFeeRatio: DefaultPsbtMaxFeeRatio,
 		},
+		Backup: &BackupConfig{},
 		AddrBook: &AddrBookConfig{
 			DisableSyncer: false,
 		},
@@ -878,6 +894,21 @@ func ValidateConfig(cfg Config, cfgLogger btclog.Logger) (*Config, error) {
 	cfg.networkDir = filepath.Join(
 		cfg.DataDir, lncfg.NormalizeNetwork(cfg.ActiveNetParams.Name),
 	)
+
+	// The backup file lives next to the database unless the user chose a
+	// different location.
+	if cfg.Backup.FilePath == "" {
+		cfg.Backup.FilePath = filepath.Join(
+			cfg.networkDir, backup.DefaultBackupFileName,
+		)
+	}
+	cfg.Backup.FilePath = CleanAndExpandPath(cfg.Backup.FilePath)
+	if info, err := os.Stat(cfg.Backup.FilePath); err == nil &&
+		info.IsDir() {
+
+		return nil, fmt.Errorf("backup.filepath %v is a directory, "+
+			"it must name a file", cfg.Backup.FilePath)
+	}
 
 	// We'll also update the database file location as well, if it wasn't
 	// set.

--- a/tapcfg/server.go
+++ b/tapcfg/server.go
@@ -7,6 +7,7 @@ import (
 	"encoding/binary"
 	"fmt"
 
+	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/wire/v2"
 	"github.com/btcsuite/btclog/v2"
 	"github.com/davecgh/go-spew/spew"
@@ -15,6 +16,7 @@ import (
 	"github.com/lightninglabs/taproot-assets/address"
 	"github.com/lightninglabs/taproot-assets/asset"
 	"github.com/lightninglabs/taproot-assets/authmailbox"
+	"github.com/lightninglabs/taproot-assets/backup"
 	"github.com/lightninglabs/taproot-assets/fn"
 	"github.com/lightninglabs/taproot-assets/healthcheck"
 	"github.com/lightninglabs/taproot-assets/lndservices"
@@ -876,6 +878,92 @@ func genServerConfig(ctx context.Context, cfg *Config,
 			err)
 	}
 
+	assetMinter := tapgarden.NewChainPlanter(tapgarden.PlanterConfig{
+		// nolint: lll
+		GardenKit: tapgarden.GardenKit{
+			Wallet:       walletAnchor,
+			ChainBridge:  chainBridge,
+			BatchStore:   assetMintingStore,
+			MintingRefs:  assetMintingStore,
+			TreeStore:    assetMintingStore,
+			KeyRing:      keyRing,
+			GenSigner:    virtualTxSigner,
+			GenTxBuilder: &tapscript.GroupTxBuilder{},
+			TxValidator:  &tap.ValidatorV0{},
+			ProofFiles:   proofFileStore,
+			MintProofPublisher: mintpublish.NewPublisher(
+				universeFederation,
+				defaultUniverseSyncBatchSize,
+			),
+			ProofWatcher:       reOrgWatcher,
+			IgnoreChecker:      ignoreCheckerOpt,
+			GenesisTxAugmenter: genesisAugmenter,
+		},
+		ChainParams:  tapChainParams,
+		ProofUpdates: proofArchive,
+		ErrChan:      mainErrChan,
+	})
+
+	// The backup updater keeps an encrypted copy of the wallet's asset
+	// state on disk, in the same spirit as lnd's channel.backup file.
+	var backupUpdater *backup.Updater
+	if !cfg.Backup.Disable {
+		backupUpdater, err = backup.NewUpdater(&backup.UpdaterConfig{
+			FetchAssets: func(ctx context.Context) (
+				[]*asset.ChainAsset, error) {
+
+				// Leased leaves are still ours until their
+				// spend confirms, so they stay in the backup.
+				assets, err := assetStore.FetchAllAssets(
+					ctx, false, true, nil,
+				)
+				if err != nil {
+					return nil, err
+				}
+
+				// Leaves that fund asset channels belong to
+				// lnd's channel state and channel.backup, a
+				// fresh tapd cannot use them on their own.
+				return fn.Filter(assets, backupEligible), nil
+			},
+			LookupSpent: func(ctx context.Context,
+				scriptKey *btcec.PublicKey,
+				anchorPoint wire.OutPoint) (bool, error) {
+
+				leaves, err := assetStore.FetchAllAssets(
+					ctx, true, true,
+					&tapdb.AssetQueryFilters{
+						ScriptKey: &asset.ScriptKey{
+							PubKey: scriptKey,
+						},
+						AnchorPoint: &anchorPoint,
+					},
+				)
+				if err != nil {
+					return false, err
+				}
+
+				return fn.Any(leaves, func(
+					a *asset.ChainAsset) bool {
+
+					return a.IsSpent
+				}), nil
+			},
+			ProofArchive:  proofArchive,
+			KeyLookup:     tapdbAddrBook,
+			ProofNotifier: assetStore,
+			EventNotifiers: []backup.EventNotifier{
+				assetMinter, chainPorter,
+			},
+			KeyDeriver: lndServices.WalletKit,
+			Swapper:    backup.NewFile(cfg.Backup.FilePath),
+		})
+		if err != nil {
+			return nil, fmt.Errorf("unable to create backup "+
+				"updater: %w", err)
+		}
+	}
+
 	// nolint: lll
 	return &tapconfig.Config{
 		DebugLevel:            cfg.DebugLevel,
@@ -887,31 +975,7 @@ func genServerConfig(ctx context.Context, cfg *Config,
 		ReOrgWatcher:          reOrgWatcher,
 		AnchoringWatcher:      anchoringWatcher,
 		AnchoringRegistry:     anchoringRegistry,
-		AssetMinter: tapgarden.NewChainPlanter(tapgarden.PlanterConfig{
-			// nolint: lll
-			GardenKit: tapgarden.GardenKit{
-				Wallet:       walletAnchor,
-				ChainBridge:  chainBridge,
-				BatchStore:   assetMintingStore,
-				MintingRefs:  assetMintingStore,
-				TreeStore:    assetMintingStore,
-				KeyRing:      keyRing,
-				GenSigner:    virtualTxSigner,
-				GenTxBuilder: &tapscript.GroupTxBuilder{},
-				TxValidator:  &tap.ValidatorV0{},
-				ProofFiles:   proofFileStore,
-				MintProofPublisher: mintpublish.NewPublisher(
-					universeFederation,
-					defaultUniverseSyncBatchSize,
-				),
-				ProofWatcher:       reOrgWatcher,
-				IgnoreChecker:      ignoreCheckerOpt,
-				GenesisTxAugmenter: genesisAugmenter,
-			},
-			ChainParams:  tapChainParams,
-			ProofUpdates: proofArchive,
-			ErrChan:      mainErrChan,
-		}),
+		AssetMinter:           assetMinter,
 		AssetCustodian: tapcustody.NewCustodian(&tapcustody.Config{
 			ChainParams:            &tapChainParams,
 			WalletAnchor:           walletAnchor,
@@ -974,8 +1038,21 @@ func genServerConfig(ctx context.Context, cfg *Config,
 			Multiverse:   multiverse,
 			FederationDB: federationDB,
 		},
-		Prometheus: cfg.Prometheus,
+		BackupUpdater: backupUpdater,
+		Prometheus:    cfg.Prometheus,
 	}, nil
+}
+
+// backupEligible reports whether a wallet leaf belongs in the asset wallet
+// backup file. Channel related leaves are excluded, they are covered by lnd's
+// channel state and cannot be used by a tapd restored on their own.
+func backupEligible(a *asset.ChainAsset) bool {
+	if a == nil || a.Asset == nil || a.ScriptKey.TweakedScriptKey == nil {
+		return true
+	}
+
+	return a.ScriptKey.TweakedScriptKey.Type !=
+		asset.ScriptKeyScriptPathChannel
 }
 
 // CreateServerFromConfig creates a new Taproot Asset server from the given CLI

--- a/tapconfig/config.go
+++ b/tapconfig/config.go
@@ -9,6 +9,7 @@ import (
 	"github.com/lightninglabs/lndclient"
 	"github.com/lightninglabs/taproot-assets/address"
 	"github.com/lightninglabs/taproot-assets/authmailbox"
+	"github.com/lightninglabs/taproot-assets/backup"
 	"github.com/lightninglabs/taproot-assets/healthcheck"
 	"github.com/lightninglabs/taproot-assets/lndservices"
 	"github.com/lightninglabs/taproot-assets/monitoring"
@@ -311,6 +312,11 @@ type Config struct {
 	AuxChanCloser *tapchannel.AuxChanCloser
 
 	AuxSweeper *tapchannel.AuxSweeper
+
+	// BackupUpdater keeps the encrypted asset wallet backup file on disk
+	// in sync with the wallet state. It is nil if the backup file is
+	// disabled.
+	BackupUpdater *backup.Updater
 
 	// UniversePublicAccess is a field that indicates the status of public
 	// access (i.e. read/write) to the universe server.


### PR DESCRIPTION
This adds an lnd `channel.backup` style file for the asset wallet. tapd now
keeps `<datadir>/<network>/assets.backup` in sync with the wallet state
instead of relying on operators to run the export RPC by hand.

### What the file is

- One compact (v2) entry per confirmed, unspent asset leaf, keyed by asset
  ID, script key and anchor outpoint.
- Encrypted with the same key lnd uses for `channel.backup`. Any tapd
  connected to an lnd restored from the same seed can read it.
- Written on startup, on every wallet change and on shutdown. Writes go
  through temp file, fsync, rename, so a copy taken at any time is complete.

### How it stays up to date

- `backup.Updater` holds the entries in memory and subscribes to the asset
  store proof notifications and the planter mint events.
- On every change it reconciles against the database after a 1s debounce:
  new and re-anchored leaves get a fresh entry, spent leaves are dropped,
  entries only found on disk are kept.
- Failed writes are retried. A file at the path that cannot be decrypted
  with the wallet key is a startup error, since it most likely belongs to
  another seed.

### Restore and compatibility

- `ImportAssetsFromBackup` accepts the encrypted file directly and detects
  the format from the content. `tapcli assets backup import` works
  unchanged.
- Plaintext exports of all existing versions import exactly as before. No
  proto change.
- New flags: `--backup.filepath` and `--backup.disable`.
- Fixes found while testing restores:
  - The import skipped assets as already present when a proof file for
    them was still on disk. A node whose database was wiped but whose
    proofs directory survived recovered nothing. The existence check now
    consults the wallet database only.
  - Backups did not record the script key type and the import guessed it
    from the tweak, so unique Pedersen keys (V2 address receives) came back
    as external script path keys, hidden from `ListAssets`, `ListBalances`
    and coin selection. Entries now carry the type as an optional TLV, and
    older backups are classified by re-deriving BIP-86 and Pedersen keys.
  - A full value send without change or tombstone output imports no local
    proof, so the spent leaf stayed in the file. The chain porter send
    events are now a trigger next to the proof notifications and the mint
    events.
- After self review: channel funding leaves are excluded from the file,
  disk-only entries the database knows as spent are pruned, type-less
  tombstone and burn entries from older backups are classified correctly, a
  decoded type outside the known range falls back to classification, an
  optimistic (v3) export at the backup path is refused, a symlinked path is
  followed, and `backup.filepath` naming a directory is a config error.

### Testing

- Unit tests for the encrypted container, the file swapper and the updater:
  add, remove, reorg, debounce, disk only retention, retries after disk and
  DB failures, startup failures, sync and stop.
- New itest `backup_file_updates`: startup, mint, send, receive, wrong key
  rejection, a grouped asset received on a V2 address, restore of a fresh
  tapd on the same lnd, restore after wiping only the database, both
  restored leaves visible with default filters and spent back.
- Manual runs on a docker regtest network covering the custom path, the
  disable flag, the foreign file at path case, and a full seed recovery
  (second lnd restored from the same mnemonic, fresh tapd, import, spend).

### Docs

- `docs/backup-file.md`: operator guide (what it covers, how to keep a copy,
  how to restore).
- `docs/backup.md`: mechanics and container format.
- `docs/safety.md`: now points at the file.

### Not in this PR

Writing the key family markers from #2225 into the file. Once that lands
the updater needs one `ListAccounts` call per write. The two format changes
are independent.
