### PR TITLE
Add Porcupine linearizability coverage across core subsystems

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/lightninglabs/taproot-assets
 go 1.26.0
 
 require (
+	github.com/anishathalye/porcupine v1.3.0
 	github.com/btcsuite/btcd v0.26.0
 	github.com/btcsuite/btcd/address/v2 v2.0.0
 	github.com/btcsuite/btcd/btcec/v2 v2.5.0

--- a/go.sum
+++ b/go.sum
@@ -624,6 +624,8 @@ github.com/ajstarks/deck/generate v0.0.0-20210309230005-c3f852c02e19/go.mod h1:T
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
 github.com/ajstarks/svgo v0.0.0-20211024235047-1546f124cd8b/go.mod h1:1KcenG0jGWcpt8ov532z81sp/kMMUG485J2InIOyADM=
 github.com/andybalholm/brotli v1.0.4/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHGRSepvi9Eig=
+github.com/anishathalye/porcupine v1.3.0 h1:yo51Niv8Tg0tAAn5XOG2UVvJXUregK4WFuLrBRoowP8=
+github.com/anishathalye/porcupine v1.3.0/go.mod h1:WM0SsFjWNl2Y4BqHr/E/ll2yY1GY1jqn+W7Z/84Zoog=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/apache/arrow/go/v10 v10.0.1/go.mod h1:YvhnlEePVnBS4+0z3fhPfUy7W1Ikj0Ih0vcRo/gZ1M0=
 github.com/apache/arrow/go/v11 v11.0.0/go.mod h1:Eg5OsL5H+e299f7u5ssuXsuHQVEGC4xei5aX110hRiI=

--- a/lndservices/block_header_cache_porcupine_test.go
+++ b/lndservices/block_header_cache_porcupine_test.go
@@ -1,0 +1,243 @@
+package lndservices
+
+import (
+	"fmt"
+	"maps"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/anishathalye/porcupine"
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/stretchr/testify/require"
+)
+
+type cacheOperation uint8
+
+const (
+	cachePut cacheOperation = iota
+	cacheGet
+)
+
+type cacheInput struct {
+	op     cacheOperation
+	height uint32
+	header wire.BlockHeader
+}
+
+type cacheOutput struct {
+	found bool
+	hash  chainhash.Hash
+	err   bool
+}
+
+type cacheModelState map[uint32]chainhash.Hash
+
+// blockHeaderCacheModel describes the expected sequential behavior of the
+// cache. Porcupine checks whether a concurrent execution can be arranged into
+// a sequence accepted by this model while preserving real-time ordering.
+//
+// This demo disables settlement depth and capacity eviction in the system
+// under test. The model therefore focuses on concurrent reads, writes, and
+// reorg invalidation.
+var blockHeaderCacheModel = porcupine.Model{
+	Init: func() interface{} {
+		return cacheModelState{}
+	},
+	Step: func(state, input, output interface{}) (bool, interface{}) {
+		current := state.(cacheModelState)
+		in := input.(cacheInput)
+		out := output.(cacheOutput)
+
+		next := maps.Clone(current)
+
+		switch in.op {
+		case cachePut:
+			if out.err {
+				return false, current
+			}
+
+			hash := in.header.BlockHash()
+			existingHash, exists := current[in.height]
+			if exists && existingHash != hash {
+				for height := range next {
+					if height >= in.height {
+						delete(next, height)
+					}
+				}
+			}
+
+			next[in.height] = hash
+			return true, next
+
+		case cacheGet:
+			expectedHash, found := current[in.height]
+			valid := out.found == found
+			if found {
+				valid = valid && out.hash == expectedHash
+			}
+
+			return valid, next
+
+		default:
+			return false, current
+		}
+	},
+	Equal: func(state1, state2 interface{}) bool {
+		return maps.Equal(
+			state1.(cacheModelState), state2.(cacheModelState),
+		)
+	},
+	DescribeOperation: func(input, output interface{}) string {
+		in := input.(cacheInput)
+		out := output.(cacheOutput)
+
+		switch in.op {
+		case cachePut:
+			return fmt.Sprintf(
+				"Put(height=%d, hash=%s) -> error=%v",
+				in.height, in.header.BlockHash(), out.err,
+			)
+
+		case cacheGet:
+			return fmt.Sprintf(
+				"GetByHeight(height=%d) -> found=%v, hash=%s",
+				in.height, out.found, out.hash,
+			)
+
+		default:
+			return "unknown operation"
+		}
+	},
+}
+
+func executeCacheOperation(cache *BlockHeaderCache,
+	in cacheInput) cacheOutput {
+
+	switch in.op {
+	case cachePut:
+		return cacheOutput{
+			err: cache.Put(in.height, in.header) != nil,
+		}
+
+	case cacheGet:
+		header, found := cache.GetByHeight(in.height)
+		if !found {
+			return cacheOutput{}
+		}
+
+		return cacheOutput{
+			found: true,
+			hash:  header.BlockHash(),
+		}
+
+	default:
+		panic("unknown cache operation")
+	}
+}
+
+func executeCacheHistory(cache *BlockHeaderCache,
+	clients [][]cacheInput) []porcupine.Operation {
+
+	var (
+		clock   atomic.Int64
+		wg      sync.WaitGroup
+		history = make(chan porcupine.Operation)
+		start   = make(chan struct{})
+	)
+
+	for clientID, operations := range clients {
+		clientID := clientID
+		operations := operations
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+
+			for _, input := range operations {
+				call := clock.Add(1)
+				output := executeCacheOperation(cache, input)
+				ret := clock.Add(1)
+
+				history <- porcupine.Operation{
+					ClientId: clientID,
+					Input:    input,
+					Call:     call,
+					Output:   output,
+					Return:   ret,
+				}
+			}
+		}()
+	}
+
+	close(start)
+	go func() {
+		wg.Wait()
+		close(history)
+	}()
+
+	result := make([]porcupine.Operation, 0)
+	for operation := range history {
+		result = append(result, operation)
+	}
+
+	return result
+}
+
+// TestBlockHeaderCacheLinearizability runs independent clients against the
+// real cache and asks Porcupine to verify the resulting concurrent history.
+func TestBlockHeaderCacheLinearizability(t *testing.T) {
+	t.Parallel()
+
+	cache, err := NewBlockHeaderCache(BlockHeaderCacheConfig{
+		MaxSize:              1_000,
+		PurgePercentage:      10,
+		MinSettledBlockDepth: 0,
+	})
+	require.NoError(t, err)
+
+	baseTime := time.Unix(1_700_000_000, 0).UTC()
+	header := func(nonce uint32) wire.BlockHeader {
+		return makeHeader(
+			nonce, baseTime.Add(time.Duration(nonce)*time.Second),
+		)
+	}
+	put := func(height, nonce uint32) cacheInput {
+		return cacheInput{
+			op:     cachePut,
+			height: height,
+			header: header(nonce),
+		}
+	}
+	get := func(height uint32) cacheInput {
+		return cacheInput{
+			op:     cacheGet,
+			height: height,
+		}
+	}
+
+	clients := [][]cacheInput{
+		{
+			put(100, 1), get(100), put(101, 2), get(101),
+		},
+		{
+			get(100), put(100, 3), get(100), get(101),
+		},
+		{
+			put(102, 4), get(102), get(101), get(100),
+		},
+		{
+			put(103, 5), get(103), put(101, 6), get(102),
+		},
+	}
+
+	history := executeCacheHistory(cache, clients)
+	result := porcupine.CheckOperationsTimeout(
+		blockHeaderCacheModel, history, 5*time.Second,
+	)
+
+	require.Equal(t, porcupine.Ok, result)
+}

--- a/proof/mailbox_porcupine_test.go
+++ b/proof/mailbox_porcupine_test.go
@@ -1,0 +1,446 @@
+package proof
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/anishathalye/porcupine"
+	"github.com/lightninglabs/lightning-node-connect/hashmailrpc"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"pgregory.net/rapid"
+)
+
+type mailboxOperation uint8
+
+const (
+	mailboxInit mailboxOperation = iota
+	mailboxWriteProof
+	mailboxReadProof
+	mailboxWriteAck
+	mailboxReadAck
+	mailboxCleanup
+)
+
+type mailboxInput struct {
+	op       mailboxOperation
+	streamID byte
+	value    byte
+}
+
+type mailboxOutput struct {
+	value  byte
+	failed bool
+}
+
+type mailboxSlot struct {
+	message byte
+	isAck   bool
+	full    bool
+}
+
+type mailboxModelState map[byte]mailboxSlot
+
+var proofMailboxModel = porcupine.Model{
+	Init: func() interface{} {
+		return mailboxModelState{}
+	},
+	Step: func(state, input, output interface{}) (bool, interface{}) {
+		current := state.(mailboxModelState)
+		in := input.(mailboxInput)
+		out := output.(mailboxOutput)
+		next := maps.Clone(current)
+		slot, initialized := current[in.streamID]
+
+		switch in.op {
+		case mailboxInit:
+			if out.failed {
+				return false, current
+			}
+			if !initialized {
+				next[in.streamID] = mailboxSlot{}
+			}
+
+		case mailboxWriteProof, mailboxWriteAck:
+			shouldFail := !initialized || slot.full
+			if out.failed != shouldFail {
+				return false, current
+			}
+			if !shouldFail {
+				message := in.value
+				if in.op == mailboxWriteAck {
+					message = ackMsg[0]
+				}
+				next[in.streamID] = mailboxSlot{
+					message: message,
+					isAck:   in.op == mailboxWriteAck,
+					full:    true,
+				}
+			}
+
+		case mailboxReadProof:
+			shouldFail := !initialized || !slot.full
+			if out.failed != shouldFail {
+				return false, current
+			}
+			if !shouldFail {
+				if out.value != slot.message {
+					return false, current
+				}
+				next[in.streamID] = mailboxSlot{}
+			}
+
+		case mailboxReadAck:
+			missing := !initialized || !slot.full
+			if missing {
+				return out.failed, current
+			}
+			if out.failed == slot.isAck {
+				return false, current
+			}
+			next[in.streamID] = mailboxSlot{}
+
+		case mailboxCleanup:
+			if out.failed {
+				return false, current
+			}
+			delete(next, in.streamID)
+
+		default:
+			return false, current
+		}
+
+		return true, next
+	},
+	Equal: func(state1, state2 interface{}) bool {
+		return maps.Equal(
+			state1.(mailboxModelState), state2.(mailboxModelState),
+		)
+	},
+	DescribeOperation: func(input, output interface{}) string {
+		in := input.(mailboxInput)
+		out := output.(mailboxOutput)
+		return fmt.Sprintf(
+			"op=%d, stream=%d, value=%d -> value=%d, failed=%v",
+			in.op, in.streamID, in.value, out.value, out.failed,
+		)
+	},
+}
+
+// porcupineHashMailClient is a synchronized, single-message implementation of
+// the hashmail RPC boundary. The production HashMailBox translates each public
+// operation into calls against this boundary.
+type porcupineHashMailClient struct {
+	mu    sync.Mutex
+	boxes map[string]mailboxSlot
+}
+
+func newPorcupineHashMailBox() *HashMailBox {
+	return &HashMailBox{client: &porcupineHashMailClient{
+		boxes: make(map[string]mailboxSlot),
+	}}
+}
+
+func (p *porcupineHashMailClient) NewCipherBox(_ context.Context,
+	in *hashmailrpc.CipherBoxAuth, _ ...grpc.CallOption) (
+	*hashmailrpc.CipherInitResp, error) {
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	key := string(in.Desc.StreamId)
+	if _, ok := p.boxes[key]; ok {
+		return nil, status.Error(codes.AlreadyExists, "mailbox exists")
+	}
+	p.boxes[key] = mailboxSlot{}
+
+	return &hashmailrpc.CipherInitResp{}, nil
+}
+
+func (p *porcupineHashMailClient) DelCipherBox(_ context.Context,
+	in *hashmailrpc.CipherBoxAuth, _ ...grpc.CallOption) (
+	*hashmailrpc.DelCipherBoxResp, error) {
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	delete(p.boxes, string(in.Desc.StreamId))
+
+	return &hashmailrpc.DelCipherBoxResp{}, nil
+}
+
+func (p *porcupineHashMailClient) SendStream(_ context.Context,
+	_ ...grpc.CallOption) (hashmailrpc.HashMail_SendStreamClient, error) {
+
+	return &porcupineHashMailSendStream{client: p}, nil
+}
+
+func (p *porcupineHashMailClient) RecvStream(_ context.Context,
+	in *hashmailrpc.CipherBoxDesc, _ ...grpc.CallOption) (
+	hashmailrpc.HashMail_RecvStreamClient, error) {
+
+	return &porcupineHashMailRecvStream{
+		client: p, streamID: append([]byte(nil), in.StreamId...),
+	}, nil
+}
+
+type porcupineHashMailSendStream struct {
+	grpc.ClientStream
+	client *porcupineHashMailClient
+	box    *hashmailrpc.CipherBox
+}
+
+func (p *porcupineHashMailSendStream) Send(box *hashmailrpc.CipherBox) error {
+	p.box = &hashmailrpc.CipherBox{
+		Desc: &hashmailrpc.CipherBoxDesc{
+			StreamId: append([]byte(nil), box.Desc.StreamId...),
+		},
+		Msg: append([]byte(nil), box.Msg...),
+	}
+
+	return nil
+}
+
+func (p *porcupineHashMailSendStream) CloseSend() error {
+	if p.box == nil {
+		return status.Error(codes.InvalidArgument, "message missing")
+	}
+
+	p.client.mu.Lock()
+	defer p.client.mu.Unlock()
+
+	key := string(p.box.Desc.StreamId)
+	slot, ok := p.client.boxes[key]
+	if !ok {
+		return status.Error(codes.NotFound, "mailbox missing")
+	}
+	if slot.full {
+		return status.Error(codes.ResourceExhausted, "mailbox full")
+	}
+
+	isAck := string(p.box.Msg) == string(ackMsg)
+	value := byte(0)
+	if !isAck && len(p.box.Msg) > 0 {
+		value = p.box.Msg[0]
+	}
+	p.client.boxes[key] = mailboxSlot{
+		message: value, isAck: isAck, full: true,
+	}
+
+	return nil
+}
+
+func (p *porcupineHashMailSendStream) CloseAndRecv() (
+	*hashmailrpc.CipherBoxDesc, error) {
+
+	if err := p.CloseSend(); err != nil {
+		return nil, err
+	}
+
+	return p.box.Desc, nil
+}
+
+type porcupineHashMailRecvStream struct {
+	grpc.ClientStream
+	client   *porcupineHashMailClient
+	streamID []byte
+}
+
+func (p *porcupineHashMailRecvStream) Recv() (*hashmailrpc.CipherBox, error) {
+	p.client.mu.Lock()
+	defer p.client.mu.Unlock()
+
+	key := string(p.streamID)
+	slot, ok := p.client.boxes[key]
+	if !ok || !slot.full {
+		return nil, status.Error(codes.NotFound, "message missing")
+	}
+	p.client.boxes[key] = mailboxSlot{}
+
+	message := []byte{slot.message}
+	if slot.isAck {
+		message = append([]byte(nil), ackMsg...)
+	}
+
+	return &hashmailrpc.CipherBox{
+		Desc: &hashmailrpc.CipherBoxDesc{
+			StreamId: append([]byte(nil), p.streamID...),
+		},
+		Msg: message,
+	}, nil
+}
+
+func porcupineStreamID(id byte) streamID {
+	var sid streamID
+	sid[0] = id
+	return sid
+}
+
+func executeMailboxOperation(mailbox *HashMailBox,
+	in mailboxInput) mailboxOutput {
+
+	ctx := context.Background()
+	sid := porcupineStreamID(in.streamID)
+	switch in.op {
+	case mailboxInit:
+		return mailboxOutput{failed: mailbox.Init(ctx, sid) != nil}
+
+	case mailboxWriteProof:
+		err := mailbox.WriteProof(ctx, sid, Blob{in.value})
+		return mailboxOutput{failed: err != nil}
+
+	case mailboxReadProof:
+		blob, err := mailbox.ReadProof(ctx, sid)
+		out := mailboxOutput{failed: err != nil}
+		if err == nil && len(blob) > 0 {
+			out.value = blob[0]
+		}
+		return out
+
+	case mailboxWriteAck:
+		return mailboxOutput{failed: mailbox.AckProof(ctx, sid) != nil}
+
+	case mailboxReadAck:
+		return mailboxOutput{failed: mailbox.RecvAck(ctx, sid) != nil}
+
+	case mailboxCleanup:
+		return mailboxOutput{failed: mailbox.CleanUp(ctx, sid) != nil}
+
+	default:
+		return mailboxOutput{failed: true}
+	}
+}
+
+func executeMailboxHistory(mailbox *HashMailBox,
+	clients [][]mailboxInput) []porcupine.Operation {
+
+	var operationCount int
+	for _, operations := range clients {
+		operationCount += len(operations)
+	}
+
+	var (
+		clock   atomic.Int64
+		wg      sync.WaitGroup
+		start   = make(chan struct{})
+		history = make(chan porcupine.Operation, operationCount)
+	)
+	for clientID, operations := range clients {
+		clientID := clientID
+		operations := operations
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			for _, input := range operations {
+				call := clock.Add(1)
+				output := executeMailboxOperation(
+					mailbox, input,
+				)
+				ret := clock.Add(1)
+				history <- porcupine.Operation{
+					ClientId: clientID,
+					Input:    input,
+					Call:     call,
+					Output:   output,
+					Return:   ret,
+				}
+			}
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+	close(history)
+
+	result := make([]porcupine.Operation, 0, operationCount)
+	for operation := range history {
+		result = append(result, operation)
+	}
+
+	return result
+}
+
+func checkProofMailboxLinearizability(rt *rapid.T) {
+	numClients := rapid.IntRange(2, 5).Draw(rt, "num_clients")
+	clients := make([][]mailboxInput, numClients)
+	for clientID := range clients {
+		numOperations := rapid.IntRange(1, 4).Draw(
+			rt, fmt.Sprintf("client_%d_operations", clientID),
+		)
+		clients[clientID] = make([]mailboxInput, numOperations)
+		for operationID := range clients[clientID] {
+			label := fmt.Sprintf(
+				"client_%d_operation_%d", clientID, operationID,
+			)
+			clients[clientID][operationID] = mailboxInput{
+				op: mailboxOperation(rapid.IntRange(0, 5).Draw(
+					rt, label+"_op",
+				)),
+				streamID: byte(rapid.IntRange(
+					0, 2,
+				).Draw(rt, label+"_stream")),
+				value: byte(rapid.IntRange(
+					1, 8,
+				).Draw(rt, label+"_value")),
+			}
+		}
+	}
+
+	history := executeMailboxHistory(newPorcupineHashMailBox(), clients)
+	result := porcupine.CheckOperationsTimeout(
+		proofMailboxModel, history, 5*time.Second,
+	)
+	if result != porcupine.Ok {
+		rt.Fatalf(
+			"proof mailbox history is not linearizable: %v", result,
+		)
+	}
+}
+
+// TestProofMailboxLinearizability checks stream initialization, proof and ACK
+// delivery, reads, cleanup, and isolation through the production adapter.
+func TestProofMailboxLinearizability(t *testing.T) {
+	t.Parallel()
+
+	const rapidBatches = 10
+	for batch := range rapidBatches {
+		t.Run(fmt.Sprintf("batch_%02d", batch), func(t *testing.T) {
+			rapid.Check(t, checkProofMailboxLinearizability)
+		})
+	}
+}
+
+// TestProofMailboxModelRejectsCrossStreamRead proves that a proof written to
+// one stream cannot be observed from another stream.
+func TestProofMailboxModelRejectsCrossStreamRead(t *testing.T) {
+	t.Parallel()
+
+	history := []porcupine.Operation{{
+		ClientId: 0, Input: mailboxInput{op: mailboxInit, streamID: 0},
+		Call: 1, Output: mailboxOutput{}, Return: 2,
+	}, {
+		ClientId: 0,
+		Input: mailboxInput{
+			op: mailboxWriteProof, streamID: 0, value: 7,
+		},
+		Call: 3, Output: mailboxOutput{}, Return: 4,
+	}, {
+		ClientId: 1,
+		Input: mailboxInput{
+			op: mailboxReadProof, streamID: 1,
+		},
+		Call: 5, Output: mailboxOutput{value: 7}, Return: 6,
+	}}
+
+	result := porcupine.CheckOperationsTimeout(
+		proofMailboxModel, history, time.Second,
+	)
+	require.Equal(t, porcupine.Illegal, result)
+}

--- a/rfq/order_porcupine_test.go
+++ b/rfq/order_porcupine_test.go
@@ -1,0 +1,229 @@
+package rfq
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/anishathalye/porcupine"
+	"github.com/lightninglabs/lndclient"
+	"github.com/lightninglabs/taproot-assets/asset"
+	"github.com/lightninglabs/taproot-assets/rfqmath"
+	"github.com/lightninglabs/taproot-assets/rfqmsg"
+	"github.com/lightningnetwork/lnd/graph/db/models"
+	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/stretchr/testify/require"
+)
+
+type salePolicyInput struct {
+	htlcID uint64
+	amount lnwire.MilliSatoshi
+}
+
+type salePolicyOutput struct {
+	accepted bool
+}
+
+type salePolicyState map[uint64]lnwire.MilliSatoshi
+
+// newSalePolicyModel describes the atomic check and track behavior of an
+// asset sale policy. A replay replaces the amount for its circuit key, while
+// distinct accepted HTLCs must never exceed the quote's maximum amount.
+func newSalePolicyModel(maxAmount lnwire.MilliSatoshi) porcupine.Model {
+	return porcupine.Model{
+		Init: func() interface{} {
+			return salePolicyState{}
+		},
+		Step: func(state, input,
+			output interface{}) (bool, interface{}) {
+
+			current := state.(salePolicyState)
+			in := input.(salePolicyInput)
+			out := output.(salePolicyOutput)
+
+			var trackedAmount lnwire.MilliSatoshi
+			for id, amount := range current {
+				if id != in.htlcID {
+					trackedAmount += amount
+				}
+			}
+
+			shouldAccept := trackedAmount <= maxAmount &&
+				in.amount <= maxAmount-trackedAmount
+			if out.accepted != shouldAccept {
+				return false, current
+			}
+
+			next := maps.Clone(current)
+			if shouldAccept {
+				next[in.htlcID] = in.amount
+			}
+
+			return true, next
+		},
+		Equal: func(state1, state2 interface{}) bool {
+			return maps.Equal(
+				state1.(salePolicyState),
+				state2.(salePolicyState),
+			)
+		},
+		DescribeOperation: func(input, output interface{}) string {
+			in := input.(salePolicyInput)
+			out := output.(salePolicyOutput)
+
+			return fmt.Sprintf(
+				"CheckHtlcCompliance(id=%d, amount_msat=%d) "+
+					"-> accepted=%v", in.htlcID, in.amount,
+				out.accepted,
+			)
+		},
+	}
+}
+
+func newPorcupineSalePolicy(t *testing.T) (*AssetSalePolicy,
+	lnwire.MilliSatoshi) {
+
+	t.Helper()
+
+	rate := rfqmsg.NewAssetRate(
+		rfqmath.NewBigIntFixedPoint(100, 0),
+		time.Now().Add(time.Hour),
+	)
+	accept := rfqmsg.BuyAccept{
+		Request: rfqmsg.BuyRequest{
+			AssetSpecifier: asset.NewSpecifierFromId(asset.ID{1}),
+			AssetMaxAmt:    1_000,
+		},
+		AssetRate: rate,
+	}
+	policy := NewAssetSalePolicy(accept, false, nil)
+
+	maxAssetAmount := rfqmath.NewBigIntFixedPoint(
+		policy.MaxOutboundAssetAmount, 0,
+	)
+	maxAmount, err := rfqmath.UnitsToMilliSatoshi(
+		maxAssetAmount, policy.AskAssetRate,
+	)
+	require.NoError(t, err)
+
+	return policy, maxAmount
+}
+
+func checkSalePolicy(policy *AssetSalePolicy,
+	in salePolicyInput) salePolicyOutput {
+
+	htlc := lndclient.InterceptedHtlc{
+		IncomingCircuitKey: models.CircuitKey{
+			ChanID: lnwire.NewShortChanIDFromInt(1),
+			HtlcID: in.htlcID,
+		},
+		OutgoingChannelID: lnwire.NewShortChanIDFromInt(
+			uint64(policy.AcceptedQuoteId.Scid()),
+		),
+		AmountOutMsat: in.amount,
+	}
+
+	err := policy.CheckHtlcCompliance(context.Background(), htlc, nil)
+	return salePolicyOutput{
+		accepted: err == nil,
+	}
+}
+
+// TestAssetSalePolicyLinearizability verifies that concurrently checked HTLCs
+// cannot collectively exceed the quote's maximum amount.
+func TestAssetSalePolicyLinearizability(t *testing.T) {
+	t.Parallel()
+
+	policy, maxAmount := newPorcupineSalePolicy(t)
+	model := newSalePolicyModel(maxAmount)
+
+	const numClients = 32
+
+	var (
+		clock   atomic.Int64
+		wg      sync.WaitGroup
+		history = make(chan porcupine.Operation, numClients)
+		start   = make(chan struct{})
+	)
+
+	for clientID := 0; clientID < numClients; clientID++ {
+		clientID := clientID
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+			<-start
+
+			input := salePolicyInput{
+				htlcID: uint64(clientID),
+				amount: maxAmount,
+			}
+			call := clock.Add(1)
+			output := checkSalePolicy(policy, input)
+			ret := clock.Add(1)
+
+			history <- porcupine.Operation{
+				ClientId: clientID,
+				Input:    input,
+				Call:     call,
+				Output:   output,
+				Return:   ret,
+			}
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+	close(history)
+
+	operations := make([]porcupine.Operation, 0, numClients)
+	for operation := range history {
+		operations = append(operations, operation)
+	}
+
+	result := porcupine.CheckOperationsTimeout(
+		model, operations, 5*time.Second,
+	)
+	require.Equal(t, porcupine.Ok, result)
+}
+
+// TestAssetSalePolicyModelRejectsOverAllocation is a negative control for the
+// model. It represents the result of a check and track race in which two
+// concurrent HTLCs each consume the full quote amount and are both accepted.
+func TestAssetSalePolicyModelRejectsOverAllocation(t *testing.T) {
+	t.Parallel()
+
+	const maxAmount = lnwire.MilliSatoshi(1_000)
+
+	operations := []porcupine.Operation{
+		{
+			ClientId: 0,
+			Input: salePolicyInput{
+				htlcID: 1,
+				amount: maxAmount,
+			},
+			Call:   1,
+			Output: salePolicyOutput{accepted: true},
+			Return: 4,
+		},
+		{
+			ClientId: 1,
+			Input: salePolicyInput{
+				htlcID: 2,
+				amount: maxAmount,
+			},
+			Call:   2,
+			Output: salePolicyOutput{accepted: true},
+			Return: 3,
+		},
+	}
+
+	result := porcupine.CheckOperationsTimeout(
+		newSalePolicyModel(maxAmount), operations, time.Second,
+	)
+	require.Equal(t, porcupine.Illegal, result)
+}

--- a/rfq/order_porcupine_test.go
+++ b/rfq/order_porcupine_test.go
@@ -182,68 +182,70 @@ func executeSalePolicyHistory(policy *AssetSalePolicy,
 	return result
 }
 
+func checkAssetSalePolicyLinearizability(rt *rapid.T) {
+	assetMaxAmount := rapid.Uint64Range(1, 10_000).Draw(
+		rt, "asset_max_amount",
+	)
+	policy, maxAmount, err := newPorcupineSalePolicy(assetMaxAmount)
+	if err != nil {
+		rt.Fatalf("unable to calculate policy maximum: %v", err)
+	}
+
+	numClients := rapid.IntRange(2, 5).Draw(rt, "num_clients")
+	clients := make([][]salePolicyInput, numClients)
+	for clientID := range clients {
+		numOperationsLabel := fmt.Sprintf(
+			"client_%d_num_operations", clientID,
+		)
+		numOperations := rapid.IntRange(1, 3).Draw(
+			rt, numOperationsLabel,
+		)
+		clients[clientID] = make([]salePolicyInput, numOperations)
+
+		for operationID := range clients[clientID] {
+			label := fmt.Sprintf(
+				"client_%d_operation_%d", clientID, operationID,
+			)
+			input := salePolicyInput{
+				htlcID: rapid.Uint64Range(
+					0, uint64(numClients),
+				).Draw(rt, label+"_htlc_id"),
+				amount: lnwire.MilliSatoshi(
+					rapid.Uint64Range(
+						1, uint64(maxAmount),
+					).Draw(rt, label+"_amount"),
+				),
+			}
+			clients[clientID][operationID] = input
+		}
+	}
+
+	history := executeSalePolicyHistory(policy, clients)
+	result := porcupine.CheckOperationsTimeout(
+		newSalePolicyModel(maxAmount), history, 5*time.Second,
+	)
+	if result != porcupine.Ok {
+		rt.Fatalf(
+			"history is not linearizable: result=%v, clients=%v",
+			result, clients,
+		)
+	}
+}
+
 // TestAssetSalePolicyLinearizability verifies that concurrently checked HTLCs
 // cannot collectively exceed the quote's maximum amount. Rapid generates the
 // quote limit and per-client operation sequences, while Porcupine validates
-// the outputs observed from the real policy.
+// the outputs observed from the real policy. Ten batches yield 1,000 generated
+// histories with Rapid's default configuration in both normal and race tests.
 func TestAssetSalePolicyLinearizability(t *testing.T) {
 	t.Parallel()
 
-	rapid.Check(t, func(rt *rapid.T) {
-		assetMaxAmount := rapid.Uint64Range(1, 10_000).Draw(
-			rt, "asset_max_amount",
-		)
-		policy, maxAmount, err := newPorcupineSalePolicy(
-			assetMaxAmount,
-		)
-		if err != nil {
-			rt.Fatalf("unable to calculate policy maximum: %v", err)
-		}
-
-		numClients := rapid.IntRange(2, 5).Draw(rt, "num_clients")
-		clients := make([][]salePolicyInput, numClients)
-		for clientID := range clients {
-			numOperationsLabel := fmt.Sprintf(
-				"client_%d_num_operations", clientID,
-			)
-			numOperations := rapid.IntRange(1, 3).Draw(
-				rt, numOperationsLabel,
-			)
-			clients[clientID] = make(
-				[]salePolicyInput, numOperations,
-			)
-
-			for operationID := range clients[clientID] {
-				label := fmt.Sprintf(
-					"client_%d_operation_%d", clientID,
-					operationID,
-				)
-				input := salePolicyInput{
-					htlcID: rapid.Uint64Range(
-						0, uint64(numClients),
-					).Draw(rt, label+"_htlc_id"),
-					amount: lnwire.MilliSatoshi(
-						rapid.Uint64Range(
-							1, uint64(maxAmount),
-						).Draw(rt, label+"_amount"),
-					),
-				}
-				clients[clientID][operationID] = input
-			}
-		}
-
-		history := executeSalePolicyHistory(policy, clients)
-		result := porcupine.CheckOperationsTimeout(
-			newSalePolicyModel(maxAmount), history, 5*time.Second,
-		)
-		if result != porcupine.Ok {
-			rt.Fatalf(
-				"history is not linearizable: result=%v, "+
-					"clients=%v",
-				result, clients,
-			)
-		}
-	})
+	const rapidBatches = 10
+	for batch := range rapidBatches {
+		name := fmt.Sprintf("batch_%02d", batch)
+		check := rapid.MakeCheck(checkAssetSalePolicyLinearizability)
+		t.Run(name, check)
+	}
 }
 
 // TestAssetSalePolicyModelRejectsOverAllocation is a negative control for the

--- a/rfq/order_porcupine_test.go
+++ b/rfq/order_porcupine_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/lightningnetwork/lnd/graph/db/models"
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/stretchr/testify/require"
+	"pgregory.net/rapid"
 )
 
 type salePolicyInput struct {
@@ -84,10 +85,8 @@ func newSalePolicyModel(maxAmount lnwire.MilliSatoshi) porcupine.Model {
 	}
 }
 
-func newPorcupineSalePolicy(t *testing.T) (*AssetSalePolicy,
-	lnwire.MilliSatoshi) {
-
-	t.Helper()
+func newPorcupineSalePolicy(assetMaxAmount uint64) (*AssetSalePolicy,
+	lnwire.MilliSatoshi, error) {
 
 	rate := rfqmsg.NewAssetRate(
 		rfqmath.NewBigIntFixedPoint(100, 0),
@@ -96,7 +95,7 @@ func newPorcupineSalePolicy(t *testing.T) (*AssetSalePolicy,
 	accept := rfqmsg.BuyAccept{
 		Request: rfqmsg.BuyRequest{
 			AssetSpecifier: asset.NewSpecifierFromId(asset.ID{1}),
-			AssetMaxAmt:    1_000,
+			AssetMaxAmt:    assetMaxAmount,
 		},
 		AssetRate: rate,
 	}
@@ -108,9 +107,7 @@ func newPorcupineSalePolicy(t *testing.T) (*AssetSalePolicy,
 	maxAmount, err := rfqmath.UnitsToMilliSatoshi(
 		maxAssetAmount, policy.AskAssetRate,
 	)
-	require.NoError(t, err)
-
-	return policy, maxAmount
+	return policy, maxAmount, err
 }
 
 func checkSalePolicy(policy *AssetSalePolicy,
@@ -133,45 +130,42 @@ func checkSalePolicy(policy *AssetSalePolicy,
 	}
 }
 
-// TestAssetSalePolicyLinearizability verifies that concurrently checked HTLCs
-// cannot collectively exceed the quote's maximum amount.
-func TestAssetSalePolicyLinearizability(t *testing.T) {
-	t.Parallel()
+func executeSalePolicyHistory(policy *AssetSalePolicy,
+	clients [][]salePolicyInput) []porcupine.Operation {
 
-	policy, maxAmount := newPorcupineSalePolicy(t)
-	model := newSalePolicyModel(maxAmount)
-
-	const numClients = 32
+	var numOperations int
+	for _, operations := range clients {
+		numOperations += len(operations)
+	}
 
 	var (
 		clock   atomic.Int64
 		wg      sync.WaitGroup
-		history = make(chan porcupine.Operation, numClients)
+		history = make(chan porcupine.Operation, numOperations)
 		start   = make(chan struct{})
 	)
 
-	for clientID := 0; clientID < numClients; clientID++ {
+	for clientID, operations := range clients {
 		clientID := clientID
+		operations := operations
 		wg.Add(1)
 
 		go func() {
 			defer wg.Done()
 			<-start
 
-			input := salePolicyInput{
-				htlcID: uint64(clientID),
-				amount: maxAmount,
-			}
-			call := clock.Add(1)
-			output := checkSalePolicy(policy, input)
-			ret := clock.Add(1)
+			for _, input := range operations {
+				call := clock.Add(1)
+				output := checkSalePolicy(policy, input)
+				ret := clock.Add(1)
 
-			history <- porcupine.Operation{
-				ClientId: clientID,
-				Input:    input,
-				Call:     call,
-				Output:   output,
-				Return:   ret,
+				history <- porcupine.Operation{
+					ClientId: clientID,
+					Input:    input,
+					Call:     call,
+					Output:   output,
+					Return:   ret,
+				}
 			}
 		}()
 	}
@@ -180,15 +174,76 @@ func TestAssetSalePolicyLinearizability(t *testing.T) {
 	wg.Wait()
 	close(history)
 
-	operations := make([]porcupine.Operation, 0, numClients)
+	result := make([]porcupine.Operation, 0, numOperations)
 	for operation := range history {
-		operations = append(operations, operation)
+		result = append(result, operation)
 	}
 
-	result := porcupine.CheckOperationsTimeout(
-		model, operations, 5*time.Second,
-	)
-	require.Equal(t, porcupine.Ok, result)
+	return result
+}
+
+// TestAssetSalePolicyLinearizability verifies that concurrently checked HTLCs
+// cannot collectively exceed the quote's maximum amount. Rapid generates the
+// quote limit and per-client operation sequences, while Porcupine validates
+// the outputs observed from the real policy.
+func TestAssetSalePolicyLinearizability(t *testing.T) {
+	t.Parallel()
+
+	rapid.Check(t, func(rt *rapid.T) {
+		assetMaxAmount := rapid.Uint64Range(1, 10_000).Draw(
+			rt, "asset_max_amount",
+		)
+		policy, maxAmount, err := newPorcupineSalePolicy(
+			assetMaxAmount,
+		)
+		if err != nil {
+			rt.Fatalf("unable to calculate policy maximum: %v", err)
+		}
+
+		numClients := rapid.IntRange(2, 5).Draw(rt, "num_clients")
+		clients := make([][]salePolicyInput, numClients)
+		for clientID := range clients {
+			numOperationsLabel := fmt.Sprintf(
+				"client_%d_num_operations", clientID,
+			)
+			numOperations := rapid.IntRange(1, 3).Draw(
+				rt, numOperationsLabel,
+			)
+			clients[clientID] = make(
+				[]salePolicyInput, numOperations,
+			)
+
+			for operationID := range clients[clientID] {
+				label := fmt.Sprintf(
+					"client_%d_operation_%d", clientID,
+					operationID,
+				)
+				input := salePolicyInput{
+					htlcID: rapid.Uint64Range(
+						0, uint64(numClients),
+					).Draw(rt, label+"_htlc_id"),
+					amount: lnwire.MilliSatoshi(
+						rapid.Uint64Range(
+							1, uint64(maxAmount),
+						).Draw(rt, label+"_amount"),
+					),
+				}
+				clients[clientID][operationID] = input
+			}
+		}
+
+		history := executeSalePolicyHistory(policy, clients)
+		result := porcupine.CheckOperationsTimeout(
+			newSalePolicyModel(maxAmount), history, 5*time.Second,
+		)
+		if result != porcupine.Ok {
+			rt.Fatalf(
+				"history is not linearizable: result=%v, "+
+					"clients=%v",
+				result, clients,
+			)
+		}
+	})
 }
 
 // TestAssetSalePolicyModelRejectsOverAllocation is a negative control for the

--- a/tapdb/export_log_porcupine_test.go
+++ b/tapdb/export_log_porcupine_test.go
@@ -1,0 +1,450 @@
+package tapdb
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"math/rand"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/anishathalye/porcupine"
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/lightninglabs/taproot-assets/asset"
+	"github.com/lightninglabs/taproot-assets/fn"
+	"github.com/lightninglabs/taproot-assets/internal/test"
+	"github.com/lightninglabs/taproot-assets/mssmt"
+	"github.com/lightninglabs/taproot-assets/proof"
+	"github.com/lightninglabs/taproot-assets/tapfreighter"
+	"github.com/lightningnetwork/lnd/keychain"
+	"github.com/stretchr/testify/require"
+	"pgregory.net/rapid"
+)
+
+type exportLogOperation uint8
+
+const (
+	exportLogConfirm exportLogOperation = iota
+	exportLogDeliverProof
+	exportLogQuery
+	exportLogQueryPending
+)
+
+type exportLogInput struct {
+	op exportLogOperation
+}
+
+type exportLogOutput struct {
+	found     bool
+	confirmed bool
+	delivered bool
+	failed    bool
+}
+
+type exportLogState struct {
+	confirmed bool
+	delivered bool
+}
+
+var exportLogModel = porcupine.Model{
+	Init: func() interface{} {
+		return exportLogState{}
+	},
+	Step: func(state, input, output interface{}) (bool, interface{}) {
+		current := state.(exportLogState)
+		in := input.(exportLogInput)
+		out := output.(exportLogOutput)
+		next := current
+
+		switch in.op {
+		case exportLogConfirm:
+			if out.failed {
+				return false, current
+			}
+			next.confirmed = true
+
+		case exportLogDeliverProof:
+			if out.failed {
+				return false, current
+			}
+			next.delivered = true
+
+		case exportLogQuery:
+			valid := !out.failed && out.found &&
+				out.confirmed == current.confirmed &&
+				out.delivered == current.delivered
+			return valid, current
+
+		case exportLogQueryPending:
+			expected := !current.confirmed || !current.delivered
+			return !out.failed && out.found == expected, current
+
+		default:
+			return false, current
+		}
+
+		return true, next
+	},
+	Equal: func(state1, state2 interface{}) bool {
+		return state1.(exportLogState) == state2.(exportLogState)
+	},
+	DescribeOperation: func(input, output interface{}) string {
+		in := input.(exportLogInput)
+		out := output.(exportLogOutput)
+		return fmt.Sprintf(
+			"op=%d -> found=%v, confirmed=%v, delivered=%v, "+
+				"failed=%v", in.op, out.found, out.confirmed,
+			out.delivered, out.failed,
+		)
+	},
+}
+
+type exportLogFixture struct {
+	store            *AssetStore
+	anchorHash       chainhash.Hash
+	confirmation     tapfreighter.AssetConfirmEvent
+	deliveryOutpoint wire.OutPoint
+	deliveryPosition uint64
+}
+
+func newExportLogFixture(t *testing.T) *exportLogFixture {
+	t.Helper()
+
+	_, store, _ := newAssetStore(t)
+	ctx := context.Background()
+	targetScriptKey := asset.NewScriptKeyBip86(keychain.KeyDescriptor{
+		PubKey: test.RandPubKey(t),
+		KeyLocator: keychain.KeyLocator{
+			Family: test.RandInt[keychain.KeyFamily](),
+			Index:  uint32(test.RandInt[int32]()),
+		},
+	})
+
+	assetVersion := asset.V1
+	assetGen := newAssetGenerator(t, 1, 1)
+	assetGen.genAssets(t, store, []assetDesc{{
+		assetGen:     assetGen.assetGens[0],
+		anchorPoint:  assetGen.anchorPoints[0],
+		scriptKey:    &targetScriptKey,
+		amt:          16,
+		assetVersion: &assetVersion,
+	}})
+
+	allAssets, err := store.FetchAllAssets(ctx, true, false, nil)
+	require.NoError(t, err)
+	require.Len(t, allAssets, 1)
+	inputAsset := allAssets[0]
+
+	anchorTx := wire.NewMsgTx(2)
+	anchorTx.AddTxIn(&wire.TxIn{SignatureScript: []byte{}})
+	anchorTx.AddTxOut(&wire.TxOut{
+		PkScript: bytes.Repeat([]byte{0x01}, 34), Value: 1000,
+	})
+	anchorTx.AddTxOut(&wire.TxOut{
+		PkScript: bytes.Repeat([]byte{0x02}, 34), Value: 1000,
+	})
+	anchorHash := anchorTx.TxHash()
+
+	firstScriptKey := asset.NewScriptKeyBip86(keychain.KeyDescriptor{
+		PubKey: test.RandPubKey(t),
+		KeyLocator: keychain.KeyLocator{
+			Family: keychain.KeyFamily(rand.Int31()),
+			Index:  uint32(rand.Int31()),
+		},
+	})
+	secondScriptKey := asset.NewScriptKeyBip86(keychain.KeyDescriptor{
+		PubKey: test.RandPubKey(t),
+		KeyLocator: keychain.KeyLocator{
+			Family: keychain.KeyFamily(rand.Int31()),
+			Index:  uint32(rand.Int31()),
+		},
+	})
+
+	firstAsset := inputAsset.Copy()
+	firstAsset.ScriptKey = firstScriptKey
+	firstProof := randProof(t, firstAsset)
+	firstProofBytes, err := firstProof.Bytes()
+	require.NoError(t, err)
+
+	secondAsset := inputAsset.Copy()
+	secondAsset.ScriptKey = secondScriptKey
+	secondProof := randProof(t, secondAsset)
+	secondProofBytes, err := secondProof.Bytes()
+	require.NoError(t, err)
+
+	witness := asset.Witness{
+		PrevID: &asset.PrevID{}, TxWitness: [][]byte{{0x01}, {0x02}},
+	}
+	rootHash := sha256.Sum256([]byte("porcupine-export-log"))
+	root := mssmt.NewComputedNode(rootHash, 16)
+	firstOutpoint := wire.OutPoint{Hash: anchorHash, Index: 0}
+	secondOutpoint := wire.OutPoint{Hash: anchorHash, Index: 1}
+
+	parcel := &tapfreighter.OutboundParcel{
+		AnchorTx: anchorTx, AnchorTxHeightHint: 1450, ChainFees: 100,
+		Inputs: []tapfreighter.TransferInput{{
+			PrevID: asset.PrevID{
+				OutPoint: assetGen.anchorPoints[0],
+				ID:       inputAsset.ID(),
+				ScriptKey: asset.ToSerialized(
+					inputAsset.ScriptKey.PubKey,
+				),
+			},
+			Amount: inputAsset.Amount,
+		}},
+		Outputs: []tapfreighter.TransferOutput{{
+			Anchor: tapfreighter.Anchor{
+				OutPoint: firstOutpoint,
+				Value:    1000,
+				InternalKey: keychain.KeyDescriptor{
+					PubKey: test.RandPubKey(t),
+				},
+				TaprootAssetRoot: bytes.Repeat(
+					[]byte{0x01}, 32,
+				),
+				MerkleRoot: bytes.Repeat([]byte{0x01}, 32),
+				PkScript:   anchorTx.TxOut[0].PkScript,
+			},
+			ScriptKey:           firstScriptKey,
+			ScriptKeyLocal:      true,
+			Amount:              9,
+			WitnessData:         []asset.Witness{witness},
+			SplitCommitmentRoot: root,
+			AssetVersion:        asset.V1,
+			ProofSuffix:         firstProofBytes,
+			ProofCourierAddr: []byte(
+				"universerpc://localhost:10009",
+			),
+			ProofDeliveryComplete: fn.Some(false),
+			Position:              0,
+		}, {
+			Anchor: tapfreighter.Anchor{
+				OutPoint: secondOutpoint,
+				Value:    1000,
+				InternalKey: keychain.KeyDescriptor{
+					PubKey: test.RandPubKey(t),
+				},
+				TaprootAssetRoot: bytes.Repeat(
+					[]byte{0x02}, 32,
+				),
+				MerkleRoot: bytes.Repeat([]byte{0x02}, 32),
+				PkScript:   anchorTx.TxOut[1].PkScript,
+			},
+			ScriptKey:           secondScriptKey,
+			ScriptKeyLocal:      true,
+			Amount:              7,
+			WitnessData:         []asset.Witness{witness},
+			SplitCommitmentRoot: root,
+			AssetVersion:        asset.V1,
+			ProofSuffix:         secondProofBytes,
+			Position:            1,
+		}},
+	}
+
+	leaseOwner := fn.ToArray[[32]byte](test.RandBytes(32))
+	err = store.LogPendingParcel(
+		ctx, parcel, leaseOwner, time.Now().Add(time.Hour),
+	)
+	require.NoError(t, err)
+
+	assetID := inputAsset.ID()
+	firstIdentifier := tapfreighter.NewOutputIdentifier(
+		assetID, 0, *firstScriptKey.PubKey,
+	)
+	secondIdentifier := tapfreighter.NewOutputIdentifier(
+		assetID, 0, *secondScriptKey.PubKey,
+	)
+	blockHash := chainhash.Hash(sha256.Sum256([]byte("confirmed")))
+	finalProofs := map[tapfreighter.OutputIdentifier]*proof.AnnotatedProof{
+		firstIdentifier: {
+			Locator: proof.Locator{
+				AssetID:   &assetID,
+				ScriptKey: *firstScriptKey.PubKey,
+			},
+			Blob: firstProofBytes,
+		},
+		secondIdentifier: {
+			Locator: proof.Locator{
+				AssetID:   &assetID,
+				ScriptKey: *secondScriptKey.PubKey,
+			},
+			Blob: secondProofBytes,
+		},
+	}
+
+	return &exportLogFixture{
+		store:            store,
+		anchorHash:       anchorHash,
+		deliveryOutpoint: firstOutpoint,
+		deliveryPosition: 0,
+		confirmation: tapfreighter.AssetConfirmEvent{
+			AnchorTXID:  anchorHash,
+			BlockHash:   blockHash,
+			BlockHeight: 100,
+			TxIndex:     1,
+			FinalProofs: finalProofs,
+		},
+	}
+}
+
+func executeExportLogOperation(fixture *exportLogFixture,
+	in exportLogInput) exportLogOutput {
+
+	ctx := context.Background()
+	switch in.op {
+	case exportLogConfirm:
+		err := fixture.store.LogAnchorTxConfirm(
+			ctx, &fixture.confirmation, nil,
+		)
+		return exportLogOutput{failed: err != nil}
+
+	case exportLogDeliverProof:
+		err := fixture.store.ConfirmProofDelivery(
+			ctx, fixture.deliveryOutpoint, fixture.deliveryPosition,
+		)
+		return exportLogOutput{failed: err != nil}
+
+	case exportLogQuery:
+		parcels, err := fixture.store.QueryParcels(
+			ctx, &fixture.anchorHash, false,
+		)
+		if err != nil || len(parcels) != 1 {
+			return exportLogOutput{failed: true}
+		}
+		parcel := parcels[0]
+		return exportLogOutput{
+			found:     true,
+			confirmed: parcel.AnchorTxBlockHash.IsSome(),
+			delivered: parcel.Outputs[0].ProofDeliveryComplete.
+				UnwrapOr(false),
+		}
+
+	case exportLogQueryPending:
+		parcels, err := fixture.store.QueryParcels(
+			ctx, &fixture.anchorHash, true,
+		)
+		return exportLogOutput{
+			found: len(parcels) == 1, failed: err != nil,
+		}
+
+	default:
+		return exportLogOutput{failed: true}
+	}
+}
+
+func executeExportLogHistory(fixture *exportLogFixture,
+	clients [][]exportLogInput) []porcupine.Operation {
+
+	var operationCount int
+	for _, operations := range clients {
+		operationCount += len(operations)
+	}
+
+	var (
+		clock   atomic.Int64
+		wg      sync.WaitGroup
+		start   = make(chan struct{})
+		history = make(chan porcupine.Operation, operationCount)
+	)
+	for clientID, operations := range clients {
+		clientID := clientID
+		operations := operations
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			for _, input := range operations {
+				call := clock.Add(1)
+				output := executeExportLogOperation(
+					fixture, input,
+				)
+				ret := clock.Add(1)
+				history <- porcupine.Operation{
+					ClientId: clientID,
+					Input:    input,
+					Call:     call,
+					Output:   output,
+					Return:   ret,
+				}
+			}
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+	close(history)
+
+	result := make([]porcupine.Operation, 0, operationCount)
+	for operation := range history {
+		result = append(result, operation)
+	}
+
+	return result
+}
+
+// TestExportLogLinearizability checks that confirmation, proof delivery, and
+// queries expose one valid atomic ordering through the production SQL store.
+func TestExportLogLinearizability(t *testing.T) {
+	t.Parallel()
+
+	rapid.Check(t, func(rt *rapid.T) {
+		queryClients := rapid.IntRange(2, 4).Draw(rt, "query_clients")
+		clients := make([][]exportLogInput, queryClients+2)
+		clients[0] = []exportLogInput{{op: exportLogConfirm}}
+		clients[1] = []exportLogInput{{op: exportLogDeliverProof}}
+		for clientID := 2; clientID < len(clients); clientID++ {
+			queryCount := rapid.IntRange(1, 3).Draw(
+				rt, fmt.Sprintf("client_%d_queries", clientID),
+			)
+			clients[clientID] = make([]exportLogInput, queryCount)
+			for operationID := range clients[clientID] {
+				pending := rapid.Bool().Draw(
+					rt, fmt.Sprintf(
+						"client_%d_query_%d_pending",
+						clientID, operationID,
+					),
+				)
+				op := exportLogQuery
+				if pending {
+					op = exportLogQueryPending
+				}
+				clients[clientID][operationID] = exportLogInput{
+					op: op,
+				}
+			}
+		}
+
+		history := executeExportLogHistory(
+			newExportLogFixture(t), clients,
+		)
+		result := porcupine.CheckOperationsTimeout(
+			exportLogModel, history, 5*time.Second,
+		)
+		if result != porcupine.Ok {
+			rt.Fatalf("export log history is not linearizable: "+
+				"%v", result)
+		}
+	})
+}
+
+// TestExportLogModelRejectsPrematureCompletion proves that the model rejects
+// a parcel disappearing before both confirmation and proof delivery finish.
+func TestExportLogModelRejectsPrematureCompletion(t *testing.T) {
+	t.Parallel()
+
+	history := []porcupine.Operation{{
+		ClientId: 0,
+		Input:    exportLogInput{op: exportLogQueryPending},
+		Call:     1,
+		Output:   exportLogOutput{found: false},
+		Return:   2,
+	}}
+	result := porcupine.CheckOperationsTimeout(
+		exportLogModel, history, time.Second,
+	)
+	require.Equal(t, porcupine.Illegal, result)
+}

--- a/tapfreighter/coin_select_porcupine_test.go
+++ b/tapfreighter/coin_select_porcupine_test.go
@@ -1,0 +1,347 @@
+package tapfreighter
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/anishathalye/porcupine"
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/lightninglabs/taproot-assets/asset"
+	"github.com/lightninglabs/taproot-assets/commitment"
+	"github.com/stretchr/testify/require"
+	"pgregory.net/rapid"
+)
+
+const porcupineCoinCount = 4
+
+type coinSelectOperation uint8
+
+const (
+	coinSelectLease coinSelectOperation = iota
+	coinSelectRelease
+)
+
+type coinSelectInput struct {
+	op   coinSelectOperation
+	coin uint32
+}
+
+type coinSelectOutput struct {
+	coin   uint32
+	found  bool
+	failed bool
+}
+
+// coinLeaseModel describes the externally visible lease set. Selection uses
+// PreferMaxAmount, so it must atomically lease the largest available coin.
+var coinLeaseModel = porcupine.Model{
+	Init: func() interface{} {
+		return uint8(0)
+	},
+	Step: func(state, input, output interface{}) (bool, interface{}) {
+		leased := state.(uint8)
+		in := input.(coinSelectInput)
+		out := output.(coinSelectOutput)
+
+		switch in.op {
+		case coinSelectLease:
+			var expected uint32
+			found := false
+			for idx := porcupineCoinCount - 1; idx >= 0; idx-- {
+				mask := uint8(1 << idx)
+				if leased&mask == 0 {
+					expected = uint32(idx)
+					found = true
+					break
+				}
+			}
+
+			if out.failed || out.found != found {
+				return false, leased
+			}
+			if !found {
+				return true, leased
+			}
+			if out.coin != expected {
+				return false, leased
+			}
+
+			return true, leased | uint8(1<<expected)
+
+		case coinSelectRelease:
+			if out.failed {
+				return false, leased
+			}
+
+			return true, leased &^ uint8(1<<in.coin)
+
+		default:
+			return false, leased
+		}
+	},
+	Equal: func(state1, state2 interface{}) bool {
+		return state1.(uint8) == state2.(uint8)
+	},
+	DescribeOperation: func(input, output interface{}) string {
+		in := input.(coinSelectInput)
+		out := output.(coinSelectOutput)
+		if in.op == coinSelectLease {
+			return fmt.Sprintf(
+				"SelectCoins() -> coin=%d, found=%v, failed=%v",
+				out.coin, out.found, out.failed,
+			)
+		}
+
+		return fmt.Sprintf(
+			"ReleaseCoins(coin=%d) -> failed=%v", in.coin,
+			out.failed,
+		)
+	},
+}
+
+// porcupineCoinLister is a transactional in-memory CoinLister used to expose
+// the real CoinSelect list then lease sequence to concurrent callers.
+type porcupineCoinLister struct {
+	mu     sync.Mutex
+	coins  []*AnchoredCommitment
+	leased map[wire.OutPoint]struct{}
+}
+
+func (p *porcupineCoinLister) ListEligibleCoins(_ context.Context,
+	constraints CommitmentConstraints) ([]*AnchoredCommitment, error) {
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	eligible := make([]*AnchoredCommitment, 0, len(p.coins))
+	for _, coin := range p.coins {
+		if _, ok := p.leased[coin.AnchorPoint]; ok {
+			continue
+		}
+
+		eligible = append(eligible, coin)
+	}
+
+	if len(eligible) == 0 {
+		return nil, ErrMatchingAssetsNotFound
+	}
+
+	return eligible, nil
+}
+
+func (p *porcupineCoinLister) LeaseCoins(_ context.Context, _ [32]byte,
+	_ time.Time, outpoints ...wire.OutPoint) error {
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	for _, outpoint := range outpoints {
+		if _, ok := p.leased[outpoint]; ok {
+			return fmt.Errorf("coin already leased")
+		}
+	}
+	for _, outpoint := range outpoints {
+		p.leased[outpoint] = struct{}{}
+	}
+
+	return nil
+}
+
+func (p *porcupineCoinLister) ReleaseCoins(_ context.Context,
+	outpoints ...wire.OutPoint) error {
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	for _, outpoint := range outpoints {
+		delete(p.leased, outpoint)
+	}
+
+	return nil
+}
+
+func (*porcupineCoinLister) DeleteExpiredLeases(context.Context) error {
+	return nil
+}
+
+func (*porcupineCoinLister) FetchOrphanUTXOs(
+	context.Context) ([]*ZeroValueInput, error) {
+
+	return nil, nil
+}
+
+func newPorcupineCoinSelector(t *testing.T) *CoinSelect {
+	t.Helper()
+
+	coins := make([]*AnchoredCommitment, porcupineCoinCount)
+	for idx := range coins {
+		coins[idx] = &AnchoredCommitment{
+			AnchorPoint: wire.OutPoint{Index: uint32(idx)},
+			Asset: &asset.Asset{
+				Amount:    uint64(idx + 1),
+				ScriptKey: asset.RandScriptKey(t),
+			},
+			Commitment: &commitment.TapCommitment{
+				Version: commitment.TapCommitmentV1,
+			},
+		}
+	}
+
+	return NewCoinSelect(&porcupineCoinLister{
+		coins:  coins,
+		leased: make(map[wire.OutPoint]struct{}),
+	})
+}
+
+func executeCoinSelect(selector *CoinSelect,
+	in coinSelectInput) coinSelectOutput {
+
+	ctx := context.Background()
+	if in.op == coinSelectRelease {
+		err := selector.ReleaseCoins(
+			ctx, wire.OutPoint{Index: in.coin},
+		)
+		return coinSelectOutput{failed: err != nil}
+	}
+
+	coins, err := selector.SelectCoins(
+		ctx, CommitmentConstraints{MinAmt: 1}, PreferMaxAmount,
+		commitment.TapCommitmentV1,
+	)
+	if errors.Is(err, ErrMatchingAssetsNotFound) {
+		return coinSelectOutput{}
+	}
+	if err != nil || len(coins) != 1 {
+		return coinSelectOutput{failed: true}
+	}
+
+	return coinSelectOutput{
+		coin:  coins[0].AnchorPoint.Index,
+		found: true,
+	}
+}
+
+func executeCoinSelectHistory(selector *CoinSelect,
+	clients [][]coinSelectInput) []porcupine.Operation {
+
+	var operationCount int
+	for _, operations := range clients {
+		operationCount += len(operations)
+	}
+
+	var (
+		clock   atomic.Int64
+		wg      sync.WaitGroup
+		start   = make(chan struct{})
+		history = make(chan porcupine.Operation, operationCount)
+	)
+	for clientID, operations := range clients {
+		clientID := clientID
+		operations := operations
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+			<-start
+			for _, input := range operations {
+				call := clock.Add(1)
+				output := executeCoinSelect(selector, input)
+				ret := clock.Add(1)
+				history <- porcupine.Operation{
+					ClientId: clientID,
+					Input:    input,
+					Call:     call,
+					Output:   output,
+					Return:   ret,
+				}
+			}
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+	close(history)
+
+	result := make([]porcupine.Operation, 0, operationCount)
+	for operation := range history {
+		result = append(result, operation)
+	}
+
+	return result
+}
+
+func checkCoinSelectLinearizability(t *testing.T, rt *rapid.T) {
+	numClients := rapid.IntRange(2, 5).Draw(rt, "num_clients")
+	clients := make([][]coinSelectInput, numClients)
+	for clientID := range clients {
+		numOperations := rapid.IntRange(1, 4).Draw(
+			rt, fmt.Sprintf("client_%d_operations", clientID),
+		)
+		clients[clientID] = make([]coinSelectInput, numOperations)
+		for operationID := range clients[clientID] {
+			label := fmt.Sprintf(
+				"client_%d_operation_%d", clientID, operationID,
+			)
+			op := rapid.IntRange(0, 1).Draw(rt, label+"_op")
+			clients[clientID][operationID] = coinSelectInput{
+				op: coinSelectOperation(op),
+				coin: uint32(rapid.IntRange(
+					0, porcupineCoinCount-1,
+				).Draw(rt, label+"_coin")),
+			}
+		}
+	}
+
+	history := executeCoinSelectHistory(
+		newPorcupineCoinSelector(t), clients,
+	)
+	result := porcupine.CheckOperationsTimeout(
+		coinLeaseModel, history, 5*time.Second,
+	)
+	if result != porcupine.Ok {
+		rt.Fatalf("coin lease history is not linearizable: %v", result)
+	}
+}
+
+// TestCoinSelectLinearizability checks that concurrent selection and release
+// calls behave like atomic operations on one shared lease set.
+func TestCoinSelectLinearizability(t *testing.T) {
+	t.Parallel()
+
+	const rapidBatches = 10
+	for batch := range rapidBatches {
+		t.Run(fmt.Sprintf("batch_%02d", batch), func(t *testing.T) {
+			rapid.Check(t, func(rt *rapid.T) {
+				checkCoinSelectLinearizability(t, rt)
+			})
+		})
+	}
+}
+
+// TestCoinLeaseModelRejectsDoubleLease is a negative control proving that the
+// model rejects two successful selections of the same coin.
+func TestCoinLeaseModelRejectsDoubleLease(t *testing.T) {
+	t.Parallel()
+
+	history := []porcupine.Operation{{
+		ClientId: 0,
+		Input:    coinSelectInput{op: coinSelectLease},
+		Call:     1,
+		Output:   coinSelectOutput{coin: 3, found: true}, Return: 4,
+	}, {
+		ClientId: 1,
+		Input:    coinSelectInput{op: coinSelectLease},
+		Call:     2,
+		Output:   coinSelectOutput{coin: 3, found: true}, Return: 3,
+	}}
+
+	result := porcupine.CheckOperationsTimeout(
+		coinLeaseModel, history, time.Second,
+	)
+	require.Equal(t, porcupine.Illegal, result)
+}


### PR DESCRIPTION
This PR introduces Porcupine as a test dependency and adds concurrency validation for five subsystems:

* `lndservices.BlockHeaderCache`: concurrent header insertion and lookup, including conflicting-header reorg invalidation.
* `rfq.AssetSalePolicy`: concurrent HTLC acceptance, quote-capacity enforcement, and circuit-key replay semantics.
* `tapfreighter.CoinSelect`: concurrent coin selection and release, including prevention of duplicate leases.
* `tapdb.AssetStore`: concurrent anchor confirmation, proof-delivery completion, and parcel queries through the SQL-backed export log.
* `proof.HashMailBox`: concurrent mailbox initialization, proof and ACK transfer, reads, cleanup, and stream isolation through an in-process RPC boundary.

The tests invoke the production Go functions and record their observed outputs. Porcupine checks whether each concurrent history has a valid sequential ordering accepted by an independent model.

Rapid generates operation sequences and inputs for RFQ allocation, coin selection, export-log queries, and proof-mailbox operations. The RFQ, coin-selection, and mailbox tests each check 1,000 generated histories in normal and race runs. The SQL-backed export-log test uses Rapid's default 100 histories because each history creates an isolated database fixture. Negative controls verify that the models reject representative invalid histories.

Run the tests with:

```bash
go test ./lndservices ./rfq ./tapfreighter ./tapdb ./proof -run 'Linearizability|ModelRejects'
```

Run with the race detector using:

```bash
go test -race ./lndservices ./rfq ./tapfreighter ./tapdb ./proof -run 'Linearizability|ModelRejects'
```