### PR TITLE
tapchannel: derive initial commitment from negotiated configs behind feature bit

### DIFF
--- a/docs/release-notes/release-notes-0.9.0.md
+++ b/docs/release-notes/release-notes-0.9.0.md
@@ -132,6 +132,17 @@
 
 ## Functional Updates
 
+- [PR#2278](https://github.com/lightninglabs/taproot-assets/pull/2278)
+  derives the initial (height zero) commitment of an asset channel from
+  the negotiated local and remote channel configs (dust limit, CSV
+  delay), which makes it consistent with the commitment that is
+  re-derived on an immediate force close. A new aux channel feature bit,
+  `negotiated-chan-cfg`, is advertised as optional. When a peer doesn't
+  signal it, the previous derivation from zeroed configs is used so that
+  channels can still be opened with older versions. The next release
+  will make the feature required, at which point peers that don't signal
+  it are rejected.
+
 - [PR#2202](https://github.com/lightninglabs/taproot-assets/pull/2202)
   adds cursor-based delta sync to the universe federation. Each server
   exposes its insertion-ordered leaf journal via the new `SyncDelta`

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/lightninglabs/lndclient v1.0.1-0.20260701212139-09c54915cfba
 	github.com/lightninglabs/neutrino/cache v1.1.4
 	github.com/lightninglabs/taproot-assets/taprpc v1.1.0
-	github.com/lightningnetwork/lnd v0.21.0-beta.rc2.0.20260828135403-cb58f8bb3d5c
+	github.com/lightningnetwork/lnd v0.21.0-beta.rc2.0.20260903094101-d66a7c137d32
 	github.com/lightningnetwork/lnd/cert v1.2.2
 	github.com/lightningnetwork/lnd/clock v1.1.1
 	github.com/lightningnetwork/lnd/fn/v2 v2.0.9

--- a/go.sum
+++ b/go.sum
@@ -1062,8 +1062,8 @@ github.com/lightninglabs/protobuf-go-hex-display v1.34.2-hex-display h1:w7FM5LH9
 github.com/lightninglabs/protobuf-go-hex-display v1.34.2-hex-display/go.mod h1:qYOHts0dSfpeUzUFpOMr/WGzszTmLH+DiWniOlNbLDw=
 github.com/lightningnetwork/lightning-onion v1.4.0 h1:qWE1icOH4AKXRcq1KCzt6P/TesqptgBTP++V7wowTc0=
 github.com/lightningnetwork/lightning-onion v1.4.0/go.mod h1:YDPkvVTVQ6FBBE6Yj93tDd7zA3iTSrryi9xq46i7bKE=
-github.com/lightningnetwork/lnd v0.21.0-beta.rc2.0.20260828135403-cb58f8bb3d5c h1:xtRCTZQ9oaA/XExHTKGhKBSXWXqjgArlwORyyaekv1M=
-github.com/lightningnetwork/lnd v0.21.0-beta.rc2.0.20260828135403-cb58f8bb3d5c/go.mod h1:deRbYNteO2ZNleUYVQLHXCTMKbiuoUO7ShmYseVRRM8=
+github.com/lightningnetwork/lnd v0.21.0-beta.rc2.0.20260903094101-d66a7c137d32 h1:lwPqwW244WCcdOZGwmS+rrieC1hTPYaRvkjHC8KXDeY=
+github.com/lightningnetwork/lnd v0.21.0-beta.rc2.0.20260903094101-d66a7c137d32/go.mod h1:deRbYNteO2ZNleUYVQLHXCTMKbiuoUO7ShmYseVRRM8=
 github.com/lightningnetwork/lnd/actor v0.0.6 h1:Ge8N2wivARG+27qJBwTlB0vwsypStZYZy8vk4Zl38sU=
 github.com/lightningnetwork/lnd/actor v0.0.6/go.mod h1:YAsoniSbY/cAM9HTVNfZLvt7RI6swDxy6wzPspTcMZg=
 github.com/lightningnetwork/lnd/cert v1.2.2 h1:71YK6hogeJtxSxw2teq3eGeuy4rHGKcFf0d0Uy4qBjI=

--- a/tapchannel/aux_funding_controller.go
+++ b/tapchannel/aux_funding_controller.go
@@ -34,6 +34,7 @@ import (
 	"github.com/lightninglabs/taproot-assets/tappsbt"
 	"github.com/lightninglabs/taproot-assets/tapsend"
 	"github.com/lightninglabs/taproot-assets/vm"
+	"github.com/lightningnetwork/lnd/channeldb"
 	lfn "github.com/lightningnetwork/lnd/fn/v2"
 	"github.com/lightningnetwork/lnd/funding"
 	"github.com/lightningnetwork/lnd/keychain"
@@ -635,6 +636,63 @@ func (p *pendingAssetFunding) addInputProofChunk(
 	}
 
 	return lfn.Ok(lfn.Some(*finalProof))
+}
+
+// ErrNegotiatedChanCfgRequired is returned when we require our peer to derive
+// the initial commitment from the negotiated channel configs but the peer
+// doesn't signal support for it.
+var ErrNegotiatedChanCfgRequired = errors.New("peer does not support " +
+	"deriving the initial commitment from the negotiated channel configs")
+
+// useNegotiatedChanCfg decides whether the initial commitment of a channel with
+// a peer is derived from the negotiated local and remote channel configs. Both
+// parties must derive the very same commitment, so if the peer doesn't signal
+// the feature we fall back to the zeroed configs that older versions used. If
+// we require the feature, a peer that lacks it is rejected.
+func useNegotiatedChanCfg(local, peer lnwire.FeatureVector) (bool, error) {
+	if peer.HasFeature(tapfeatures.NegotiatedChanCfgOptional) {
+		return true, nil
+	}
+
+	if local.RequiresFeature(tapfeatures.NegotiatedChanCfgOptional) {
+		return false, ErrNegotiatedChanCfgRequired
+	}
+
+	return false, nil
+}
+
+// applyNegotiatedChanCfg makes sure the channel configs in the given aux
+// channel state match what our peer uses to derive the initial commitment.
+// Older peers derive it from zeroed channel configs, so if the peer doesn't
+// signal the feature we zero them as well to arrive at the very same commitment
+// transaction. If we require the feature, such a peer is rejected.
+func (f *FundingController) applyNegotiatedChanCfg(peerPub btcec.PublicKey,
+	openChan *lnwallet.AuxChanState) error {
+
+	peerKey := peerPub.SerializeCompressed()
+	peerFeatures := f.cfg.AuxChanNegotiator.GetPeerFeatures(
+		route.Vertex(peerKey),
+	)
+
+	useCfg, err := useNegotiatedChanCfg(
+		tapfeatures.LocalFeatures(), peerFeatures,
+	)
+	if err != nil {
+		return err
+	}
+
+	if useCfg {
+		return nil
+	}
+
+	log.Infof("Peer %x doesn't signal %v, deriving initial commitment "+
+		"from zeroed channel configs", peerKey,
+		tapfeatures.NegotiatedChanCfgOptional)
+
+	openChan.LocalChanCfg = channeldb.ChannelConfig{}
+	openChan.RemoteChanCfg = channeldb.ChannelConfig{}
+
+	return nil
 }
 
 // newCommitBlobAndLeaves creates a new commitment blob that'll be stored in
@@ -2365,6 +2423,17 @@ func (f *FundingController) chanFunder() {
 					ctxc, fundingFlow.peerPub, pid, fErr,
 				)
 				req.errChan <- fErr
+				continue
+			}
+
+			err = f.applyNegotiatedChanCfg(
+				fundingFlow.peerPub, &req.openChan,
+			)
+			if err != nil {
+				f.cfg.ErrReporter.ReportError(
+					ctxc, fundingFlow.peerPub, pid, err,
+				)
+				req.errChan <- err
 				continue
 			}
 

--- a/tapchannel/aux_funding_negotiated_cfg_test.go
+++ b/tapchannel/aux_funding_negotiated_cfg_test.go
@@ -1,0 +1,92 @@
+package tapchannel
+
+import (
+	"testing"
+
+	"github.com/lightninglabs/taproot-assets/tapfeatures"
+	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/stretchr/testify/require"
+)
+
+// TestUseNegotiatedChanCfg asserts the decision of whether the initial
+// commitment is derived from the negotiated channel configs, depending on what
+// we and our peer signal.
+func TestUseNegotiatedChanCfg(t *testing.T) {
+	t.Parallel()
+
+	// The negotiator hands out vectors that know the feature names, which
+	// is what makes the required and optional bit a pair.
+	names := map[lnwire.FeatureBit]string{
+		tapfeatures.NegotiatedChanCfgRequired: "negotiated-chan-cfg",
+		tapfeatures.NegotiatedChanCfgOptional: "negotiated-chan-cfg",
+	}
+	vec := func(bits ...lnwire.FeatureBit) lnwire.FeatureVector {
+		return *lnwire.NewFeatureVector(
+			lnwire.NewRawFeatureVector(bits...), names,
+		)
+	}
+
+	testCases := []struct {
+		name   string
+		local  lnwire.FeatureVector
+		peer   lnwire.FeatureVector
+		useCfg bool
+		err    error
+	}{{
+		name:   "peer optional, we optional",
+		local:  vec(tapfeatures.NegotiatedChanCfgOptional),
+		peer:   vec(tapfeatures.NegotiatedChanCfgOptional),
+		useCfg: true,
+	}, {
+		name:   "peer required, we optional",
+		local:  vec(tapfeatures.NegotiatedChanCfgOptional),
+		peer:   vec(tapfeatures.NegotiatedChanCfgRequired),
+		useCfg: true,
+	}, {
+		name:   "peer optional, we required",
+		local:  vec(tapfeatures.NegotiatedChanCfgRequired),
+		peer:   vec(tapfeatures.NegotiatedChanCfgOptional),
+		useCfg: true,
+	}, {
+		name:   "peer lacks feature, we optional",
+		local:  vec(tapfeatures.NegotiatedChanCfgOptional),
+		peer:   vec(tapfeatures.STXOOptional),
+		useCfg: false,
+	}, {
+		name:   "peer lacks feature, no feature bits at all",
+		local:  vec(tapfeatures.NegotiatedChanCfgOptional),
+		peer:   vec(),
+		useCfg: false,
+	}, {
+		name:  "peer lacks feature, we required",
+		local: vec(tapfeatures.NegotiatedChanCfgRequired),
+		peer:  vec(tapfeatures.STXOOptional),
+		err:   ErrNegotiatedChanCfgRequired,
+	}, {
+		name:  "peer has no feature bits at all, we required",
+		local: vec(tapfeatures.NegotiatedChanCfgRequired),
+		peer:  vec(),
+		err:   ErrNegotiatedChanCfgRequired,
+	}}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			useCfg, err := useNegotiatedChanCfg(tc.local, tc.peer)
+			if tc.err != nil {
+				require.ErrorIs(t, err, tc.err)
+				require.False(t, useCfg)
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tc.useCfg, useCfg)
+		})
+	}
+
+	// The feature vector we actually advertise must lead to the fallback,
+	// not a rejection, for peers that don't know the feature yet.
+	useCfg, err := useNegotiatedChanCfg(tapfeatures.LocalFeatures(), vec())
+	require.NoError(t, err)
+	require.False(t, useCfg)
+}

--- a/tapfeatures/aux_channel_negotiator_test.go
+++ b/tapfeatures/aux_channel_negotiator_test.go
@@ -56,3 +56,25 @@ func TestFeatureBits(t *testing.T) {
 
 	require.Error(t, err)
 }
+
+// TestNegotiatedChanCfgFeature asserts that we advertise the negotiated channel
+// config feature as optional. Flipping it to required is a deliberate,
+// separate step, as it rejects every peer that doesn't signal the feature.
+func TestNegotiatedChanCfgFeature(t *testing.T) {
+	local := LocalFeatures()
+
+	require.True(t, local.HasFeature(NegotiatedChanCfgOptional))
+	require.False(t, local.RequiresFeature(NegotiatedChanCfgOptional))
+
+	// A peer that doesn't know the feature at all must still pass our
+	// required bits check while the feature is optional.
+	peer := lnwire.NewRawFeatureVector(NoOpHTLCsOptional, STXOOptional)
+	require.NoError(t, checkRequiredBits(getLocalFeatureVec(), peer))
+
+	// Once we require it, such a peer is rejected at init.
+	required := lnwire.NewRawFeatureVector(NegotiatedChanCfgRequired)
+	require.Error(t, checkRequiredBits(required, peer))
+
+	peer.Set(NegotiatedChanCfgOptional)
+	require.NoError(t, checkRequiredBits(required, peer))
+}

--- a/tapfeatures/aux_feature_bits.go
+++ b/tapfeatures/aux_feature_bits.go
@@ -18,6 +18,18 @@ const (
 	// STXOOptional is a feature bit that declares the STXO proofs as an
 	// optional feature.
 	STXOOptional lnwire.FeatureBit = 3
+
+	// NegotiatedChanCfgRequired is a feature bit that declares as required
+	// that the initial (height zero) commitment of an asset channel is
+	// derived from the negotiated local and remote channel configs (dust
+	// limit, CSV delay). Peers without this feature derive it from zeroed
+	// configs instead.
+	NegotiatedChanCfgRequired lnwire.FeatureBit = 4
+
+	// NegotiatedChanCfgOptional is a feature bit that declares as optional
+	// that the initial commitment of an asset channel is derived from the
+	// negotiated local and remote channel configs.
+	NegotiatedChanCfgOptional lnwire.FeatureBit = 5
 )
 
 // featureNames keeps track of the string description of known features.
@@ -26,6 +38,9 @@ var featureNames = map[lnwire.FeatureBit]string{
 	NoOpHTLCsOptional: "noop-htlcs",
 	STXORequired:      "stxo-proofs",
 	STXOOptional:      "stxo-proofs",
+
+	NegotiatedChanCfgRequired: "negotiated-chan-cfg",
+	NegotiatedChanCfgOptional: "negotiated-chan-cfg",
 }
 
 // ourFeatures returns a slice containing all of the locally supported features.
@@ -35,7 +50,13 @@ func ourFeatures() []lnwire.FeatureBit {
 	return []lnwire.FeatureBit{
 		NoOpHTLCsOptional,
 		STXOOptional,
+		NegotiatedChanCfgOptional,
 	}
+}
+
+// LocalFeatures returns the feature vector that we advertise to our peers.
+func LocalFeatures() lnwire.FeatureVector {
+	return *lnwire.NewFeatureVector(getLocalFeatureVec(), featureNames)
 }
 
 // getLocalFeatureVec returns the feature vector of the currently supported


### PR DESCRIPTION
## Description

lightningnetwork/lnd#10804 hands the aux funding controller the negotiated
local and remote channel configs when the initial commitment is derived.
That makes the height zero state consistent with what is re-derived on an
immediate force close, but it also changes the commitment we build at
funding time. Peers on older versions still derive it from zeroed configs,
so funding a channel between a node on lnd master and a v0.8.0 node fails
with `counterparty's commitment signature is invalid` (the `Compat Tests`
job on #2177 shows this).

This PR bumps lnd to a master commit that includes #10804 and gates the new
derivation behind an aux channel feature bit:

- `negotiated-chan-cfg` (bits 4/5) is added to `tapfeatures` and advertised
  as optional.
- If the peer signals it, the configs are used as handed by lnd.
- If the peer doesn't, both configs are zeroed before the initial
  commitment is derived. That is exactly what older lnd passed at that
  point, so both sides arrive at the same commitment transaction.
- If we advertise the feature as required and the peer lacks it, the
  funding flow fails with `ErrNegotiatedChanCfgRequired`. This path is
  inactive until the bit is flipped.

Phase 2 (next release) is a follow-up that moves the bit to required. At
that point peers without it are rejected at init by `checkRequiredBits`,
with the funding check as a second line of defence.

Manually verified with the bit flipped to required: a v0.8.0 peer is
dropped at connect time with `peer does not support required feature:
negotiated-chan-cfg`, new to new channels keep working.

Needed by #2177 (its compat job goes green once this lands).

## Testing

- Unit tests for the decision helper across all local/peer bit
  combinations, plus a guard that the bit is advertised as optional.
- `TestBackwardsCompatChannels` (v0.8.0 vs tip) passes again and takes the
  zeroed config path.
- `TestCustomChannels/force_close` passes without touching the fallback.
