### PR TITLE
tapreorg: admit transient burials in the rapid oracle

### DIFF
--- a/tapreorg/service_test.go
+++ b/tapreorg/service_test.go
@@ -2447,7 +2447,10 @@ func TestWatcherRapid(t *testing.T) {
 		}
 
 		// recordPossible captures the current chain state's
-		// terminal reading, if any; called after every action.
+		// terminal reading, if any. It must run after every
+		// chain state the notifier dispatched from, including
+		// states an action passes through on its way to its
+		// final one: sensing may have observed any of them.
 		recordPossible := func() {
 			kind, witness := oracle()
 			switch kind {
@@ -2747,6 +2750,12 @@ func TestWatcherRapid(t *testing.T) {
 					rt, label+".alsoReorg",
 				) {
 
+					// The notifier dispatched from the
+					// state the block just made, so a
+					// terminal it made sensible must be
+					// admitted even though the re-org
+					// erases it before the action ends.
+					recordPossible()
 					h.sim.Reorg(1)
 				}
 				h.sim.ReleaseDeliveries()


### PR DESCRIPTION
(N.b., fixes a flake observed in [this CI job](https://github.com/lightninglabs/taproot-assets/actions/runs/34239845647/job/102106895032?pr=2283). Fable's summary follows.)

The randomized watcher test accepts a terminal phase exactly when the simulated chain made it sensible at some point, recording the oracle's reading after every action. The lagging-consumer action (hold deliveries, mine, re-org one block, release) dispatches from a chain state that exists only mid-action: the mined block can carry a candidate to act depth, the notifier fires the threshold confirmation, and the watcher certifies from that held event since the location still holds. The subsequent re-org erases the depth before the action ends, so the oracle never sampled the burial and a later shrink left the registry buried against an unwitnessed oracle, failing with "never settled".

Whether the certification lands before the next settle poll, after it, or only after the shrink (where it is disproved) is a timing race, which is why rapid could not reproduce the failure on replay.

Record the possible terminal between the mine and the re-org, and state the invariant: the oracle must sample every chain state the notifier dispatched from, intermediate ones included.