### PR TITLE
tapfeatures: require negotiated-chan-cfg feature bit

### DIFF
--- a/docs/release-notes/release-notes-0.10.0.md
+++ b/docs/release-notes/release-notes-0.10.0.md
@@ -1,0 +1,69 @@
+# Release Notes
+- [Bug Fixes](#bug-fixes)
+- [New Features](#new-features)
+    - [Functional Enhancements](#functional-enhancements)
+    - [RPC Additions](#rpc-additions)
+    - [tapcli Additions](#tapcli-additions)
+- [Improvements](#improvements)
+    - [Functional Updates](#functional-updates)
+    - [RPC Updates](#rpc-updates)
+    - [tapcli Updates](#tapcli-updates)
+    - [Config Changes](#config-changes)
+    - [Breaking Changes](#breaking-changes)
+    - [Performance Improvements](#performance-improvements)
+    - [Deprecations](#deprecations)
+- [Technical and Architectural Updates](#technical-and-architectural-updates)
+    - [BIP/bLIP Spec Updates](#bipblip-spec-updates)
+    - [Testing](#testing)
+    - [Database](#database)
+    - [Code Health](#code-health)
+    - [Tooling and Documentation](#tooling-and-documentation)
+
+# Bug Fixes
+
+# New Features
+
+## Functional Enhancements
+
+## RPC Additions
+
+## tapcli Additions
+
+# Improvements
+
+## Functional Updates
+
+## RPC Updates
+
+## tapcli Updates
+
+## Config Changes
+
+## Code Health
+
+## Breaking Changes
+
+* [PR#2288](https://github.com/lightninglabs/taproot-assets/pull/2288)
+  makes the `negotiated-chan-cfg` aux channel feature bit required. Peers
+  that don't signal it, which is every version before `v0.9.0`, are
+  disconnected at init and can no longer open asset channels with this
+  node. The initial commitment of an asset channel is now always derived
+  from the negotiated local and remote channel configs.
+
+## Performance Improvements
+
+## Deprecations
+
+# Technical and Architectural Updates
+
+## BIP/bLIP Spec Updates
+
+## Testing
+
+## Database
+
+## Code Health
+
+## Tooling and Documentation
+
+# Contributors (Alphabetical Order)

--- a/tapchannel/aux_funding_negotiated_cfg_test.go
+++ b/tapchannel/aux_funding_negotiated_cfg_test.go
@@ -84,9 +84,9 @@ func TestUseNegotiatedChanCfg(t *testing.T) {
 		})
 	}
 
-	// The feature vector we actually advertise must lead to the fallback,
-	// not a rejection, for peers that don't know the feature yet.
+	// The feature vector we actually advertise must reject peers that don't
+	// signal the feature, instead of falling back to zeroed configs.
 	useCfg, err := useNegotiatedChanCfg(tapfeatures.LocalFeatures(), vec())
-	require.NoError(t, err)
+	require.ErrorIs(t, err, ErrNegotiatedChanCfgRequired)
 	require.False(t, useCfg)
 }

--- a/tapfeatures/aux_channel_negotiator_test.go
+++ b/tapfeatures/aux_channel_negotiator_test.go
@@ -58,23 +58,23 @@ func TestFeatureBits(t *testing.T) {
 }
 
 // TestNegotiatedChanCfgFeature asserts that we advertise the negotiated channel
-// config feature as optional. Flipping it to required is a deliberate,
-// separate step, as it rejects every peer that doesn't signal the feature.
+// config feature as required, which rejects every peer that doesn't signal the
+// feature at init.
 func TestNegotiatedChanCfgFeature(t *testing.T) {
 	local := LocalFeatures()
 
 	require.True(t, local.HasFeature(NegotiatedChanCfgOptional))
-	require.False(t, local.RequiresFeature(NegotiatedChanCfgOptional))
+	require.True(t, local.RequiresFeature(NegotiatedChanCfgOptional))
 
-	// A peer that doesn't know the feature at all must still pass our
-	// required bits check while the feature is optional.
+	// A peer that doesn't know the feature is rejected at init.
 	peer := lnwire.NewRawFeatureVector(NoOpHTLCsOptional, STXOOptional)
+	require.Error(t, checkRequiredBits(getLocalFeatureVec(), peer))
+
+	// A peer that signals it, as optional or required, is accepted.
+	peer.Set(NegotiatedChanCfgOptional)
 	require.NoError(t, checkRequiredBits(getLocalFeatureVec(), peer))
 
-	// Once we require it, such a peer is rejected at init.
-	required := lnwire.NewRawFeatureVector(NegotiatedChanCfgRequired)
-	require.Error(t, checkRequiredBits(required, peer))
-
-	peer.Set(NegotiatedChanCfgOptional)
-	require.NoError(t, checkRequiredBits(required, peer))
+	peer.Unset(NegotiatedChanCfgOptional)
+	peer.Set(NegotiatedChanCfgRequired)
+	require.NoError(t, checkRequiredBits(getLocalFeatureVec(), peer))
 }

--- a/tapfeatures/aux_feature_bits.go
+++ b/tapfeatures/aux_feature_bits.go
@@ -50,7 +50,7 @@ func ourFeatures() []lnwire.FeatureBit {
 	return []lnwire.FeatureBit{
 		NoOpHTLCsOptional,
 		STXOOptional,
-		NegotiatedChanCfgOptional,
+		NegotiatedChanCfgRequired,
 	}
 }
 


### PR DESCRIPTION
## Description

Phase 2 of #2278. This is only the feature bit flip and is scheduled for
v0.10, nothing else in here.

`negotiated-chan-cfg` moves from optional to required in `ourFeatures()`.
Peers that don't signal it (every version before v0.9.0) are disconnected at
init by `checkRequiredBits`, and the funding controller rejects them with
`ErrNegotiatedChanCfgRequired` as a second line of defence. The fallback to
zeroed channel configs for the initial commitment goes away with it, both
sides now always derive it from the negotiated configs.

The two guard tests that pinned the bit as optional now pin it as required.

Draft until v0.9.0 is tagged: `compatVersions` in the backwards compat itest
still lists `v0.8.0`, which this PR rejects by design, so `Compat Tests`
fails until that list is bumped to a version that signals the bit.
