### PR TITLE
tapdb: complete an address event by asset

### DIFF
--- a/docs/release-notes/release-notes-0.9.0.md
+++ b/docs/release-notes/release-notes-0.9.0.md
@@ -139,6 +139,14 @@
   every block. The sweeper now returns an empty resolution for such
   outputs, so lnd sweeps them as plain BTC outputs.
 
+* [PR#2294](https://github.com/lightninglabs/taproot-assets/pull/2294)
+  fixes a bug in which a grouped receive holding several assets under
+  one script key at one outpoint could be imported but never completed.
+  Completing the address event looked each output's proof up by script
+  key and outpoint alone, so the lookup returned every asset's proof at
+  once and the event failed with `ErrMultipleProofs` on every attempt.
+  The proof is now looked up by asset as well.
+
 # New Features
 
 ## Functional Enhancements

--- a/tapdb/addrs.go
+++ b/tapdb/addrs.go
@@ -1241,12 +1241,16 @@ func (t *TapAddressBook) CompleteEvent(ctx context.Context,
 			return fmt.Errorf("error updating addr event: %w", err)
 		}
 
-		for _, output := range event.Outputs {
+		// Each output is one asset; a grouped receive can hold
+		// several under one script key at this outpoint, so the
+		// proof is looked up by asset as well.
+		for assetID, output := range event.Outputs {
 			scriptPubKey := output.ScriptKey.PubKey
 			scriptPubKeyBytes := scriptPubKey.SerializeCompressed()
 			args := FetchAssetProof{
 				TweakedScriptKey: scriptPubKeyBytes,
 				Outpoint:         outpoint,
+				AssetID:          assetID[:],
 			}
 
 			proofData, err := db.FetchAssetProof(ctx, args)
@@ -1256,15 +1260,16 @@ func (t *TapAddressBook) CompleteEvent(ctx context.Context,
 			}
 
 			switch {
-			// We have no proof for this script key and outpoint.
+			// We have no proof for this asset at this script key
+			// and outpoint.
 			case len(proofData) == 0:
-				return fmt.Errorf("proof for script key %x "+
-					"and outpoint %v not found: %w",
-					args.TweakedScriptKey, anchorPoint,
-					proof.ErrProofNotFound)
+				return fmt.Errorf("proof for asset %x, script "+
+					"key %x and outpoint %v not found: %w",
+					assetID[:], args.TweakedScriptKey,
+					anchorPoint, proof.ErrProofNotFound)
 
 			// Something is quite wrong if we have multiple proofs
-			// for the same script key and outpoint.
+			// for the same asset, script key and outpoint.
 			case len(proofData) > 1:
 				return fmt.Errorf("expected exactly one "+
 					"proof, got %d: %w", len(proofData),

--- a/tapdb/addrs_test.go
+++ b/tapdb/addrs_test.go
@@ -1,6 +1,7 @@
 package tapdb
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"math/rand"
@@ -13,6 +14,7 @@ import (
 	"github.com/lightninglabs/taproot-assets/address"
 	"github.com/lightninglabs/taproot-assets/asset"
 	"github.com/lightninglabs/taproot-assets/internal/test"
+	"github.com/lightninglabs/taproot-assets/proof"
 	"github.com/lightninglabs/taproot-assets/tapdb/sqlc"
 	"github.com/lightningnetwork/lnd/clock"
 	"github.com/lightningnetwork/lnd/keychain"
@@ -1069,4 +1071,133 @@ func TestAddrByScriptKeyAndVersion(t *testing.T) {
 	// Verify the returned address matches the inserted address.
 	require.Equal(t, addr.ScriptKey, result.ScriptKey)
 	require.Equal(t, addr.Version, result.Version)
+}
+
+// TestCompleteEventGroupedReceive follows the grouped-receive shape —
+// two assets under one script key at one outpoint, each with its own
+// proof — through address event completion: the event names each
+// asset it holds, and completion must find each asset's proof by
+// asset, not by the shared script key and outpoint alone.
+func TestCompleteEventGroupedReceive(t *testing.T) {
+	t.Parallel()
+
+	db := NewTestDB(t)
+	_, assetsStore := newAssetStoreFromDB(db.BaseDB)
+	ctx := context.Background()
+
+	sharedKey := asset.NewScriptKeyBip86(keychain.KeyDescriptor{
+		PubKey: test.RandPubKey(t),
+		KeyLocator: keychain.KeyLocator{
+			Family: test.RandInt[keychain.KeyFamily](),
+			Index:  uint32(test.RandInt[int32]()),
+		},
+	})
+
+	assetGen := newAssetGenerator(t, 2, 1)
+	assetGen.genAssets(t, assetsStore, []assetDesc{{
+		assetGen:    assetGen.assetGens[0],
+		anchorPoint: assetGen.anchorPoints[0],
+		scriptKey:   &sharedKey,
+		amt:         10,
+	}, {
+		assetGen:    assetGen.assetGens[1],
+		anchorPoint: assetGen.anchorPoints[0],
+		scriptKey:   &sharedKey,
+		amt:         20,
+	}})
+	anchorTx := assetGen.anchorTxs[0]
+	anchorPoint := assetGen.anchorPoints[0]
+
+	assets, err := assetsStore.FetchAllAssets(ctx, true, true, nil)
+	require.NoError(t, err)
+	require.Len(t, assets, 2)
+
+	// Each leaf's proof file, stored against its own asset row.
+	outputs := make(map[asset.ID]address.AssetOutput, 2)
+	for _, a := range assets {
+		tipProof := randProof(t, a.Asset)
+		tipProof.AnchorTx = *anchorTx
+		file, err := proof.NewFile(proof.V0, *tipProof)
+		require.NoError(t, err)
+		var buf bytes.Buffer
+		require.NoError(t, file.Encode(&buf))
+
+		var dbID int64
+		assetID := a.ID()
+		err = db.DB.QueryRowContext(
+			ctx, "SELECT assets.asset_id FROM assets "+
+				"JOIN genesis_assets ON assets.genesis_id = "+
+				"genesis_assets.gen_asset_id "+
+				"WHERE genesis_assets.asset_id = $1",
+			assetID[:],
+		).Scan(&dbID)
+		require.NoError(t, err)
+		require.NoError(t, db.UpsertAssetProofByID(
+			ctx, ProofUpdateByID{
+				AssetID:   dbID,
+				ProofFile: buf.Bytes(),
+			},
+		))
+
+		outputs[assetID] = address.AssetOutput{
+			Amount:    a.Amount,
+			ScriptKey: sharedKey,
+		}
+	}
+
+	// The address event names both assets at the shared script key:
+	// the shape a V2 grouped receive records. The V1 wallet-transaction
+	// constructor builds the same event from the outputs handed to it,
+	// without the block and fragment the V2 constructor wants.
+	testClock := clock.NewTestClock(time.Now())
+	addrTx := NewTransactionExecutor(
+		db, func(tx *sql.Tx) AddrBook {
+			return db.WithTx(tx)
+		},
+	)
+	addrBook := NewTapAddressBook(addrTx, chainParams, testClock)
+
+	proofCourierAddr := address.RandProofCourierAddrForVersion(
+		t, address.V1,
+	)
+	addr, addrGen, addrGroup := address.RandAddrWithVersion(
+		t, chainParams, proofCourierAddr, address.V1,
+	)
+	err = addrTx.ExecTx(
+		ctx, WriteTxOption(),
+		insertFullAssetGen(ctx, addrGen, addrGroup),
+	)
+	require.NoError(t, err)
+	require.NoError(t, addrBook.InsertAddrs(ctx, *addr))
+
+	transfer, err := address.NewTransferFromWalletTx(
+		addr, &lndclient.Transaction{
+			Tx:        anchorTx,
+			Timestamp: time.Now(),
+		}, anchorPoint.Index, outputs,
+	)
+	require.NoError(t, err)
+	event, err := addrBook.GetOrCreateEvent(
+		ctx, address.StatusProofReceived, transfer,
+	)
+	require.NoError(t, err)
+	require.Len(t, event.Outputs, 2)
+
+	// Completion finds each asset's proof and links both.
+	err = addrBook.CompleteEvent(
+		ctx, event, address.StatusCompleted, anchorPoint,
+	)
+	require.NoError(t, err)
+
+	completed, err := addrBook.QueryEvent(ctx, addr, anchorPoint)
+	require.NoError(t, err)
+	require.Equal(t, address.StatusCompleted, completed.Status)
+
+	var linked int
+	err = db.DB.QueryRowContext(
+		ctx, "SELECT COUNT(*) FROM addr_event_proofs "+
+			"WHERE addr_event_id = $1", event.ID,
+	).Scan(&linked)
+	require.NoError(t, err)
+	require.Equal(t, 2, linked)
 }


### PR DESCRIPTION
Consider group key G that mints a tranche A, and then later a tranche B. Previously, proofs for a receive of units from both A and B in the same payment would import, but the receive event itself wouldn't complete. Both A and B land under the same script key and outpoint, so the CompleteEvent lookup couldn't separate them.

The fix contained here is just to augment the CompleteEvent lookup with tranche information, so that the lookup can disambiguate the tranches appropriately.