### PR TITLE
itest: restart lnd alongside tapd in the RFQ buy test

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -232,3 +232,8 @@ replace github.com/prometheus/common => github.com/prometheus/common v0.66.1
 
 // Note this is a temporary replace and will be removed when taprpc is tagged.
 replace github.com/lightninglabs/taproot-assets/taprpc => ./taprpc
+
+// Temporary replace that points to lightningnetwork/lnd#10411 (persistent
+// scid aliases) rebased on the pinned lnd commit. Remove once the PR is merged
+// and lnd is bumped.
+replace github.com/lightningnetwork/lnd => github.com/GeorgeTsagk/lnd v0.0.0-20260907135521-53a43e15f745

--- a/go.sum
+++ b/go.sum
@@ -603,6 +603,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/toml v1.4.0 h1:kuoIxZQy2WRRk1pttg9asf+WVv6tWQuBNVmK8+nqPr0=
 github.com/BurntSushi/toml v1.4.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/GeorgeTsagk/lnd v0.0.0-20260907135521-53a43e15f745 h1:LLA0JnhNKfrohSSOgWXeyuIbRTqJFM1tXd/Yew9xNRg=
+github.com/GeorgeTsagk/lnd v0.0.0-20260907135521-53a43e15f745/go.mod h1:deRbYNteO2ZNleUYVQLHXCTMKbiuoUO7ShmYseVRRM8=
 github.com/JohnCGriffin/overflow v0.0.0-20211019200055-46fa312c352c/go.mod h1:X0CRv0ky0k6m906ixxpzmDRLvX58TFUKS2eePweuyxk=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
@@ -1062,8 +1064,6 @@ github.com/lightninglabs/protobuf-go-hex-display v1.34.2-hex-display h1:w7FM5LH9
 github.com/lightninglabs/protobuf-go-hex-display v1.34.2-hex-display/go.mod h1:qYOHts0dSfpeUzUFpOMr/WGzszTmLH+DiWniOlNbLDw=
 github.com/lightningnetwork/lightning-onion v1.4.0 h1:qWE1icOH4AKXRcq1KCzt6P/TesqptgBTP++V7wowTc0=
 github.com/lightningnetwork/lightning-onion v1.4.0/go.mod h1:YDPkvVTVQ6FBBE6Yj93tDd7zA3iTSrryi9xq46i7bKE=
-github.com/lightningnetwork/lnd v0.21.0-beta.rc2.0.20260903094101-d66a7c137d32 h1:lwPqwW244WCcdOZGwmS+rrieC1hTPYaRvkjHC8KXDeY=
-github.com/lightningnetwork/lnd v0.21.0-beta.rc2.0.20260903094101-d66a7c137d32/go.mod h1:deRbYNteO2ZNleUYVQLHXCTMKbiuoUO7ShmYseVRRM8=
 github.com/lightningnetwork/lnd/actor v0.0.6 h1:Ge8N2wivARG+27qJBwTlB0vwsypStZYZy8vk4Zl38sU=
 github.com/lightningnetwork/lnd/actor v0.0.6/go.mod h1:YAsoniSbY/cAM9HTVNfZLvt7RI6swDxy6wzPspTcMZg=
 github.com/lightningnetwork/lnd/cert v1.2.2 h1:71YK6hogeJtxSxw2teq3eGeuy4rHGKcFf0d0Uy4qBjI=

--- a/itest/rfq_test.go
+++ b/itest/rfq_test.go
@@ -231,10 +231,35 @@ func testRfqAssetBuyHtlcIntercept(t *harnessTest) {
 	expectedAssetID := mintedAssetId
 	require.Equal(t.t, expectedAssetID, actualAssetID)
 
-	// Restart Bob's tapd to ensure the accepted quote policy survives a
-	// restart and is restored.
+	// When accepting the quote, Bob's tapd registered the quote's SCID
+	// alias with Bob's lnd node, mapping it to the Bob->Carol channel. The
+	// alias must resolve to that channel's base SCID.
+	bobCarolChan := t.lndHarness.QueryChannelByChanPoint(
+		ts.BobLnd, ts.BobCarolChannel,
+	)
+	assertQuoteAliasResolves := func() {
+		resp, err := ts.BobLnd.RPC.Router.XFindBaseLocalChanAlias(
+			ctx, &routerrpc.FindBaseAliasRequest{
+				Alias: acceptedQuote.Scid,
+			},
+		)
+		require.NoError(t.t, err)
+		require.Equal(t.t, bobCarolChan.ChanId, resp.Base)
+	}
+	assertQuoteAliasResolves()
+
+	// Restart both Bob's tapd and lnd. The accepted quote policy must be
+	// restored by tapd and the SCID alias mapping must be restored by lnd,
+	// as neither is re-created on startup.
 	require.NoError(t.t, ts.BobTapd.stop(false))
+	t.lndHarness.RestartNode(ts.BobLnd)
 	require.NoError(t.t, ts.BobTapd.start(false))
+
+	// Wait for Bob's channels to become active again before continuing.
+	t.lndHarness.EnsureConnected(ts.AliceLnd, ts.BobLnd)
+	t.lndHarness.EnsureConnected(ts.BobLnd, ts.CarolLnd)
+	t.lndHarness.AssertChannelActive(ts.BobLnd, ts.AliceBobChannel)
+	t.lndHarness.AssertChannelActive(ts.BobLnd, ts.BobCarolChannel)
 
 	// Carol should still see the accepted quote after Bob's restart.
 	acceptedQuotes, err = ts.CarolTapd.QueryPeerAcceptedQuotes(
@@ -243,6 +268,9 @@ func testRfqAssetBuyHtlcIntercept(t *harnessTest) {
 	require.NoError(t.t, err)
 	require.Len(t.t, acceptedQuotes.BuyQuotes, 1)
 	acceptedQuote = acceptedQuotes.BuyQuotes[0]
+
+	// The quote's SCID alias must still resolve on Bob's lnd node.
+	assertQuoteAliasResolves()
 
 	// Carol will now use the accepted quote (received from Bob) to create
 	// a lightning invoice which will be given to and settled by Alice.


### PR DESCRIPTION
Companion to lightningnetwork/lnd#10411.

The RFQ buy itest already restarts Bob's tapd to check the accepted quote is restored. The quote's scid alias lives in lnd though and tapd does not re-add it on startup. The test now restarts Bob's lnd as well and asserts before and after the restart that the alias still resolves to the Bob to Carol base scid via XFindBaseLocalChanAlias. The payment that follows uses the restored mapping.

Without the lnd change the test fails on the first lookup with "unknown permissions required for method", since the RPC was never in the router macaroon permission map. With only the permission added it fails after the restart with "no base found".

go.mod temporarily points to the lnd PR rebased on the pinned lnd commit. To be removed once the PR is merged and lnd is bumped.