### PR TITLE
itest: don't log a tapd exit via t.Logf from a background goroutine

### DIFF
--- a/itest/tapd_harness.go
+++ b/itest/tapd_harness.go
@@ -630,14 +630,22 @@ func (hs *tapdHarness) start(expectErrExit bool) error {
 		hs.cmd.Process.Pid)
 
 	// Wait for the process to exit in the background. If it exits
-	// unexpectedly, log the error. Signal processDone when complete
+	// unexpectedly, record the error. Signal processDone when complete
 	// so stop() can wait for the process to fully exit.
 	hs.processDone = make(chan struct{})
 	go func() {
 		err := hs.cmd.Wait()
-		if err != nil && !expectErrExit {
-			hs.ht.t.Logf("tapd process (name=%v) exited with "+
-				"error: %v", hs.cfg.LndNode.Cfg.Name, err)
+
+		// This goroutine outlives the subtest, so it must not use
+		// t.Logf: a process exit after the test has completed panics
+		// the testing framework and aborts the whole tranche. Write to
+		// the node's log file instead, where the process' own output
+		// already goes; stop() closes that file only after processDone,
+		// so it is still open here.
+		if err != nil && !expectErrExit && hs.logFile != nil {
+			_, _ = fmt.Fprintf(hs.logFile, "tapd process (name=%v) "+
+				"exited with error: %v\n",
+				hs.cfg.LndNode.Cfg.Name, err)
 		}
 		close(hs.processDone)
 	}()


### PR DESCRIPTION
`tapdHarness.start` waits for the tapd process in a background goroutine and logs an unexpected exit with `t.Logf` (`itest/tapd_harness.go:639`). That goroutine outlives the subtest, so when the process exits after the test has already finished, `t.Logf` panics ("Log in goroutine after test has completed") and Go aborts the whole tranche binary with exit code 2, discarding every remaining test.

This is the amplifier in #2258 item 5: one late-exiting node becomes a whole-tranche failure, which accounts for a share of the `postgres` itest noise.

The fix routes the diagnostic to the node's log file, where the process' own stdout/stderr already go. `stop()` closes that file only after it observes `processDone`, so writing before `close(processDone)` keeps the file open at write time.

Scoped to the log-after-test amplifier. The environmental postgres-container pressure (#2258 items 1-4) is a separate change. Addresses #2258.

Test-infra only, so this carries no user-facing change and should get the `no-changelog` label.
