### PR TITLE
lndservices: re-register chain notifier on stream error

### DIFF
--- a/docs/release-notes/release-notes-0.9.0.md
+++ b/docs/release-notes/release-notes-0.9.0.md
@@ -139,6 +139,16 @@
   every block. The sweeper now returns an empty resolution for such
   outputs, so lnd sweeps them as plain BTC outputs.
 
+* [PR#2291](https://github.com/lightninglabs/taproot-assets/pull/2291)
+  fixes a bug in which the FSM chain-notifier adapter discarded the
+  error channel lndclient returns, so a dropped notifier stream (for
+  example an lnd restart) left the confirmation or spend event channel
+  open forever. The affected protofsm state machine, such as the
+  supply-commit machine or the supply verifier, would then stall
+  silently until tapd restarted. The adapter now re-registers on a
+  stream error and keeps forwarding events. Fixes
+  [#2286](https://github.com/lightninglabs/taproot-assets/issues/2286).
+
 # New Features
 
 ## Functional Enhancements

--- a/lndservices/daemon_adapters.go
+++ b/lndservices/daemon_adapters.go
@@ -2,6 +2,8 @@ package lndservices
 
 import (
 	"bytes"
+	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -163,17 +165,23 @@ func (l *LndFsmDaemonAdapters) RegisterConfirmationsNtfn(
 		lndCliOpt = append(lndCliOpt, lndclient.WithIncludeBlock())
 	}
 
-	ctx, cancel := l.WithCtxQuitNoTimeout()
-	spendDetail, _, err := l.lnd.ChainNotifier.RegisterConfirmationsNtfn(
-		ctx, txid, pkScript, int32(numConfs), int32(heightHint),
-		lndCliOpt...,
+	confChan, cancel, err := subscribeWithReconnect(
+		&l.ContextGuard, l.retryConfig,
+		func(ctx context.Context) (chan *chainntnfs.TxConfirmation,
+			chan error, error) {
+
+			return l.lnd.ChainNotifier.RegisterConfirmationsNtfn(
+				ctx, txid, pkScript, int32(numConfs),
+				int32(heightHint), lndCliOpt...,
+			)
+		},
 	)
 	if err != nil {
 		return nil, fmt.Errorf("unable to register for conf: %w", err)
 	}
 
 	return &chainntnfs.ConfirmationEvent{
-		Confirmed:    spendDetail,
+		Confirmed:    confChan,
 		Updates:      make(chan chainntnfs.TxUpdateInfo),
 		NegativeConf: make(chan int32),
 		Done:         make(chan struct{}),
@@ -186,20 +194,134 @@ func (l *LndFsmDaemonAdapters) RegisterConfirmationsNtfn(
 func (l *LndFsmDaemonAdapters) RegisterSpendNtfn(outpoint *wire.OutPoint,
 	pkScript []byte, heightHint uint32) (*chainntnfs.SpendEvent, error) {
 
-	ctx, cancel := l.WithCtxQuitNoTimeout()
-	spendDetail, _, err := l.lnd.ChainNotifier.RegisterSpendNtfn(
-		ctx, outpoint, pkScript, int32(heightHint),
+	spendChan, cancel, err := subscribeWithReconnect(
+		&l.ContextGuard, l.retryConfig,
+		func(ctx context.Context) (chan *chainntnfs.SpendDetail,
+			chan error, error) {
+
+			return l.lnd.ChainNotifier.RegisterSpendNtfn(
+				ctx, outpoint, pkScript, int32(heightHint),
+			)
+		},
 	)
 	if err != nil {
 		return nil, fmt.Errorf("unable to register for spend: %w", err)
 	}
 
 	return &chainntnfs.SpendEvent{
-		Spend:  spendDetail,
+		Spend:  spendChan,
 		Reorg:  make(chan struct{}, 1),
 		Done:   make(chan struct{}, 1),
 		Cancel: cancel,
 	}, nil
+}
+
+// subscription bundles the event and error channels returned by a chain
+// notifier registration so they can be passed through fn.RetryFuncN as one
+// value.
+type subscription[T any] struct {
+	eventChan chan T
+	errChan   chan error
+}
+
+// subscribeWithReconnect drives a chain notifier subscription that survives a
+// dropped notifier stream. It performs the initial registration, then runs a
+// guard-managed goroutine that forwards the single event to the returned
+// channel. If the stream reports an error (or closes) before the event
+// arrives, it re-registers with the same parameters, using a bounded backoff;
+// reusing the original height hint makes the replay safe. The returned cancel
+// function, and the guard's quit signal, both stop the goroutine.
+func subscribeWithReconnect[T any](g *fn.ContextGuard, cfg fn.RetryConfig,
+	register func(context.Context) (chan T, chan error, error)) (chan T,
+	func(), error) {
+
+	ctx, cancel := g.WithCtxQuitNoTimeout()
+
+	eventChan, errChan, err := register(ctx)
+	if err != nil {
+		cancel()
+		return nil, nil, err
+	}
+
+	// The chainntnfs event channels must be buffered so a delivered event
+	// is never lost if the consumer is not yet selecting on it.
+	out := make(chan T, 1)
+
+	reRegister := func() error {
+		reg, regErr := fn.RetryFuncN(
+			ctx, cfg, func() (subscription[T], error) {
+				e, ec, rErr := register(ctx)
+				return subscription[T]{
+					eventChan: e,
+					errChan:   ec,
+				}, rErr
+			},
+		)
+		if regErr != nil {
+			return regErr
+		}
+
+		eventChan = reg.eventChan
+		errChan = reg.errChan
+
+		return nil
+	}
+
+	forward := func() error {
+		for {
+			select {
+			case event, ok := <-eventChan:
+				if ok {
+					select {
+					case out <- event:
+					case <-ctx.Done():
+					}
+
+					return nil
+				}
+
+				// The stream closed without delivering an
+				// event; re-register and keep waiting.
+				log.Warnf("Chain notifier event channel " +
+					"closed early, re-registering")
+
+				if err := reRegister(); err != nil {
+					return fmt.Errorf("unable to "+
+						"re-register notifier: %w", err)
+				}
+
+			case streamErr, ok := <-errChan:
+				if !ok {
+					errChan = nil
+
+					continue
+				}
+
+				log.Warnf("Chain notifier stream errored, "+
+					"re-registering: %v", streamErr)
+
+				if err := reRegister(); err != nil {
+					return fmt.Errorf("unable to "+
+						"re-register notifier: %w", err)
+				}
+
+			case <-ctx.Done():
+				return nil
+			}
+		}
+	}
+
+	g.Goroutine(forward, func(err error) {
+		// A cancelled context is a clean shutdown, not a failure to
+		// surface.
+		if errors.Is(err, context.Canceled) {
+			return
+		}
+
+		log.Errorf("Chain notifier subscription stopped: %v", err)
+	})
+
+	return out, cancel, nil
 }
 
 // Ensure LndFsmDaemonAdapters implements the protofsm.DaemonAdapters

--- a/lndservices/daemon_adapters_test.go
+++ b/lndservices/daemon_adapters_test.go
@@ -1,0 +1,169 @@
+package lndservices
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/lightninglabs/lndclient"
+	"github.com/lightninglabs/taproot-assets/fn"
+	"github.com/lightningnetwork/lnd/chainntnfs"
+	"github.com/lightningnetwork/lnd/lnrpc/chainrpc"
+	"github.com/stretchr/testify/require"
+)
+
+// queuedNotifier is a fake lndclient.ChainNotifierClient that hands out a
+// pre-seeded sequence of (event, error) channel pairs, one per registration,
+// so a test can drive the adapter through a stream error and its
+// re-registration. It mirrors lndclient's behaviour of surfacing a stream error
+// on the error channel without closing the event channel.
+type queuedNotifier struct {
+	mu sync.Mutex
+
+	confChans []chan *chainntnfs.TxConfirmation
+	confErrs  []chan error
+	confCalls int
+
+	spendChans []chan *chainntnfs.SpendDetail
+	spendErrs  []chan error
+	spendCalls int
+}
+
+func (q *queuedNotifier) RegisterConfirmationsNtfn(_ context.Context,
+	_ *chainhash.Hash, _ []byte, _, _ int32,
+	_ ...lndclient.NotifierOption) (chan *chainntnfs.TxConfirmation,
+	chan error, error) {
+
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	i := q.confCalls
+	q.confCalls++
+
+	return q.confChans[i], q.confErrs[i], nil
+}
+
+func (q *queuedNotifier) RegisterSpendNtfn(_ context.Context, _ *wire.OutPoint,
+	_ []byte, _ int32, _ ...lndclient.NotifierOption) (
+	chan *chainntnfs.SpendDetail, chan error, error) {
+
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	i := q.spendCalls
+	q.spendCalls++
+
+	return q.spendChans[i], q.spendErrs[i], nil
+}
+
+func (q *queuedNotifier) RegisterBlockEpochNtfn(_ context.Context) (chan int32,
+	chan error, error) {
+
+	return nil, nil, nil
+}
+
+func (q *queuedNotifier) RawClientWithMacAuth(ctx context.Context) (
+	context.Context, time.Duration, chainrpc.ChainNotifierClient) {
+
+	return ctx, 0, nil
+}
+
+func testAdapters(
+	notifier lndclient.ChainNotifierClient) *LndFsmDaemonAdapters {
+
+	return &LndFsmDaemonAdapters{
+		lnd:         &lndclient.LndServices{ChainNotifier: notifier},
+		retryConfig: fn.DefaultRetryConfig(),
+		ContextGuard: fn.ContextGuard{
+			DefaultTimeout: DefaultTimeout,
+			Quit:           make(chan struct{}),
+		},
+	}
+}
+
+// TestRegisterConfirmationsNtfnResubscribes asserts that after the notifier
+// stream errors, the adapter re-registers and a later confirmation still
+// reaches the consumer. This is the #2286 regression: on the unfixed adapter
+// the error channel is dropped, the confirmation never arrives, and this times
+// out.
+func TestRegisterConfirmationsNtfnResubscribes(t *testing.T) {
+	t.Parallel()
+
+	conf := &chainntnfs.TxConfirmation{}
+
+	// The second registration's channel is pre-loaded with the
+	// confirmation, so it is delivered as soon as the adapter re-registers.
+	confChan2 := make(chan *chainntnfs.TxConfirmation, 1)
+	confChan2 <- conf
+
+	notifier := &queuedNotifier{
+		confChans: []chan *chainntnfs.TxConfirmation{
+			make(chan *chainntnfs.TxConfirmation), confChan2,
+		},
+		confErrs: []chan error{
+			make(chan error, 1), make(chan error, 1),
+		},
+	}
+
+	adapters := testAdapters(notifier)
+	defer func() { require.NoError(t, adapters.Stop()) }()
+
+	event, err := adapters.RegisterConfirmationsNtfn(
+		&chainhash.Hash{}, []byte{}, 1, 100,
+	)
+	require.NoError(t, err)
+
+	// Sever the first stream.
+	notifier.confErrs[0] <- fmt.Errorf("stream died")
+
+	select {
+	case got := <-event.Confirmed:
+		require.Same(t, conf, got)
+
+	case <-time.After(5 * time.Second):
+		t.Fatal("confirmation never arrived after re-registration")
+	}
+}
+
+// TestRegisterSpendNtfnResubscribes is the spend-side twin of the confirmation
+// regression test above.
+func TestRegisterSpendNtfnResubscribes(t *testing.T) {
+	t.Parallel()
+
+	spend := &chainntnfs.SpendDetail{}
+
+	spendChan2 := make(chan *chainntnfs.SpendDetail, 1)
+	spendChan2 <- spend
+
+	notifier := &queuedNotifier{
+		spendChans: []chan *chainntnfs.SpendDetail{
+			make(chan *chainntnfs.SpendDetail), spendChan2,
+		},
+		spendErrs: []chan error{
+			make(chan error, 1), make(chan error, 1),
+		},
+	}
+
+	adapters := testAdapters(notifier)
+	defer func() { require.NoError(t, adapters.Stop()) }()
+
+	event, err := adapters.RegisterSpendNtfn(
+		&wire.OutPoint{}, []byte{}, 100,
+	)
+	require.NoError(t, err)
+
+	// Sever the first stream.
+	notifier.spendErrs[0] <- fmt.Errorf("stream died")
+
+	select {
+	case got := <-event.Spend:
+		require.Same(t, spend, got)
+
+	case <-time.After(5 * time.Second):
+		t.Fatal("spend never arrived after re-registration")
+	}
+}


### PR DESCRIPTION
The adapter dropped the error channel lndclient returns. A severed notifier stream then left the `chainntnfs.*Event` channel open forever, and the protofsm machine stalled silently with no re-arm.

Both register methods now forward events through a guard-managed goroutine. On a stream error it re-registers with the same height hint via `fn.RetryFuncN` backoff. The `chainntnfs.*Event` contract is unchanged, so every caller is fixed at once.

Fixes #2286.
