### PR TITLE
rfq: make the price oracle optional for end users

### DIFF
--- a/docs/portfolio_pilot_architecture.md
+++ b/docs/portfolio_pilot_architecture.md
@@ -1084,7 +1084,7 @@ The matrix:
 
 | Oracle set?   | Pilot set?      | Result                                                |
 |---------------|-----------------|-------------------------------------------------------|
-| No            | No              | All inbound RFQs rejected; no outbound hints.         |
+| No            | No              | Inbound RFQs rejected; no outbound hints. Quotes accepted by a peer are still verified against the constraints of our own order. |
 | Yes           | No              | Internal pilot driving the configured oracle.         |
 | No            | Yes             | External pilot, no internal oracle (pilot drives its own pricing). |
 | Yes           | Yes             | External pilot; oracle is unused by the manager but may be reused by the pilot through its own client. |

--- a/docs/release-notes/release-notes-0.9.0.md
+++ b/docs/release-notes/release-notes-0.9.0.md
@@ -21,6 +21,13 @@
 
 # Bug Fixes
 
+- [A node with no price
+  oracle](https://github.com/lightninglabs/taproot-assets/pull/2296) configured
+  no longer panics when `AddInvoice` is called with a satoshi denominated
+  amount. Converting satoshis into asset units requires a rate, so this now
+  returns an error telling the caller to denominate the invoice in asset units
+  instead.
+
 - [Importing an asset wallet
   backup](https://github.com/lightninglabs/taproot-assets/pull/2277) into a
   node whose database was wiped but whose proofs directory survived no longer
@@ -224,6 +231,16 @@
 
 ## Config Changes
 
+- [`experimental.rfq.priceoracleaddress` is now
+  optional](https://github.com/lightninglabs/taproot-assets/pull/2296) for an
+  end user's wallet. A wallet only requests quotes and never has to answer one,
+  so it does not need to be able to name a price of its own. With no oracle
+  configured, a quote accepted by a peer is still verified against the quote
+  expiry and against the limit-order constraints of the wallet's own order
+  (`asset_rate_limit`, min/max amount, execution policy), which previously were
+  never reached in this configuration. An edge node that answers incoming quote
+  requests still requires an oracle.
+
 - The new [`--backup.filepath`
   flag](https://github.com/lightninglabs/taproot-assets/pull/2277) sets the
   location of the encrypted asset wallet backup file (default: `assets.backup` in the network data
@@ -302,6 +319,12 @@
 ## BIP/bLIP Spec Updates
 
 ## Testing
+
+* [PR#2296](https://github.com/lightninglabs/taproot-assets/pull/2296)
+  adds coverage for verifying quotes with no price oracle configured,
+  asserting that the quote expiry bound and the rate bound of the
+  node's own order are still enforced in both the buy and the sell
+  direction.
 
 ## Database
 

--- a/docs/rfq-and-decimal-display.md
+++ b/docs/rfq-and-decimal-display.md
@@ -422,8 +422,9 @@ Price Out Asset: 				1420000000000
 The price oracle is an important component in the RFQ system, as it provides the
 values for the exchange rates mentioned above.
 
-Both parties of an asset channel (the wallet end user and the edge node) might
-use a price oracle, but its role is different for those parties:
+An edge node requires a price oracle, because it has to name a price. For the
+wallet end user a price oracle is optional. Both parties of an asset channel
+might use one, but its role is different for those parties:
 * The **Price Oracle for the edge node** is responsible for putting a price tag
   on the service that is offered by the edge node, which is an atomic swap
   between two types of assets (often one of them being BTC). In other words,
@@ -441,6 +442,11 @@ use a price oracle, but its role is different for those parties:
 * The **Price Oracle for the wallet end user** on the other hand is simply
   tasked with validating exchange rates offered to them by the edge node, to
   make sure they aren't proposing absurd rates (by accident or on purpose).
+  This is optional, and it is a second opinion rather than a limit. A wallet
+  that instead states the worst rate it is willing to accept (using the
+  `asset_rate_limit` field of its buy or sell order) needs no oracle at all;
+  see [Wallet end user](#wallet-end-user) below for which bounds are
+  reachable on which RPC.
 
 **NOTE**: By default, the _minimum_ quote expiry at tapd node will accept is _10
 seconds_.
@@ -464,17 +470,66 @@ interface with Golang can be found in
 
 ## Wallet end user
 
-The wallet end user's price oracle implementation can be quite simple. All it
-needs to do is to query an exchange provider's API for the current exchange
-rate of an asset. Then the maximum deviation from that "official" market rate
+A price oracle is **optional** for the wallet end user. A wallet only ever
+_requests_ quotes, it never has to answer one, so it does not need to be able
+to name a price of its own. With no
+`experimental.rfq.priceoracleaddress` configured, a quote accepted by an edge
+node is still verified, but only against the limits that the wallet itself
+expressed in its order:
+
+* the quote expiry must be far enough in the future (see the note above),
+* the accepted rate must satisfy the order's `asset_rate_limit`, if one was
+  given,
+* the accepted fill amount must satisfy the order's min/max amount and
+  execution policy.
+
+The `asset_rate_limit` field on `AddAssetBuyOrder`/`AddAssetSellOrder` is the
+wallet side sanity check, and it is the one worth using: it is a hard bound the
+user names themselves ("I will not accept fewer than X units per BTC"), rather
+than a tolerance band around a third party's opinion of the price. Note that a
+bound that is not set is not enforced.
+
+How reachable that bound is depends on the direction:
+
+* **Receiving** (`tapchannelrpc.AddInvoice`): the request has an
+  `asset_rate_limit` field which is passed through to the buy order, so the
+  bound can be set directly on the call. The invoice's `asset_amount` also
+  caps the units involved.
+* **Paying** (`tapchannelrpc.SendPayment`): the request has **no**
+  `asset_rate_limit` field today, and the sell order that `SendPayment`
+  negotiates internally leaves the limit unset, so no rate bound is applied.
+  `payment_max_amt` caps the _satoshis_ sent, not the asset units spent, and
+  the units spent scale with whatever rate the peer quotes. To bound the rate
+  on a payment, negotiate the quote first with `rfqrpc.AddAssetSellOrder`
+  (setting `asset_rate_limit`) and then pass the resulting `rfq_id` to
+  `SendPayment`.
+
+Until `SendPayment` accepts a rate limit of its own, a wallet that pays over
+asset channels and configures neither an oracle nor a pre-negotiated quote has
+no bound on the rate it will accept. That is the one case where dropping the
+oracle removes a check without a wallet side replacement in the same call.
+
+If a wallet _does_ configure an oracle, the accepted rate is additionally
+compared against it, and the maximum deviation from that "official" market rate
 that is accepted from edge nodes can be configured using the
 `experimental.rfq.acceptpricedeviationppm=` configuration value (which is in
-parts per million and the default value is `50000` which is equal to `5%`).
+parts per million and the default value is `50000` which is equal to `5%`). Be
+aware that this is a comparison of two rates rather than a bound on one: an
+edge node whose spread exceeds the configured deviation has its quotes
+rejected, so a deviation that is tighter than the spreads in the market the
+wallet actually transacts in will cause otherwise fine quotes to be discarded.
 
+Such an oracle implementation can be quite simple. All it needs to do is to
+query an exchange provider's API for the current exchange rate of an asset.
 Because the API endpoints of public exchange platforms aren't standardized,
-there also isn't a default implementation of an end user price oracle available.
+there isn't a default implementation of an end user price oracle available.
 It is expected that third party developers (or at some point even the exchange
 platforms themselves) will offer a gRPC (`rfqrpc`) compatible price oracle
 endpoint that can directly be plugged into the
 `experimental.rfq.priceoracleaddress=rfqrpc://<hostname>:<port>` configuration
 value on the wallet end user side.
+
+**NOTE**: An amount denominated in satoshis cannot be converted into asset
+units without a rate, so a wallet with no oracle configured must denominate
+asset invoices in asset units (`asset_amount`) rather than in satoshis
+(`value`/`value_msat`).

--- a/rfq/manager.go
+++ b/rfq/manager.go
@@ -1437,6 +1437,15 @@ func EstimateAssetUnits(ctx context.Context, oracle PriceOracle,
 	counterparty fn.Option[route.Vertex], metadata string,
 	intent PriceQueryIntent) (uint64, error) {
 
+	// The price oracle is optional, but there is no way to convert a
+	// satoshi denominated amount into asset units without a rate to
+	// convert it with.
+	if oracle == nil {
+		return 0, fmt.Errorf("no price oracle configured, cannot " +
+			"convert a satoshi denominated amount into asset " +
+			"units; specify the amount in asset units instead")
+	}
+
 	oracleRes, err := oracle.QueryBuyPrice(
 		ctx, specifier, fn.None[uint64](), fn.Some(amtMsat),
 		fn.None[rfqmsg.AssetRate](), counterparty, metadata, intent,

--- a/rfq/negotiator.go
+++ b/rfq/negotiator.go
@@ -190,13 +190,25 @@ func (n *Negotiator) getAssetRateHint(ctx context.Context, order Order,
 	}
 
 	assetRate, err := n.cfg.PortfolioPilot.QueryAssetRates(ctx, query)
-	if err != nil {
-		// If we fail to query the portfolio pilot for a rate, we
-		// will log a warning and continue without a rate since this
-		// is not a critical failure.
+	switch {
+	// A price oracle is optional, and running without one is the expected
+	// configuration for an end user's wallet. Since the rate hint is only
+	// a suggestion, this is not worth warning about on every order.
+	case errors.Is(err, ErrNoPriceOracle):
+		log.Debugf("Not setting a rate hint on outgoing request, no "+
+			"price oracle configured (direction=%s)",
+			direction.String())
+
+		return fn.None[rfqmsg.AssetRate]()
+
+	// If we fail to query the portfolio pilot for a rate, we will log a
+	// warning and continue without a rate since this is not a critical
+	// failure.
+	case err != nil:
 		log.Warnf("Failed to query rate from portfolio pilot "+
 			"for outgoing request: (direction=%s, err=%v)",
 			direction.String(), err)
+
 		return fn.None[rfqmsg.AssetRate]()
 	}
 

--- a/rfq/portfolio_pilot.go
+++ b/rfq/portfolio_pilot.go
@@ -2,6 +2,7 @@ package rfq
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -12,6 +13,11 @@ import (
 	"github.com/lightningnetwork/lnd/lnwire"
 	"github.com/lightningnetwork/lnd/routing/route"
 )
+
+// ErrNoPriceOracle is returned when an operation needs a price oracle but none
+// is configured. A price oracle is optional, so for an end user's wallet this
+// is an expected condition rather than a failure.
+var ErrNoPriceOracle = errors.New("no price oracle configured")
 
 // AssetTransferDirection represents the direction of an asset transfer
 // from our perspective for pricing and rate queries.
@@ -180,8 +186,12 @@ type PortfolioPilot interface {
 // InternalPortfolioPilotConfig holds settings for the built-in pilot that uses
 // a price oracle for pricing decisions.
 type InternalPortfolioPilotConfig struct {
-	// PriceOracle supplies pricing data. If nil, the pilot rejects requests
-	// as the oracle is considered unavailable.
+	// PriceOracle supplies pricing data. It is optional: if nil, the pilot
+	// cannot price incoming quote requests from peers and rejects them, but
+	// it still verifies quotes accepted by a peer against the limit-order
+	// constraints of our own request. Running without an oracle is the
+	// expected configuration for an end user's wallet, which only requests
+	// quotes and never answers them.
 	PriceOracle PriceOracle
 
 	// ForwardPeerIDToOracle controls whether the requesting peer ID is sent
@@ -305,8 +315,14 @@ func (p *InternalPortfolioPilot) ResolveRequest(ctx context.Context,
 }
 
 // VerifyAcceptQuote verifies that an accepted quote from a peer meets
-// acceptable conditions. It validates the quote expiry and checks that the
-// peer's proposed rate falls within acceptable tolerance of the oracle price.
+// acceptable conditions. It validates the quote expiry, compares the peer's
+// proposed rate against the price oracle if one is configured, and enforces
+// the limit-order constraints of the original request.
+//
+// A price oracle is optional. When none is configured we have no independent
+// reference price to compare the peer's rate against, so the rate is accepted
+// as long as it satisfies the constraints that the user expressed in their own
+// request.
 func (p *InternalPortfolioPilot) VerifyAcceptQuote(ctx context.Context,
 	accept rfqmsg.Accept) (QuoteRespStatus, error) {
 
@@ -319,14 +335,49 @@ func (p *InternalPortfolioPilot) VerifyAcceptQuote(ctx context.Context,
 		return InvalidExpiryQuoteRespStatus, nil
 	}
 
-	if p.cfg.PriceOracle == nil {
-		return PriceOracleQueryErrQuoteRespStatus, nil
+	req := accept.OriginalRequest()
+
+	// Compare the peer's rate against our own view of the market, but only
+	// if we have a price oracle available to give us one.
+	if p.cfg.PriceOracle != nil {
+		status, err := p.checkRateAgainstOracle(
+			ctx, req, counterRate, accept.MsgPeer(),
+		)
+		if err != nil {
+			return status, err
+		}
+
+		if status != ValidAcceptQuoteRespStatus {
+			return status, nil
+		}
 	}
+
+	// Enforce all limit-order constraints (rate bound, min fill, FOK, and
+	// fill-vs-constraint compatibility). These are derived entirely from
+	// the locally stored request, so they are enforced with or without an
+	// oracle, and they are the only price protection that an oracle-less
+	// node has.
+	status := checkAllConstraints(
+		req, counterRate.Rate, accept.AcceptedFillAmount(),
+	)
+	if status != ValidAcceptQuoteRespStatus {
+		return status, nil
+	}
+
+	return ValidAcceptQuoteRespStatus, nil
+}
+
+// checkRateAgainstOracle queries the configured price oracle for our own view
+// of the rate, and checks that the peer's counter rate is within the
+// configured deviation tolerance of it.
+func (p *InternalPortfolioPilot) checkRateAgainstOracle(ctx context.Context,
+	req rfqmsg.Request, counterRate rfqmsg.AssetRate,
+	msgPeer route.Vertex) (QuoteRespStatus, error) {
 
 	// Build peer ID option based on config.
 	peerID := fn.None[route.Vertex]()
 	if p.cfg.ForwardPeerIDToOracle {
-		peerID = fn.Some(accept.MsgPeer())
+		peerID = fn.Some(msgPeer)
 	}
 
 	// Query the oracle based on the request type. For a buy request (peer
@@ -335,7 +386,6 @@ func (p *InternalPortfolioPilot) VerifyAcceptQuote(ctx context.Context,
 	var resp *OracleResponse
 	var err error
 
-	req := accept.OriginalRequest()
 	switch r := req.(type) {
 	case *rfqmsg.BuyRequest:
 		resp, err = p.cfg.PriceOracle.QueryBuyPrice(
@@ -389,15 +439,6 @@ func (p *InternalPortfolioPilot) VerifyAcceptQuote(ctx context.Context,
 		return InvalidAssetRatesQuoteRespStatus, nil
 	}
 
-	// Enforce all limit-order constraints (rate bound, min fill,
-	// FOK, and fill-vs-constraint compatibility).
-	status := checkAllConstraints(
-		req, counterRate.Rate, accept.AcceptedFillAmount(),
-	)
-	if status != ValidAcceptQuoteRespStatus {
-		return status, nil
-	}
-
 	return ValidAcceptQuoteRespStatus, nil
 }
 
@@ -417,7 +458,7 @@ func (p *InternalPortfolioPilot) QueryAssetRates(ctx context.Context,
 	var zero rfqmsg.AssetRate
 
 	if p.cfg.PriceOracle == nil {
-		return zero, fmt.Errorf("no price oracle found")
+		return zero, ErrNoPriceOracle
 	}
 
 	// Build peer ID option based on config.

--- a/rfq/portfolio_pilot_test.go
+++ b/rfq/portfolio_pilot_test.go
@@ -1876,7 +1876,10 @@ func TestVerifyAcceptQuote(t *testing.T) {
 
 // TestResolveRequestWithoutPriceOracleRejects ensures that requests are
 // rejected during resolution if a price oracle is not configured for the
-// internal portfolio pilot.
+// internal portfolio pilot. Answering an incoming quote request requires us to
+// name a price, which we cannot do without an oracle. This is deliberately
+// asymmetric with verifying a quote that a peer accepted, which does not need
+// an oracle, see TestVerifyAcceptQuoteWithoutPriceOracle.
 func TestResolveRequestWithoutPriceOracleRejects(t *testing.T) {
 	t.Parallel()
 
@@ -1915,46 +1918,168 @@ func TestResolveRequestWithoutPriceOracleRejects(t *testing.T) {
 	require.True(t, called)
 }
 
-// TestVerifyAcceptQuoteWithoutPriceOracle ensures that quote accept messages
-// fail verification if a price oracle is not configured for the internal
-// portfolio pilot.
-func TestVerifyAcceptQuoteWithoutPriceOracle(t *testing.T) {
-	t.Parallel()
+// newNoOraclePilot returns an internal portfolio pilot that has no price
+// oracle configured, which is the expected configuration for an end user's
+// wallet.
+func newNoOraclePilot(t *testing.T) InternalPortfolioPilot {
+	t.Helper()
+
+	pilot, err := NewInternalPortfolioPilot(InternalPortfolioPilotConfig{
+		PriceOracle:                 nil,
+		ForwardPeerIDToOracle:       false,
+		AcceptPriceDeviationPpm:     50_000,
+		MinAssetRatesExpiryLifetime: 10,
+	})
+	require.NoError(t, err)
+
+	return pilot
+}
+
+// newNoOracleBuyAccept returns a buy accept message at the given rate, for a
+// buy request carrying the given expiry and optional rate limit.
+func newNoOracleBuyAccept(t *testing.T, acceptRate uint64, expiry time.Time,
+	rateLimit fn.Option[rfqmath.BigIntFixedPoint]) *rfqmsg.BuyAccept {
+
+	t.Helper()
 
 	assetSpec := asset.NewSpecifierFromId(asset.ID{0x01, 0x02, 0x03})
 	peerID := route.Vertex{0x0A, 0x0B, 0x0C}
-	expiry := time.Now().Add(30 * time.Second)
 
 	buyReq, err := rfqmsg.NewBuyRequest(
 		peerID, assetSpec, 100,
 		fn.None[uint64](),
-		fn.None[rfqmath.BigIntFixedPoint](),
+		rateLimit,
 		fn.None[rfqmsg.AssetRate](),
 		"metadata",
 		fn.None[rfqmsg.ExecutionPolicy](),
 	)
 	require.NoError(t, err)
 
-	accept := &rfqmsg.BuyAccept{
+	return &rfqmsg.BuyAccept{
 		Peer:    peerID,
 		Request: *buyReq,
 		AssetRate: rfqmsg.NewAssetRate(
-			rfqmath.NewBigIntFixedPoint(100, 0), expiry,
+			rfqmath.NewBigIntFixedPoint(acceptRate, 0), expiry,
 		),
 	}
+}
 
-	cfg := InternalPortfolioPilotConfig{
-		PriceOracle:                 nil,
-		ForwardPeerIDToOracle:       false,
-		AcceptPriceDeviationPpm:     50_000,
-		MinAssetRatesExpiryLifetime: 10,
-	}
-	pilot, err := NewInternalPortfolioPilot(cfg)
-	require.NoError(t, err)
+// TestVerifyAcceptQuoteWithoutPriceOracle ensures that a quote accepted by a
+// peer passes verification when no price oracle is configured. Without an
+// oracle we have no independent reference price, so the peer's rate is
+// accepted as long as it satisfies the constraints of our own request.
+func TestVerifyAcceptQuoteWithoutPriceOracle(t *testing.T) {
+	t.Parallel()
+
+	expiry := time.Now().Add(30 * time.Second)
+	accept := newNoOracleBuyAccept(
+		t, 100, expiry, fn.None[rfqmath.BigIntFixedPoint](),
+	)
+
+	pilot := newNoOraclePilot(t)
 
 	status, err := pilot.VerifyAcceptQuote(context.Background(), accept)
 	require.NoError(t, err)
-	require.Equal(t, PriceOracleQueryErrQuoteRespStatus, status)
+	require.Equal(t, ValidAcceptQuoteRespStatus, status)
+}
+
+// TestVerifyAcceptQuoteWithoutPriceOracleEnforcesRateBound ensures that the
+// user's own rate limit is still enforced when no price oracle is configured.
+// This is the wallet side sanity check that replaces the oracle comparison: a
+// buy request rejects any rate below the limit, so a peer cannot quote an
+// arbitrarily bad price just because we have no oracle.
+func TestVerifyAcceptQuoteWithoutPriceOracleEnforcesRateBound(t *testing.T) {
+	t.Parallel()
+
+	// We ask for at least 200 units per BTC, but the peer only offers 100.
+	rateLimit := fn.Some(rfqmath.NewBigIntFixedPoint(200, 0))
+	expiry := time.Now().Add(30 * time.Second)
+	accept := newNoOracleBuyAccept(t, 100, expiry, rateLimit)
+
+	pilot := newNoOraclePilot(t)
+
+	status, err := pilot.VerifyAcceptQuote(context.Background(), accept)
+	require.NoError(t, err)
+	require.Equal(t, RateBoundMissQuoteRespStatus, status)
+
+	// The same rate limit is satisfied by a rate at or above the limit.
+	accept = newNoOracleBuyAccept(t, 200, expiry, rateLimit)
+
+	status, err = pilot.VerifyAcceptQuote(context.Background(), accept)
+	require.NoError(t, err)
+	require.Equal(t, ValidAcceptQuoteRespStatus, status)
+}
+
+// TestVerifyAcceptQuoteWithoutPriceOracleEnforcesSellRateBound ensures that
+// the user's own rate limit is still enforced on the pay direction when no
+// price oracle is configured. For a sell request the limit is a ceiling on the
+// units given per BTC, the opposite direction from a buy request, and it is
+// the bound that caps how many asset units a payment can spend.
+func TestVerifyAcceptQuoteWithoutPriceOracleEnforcesSellRateBound(
+	t *testing.T) {
+
+	t.Parallel()
+
+	assetSpec := asset.NewSpecifierFromId(asset.ID{0x01, 0x02, 0x03})
+	peerID := route.Vertex{0x0A, 0x0B, 0x0C}
+	expiry := time.Now().Add(30 * time.Second)
+
+	// We are willing to give at most 100 units per BTC.
+	rateLimit := fn.Some(rfqmath.NewBigIntFixedPoint(100, 0))
+
+	sellReq, err := rfqmsg.NewSellRequest(
+		peerID, assetSpec, 100_000,
+		fn.None[lnwire.MilliSatoshi](),
+		rateLimit,
+		fn.None[rfqmsg.AssetRate](),
+		"metadata",
+		fn.None[rfqmsg.ExecutionPolicy](),
+	)
+	require.NoError(t, err)
+
+	newAccept := func(rate uint64) *rfqmsg.SellAccept {
+		return &rfqmsg.SellAccept{
+			Peer:    peerID,
+			Request: *sellReq,
+			AssetRate: rfqmsg.NewAssetRate(
+				rfqmath.NewBigIntFixedPoint(rate, 0), expiry,
+			),
+		}
+	}
+
+	pilot := newNoOraclePilot(t)
+
+	// The peer demands 200 units per BTC, twice what we said we would give.
+	status, err := pilot.VerifyAcceptQuote(
+		context.Background(), newAccept(200),
+	)
+	require.NoError(t, err)
+	require.Equal(t, RateBoundMissQuoteRespStatus, status)
+
+	// A rate at or below our ceiling is accepted.
+	status, err = pilot.VerifyAcceptQuote(
+		context.Background(), newAccept(50),
+	)
+	require.NoError(t, err)
+	require.Equal(t, ValidAcceptQuoteRespStatus, status)
+}
+
+// TestVerifyAcceptQuoteWithoutPriceOracleEnforcesExpiry ensures that the quote
+// expiry bound is still enforced when no price oracle is configured.
+func TestVerifyAcceptQuoteWithoutPriceOracleEnforcesExpiry(t *testing.T) {
+	t.Parallel()
+
+	// The pilot requires a minimum expiry lifetime of 10 seconds.
+	expiry := time.Now().Add(time.Second)
+	accept := newNoOracleBuyAccept(
+		t, 100, expiry, fn.None[rfqmath.BigIntFixedPoint](),
+	)
+
+	pilot := newNoOraclePilot(t)
+
+	status, err := pilot.VerifyAcceptQuote(context.Background(), accept)
+	require.NoError(t, err)
+	require.Equal(t, InvalidExpiryQuoteRespStatus, status)
 }
 
 // TestCheckRateBound exercises the checkRateBound helper directly.

--- a/sample-tapd.conf
+++ b/sample-tapd.conf
@@ -488,6 +488,11 @@
 ; Price oracle gRPC server address (rfqrpc://<hostname>:<port>)
 ; To use the integrated mock, use the following value:
 ; use_mock_price_oracle_service_promise_to_not_use_on_mainnet
+; Optional. An edge node that answers incoming quote requests needs an oracle
+; to price them. A wallet that only requests quotes does not: leave this unset
+; and bound the rate you are willing to accept with the asset_rate_limit field
+; of your buy or sell order instead. See docs/rfq-and-decimal-display.md for
+; which bounds are reachable on which RPC.
 ; experimental.rfq.priceoracleaddress=
 
 ; Path to the macaroon to use when connecting to the price oracle gRPC server.

--- a/tapcfg/server.go
+++ b/tapcfg/server.go
@@ -595,9 +595,12 @@ func genServerConfig(ctx context.Context, cfg *Config,
 		}
 
 	case "":
-		// Leave the price oracle as nil, which will cause the RFQ
-		// manager to reject all incoming RFQ requests. It will also
-		// skip setting suggested prices for outgoing quote requests.
+		// Leave the price oracle as nil. This is the expected
+		// configuration for an end user's wallet: quotes we request
+		// from a peer are still verified against the constraints of
+		// our own order, but we cannot price incoming RFQ requests
+		// from peers, so those are rejected. Suggested prices are also
+		// not set on outgoing quote requests.
 
 	default:
 		macaroonOpt, err := getPriceOracleMacaroonOpt(rfqCfg)


### PR DESCRIPTION
### Motivation

Edge nodes charge a spread. If that spread is wide enough, a wallet that
compares the offered rate against its own price oracle rejects the quote — this
was hit in practice with an edge node charging ~4.5% over the BTC/USD rate.

The deeper problem is what the check actually does. `AcceptPriceDeviationPpm`
does not ask "is this peer's spread under 5%". It asks "do this peer's rate and
*my* oracle's rate differ by less than 5%". A legitimate 4.5% spread plus any
drift between the two oracles exceeds the band, and the quote is discarded. A
tolerance band around a third party's opinion of the price is a poor instrument
compared to a bound the user names themselves.

An end user's wallet also has no structural need for an oracle. It only ever
*requests* quotes; it never has to answer one, so it never has to name a price.
Requiring every wallet to source and run a price oracle is a real adoption tax
for no protection that the user's own limits don't already provide.

### What this changes

**A price oracle is now optional for verifying a quote a peer accepted.**
`InternalPortfolioPilot.VerifyAcceptQuote` previously returned
`PriceOracleQueryErrQuoteRespStatus` when no oracle was configured, so an
oracle-less node could never use *any* accepted quote. The oracle comparison is
now conditional.

**The user's own limits are now actually enforced.** `checkAllConstraints` sat
*after* the oracle query, so in the no-oracle configuration the request's
`asset_rate_limit`, min fill, FOK policy and fill bounds were never reached —
dead code in precisely the configuration this PR is about. Constraints now run
whether or not an oracle is present. This is the wallet-side sanity check, and
it already existed; it just wasn't reachable.

The ordering for oracle-configured nodes is unchanged (oracle comparison first,
then constraints), so their behaviour is identical. The oracle block was
extracted verbatim into `checkRateAgainstOracle` — same statuses, same error
wrapping, same `//nolint:nilerr` placement.

**Answering incoming quote requests still requires an oracle.** `ResolveRequest`
continues to reject with `ErrPriceOracleUnavailable`. Responding to an RFQ means
naming a price, which cannot be done without one. The asymmetry is deliberate
and is documented in the config field and covered by tests.

**Fixes a nil-interface panic.** `rfq.EstimateAssetUnits` called
`QueryBuyPrice` on the oracle interface with no nil check. With no oracle
configured, `AddInvoice` with `value`/`value_msat` set reached it via
`calculateAssetMaxAmount` and panicked. There is no gRPC recovery interceptor in
the tree, so this took down `tapd`. It now returns an actionable error. Asset
unit denominated invoices short-circuit before this point and were never
affected.

**Log noise.** `QueryAssetRates` returns a new sentinel `ErrNoPriceOracle`, so
the optional rate hint on an outgoing request logs at debug instead of emitting
a WARN on every invoice and payment in what is now the expected wallet
configuration.

### Known gap, and the companion change

`tapchannelrpc.SendPayment` has **no** `asset_rate_limit` field, and
`acquireSellQuote` leaves the limit unset on the sell order it negotiates
internally. `payment_max_amt` caps the *satoshis* sent, not the asset units
spent, and units spent scale with whatever rate the peer quotes.

So on the pay path, a wallet with neither an oracle nor a pre-negotiated quote
has no bound on the rate it will accept. This is the one direction where
dropping the oracle removes a check without a wallet-side replacement reachable
from the same call. The workaround today is to negotiate with
`rfqrpc.AddAssetSellOrder` (setting `asset_rate_limit`) and pass the resulting
`rfq_id` to `SendPayment`.

Plumbing a rate limit through `SendPayment` requires a proto field and is left
to a follow-up. It is documented explicitly in
`docs/rfq-and-decimal-display.md` rather than glossed over, and I'd argue it is
the more important half of this work. Happy to take it in this PR if preferred.

### Verification

- `go build ./...` clean.
- `go test ./rfq/... ./rfqmsg/... ./rfqmath/... ./tapchannel/... -count=1` all
  pass, including the pre-existing `TestVerifyAcceptQuote` /
  `TestResolveRequest` tables that cover the oracle-configured paths and the
  deviation tolerance cases.
- `gofmt -l` and `go vet` clean on the touched packages.
- The two new rate-bound tests were mutation-checked: deleting the
  `checkAllConstraints` call makes both fail, so they assert the behaviour
  rather than passing incidentally.
- The oracle-path extraction was diffed statement by statement against
  `origin/main` to confirm no status code, error wrap, or check order changed.

New test coverage: no-oracle accept passes; no-oracle **buy** rate bound
enforced (floor, `RateBoundCmp == -1`); no-oracle **sell** rate bound enforced
(ceiling, `RateBoundCmp == +1` — the direction that governs asset outflow on a
payment); no-oracle expiry bound still enforced.

### Not done, deliberately

- **No itest.** `tapdArgsTemplateNoOracle` exists but all four of its consumers
  immediately append an oracle address, so there is currently no way to launch
  an oracle-less itest node. That harness change plus an end-to-end test is
  worth doing, but I'd rather add it with a run I can verify than ship an itest
  I haven't executed.
- **Commits are unsigned** — no GPG key available in the environment this was
  prepared in. Happy for these to be rebased/re-signed before merge.
- Release note will be added as a `docs:` commit now that this PR has a number.

---

Requested by @Roasbeef in the `lightninglabs#taproot-assets` Keybase channel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
