### PR TITLE
universe: move federation pushes off sync loop

### DIFF
--- a/tapdb/universe_federation_fifo.go
+++ b/tapdb/universe_federation_fifo.go
@@ -1,0 +1,72 @@
+package tapdb
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"sort"
+
+	"github.com/lightninglabs/taproot-assets/universe"
+)
+
+// FetchPendingProofsSyncLogFIFO returns pending federation proof pushes in
+// insertion order. The federation pusher relies on this order so an anchor
+// proof cannot be overtaken by a later reissuance after a retry or restart.
+func (u *UniverseFederationDB) FetchPendingProofsSyncLogFIFO(
+	ctx context.Context,
+	syncDirection *universe.SyncDirection) ([]*universe.ProofSyncLogEntry,
+	error) {
+
+	var (
+		readTx        = NewUniverseFederationReadTx()
+		proofSyncLogs []*universe.ProofSyncLogEntry
+	)
+
+	err := u.db.ExecTx(ctx, &readTx, func(db UniverseServerStore) error {
+		var sqlSyncDirection sql.NullString
+		if syncDirection != nil {
+			sqlSyncDirection = sqlStr(string(*syncDirection))
+		}
+
+		params := QueryFedProofSyncLogParams{
+			SyncDirection: sqlSyncDirection,
+			Status: sqlStr(
+				string(universe.ProofSyncStatusPending),
+			),
+		}
+		logEntries, err := db.QueryFederationProofSyncLog(ctx, params)
+		if err != nil {
+			return fmt.Errorf("unable to query proof sync log: %w",
+				err)
+		}
+
+		// The row ID is allocated when the push is first queued and is
+		// not changed by later attempts, making it the durable FIFO key.
+		sort.Slice(logEntries, func(i, j int) bool {
+			return logEntries[i].ID < logEntries[j].ID
+		})
+
+		proofSyncLogs = make(
+			[]*universe.ProofSyncLogEntry, 0, len(logEntries),
+		)
+		for idx := range logEntries {
+			entry := logEntries[idx]
+
+			parsedLogEntry, err := fetchProofSyncLogEntry(
+				ctx, entry, db,
+			)
+			if err != nil {
+				return err
+			}
+
+			proofSyncLogs = append(proofSyncLogs, parsedLogEntry)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return proofSyncLogs, nil
+}

--- a/tapdb/universe_federation_fifo_test.go
+++ b/tapdb/universe_federation_fifo_test.go
@@ -1,0 +1,54 @@
+package tapdb
+
+import (
+	"context"
+	"testing"
+
+	"github.com/lightninglabs/taproot-assets/universe"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFederationPendingProofSyncFIFO(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbHandle := NewDbHandle(t)
+	fedStore := dbHandle.UniverseFederationStore
+
+	testAsset, annotatedProof := dbHandle.AddRandomAssetProof(t)
+	uniProof := dbHandle.AddUniProofLeaf(t, testAsset, annotatedProof)
+	uniID := universe.NewUniIDFromAsset(*testAsset)
+	servers := dbHandle.AddRandomServerAddrs(t, 3)
+
+	insertOrder := []universe.ServerAddr{
+		servers[2], servers[0], servers[1],
+	}
+	for _, server := range insertOrder {
+		_, err := fedStore.UpsertFederationProofSyncLog(
+			ctx, uniID, uniProof.LeafKey, server,
+			universe.SyncDirectionPush,
+			universe.ProofSyncStatusPending, false,
+		)
+		require.NoError(t, err)
+	}
+
+	// A retry updates the existing row but must not move it behind work
+	// that was queued later.
+	_, err := fedStore.UpsertFederationProofSyncLog(
+		ctx, uniID, uniProof.LeafKey, insertOrder[0],
+		universe.SyncDirectionPush, universe.ProofSyncStatusPending,
+		true,
+	)
+	require.NoError(t, err)
+
+	direction := universe.SyncDirectionPush
+	pending, err := fedStore.FetchPendingProofsSyncLogFIFO(
+		ctx, &direction,
+	)
+	require.NoError(t, err)
+	require.Len(t, pending, len(insertOrder))
+
+	for idx := range pending {
+		require.Equal(t, insertOrder[idx], pending[idx].ServerAddr)
+	}
+}

--- a/universe/federation.go
+++ b/universe/federation.go
@@ -78,42 +78,6 @@ type FederationConfig struct {
 	ServerChecker func(ServerAddr) error
 }
 
-// FederationPushReq is used to push out new updates to all or some members of
-// the federation.
-type FederationPushReq struct {
-	// ID identifies the Universe tree to push this new update out to.
-	ID Identifier
-
-	// Key is the leaf key in the Universe that the new leaf should be
-	// added to.
-	Key LeafKey
-
-	// Leaf is the new leaf to add.
-	Leaf *Leaf
-
-	// resp is a channel that will be sent the asset issuance/transfer
-	// proof and corresponding universe/multiverse inclusion proofs if the
-	// federation proof push was successful.
-	resp chan *Proof
-
-	// LogProofSync is a boolean that indicates, if true, that the proof
-	// leaf sync attempt should be logged and actively managed to ensure
-	// that the federation push procedure is repeated in the event of a
-	// failure.
-	LogProofSync bool
-
-	err chan error
-}
-
-// FederationProofBatchPushReq is used to push out a batch of universe proof
-// leaves to all or some members of the federation.
-type FederationProofBatchPushReq struct {
-	Batch []*Item
-
-	resp chan struct{}
-	err  chan error
-}
-
 // FederationEnvoy is used to manage synchronization between the set of
 // federated Universe servers. It handles the periodic sync between universe
 // servers, and can also be used to push out new locally created proofs to the
@@ -127,13 +91,9 @@ type FederationEnvoy struct {
 
 	stopOnce sync.Once
 
-	// pushRequests is a channel that will be sent new requests to push out
-	// proof leaves to the federation.
-	pushRequests chan *FederationPushReq
-
-	// batchPushRequests is a channel that will be sent new requests to push
-	// out batch proof leaves to the federation.
-	batchPushRequests chan *FederationProofBatchPushReq
+	// pushWake wakes the dedicated federation pusher. Durable work lives in
+	// the federation proof sync log, so the channel only carries a wakeup.
+	pushWake chan struct{}
 
 	// lastEnumSync tracks, per server host, when a full enumeration
 	// sync last completed (or when the server was first seen), driving
@@ -151,10 +111,9 @@ var _ address.AssetSyncer = (*FederationEnvoy)(nil)
 // NewFederationEnvoy creates a new federation envoy from the passed config.
 func NewFederationEnvoy(cfg FederationConfig) *FederationEnvoy {
 	return &FederationEnvoy{
-		cfg:               cfg,
-		pushRequests:      make(chan *FederationPushReq),
-		batchPushRequests: make(chan *FederationProofBatchPushReq),
-		lastEnumSync:      make(map[string]time.Time),
+		cfg:          cfg,
+		pushWake:     make(chan struct{}, 1),
+		lastEnumSync: make(map[string]time.Time),
 		ContextGuard: &fn.ContextGuard{
 			DefaultTimeout: DefaultTimeout,
 			Quit:           make(chan struct{}),
@@ -192,9 +151,13 @@ func (f *FederationEnvoy) Start() error {
 				"servers: %v", err)
 		}
 
-		f.Wg.Add(1)
+		f.Wg.Add(2)
 
 		go f.syncer()
+		go f.pusher()
+
+		// Replay any durable pending pushes left by a previous run.
+		f.signalPusher()
 	})
 
 	return nil
@@ -530,60 +493,8 @@ func (f *FederationEnvoy) pushProofToFederation(ctx context.Context,
 	}
 }
 
-// filterProofSyncPending filters out servers that have already been synced
-// with for the given leaf.
-func (f *FederationEnvoy) filterProofSyncPending(fedServers []ServerAddr,
-	uniID Identifier, key LeafKey) ([]ServerAddr, error) {
-
-	// If there are no servers to filter, then we'll return early. This
-	// saves from querying the database unnecessarily.
-	if len(fedServers) == 0 {
-		return nil, nil
-	}
-
-	ctx, cancel := f.WithCtxQuit()
-	defer cancel()
-
-	// Select all sync push complete log entries for the given universe
-	// leaf. If there are any servers which are sync complete within this
-	// log set, we will filter them out of our target server set.
-	logs, err := f.cfg.FederationDB.QueryFederationProofSyncLog(
-		ctx, uniID, key, SyncDirectionPush,
-		ProofSyncStatusComplete,
-	)
-	if err != nil {
-		return nil, fmt.Errorf("unable to query federation sync log: %w",
-			err)
-	}
-
-	// Construct a map of servers that have already been synced with for the
-	// given leaf.
-	syncedServers := make(map[string]struct{})
-	for idx := range logs {
-		logEntry := logs[idx]
-		syncedServers[logEntry.ServerAddr.HostStr()] = struct{}{}
-	}
-
-	// Filter out servers that we've already pushed to.
-	filteredFedServers := fn.Filter(fedServers, func(a ServerAddr) bool {
-		// Filter out servers that have a log entry with sync status
-		// complete.
-		if _, ok := syncedServers[a.HostStr()]; ok {
-			return false
-		}
-
-		// By this point we haven't found logs corresponding to the
-		// given server, we will therefore return true and include the
-		// server as a sync target for the given leaf.
-		return true
-	})
-
-	return filteredFedServers, nil
-}
-
-// syncer is the main goroutine that's responsible for interacting with the
-// federation envoy. It also accepts incoming requests to push out new updates
-// to the federation.
+// syncer is the main goroutine that's responsible for periodic federation
+// synchronization. Remote proof pushes run in the dedicated pusher goroutine.
 //
 // NOTE: This function MUST be run as a goroutine.
 func (f *FederationEnvoy) syncer() {
@@ -606,30 +517,6 @@ func (f *FederationEnvoy) syncer() {
 				// more events.
 				log.Warnf("Unable to handle tick event: %v",
 					err)
-			}
-
-		// Handle a new push request.
-		case pushReq := <-f.pushRequests:
-			log.Debug("Federation envoy handling push request")
-			err := f.handlePushRequest(pushReq)
-			if err != nil {
-				// Warn, but don't exit the syncer. The syncer
-				// should continue to run and attempt handle
-				// more events.
-				log.Warnf("Unable to handle push request: %v",
-					err)
-			}
-
-		// Handle a new batch push request.
-		case pushReq := <-f.batchPushRequests:
-			log.Debug("Federation envoy handling batch push " +
-				"request")
-			err := f.handleBatchPushRequest(pushReq)
-			if err != nil {
-				// Warn, but don't exit the event handler
-				// routine.
-				log.Warnf("Unable to handle batch push "+
-					"request: %v", err)
 			}
 
 		case <-f.Quit:
@@ -656,208 +543,9 @@ func (f *FederationEnvoy) handleTickEvent() error {
 			err)
 	}
 
-	// After we've synced with the federation, we'll attempt to push out any
-	// pending proofs that we haven't yet completed.
-	ctx, cancel := f.WithCtxQuitNoTimeout()
-	defer cancel()
-
-	syncDirection := SyncDirectionPush
-	db := f.cfg.FederationDB
-
-	logEntries, err := db.FetchPendingProofsSyncLog(
-		ctx, &syncDirection,
-	)
-	if err != nil {
-		return fmt.Errorf("unable to query pending push sync log: %w",
-			err)
-	}
-
-	if len(logEntries) > 0 {
-		log.Debugf("Handling pending proof sync log entries "+
-			"(entries_count=%d)", len(logEntries))
-	}
-
-	// TODO(ffranr): Take account of any new servers that have been added
-	//  since the last time we populated the log for a given proof leaf.
-	//  Pending proof sync log entries are only relevant for the set of
-	//  servers that existed at the time the log entry was created. If a new
-	//  server is added, then we should create a new log entry for the new
-	//  server.
-
-	// We'll use a timeout that's slightly less than the sync interval to
-	// help avoid ticking into a new sync event before the previous event
-	// has finished.
-	syncContextTimeout := f.cfg.SyncInterval - 1*time.Second
-	if syncContextTimeout < 0 {
-		// If the sync interval is less than a second, then we'll use
-		// the sync interval as the timeout.
-		syncContextTimeout = f.cfg.SyncInterval
-	}
-
-	for idx := range logEntries {
-		entry := logEntries[idx]
-
-		servers := []ServerAddr{
-			entry.ServerAddr,
-		}
-
-		ctxPush, cancelPush := f.CtxBlockingCustomTimeout(
-			syncContextTimeout,
-		)
-		f.pushProofToFederation(
-			ctxPush, entry.UniID, entry.LeafKey, &entry.Leaf,
-			servers, true,
-		)
-		cancelPush()
-	}
-
-	return nil
-}
-
-// handlePushRequest is called each time a new push request is received. It will
-// perform an asynchronous registration with the local Universe registrar, then
-// push the proof leaf out in an async manner to the federation members.
-func (f *FederationEnvoy) handlePushRequest(pushReq *FederationPushReq) error {
-	if pushReq == nil {
-		return fmt.Errorf("nil push request")
-	}
-
-	// First, we'll attempt to registrar the proof leaf with the local
-	// registrar server.
-	ctx, cancel := f.WithCtxQuit()
-	defer cancel()
-	newProof, err := f.cfg.LocalRegistrar.UpsertProofLeaf(
-		ctx, pushReq.ID, pushReq.Key, pushReq.Leaf,
-	)
-	switch {
-	// The proof leaf is durably stored; only its entry in the shared
-	// multiverse trees is still outstanding, and the archive repairs
-	// that in the background. The caller cannot receive a composing
-	// receipt, but the proof must not be stranded local-only, so the
-	// federation push below proceeds.
-	case errors.Is(err, ErrMultiversePending):
-		log.Warnf("Proof stored with multiverse update pending, "+
-			"proceeding with federation push (id=%v): %v",
-			pushReq.ID.StringForLog(), err)
-		pushReq.err <- err
-
-	case err != nil:
-		err = fmt.Errorf("unable to insert proof into local "+
-			"universe: %w", err)
-		pushReq.err <- err
-		return err
-
-	default:
-		// Now that we know we were able to register the proof, we'll
-		// return back to the caller, and push the new proof out to
-		// the federation in the background.
-		pushReq.resp <- newProof
-	}
-
-	// Fetch all universe servers in our federation.
-	fedServers, err := f.tryFetchServers()
-	if err != nil {
-		err = fmt.Errorf("unable to fetch federation servers: %w", err)
-		pushReq.err <- err
-		return err
-	}
-
-	if len(fedServers) == 0 {
-		log.Warnf("could not find any federation servers")
-		return nil
-	}
-
-	if pushReq.LogProofSync {
-		// We are attempting to sync using the logged proof sync
-		// procedure. We will therefore narrow down the set of target
-		// servers based on the sync log. Only servers that are not yet
-		// push sync complete will be targeted.
-		fedServers, err = f.filterProofSyncPending(
-			fedServers, pushReq.ID, pushReq.Key,
-		)
-		if err != nil {
-			err = fmt.Errorf("failed to filter federation "+
-				"servers: %w", err)
-			pushReq.err <- err
-			return err
-		}
-	}
-
-	// With the response sent above, we'll push this out to all the Universe
-	// servers in the background.
-	ctx, cancel = f.WithCtxQuitNoTimeout()
-	defer cancel()
-	f.pushProofToFederation(
-		ctx, pushReq.ID, pushReq.Key, pushReq.Leaf, fedServers,
-		pushReq.LogProofSync,
-	)
-
-	return nil
-}
-
-// handleBatchPushRequest is called each time a new batch push request is
-// received. It will perform an asynchronous registration with the local
-// Universe registrar, then push each leaf from the batch out in an async manner
-// to the federation members.
-func (f *FederationEnvoy) handleBatchPushRequest(
-	pushReq *FederationProofBatchPushReq) error {
-
-	if pushReq == nil {
-		return fmt.Errorf("nil batch push request")
-	}
-
-	ctx, cancel := f.WithCtxQuitNoTimeout()
-	defer cancel()
-
-	// First, we'll attempt to registrar the proof leaf with the local
-	// registrar server.
-	err := f.cfg.LocalRegistrar.UpsertProofLeafBatch(ctx, pushReq.Batch)
-	switch {
-	// The proof leaves are durably stored; only their entries in the
-	// shared multiverse trees are still outstanding, and the archive
-	// repairs that in the background. The proofs must not be stranded
-	// local-only, so the federation push below proceeds.
-	case errors.Is(err, ErrMultiversePending):
-		log.Warnf("Proof batch stored with multiverse updates "+
-			"pending, proceeding with federation push "+
-			"(num_leaves=%d): %v", len(pushReq.Batch), err)
-		pushReq.err <- err
-
-	case err != nil:
-		err = fmt.Errorf("unable to insert proof batch into local "+
-			"universe: %w", err)
-		pushReq.err <- err
-		return err
-
-	default:
-		// Now that we know we were able to register the proof, we'll
-		// return back to the caller.
-		pushReq.resp <- struct{}{}
-	}
-
-	// Fetch all universe servers in our federation.
-	fedServers, err := f.tryFetchServers()
-	if err != nil {
-		err = fmt.Errorf("unable to fetch federation servers: %w", err)
-		pushReq.err <- err
-		return err
-	}
-
-	if len(fedServers) == 0 {
-		log.Warnf("could not find any federation servers")
-		return nil
-	}
-
-	// With the response sent above, we'll push this out to all the Universe
-	// servers in the background.
-	for idx := range pushReq.Batch {
-		item := pushReq.Batch[idx]
-
-		f.pushProofToFederation(
-			ctx, item.ID, item.Key, item.Leaf, fedServers,
-			item.LogProofSync,
-		)
-	}
+	// Pending federation pushes are retried by the dedicated pusher rather
+	// than on this serial sync loop.
+	f.signalPusher()
 
 	return nil
 }
@@ -867,28 +555,46 @@ func (f *FederationEnvoy) handleBatchPushRequest(
 // ultimately queuing it to also be sent to the set of active universe servers.
 //
 // NOTE: This is part of the universe.Registrar interface.
-func (f *FederationEnvoy) UpsertProofLeaf(_ context.Context, id Identifier,
+func (f *FederationEnvoy) UpsertProofLeaf(ctx context.Context, id Identifier,
 	key LeafKey, leaf *Leaf) (*Proof, error) {
 
-	// If we're attempting to push an issuance proof, then we'll ensure
-	// that we track the sync attempt to ensure that we retry in the event
-	// of a failure.
-	logProofSync := id.ProofType == ProofTypeIssuance
+	newProof, err := f.cfg.LocalRegistrar.UpsertProofLeaf(
+		ctx, id, key, leaf,
+	)
+	var pendingErr error
+	switch {
+	case errors.Is(err, ErrMultiversePending):
+		pendingErr = err
+		log.Warnf("Proof stored with multiverse update pending, "+
+			"proceeding with federation push (id=%v): %v",
+			id.StringForLog(), err)
 
-	pushReq := &FederationPushReq{
+	case err != nil:
+		return nil, fmt.Errorf("unable to insert proof into local "+
+			"universe: %w", err)
+	}
+
+	item := &Item{
 		ID:           id,
 		Key:          key,
 		Leaf:         leaf,
-		LogProofSync: logProofSync,
-		resp:         make(chan *Proof, 1),
-		err:          make(chan error, 1),
+		LogProofSync: id.ProofType == ProofTypeIssuance,
+	}
+	if err := f.queueProofPushes(ctx, []*Item{item}); err != nil {
+		if pendingErr != nil {
+			log.Warnf("Unable to queue federation push after "+
+				"multiverse-pending upsert: %v", err)
+			return nil, pendingErr
+		}
+
+		return nil, err
 	}
 
-	if !fn.SendOrQuit(f.pushRequests, pushReq, f.Quit) {
-		return nil, fmt.Errorf("unable to push new proof event")
+	if pendingErr != nil {
+		return nil, pendingErr
 	}
 
-	return fn.RecvResp(pushReq.resp, pushReq.err, f.Quit)
+	return newProof, nil
 }
 
 // UpsertProofLeafBatch inserts a batch of proof leaves within the target
@@ -896,21 +602,34 @@ func (f *FederationEnvoy) UpsertProofLeaf(_ context.Context, id Identifier,
 // checked that they don't yet exist in the local database.
 //
 // NOTE: This is part of the universe.BatchRegistrar interface.
-func (f *FederationEnvoy) UpsertProofLeafBatch(_ context.Context,
+func (f *FederationEnvoy) UpsertProofLeafBatch(ctx context.Context,
 	items []*Item) error {
 
-	pushReq := &FederationProofBatchPushReq{
-		Batch: items,
-		resp:  make(chan struct{}, 1),
-		err:   make(chan error, 1),
+	err := f.cfg.LocalRegistrar.UpsertProofLeafBatch(ctx, items)
+	var pendingErr error
+	switch {
+	case errors.Is(err, ErrMultiversePending):
+		pendingErr = err
+		log.Warnf("Proof batch stored with multiverse updates "+
+			"pending, proceeding with federation push "+
+			"(num_leaves=%d): %v", len(items), err)
+
+	case err != nil:
+		return fmt.Errorf("unable to insert proof batch into local "+
+			"universe: %w", err)
 	}
 
-	if !fn.SendOrQuit(f.batchPushRequests, pushReq, f.Quit) {
-		return fmt.Errorf("unable to push new proof event batch")
+	if err := f.queueProofPushes(ctx, items); err != nil {
+		if pendingErr != nil {
+			log.Warnf("Unable to queue federation push after "+
+				"multiverse-pending batch upsert: %v", err)
+			return pendingErr
+		}
+
+		return err
 	}
 
-	_, err := fn.RecvResp(pushReq.resp, pushReq.err, f.Quit)
-	return err
+	return pendingErr
 }
 
 // AddServer adds a new set of servers to the federation, then immediately

--- a/universe/federation_push_req.go
+++ b/universe/federation_push_req.go
@@ -1,0 +1,36 @@
+package universe
+
+// FederationPushReq describes a proof leaf federation push request.
+type FederationPushReq struct {
+	// ID identifies the Universe tree to push this new update out to.
+	ID Identifier
+
+	// Key is the leaf key in the Universe that the new leaf should be
+	// added to.
+	Key LeafKey
+
+	// Leaf is the new leaf to add.
+	Leaf *Leaf
+
+	// resp is a channel that will be sent the asset issuance/transfer
+	// proof and corresponding universe/multiverse inclusion proofs if the
+	// federation proof push was successful.
+	resp chan *Proof
+
+	// LogProofSync is a boolean that indicates, if true, that the proof
+	// leaf sync attempt should be logged and actively managed to ensure
+	// that the federation push procedure is repeated in the event of a
+	// failure.
+	LogProofSync bool
+
+	err chan error
+}
+
+// FederationProofBatchPushReq describes a batch of universe proof leaves to
+// push to the federation.
+type FederationProofBatchPushReq struct {
+	Batch []*Item
+
+	resp chan struct{}
+	err  chan error
+}

--- a/universe/federation_pusher.go
+++ b/universe/federation_pusher.go
@@ -1,0 +1,245 @@
+package universe
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// fifoFederationProofSyncLog is implemented by federation stores that can
+// return pending pushes in their durable insertion order.
+type fifoFederationProofSyncLog interface {
+	FetchPendingProofsSyncLogFIFO(context.Context,
+		*SyncDirection) ([]*ProofSyncLogEntry, error)
+}
+
+// signalPusher wakes the federation pusher without coupling callers to the
+// pusher's current progress. The durable proof sync log is the work queue, so
+// this channel only needs to carry an edge-triggered wakeup.
+func (f *FederationEnvoy) signalPusher() {
+	select {
+	case f.pushWake <- struct{}{}:
+	default:
+	}
+}
+
+// pusher serially drains pending federation proof pushes. Keeping this work in
+// a dedicated goroutine prevents a slow remote federation member from blocking
+// the periodic federation sync loop.
+func (f *FederationEnvoy) pusher() {
+	defer f.Wg.Done()
+
+	retryInterval := f.cfg.SyncInterval
+	if retryInterval <= 0 {
+		retryInterval = DefaultTimeout
+	}
+
+	retryTicker := time.NewTicker(retryInterval)
+	defer retryTicker.Stop()
+
+	for {
+		select {
+		case <-f.pushWake:
+		case <-retryTicker.C:
+		case <-f.Quit:
+			return
+		}
+
+		if err := f.handlePendingProofPushes(); err != nil {
+			log.Warnf("Unable to handle pending federation push: %v",
+				err)
+		}
+	}
+}
+
+// pendingProofPushes fetches pending work in durable FIFO order when the
+// backing store supports it. Alternate FederationDB implementations retain the
+// existing method contract, which is useful for lightweight test stores.
+func (f *FederationEnvoy) pendingProofPushes(ctx context.Context,
+	syncDirection *SyncDirection) ([]*ProofSyncLogEntry, error) {
+
+	fifoLog, ok := f.cfg.FederationDB.(fifoFederationProofSyncLog)
+	if ok {
+		return fifoLog.FetchPendingProofsSyncLogFIFO(
+			ctx, syncDirection,
+		)
+	}
+
+	return f.cfg.FederationDB.FetchPendingProofsSyncLog(
+		ctx, syncDirection,
+	)
+}
+
+// handlePendingProofPushes drains the durable push log in FIFO order. A
+// failed push blocks only later entries for that same federation member during
+// this pass. This prevents a reissuance from overtaking its anchor while still
+// allowing healthy members to make progress.
+func (f *FederationEnvoy) handlePendingProofPushes() error {
+	ctx, cancel := f.WithCtxQuitNoTimeout()
+	defer cancel()
+
+	syncDirection := SyncDirectionPush
+	logEntries, err := f.pendingProofPushes(ctx, &syncDirection)
+	if err != nil {
+		return fmt.Errorf("unable to query pending push sync log: %w",
+			err)
+	}
+
+	if len(logEntries) > 0 {
+		log.Debugf("Handling pending proof sync log entries "+
+			"(entries_count=%d)", len(logEntries))
+	}
+
+	blockedServers := make(map[string]struct{})
+	for idx := range logEntries {
+		entry := logEntries[idx]
+		serverHost := entry.ServerAddr.HostStr()
+
+		if _, blocked := blockedServers[serverHost]; blocked {
+			continue
+		}
+
+		err := f.pushProofToServerLogged(
+			ctx, entry.UniID, entry.LeafKey, &entry.Leaf,
+			entry.ServerAddr,
+		)
+		if err != nil {
+			// Keep the remaining FIFO entries for this server pending
+			// until the next pass, but do not stall unrelated members.
+			blockedServers[serverHost] = struct{}{}
+			log.Warnf("Cannot push queued proof to federation "+
+				"server(%v): %v", serverHost, err)
+		}
+	}
+
+	return nil
+}
+
+// filterProofSyncPendingCtx filters out federation servers that already have a
+// completed push log entry for the given proof leaf.
+func (f *FederationEnvoy) filterProofSyncPendingCtx(ctx context.Context,
+	fedServers []ServerAddr, uniID Identifier,
+	key LeafKey) ([]ServerAddr, error) {
+
+	if len(fedServers) == 0 {
+		return nil, nil
+	}
+
+	logs, err := f.cfg.FederationDB.QueryFederationProofSyncLog(
+		ctx, uniID, key, SyncDirectionPush,
+		ProofSyncStatusComplete,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("unable to query federation sync log: %w",
+			err)
+	}
+
+	syncedServers := make(map[string]struct{}, len(logs))
+	for idx := range logs {
+		logEntry := logs[idx]
+		syncedServers[logEntry.ServerAddr.HostStr()] = struct{}{}
+	}
+
+	filteredFedServers := make([]ServerAddr, 0, len(fedServers))
+	for idx := range fedServers {
+		server := fedServers[idx]
+		if _, ok := syncedServers[server.HostStr()]; ok {
+			continue
+		}
+
+		filteredFedServers = append(filteredFedServers, server)
+	}
+
+	return filteredFedServers, nil
+}
+
+// queueProofPushes records durable push work before returning to the caller.
+// Federation delivery is best effort from the caller's point of view, matching
+// the existing envoy contract: failures to enumerate members or write the push
+// log are reported through logs and retried only when durable work exists.
+// Items that explicitly opt out of the proof sync log keep their existing
+// best-effort behavior and are pushed outside the sync loop.
+func (f *FederationEnvoy) queueProofPushes(ctx context.Context,
+	items []*Item) error {
+
+	fedServers, err := f.cfg.FederationDB.UniverseServers(ctx)
+	if err != nil {
+		log.Warnf("Unable to fetch federation servers while queuing "+
+			"proof push: %v", err)
+		return nil
+	}
+	if len(fedServers) == 0 {
+		log.Warnf("could not find any federation servers")
+		return nil
+	}
+
+	var (
+		loggedWork bool
+		bestEffort = make([]*Item, 0, len(items))
+	)
+
+	for idx := range items {
+		item := items[idx]
+		if !item.LogProofSync {
+			bestEffort = append(bestEffort, item)
+			continue
+		}
+
+		pendingServers, err := f.filterProofSyncPendingCtx(
+			ctx, fedServers, item.ID, item.Key,
+		)
+		if err != nil {
+			log.Warnf("Unable to filter pending federation pushes: %v",
+				err)
+			continue
+		}
+
+		for serverIdx := range pendingServers {
+			server := pendingServers[serverIdx]
+			_, err := f.cfg.FederationDB.UpsertFederationProofSyncLog(
+				ctx, item.ID, item.Key, server,
+				SyncDirectionPush, ProofSyncStatusPending, false,
+			)
+			if err != nil {
+				log.Warnf("Unable to queue federation push to "+
+					"server=%v: %v", server.HostStr(), err)
+				continue
+			}
+
+			loggedWork = true
+		}
+	}
+
+	if loggedWork {
+		f.signalPusher()
+	}
+
+	if len(bestEffort) > 0 {
+		f.pushBestEffort(bestEffort, fedServers)
+	}
+
+	return nil
+}
+
+// pushBestEffort preserves the existing behavior for proof updates that are
+// intentionally not written to the durable federation push log. The work is
+// detached from the caller and from the federation sync loop.
+func (f *FederationEnvoy) pushBestEffort(items []*Item,
+	fedServers []ServerAddr) {
+
+	f.Wg.Add(1)
+	go func() {
+		defer f.Wg.Done()
+
+		ctx, cancel := f.WithCtxQuitNoTimeout()
+		defer cancel()
+
+		for idx := range items {
+			item := items[idx]
+			f.pushProofToFederation(
+				ctx, item.ID, item.Key, item.Leaf, fedServers,
+				false,
+			)
+		}
+	}()
+}

--- a/universe/federation_pusher_test.go
+++ b/universe/federation_pusher_test.go
@@ -1,0 +1,398 @@
+package universe
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/stretchr/testify/require"
+)
+
+type pusherTestDB struct {
+	FederationDB
+
+	mu      sync.Mutex
+	servers []ServerAddr
+	entries map[string]*ProofSyncLogEntry
+	order   []string
+}
+
+func newPusherTestDB() *pusherTestDB {
+	return &pusherTestDB{
+		servers: []ServerAddr{
+			NewServerAddr(1, "test-server:10029"),
+		},
+		entries: make(map[string]*ProofSyncLogEntry),
+	}
+}
+
+func proofPushKey(id Identifier, key LeafKey, addr ServerAddr) string {
+	outpoint := key.LeafOutPoint()
+	return fmt.Sprintf(
+		"%s/%s/%s/%d", id.String(), addr.HostStr(),
+		outpoint.Hash.String(), outpoint.Index,
+	)
+}
+
+func (d *pusherTestDB) UniverseServers(
+	context.Context) ([]ServerAddr, error) {
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	return append([]ServerAddr(nil), d.servers...), nil
+}
+
+func (d *pusherTestDB) QueryFederationProofSyncLog(_ context.Context,
+	id Identifier, key LeafKey, _ SyncDirection,
+	status ProofSyncStatus) ([]*ProofSyncLogEntry, error) {
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	var result []*ProofSyncLogEntry
+	for _, addr := range d.servers {
+		entry, ok := d.entries[proofPushKey(id, key, addr)]
+		if !ok || entry.SyncStatus != status {
+			continue
+		}
+
+		copyEntry := *entry
+		result = append(result, &copyEntry)
+	}
+
+	return result, nil
+}
+
+func (d *pusherTestDB) UpsertFederationProofSyncLog(_ context.Context,
+	id Identifier, key LeafKey, addr ServerAddr, direction SyncDirection,
+	status ProofSyncStatus, bump bool) (int64, error) {
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	mapKey := proofPushKey(id, key, addr)
+	entry, ok := d.entries[mapKey]
+	if !ok {
+		entry = &ProofSyncLogEntry{
+			SyncDirection: direction,
+			ServerAddr:    addr,
+			UniID:         id,
+			LeafKey:       key,
+			Leaf:          Leaf{},
+		}
+		d.entries[mapKey] = entry
+		d.order = append(d.order, mapKey)
+	}
+
+	entry.SyncStatus = status
+	if bump {
+		entry.AttemptCounter++
+	}
+
+	return int64(len(d.order)), nil
+}
+
+func (d *pusherTestDB) pending() []*ProofSyncLogEntry {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	result := make([]*ProofSyncLogEntry, 0, len(d.order))
+	for _, mapKey := range d.order {
+		entry := d.entries[mapKey]
+		if entry.SyncStatus != ProofSyncStatusPending {
+			continue
+		}
+
+		copyEntry := *entry
+		result = append(result, &copyEntry)
+	}
+
+	return result
+}
+
+func (d *pusherTestDB) FetchPendingProofsSyncLog(
+	context.Context, *SyncDirection) ([]*ProofSyncLogEntry, error) {
+
+	return d.pending(), nil
+}
+
+func (d *pusherTestDB) FetchPendingProofsSyncLogFIFO(
+	context.Context, *SyncDirection) ([]*ProofSyncLogEntry, error) {
+
+	return d.pending(), nil
+}
+
+type queueErrorDB struct {
+	FederationDB
+	err error
+}
+
+func (d *queueErrorDB) UniverseServers(
+	context.Context) ([]ServerAddr, error) {
+
+	return nil, d.err
+}
+
+type contextRegistrar struct{}
+
+func (*contextRegistrar) UpsertProofLeaf(ctx context.Context, _ Identifier,
+	_ LeafKey, _ *Leaf) (*Proof, error) {
+
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+func (*contextRegistrar) UpsertProofLeafBatch(ctx context.Context,
+	_ []*Item) error {
+
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+func (*contextRegistrar) Close() error {
+	return nil
+}
+
+type successfulRegistrar struct{}
+
+func (*successfulRegistrar) UpsertProofLeaf(context.Context, Identifier,
+	LeafKey, *Leaf) (*Proof, error) {
+
+	return &Proof{}, nil
+}
+
+func (*successfulRegistrar) UpsertProofLeafBatch(context.Context,
+	[]*Item) error {
+
+	return nil
+}
+
+func (*successfulRegistrar) Close() error {
+	return nil
+}
+
+type blockingRegistrar struct {
+	once    sync.Once
+	entered chan struct{}
+	release chan struct{}
+}
+
+func (r *blockingRegistrar) UpsertProofLeaf(ctx context.Context, _ Identifier,
+	_ LeafKey, _ *Leaf) (*Proof, error) {
+
+	r.once.Do(func() {
+		close(r.entered)
+	})
+
+	select {
+	case <-r.release:
+		return &Proof{}, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+func (*blockingRegistrar) Close() error {
+	return nil
+}
+
+type orderedFailRegistrar struct {
+	mu        sync.Mutex
+	attempts  []uint32
+	failIndex uint32
+}
+
+func (r *orderedFailRegistrar) UpsertProofLeaf(_ context.Context,
+	_ Identifier, key LeafKey, _ *Leaf) (*Proof, error) {
+
+	index := key.LeafOutPoint().Index
+
+	r.mu.Lock()
+	r.attempts = append(r.attempts, index)
+	r.mu.Unlock()
+
+	if r.failIndex != 0 && index == r.failIndex {
+		return nil, errors.New("configured push failure")
+	}
+
+	return &Proof{}, nil
+}
+
+func (*orderedFailRegistrar) Close() error {
+	return nil
+}
+
+func (r *orderedFailRegistrar) pushed() []uint32 {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return append([]uint32(nil), r.attempts...)
+}
+
+func issuanceID() Identifier {
+	id := randIdentifier()
+	id.ProofType = ProofTypeIssuance
+	return id
+}
+
+func leafKey(index uint32) BaseLeafKey {
+	return BaseLeafKey{
+		OutPoint: wire.OutPoint{Index: index},
+	}
+}
+
+func TestFederationUpsertUsesCallerContext(t *testing.T) {
+	t.Parallel()
+
+	envoy := NewFederationEnvoy(FederationConfig{
+		LocalRegistrar: &contextRegistrar{},
+		FederationDB:   newPusherTestDB(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := envoy.UpsertProofLeaf(
+		ctx, issuanceID(), leafKey(1), &Leaf{},
+	)
+	require.ErrorIs(t, err, context.Canceled)
+
+	err = envoy.UpsertProofLeafBatch(ctx, []*Item{
+		{
+			ID:           issuanceID(),
+			Key:          leafKey(2),
+			Leaf:         &Leaf{},
+			LogProofSync: true,
+		},
+	})
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestFederationQueueFailureRemainsBestEffort(t *testing.T) {
+	t.Parallel()
+
+	queueErr := errors.New("federation database unavailable")
+	envoy := NewFederationEnvoy(FederationConfig{
+		LocalRegistrar: &successfulRegistrar{},
+		FederationDB: &queueErrorDB{
+			err: queueErr,
+		},
+	})
+
+	_, err := envoy.UpsertProofLeaf(
+		context.Background(), issuanceID(), leafKey(1), &Leaf{},
+	)
+	require.NoError(t, err)
+
+	err = envoy.UpsertProofLeafBatch(context.Background(), []*Item{
+		{
+			ID:           issuanceID(),
+			Key:          leafKey(2),
+			Leaf:         &Leaf{},
+			LogProofSync: true,
+		},
+	})
+	require.NoError(t, err)
+}
+
+func TestFederationSlowPushDoesNotBlockLocalUpsert(t *testing.T) {
+	t.Parallel()
+
+	db := newPusherTestDB()
+	remote := &blockingRegistrar{
+		entered: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	envoy := NewFederationEnvoy(FederationConfig{
+		LocalRegistrar: &successfulRegistrar{},
+		FederationDB:   db,
+		SyncInterval:   time.Minute,
+		NewRemoteRegistrar: func(ServerAddr) (Registrar, error) {
+			return remote, nil
+		},
+	})
+
+	envoy.Wg.Add(1)
+	go envoy.pusher()
+	defer envoy.Stop()
+
+	_, err := envoy.UpsertProofLeaf(
+		context.Background(), issuanceID(), leafKey(1), &Leaf{},
+	)
+	require.NoError(t, err)
+
+	select {
+	case <-remote.entered:
+	case <-time.After(time.Second):
+		t.Fatal("remote federation push did not start")
+	}
+
+	secondDone := make(chan error, 1)
+	go func() {
+		_, err := envoy.UpsertProofLeaf(
+			context.Background(), issuanceID(), leafKey(2), &Leaf{},
+		)
+		secondDone <- err
+	}()
+
+	select {
+	case err := <-secondDone:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("local upsert blocked behind remote federation push")
+	}
+
+	close(remote.release)
+}
+
+func TestFederationPusherPreservesPerServerFIFO(t *testing.T) {
+	t.Parallel()
+
+	db := newPusherTestDB()
+	blockedServer := NewServerAddr(1, "blocked-server:10029")
+	healthyServer := NewServerAddr(2, "healthy-server:10029")
+	db.servers = []ServerAddr{blockedServer, healthyServer}
+
+	id := issuanceID()
+	for idx := uint32(1); idx <= 2; idx++ {
+		for _, server := range db.servers {
+			_, err := db.UpsertFederationProofSyncLog(
+				context.Background(), id, leafKey(idx), server,
+				SyncDirectionPush, ProofSyncStatusPending, false,
+			)
+			require.NoError(t, err)
+		}
+	}
+
+	blockedRemote := &orderedFailRegistrar{failIndex: 1}
+	healthyRemote := &orderedFailRegistrar{}
+	envoy := NewFederationEnvoy(FederationConfig{
+		FederationDB: db,
+		SyncInterval: time.Minute,
+		NewRemoteRegistrar: func(addr ServerAddr) (Registrar, error) {
+			switch addr.HostStr() {
+			case blockedServer.HostStr():
+				return blockedRemote, nil
+			case healthyServer.HostStr():
+				return healthyRemote, nil
+			default:
+				return nil, fmt.Errorf("unexpected server: %v",
+					addr.HostStr())
+			}
+		},
+	})
+
+	err := envoy.handlePendingProofPushes()
+	require.NoError(t, err)
+
+	// The second proof for the failing member remains behind the failed
+	// first proof, while the healthy member drains both entries in order.
+	require.Equal(t, []uint32{1}, blockedRemote.pushed())
+	require.Equal(t, []uint32{1, 2}, healthyRemote.pushed())
+	require.Len(t, db.pending(), 2)
+}

--- a/universe/federation_test.go
+++ b/universe/federation_test.go
@@ -4,14 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
-// errRegistrar is a BatchRegistrar whose upserts return the configured
-// error without storing anything.
+// errRegistrar is a BatchRegistrar whose upserts return the configured error
+// without storing anything.
 type errRegistrar struct {
 	err error
 }
@@ -28,189 +27,93 @@ func (r *errRegistrar) UpsertProofLeafBatch(context.Context,
 	return r.err
 }
 
-func (r *errRegistrar) Close() error { return nil }
-
-// recordingRegistrar records every proof leaf pushed to it, standing
-// in for a remote federation server.
-type recordingRegistrar struct {
-	mu   sync.Mutex
-	keys []LeafKey
+func (r *errRegistrar) Close() error {
+	return nil
 }
 
-func (r *recordingRegistrar) UpsertProofLeaf(_ context.Context,
-	_ Identifier, key LeafKey, _ *Leaf) (*Proof, error) {
-
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	r.keys = append(r.keys, key)
-
-	return &Proof{}, nil
-}
-
-func (r *recordingRegistrar) Close() error { return nil }
-
-func (r *recordingRegistrar) numPushed() int {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-
-	return len(r.keys)
-}
-
-// staticServerDB serves a fixed federation server list; every other
-// FederationDB method panics via the embedded nil interface.
-type staticServerDB struct {
-	FederationDB
-
-	servers []ServerAddr
-}
-
-func (s *staticServerDB) UniverseServers(
-	context.Context) ([]ServerAddr, error) {
-
-	return s.servers, nil
-}
-
-// newTestEnvoy wires a federation envoy whose local registrar is the
-// given mock and whose single federation server records what is
-// pushed to it. The envoy is not started; tests drive the push
-// handlers directly.
-func newTestEnvoy(local BatchRegistrar,
-	remote *recordingRegistrar) *FederationEnvoy {
-
-	return NewFederationEnvoy(FederationConfig{
-		LocalRegistrar: local,
-		FederationDB: &staticServerDB{
-			servers: []ServerAddr{
-				NewServerAddr(1, "test-server:10029"),
-			},
-		},
-		NewRemoteRegistrar: func(ServerAddr) (Registrar, error) {
-			return remote, nil
-		},
-	})
-}
-
-// TestFederationPushPendingMultiverse asserts the push handlers honour
-// the weakened upsert contract: an error wrapping ErrMultiversePending
-// means the leaves are durably stored, so the federation push must
-// still run — skipping it would strand the proofs local-only — while
-// the caller receives the typed error. Any other upsert error must
-// abort the push.
+// TestFederationPushPendingMultiverse asserts the weakened local upsert
+// contract: ErrMultiversePending means the leaf is durable, so federation work
+// is still queued while the caller receives the typed error. Other local
+// upsert errors must not enqueue remote work.
 func TestFederationPushPendingMultiverse(t *testing.T) {
 	t.Parallel()
 
 	pendingErr := fmt.Errorf("upsert: %w", ErrMultiversePending)
 	hardErr := errors.New("database exploded")
 
-	newBatch := func(n int) []*Item {
-		items := make([]*Item, n)
-		for i := range items {
-			items[i] = &Item{
-				ID:   randIdentifier(),
-				Key:  BaseLeafKey{},
-				Leaf: &Leaf{},
-			}
+	newItem := func(index uint32) *Item {
+		return &Item{
+			ID:           issuanceID(),
+			Key:          leafKey(index),
+			Leaf:         &Leaf{},
+			LogProofSync: true,
 		}
-
-		return items
 	}
 
-	t.Run("single_pending_pushes", func(t *testing.T) {
+	t.Run("single_pending_queues_push", func(t *testing.T) {
 		t.Parallel()
 
-		remote := &recordingRegistrar{}
-		envoy := newTestEnvoy(&errRegistrar{err: pendingErr}, remote)
+		db := newPusherTestDB()
+		envoy := NewFederationEnvoy(FederationConfig{
+			LocalRegistrar: &errRegistrar{err: pendingErr},
+			FederationDB:   db,
+		})
 
-		pushReq := &FederationPushReq{
-			ID:   randIdentifier(),
-			Key:  BaseLeafKey{},
-			Leaf: &Leaf{},
-			resp: make(chan *Proof, 1),
-			err:  make(chan error, 1),
-		}
-		require.NoError(t, envoy.handlePushRequest(pushReq))
-
-		// The caller must see the typed error, and the proof must
-		// have been pushed to the federation server regardless.
-		select {
-		case err := <-pushReq.err:
-			require.ErrorIs(t, err, ErrMultiversePending)
-		default:
-			t.Fatal("caller was not served the pending error")
-		}
-		require.Equal(t, 1, remote.numPushed())
+		_, err := envoy.UpsertProofLeaf(
+			context.Background(), issuanceID(), leafKey(1), &Leaf{},
+		)
+		require.ErrorIs(t, err, ErrMultiversePending)
+		require.Len(t, db.pending(), 1)
 	})
 
-	t.Run("batch_pending_pushes", func(t *testing.T) {
+	t.Run("batch_pending_queues_pushes", func(t *testing.T) {
 		t.Parallel()
 
-		remote := &recordingRegistrar{}
-		envoy := newTestEnvoy(&errRegistrar{err: pendingErr}, remote)
+		db := newPusherTestDB()
+		envoy := NewFederationEnvoy(FederationConfig{
+			LocalRegistrar: &errRegistrar{err: pendingErr},
+			FederationDB:   db,
+		})
 
-		batch := newBatch(3)
-		pushReq := &FederationProofBatchPushReq{
-			Batch: batch,
-			resp:  make(chan struct{}, 1),
-			err:   make(chan error, 1),
+		items := []*Item{
+			newItem(1),
+			newItem(2),
+			newItem(3),
 		}
-		require.NoError(t, envoy.handleBatchPushRequest(pushReq))
-
-		// The caller must see the typed error, and every leaf of
-		// the batch must have been pushed regardless.
-		select {
-		case err := <-pushReq.err:
-			require.ErrorIs(t, err, ErrMultiversePending)
-		default:
-			t.Fatal("caller was not served the pending error")
-		}
-		require.Equal(t, len(batch), remote.numPushed())
+		err := envoy.UpsertProofLeafBatch(context.Background(), items)
+		require.ErrorIs(t, err, ErrMultiversePending)
+		require.Len(t, db.pending(), len(items))
 	})
 
 	t.Run("single_hard_error_aborts", func(t *testing.T) {
 		t.Parallel()
 
-		remote := &recordingRegistrar{}
-		envoy := newTestEnvoy(&errRegistrar{err: hardErr}, remote)
+		db := newPusherTestDB()
+		envoy := NewFederationEnvoy(FederationConfig{
+			LocalRegistrar: &errRegistrar{err: hardErr},
+			FederationDB:   db,
+		})
 
-		pushReq := &FederationPushReq{
-			ID:   randIdentifier(),
-			Key:  BaseLeafKey{},
-			Leaf: &Leaf{},
-			resp: make(chan *Proof, 1),
-			err:  make(chan error, 1),
-		}
-		require.ErrorIs(t, envoy.handlePushRequest(pushReq), hardErr)
-
-		select {
-		case err := <-pushReq.err:
-			require.ErrorIs(t, err, hardErr)
-		default:
-			t.Fatal("caller was not served the upsert error")
-		}
-		require.Zero(t, remote.numPushed())
+		_, err := envoy.UpsertProofLeaf(
+			context.Background(), issuanceID(), leafKey(1), &Leaf{},
+		)
+		require.ErrorIs(t, err, hardErr)
+		require.Empty(t, db.pending())
 	})
 
 	t.Run("batch_hard_error_aborts", func(t *testing.T) {
 		t.Parallel()
 
-		remote := &recordingRegistrar{}
-		envoy := newTestEnvoy(&errRegistrar{err: hardErr}, remote)
+		db := newPusherTestDB()
+		envoy := NewFederationEnvoy(FederationConfig{
+			LocalRegistrar: &errRegistrar{err: hardErr},
+			FederationDB:   db,
+		})
 
-		pushReq := &FederationProofBatchPushReq{
-			Batch: newBatch(3),
-			resp:  make(chan struct{}, 1),
-			err:   make(chan error, 1),
-		}
-		require.ErrorIs(
-			t, envoy.handleBatchPushRequest(pushReq), hardErr,
-		)
-
-		select {
-		case err := <-pushReq.err:
-			require.ErrorIs(t, err, hardErr)
-		default:
-			t.Fatal("caller was not served the upsert error")
-		}
-		require.Zero(t, remote.numPushed())
+		err := envoy.UpsertProofLeafBatch(context.Background(), []*Item{
+			newItem(1), newItem(2), newItem(3),
+		})
+		require.ErrorIs(t, err, hardErr)
+		require.Empty(t, db.pending())
 	})
 }


### PR DESCRIPTION
## Summary

- perform local proof inserts on the caller goroutine using the caller's context
- move remote federation delivery to a dedicated pusher backed by the durable proof sync log
- drain logged pushes in durable log-ID order and preserve FIFO independently per federation member
- keep federation delivery best-effort from the caller's point of view
- keep unlogged proof updates detached and best-effort
- preserve `ErrMultiversePending` handling and the existing caller-visible contract
- leave the periodic federation sync loop responsible only for sync ticks

If a federation member returns an error, later entries for that member remain behind it during the current drain pass, while unrelated members can continue making progress.

## Regression coverage

- caller context cancellation reaches single and batch local inserts
- a blocked remote federation push does not block a later local upsert
- federation queue failures do not change a successful local upsert result
- a failed member preserves its FIFO while another member continues draining
- retrying an existing durable sync-log row does not change its FIFO position

Fixes #2290