### PR TITLE
asset+proof+commitment+address: encode nested TLV records once

### DIFF
--- a/address/records.go
+++ b/address/records.go
@@ -1,7 +1,6 @@
 package address
 
 import (
-	"bytes"
 	"net/url"
 
 	"github.com/btcsuite/btcd/btcec/v2"
@@ -95,18 +94,9 @@ func newAddressInternalKeyRecord(internalKey *btcec.PublicKey) tlv.Record {
 func newAddressTapscriptSiblingRecord(
 	tapscriptSibling **commitment.TapscriptPreimage) tlv.Record {
 
-	sizeFunc := func() uint64 {
-		var buf bytes.Buffer
-		err := commitment.TapscriptPreimageEncoder(
-			&buf, tapscriptSibling, &[8]byte{},
-		)
-		if err != nil {
-			panic(err)
-		}
-		return uint64(len(buf.Bytes()))
-	}
-	return tlv.MakeDynamicRecord(
-		addrTapscriptSiblingType, tapscriptSibling, sizeFunc,
+	return asset.EncodeOnceRecord(
+		addrTapscriptSiblingType,
+		tapscriptSibling,
 		commitment.TapscriptPreimageEncoder,
 		commitment.TapscriptPreimageDecoder,
 	)

--- a/asset/asset.go
+++ b/asset/asset.go
@@ -2186,19 +2186,9 @@ func (a *Asset) EncodeRecords() []tlv.Record {
 //
 // NOTE: This is part of the tlv.RecordProducer interface.
 func (a *Asset) Record() tlv.Record {
-	sizeFunc := func() uint64 {
-		var buf bytes.Buffer
-		if err := a.Encode(&buf); err != nil {
-			panic(err)
-		}
-		return uint64(len(buf.Bytes()))
-	}
-
 	// We pass 0 here as the type will be overridden when used along with
 	// the tlv.RecordT type.
-	return tlv.MakeDynamicRecord(
-		0, a, sizeFunc, LeafEncoder, LeafDecoder,
-	)
+	return EncodeOnceRecord(0, a, LeafEncoder, LeafDecoder)
 }
 
 // DecodeRecords provides all records known for an asset witness for proper

--- a/asset/encoding.go
+++ b/asset/encoding.go
@@ -38,6 +38,59 @@ var (
 	ErrDuplicateScriptKeys = errors.New("alt leaf: duplicate script keys")
 )
 
+// encodeOnce caches the serialization of a TLV record value so that the
+// record's size function and encoder share a single encoding pass.
+type encodeOnce struct {
+	val     any
+	enc     tlv.Encoder
+	encoded []byte
+	err     error
+	done    bool
+}
+
+func (e *encodeOnce) run() {
+	if e.done {
+		return
+	}
+	e.done = true
+
+	var buf bytes.Buffer
+	e.err = e.enc(&buf, e.val, &[8]byte{})
+	e.encoded = buf.Bytes()
+}
+
+func (e *encodeOnce) size() uint64 {
+	e.run()
+	if e.err != nil {
+		panic(e.err)
+	}
+	return uint64(len(e.encoded))
+}
+
+func (e *encodeOnce) encode(w io.Writer, _ any, _ *[8]byte) error {
+	e.run()
+	if e.err != nil {
+		return e.err
+	}
+	_, err := w.Write(e.encoded)
+	return err
+}
+
+// EncodeOnceRecord returns a dynamic TLV record whose value is serialized at
+// most once. A TLV stream asks every record for its size before encoding it,
+// so a size function that serializes the value doubles the work, and for
+// values that are TLV streams themselves the doubling compounds at every
+// level of nesting. Here the first request encodes the value and both the
+// size function and the encoder reuse the result. The value must not change
+// between the record's creation and its encoding, since the first size or
+// encode request pins the bytes.
+func EncodeOnceRecord(typ tlv.Type, val any, enc tlv.Encoder,
+	dec tlv.Decoder) tlv.Record {
+
+	e := &encodeOnce{val: val, enc: enc}
+	return tlv.MakeDynamicRecord(typ, val, e.size, e.encode, dec)
+}
+
 func VarIntEncoder(w io.Writer, val any, buf *[8]byte) error {
 	if t, ok := val.(*uint64); ok {
 		return tlv.WriteVarInt(w, *t, buf)

--- a/asset/records.go
+++ b/asset/records.go
@@ -231,19 +231,8 @@ func NewLeafRelativeLockTimeRecord(relativeLockTime *uint64) tlv.Record {
 func NewLeafPrevWitnessRecord(prevWitnesses *[]Witness,
 	encodeType EncodeType) tlv.Record {
 
-	recordSize := func() uint64 {
-		var (
-			b   bytes.Buffer
-			buf [8]byte
-		)
-		witnessEncoder := WitnessEncoderWithType(encodeType)
-		if err := witnessEncoder(&b, prevWitnesses, &buf); err != nil {
-			panic(err)
-		}
-		return uint64(len(b.Bytes()))
-	}
-	return tlv.MakeDynamicRecord(
-		LeafPrevWitness, prevWitnesses, recordSize,
+	return EncodeOnceRecord(
+		LeafPrevWitness, prevWitnesses,
 		WitnessEncoderWithType(encodeType), WitnessDecoder,
 	)
 }
@@ -300,17 +289,9 @@ func NewWitnessTxWitnessRecord(witness *wire.TxWitness) tlv.Record {
 }
 
 func NewWitnessSplitCommitmentRecord(commitment **SplitCommitment) tlv.Record {
-	recordSize := func() uint64 {
-		var buf bytes.Buffer
-		err := SplitCommitmentEncoder(&buf, commitment, &[8]byte{})
-		if err != nil {
-			panic(err)
-		}
-		return uint64(buf.Len())
-	}
-	return tlv.MakeDynamicRecord(
-		WitnessSplitCommitment, commitment, recordSize,
-		SplitCommitmentEncoder, SplitCommitmentDecoder,
+	return EncodeOnceRecord(
+		WitnessSplitCommitment, commitment, SplitCommitmentEncoder,
+		SplitCommitmentDecoder,
 	)
 }
 

--- a/commitment/records.go
+++ b/commitment/records.go
@@ -1,8 +1,6 @@
 package commitment
 
 import (
-	"bytes"
-
 	"github.com/lightninglabs/taproot-assets/asset"
 	"github.com/lightninglabs/taproot-assets/fn"
 	"github.com/lightninglabs/taproot-assets/mssmt"
@@ -41,31 +39,15 @@ var KnownProofTypes = fn.NewSet(
 )
 
 func ProofAssetProofRecord(proof **AssetProof) tlv.Record {
-	sizeFunc := func() uint64 {
-		var buf bytes.Buffer
-		err := AssetProofEncoder(&buf, proof, &[8]byte{})
-		if err != nil {
-			panic(err)
-		}
-		return uint64(len(buf.Bytes()))
-	}
-	return tlv.MakeDynamicRecord(
-		ProofAssetProofType, proof, sizeFunc,
+	return asset.EncodeOnceRecord(
+		ProofAssetProofType, proof,
 		AssetProofEncoder, AssetProofDecoder,
 	)
 }
 
 func ProofTaprootAssetProofRecord(proof *TaprootAssetProof) tlv.Record {
-	sizeFunc := func() uint64 {
-		var buf bytes.Buffer
-		err := TaprootAssetProofEncoder(&buf, proof, &[8]byte{})
-		if err != nil {
-			panic(err)
-		}
-		return uint64(len(buf.Bytes()))
-	}
-	return tlv.MakeDynamicRecord(
-		ProofTaprootAssetProofType, proof, sizeFunc,
+	return asset.EncodeOnceRecord(
+		ProofTaprootAssetProofType, proof,
 		TaprootAssetProofEncoder, TaprootAssetProofDecoder,
 	)
 }
@@ -82,16 +64,8 @@ func AssetProofAssetIDRecord(assetID *[32]byte) tlv.Record {
 }
 
 func AssetProofRecord(proof *mssmt.Proof) tlv.Record {
-	sizeFunc := func() uint64 {
-		var buf bytes.Buffer
-		if err := proof.Compress().Encode(&buf); err != nil {
-			panic(err)
-		}
-		return uint64(len(buf.Bytes()))
-	}
-	return tlv.MakeDynamicRecord(
-		AssetProofType, proof, sizeFunc, TreeProofEncoder,
-		TreeProofDecoder,
+	return asset.EncodeOnceRecord(
+		AssetProofType, proof, TreeProofEncoder, TreeProofDecoder,
 	)
 }
 
@@ -103,15 +77,8 @@ func TaprootAssetProofVersionRecord(version *TapCommitmentVersion) tlv.Record {
 }
 
 func TaprootAssetProofRecord(proof *mssmt.Proof) tlv.Record {
-	sizeFunc := func() uint64 {
-		var buf bytes.Buffer
-		if err := proof.Compress().Encode(&buf); err != nil {
-			panic(err)
-		}
-		return uint64(len(buf.Bytes()))
-	}
-	return tlv.MakeDynamicRecord(
-		TaprootAssetProofType, proof, sizeFunc, TreeProofEncoder,
-		TreeProofDecoder,
+	return asset.EncodeOnceRecord(
+		TaprootAssetProofType, proof,
+		TreeProofEncoder, TreeProofDecoder,
 	)
 }

--- a/docs/release-notes/release-notes-0.9.0.md
+++ b/docs/release-notes/release-notes-0.9.0.md
@@ -303,6 +303,14 @@
   single database query instead of materializing assets once per managed
   UTXO.
 
+* [PR#2299](https://github.com/lightninglabs/taproot-assets/pull/2299)
+  encodes nested TLV records once. The TLV stream asks each record for
+  its size before writing it, and the size functions of nested records
+  serialized their value to measure it, so every level of nesting
+  doubled the encoding work below it. Encoding a single proof is now
+  roughly seven times faster, and encoding a channel commitment blob
+  carrying proofs for a dozen outputs roughly nineteen times faster.
+
 * [PR#2300](https://github.com/lightninglabs/taproot-assets/pull/2300)
   avoids deep-copying the split commitment proof when the VM validates
   a split asset, cutting the allocations of split validation by roughly

--- a/proof/encode_bench_test.go
+++ b/proof/encode_bench_test.go
@@ -1,0 +1,48 @@
+package proof
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/lightninglabs/taproot-assets/asset"
+)
+
+// BenchmarkProofEncode measures encoding a single proof, the unit of work
+// behind proof files, universe leaves and channel commitment blobs.
+func BenchmarkProofEncode(b *testing.B) {
+	amt := uint64(5000)
+	genesisProof, _ := genRandomGenesisWithProof(
+		b, asset.Normal, &amt, nil, false, nil, nil, nil, nil, asset.V0,
+	)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		var buf bytes.Buffer
+		if err := genesisProof.Encode(&buf); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkProofDecode measures decoding a single proof from its bytes.
+func BenchmarkProofDecode(b *testing.B) {
+	amt := uint64(5000)
+	genesisProof, _ := genRandomGenesisWithProof(
+		b, asset.Normal, &amt, nil, false, nil, nil, nil, nil, asset.V0,
+	)
+	proofBytes, err := genesisProof.Bytes()
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		if _, err := Decode(proofBytes); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/proof/proof.go
+++ b/proof/proof.go
@@ -482,17 +482,9 @@ func (p *Proof) Bytes() ([]byte, error) {
 //
 // NOTE: This is part of the tlv.RecordProducer interface.
 func (p *Proof) Record() tlv.Record {
-	sizeFunc := func() uint64 {
-		proofBytes, err := p.Bytes()
-		if err != nil {
-			panic(err)
-		}
-		return uint64(len(proofBytes))
-	}
-
 	// Note that we set the type here as zero, as when used with a
 	// tlv.RecordT, the type param will be used as the type.
-	return tlv.MakeDynamicRecord(0, p, sizeFunc, Encoder, Decoder)
+	return asset.EncodeOnceRecord(0, p, Encoder, Decoder)
 }
 
 // IsUnknownVersion returns true if a proof has a version that is not recognized

--- a/proof/records.go
+++ b/proof/records.go
@@ -166,90 +166,43 @@ func AnchorTxRecord(tx *wire.MsgTx) tlv.Record {
 }
 
 func TxMerkleProofRecord(proof *TxMerkleProof) tlv.Record {
-	sizeFunc := func() uint64 {
-		var buf bytes.Buffer
-		if err := proof.Encode(&buf); err != nil {
-			panic(err)
-		}
-		return uint64(len(buf.Bytes()))
-	}
-	return tlv.MakeDynamicRecord(
-		TxMerkleProofType, proof, sizeFunc, TxMerkleProofEncoder,
-		TxMerkleProofDecoder,
+	return asset.EncodeOnceRecord(
+		TxMerkleProofType, proof,
+		TxMerkleProofEncoder, TxMerkleProofDecoder,
 	)
 }
 
 func AssetLeafRecord(a *asset.Asset) tlv.Record {
-	sizeFunc := func() uint64 {
-		var buf bytes.Buffer
-		if err := a.Encode(&buf); err != nil {
-			panic(err)
-		}
-		return uint64(len(buf.Bytes()))
-	}
-	return tlv.MakeDynamicRecord(
-		AssetLeafType, a, sizeFunc, asset.LeafEncoder,
-		asset.LeafDecoder,
+	return asset.EncodeOnceRecord(
+		AssetLeafType, a, asset.LeafEncoder, asset.LeafDecoder,
 	)
 }
 
 func InclusionProofRecord(proof *TaprootProof) tlv.Record {
-	sizeFunc := func() uint64 {
-		var buf bytes.Buffer
-		err := TaprootProofEncoder(&buf, proof, &[8]byte{})
-		if err != nil {
-			panic(err)
-		}
-		return uint64(len(buf.Bytes()))
-	}
-	return tlv.MakeDynamicRecord(
-		InclusionProofType, proof, sizeFunc, TaprootProofEncoder,
-		TaprootProofDecoder,
+	return asset.EncodeOnceRecord(
+		InclusionProofType, proof,
+		TaprootProofEncoder, TaprootProofDecoder,
 	)
 }
 
 func ExclusionProofsRecord(proofs *[]TaprootProof) tlv.Record {
-	sizeFunc := func() uint64 {
-		var buf bytes.Buffer
-		err := TaprootProofsEncoder(&buf, proofs, &[8]byte{})
-		if err != nil {
-			panic(err)
-		}
-		return uint64(len(buf.Bytes()))
-	}
-	return tlv.MakeDynamicRecord(
-		ExclusionProofsType, proofs, sizeFunc, TaprootProofsEncoder,
-		TaprootProofsDecoder,
+	return asset.EncodeOnceRecord(
+		ExclusionProofsType, proofs,
+		TaprootProofsEncoder, TaprootProofsDecoder,
 	)
 }
 
 func SplitRootProofRecord(proof **TaprootProof) tlv.Record {
-	sizeFunc := func() uint64 {
-		var buf bytes.Buffer
-		err := SplitRootProofEncoder(&buf, proof, &[8]byte{})
-		if err != nil {
-			panic(err)
-		}
-		return uint64(len(buf.Bytes()))
-	}
-	return tlv.MakeDynamicRecord(
-		SplitRootProofType, proof, sizeFunc, SplitRootProofEncoder,
-		SplitRootProofDecoder,
+	return asset.EncodeOnceRecord(
+		SplitRootProofType, proof,
+		SplitRootProofEncoder, SplitRootProofDecoder,
 	)
 }
 
 func AdditionalInputsRecord(inputs *[]File) tlv.Record {
-	sizeFunc := func() uint64 {
-		var buf bytes.Buffer
-		err := AdditionalInputsEncoder(&buf, inputs, &[8]byte{})
-		if err != nil {
-			panic(err)
-		}
-		return uint64(len(buf.Bytes()))
-	}
-	return tlv.MakeDynamicRecord(
-		AdditionalInputsType, inputs, sizeFunc, AdditionalInputsEncoder,
-		AdditionalInputsDecoder,
+	return asset.EncodeOnceRecord(
+		AdditionalInputsType, inputs,
+		AdditionalInputsEncoder, AdditionalInputsDecoder,
 	)
 }
 
@@ -276,31 +229,15 @@ func TaprootProofInternalKeyRecord(internalKey **btcec.PublicKey) tlv.Record {
 }
 
 func TaprootProofCommitmentProofRecord(proof **CommitmentProof) tlv.Record {
-	sizeFunc := func() uint64 {
-		var buf bytes.Buffer
-		err := CommitmentProofEncoder(&buf, proof, &[8]byte{})
-		if err != nil {
-			panic(err)
-		}
-		return uint64(len(buf.Bytes()))
-	}
-	return tlv.MakeDynamicRecord(
-		TaprootProofCommitmentProofType, proof, sizeFunc,
+	return asset.EncodeOnceRecord(
+		TaprootProofCommitmentProofType, proof,
 		CommitmentProofEncoder, CommitmentProofDecoder,
 	)
 }
 
 func TaprootProofTapscriptProofRecord(proof **TapscriptProof) tlv.Record {
-	sizeFunc := func() uint64 {
-		var buf bytes.Buffer
-		err := TapscriptProofEncoder(&buf, proof, &[8]byte{})
-		if err != nil {
-			panic(err)
-		}
-		return uint64(len(buf.Bytes()))
-	}
-	return tlv.MakeDynamicRecord(
-		TaprootProofTapscriptProofType, proof, sizeFunc,
+	return asset.EncodeOnceRecord(
+		TaprootProofTapscriptProofType, proof,
 		TapscriptProofEncoder, TapscriptProofDecoder,
 	)
 }
@@ -308,18 +245,9 @@ func TaprootProofTapscriptProofRecord(proof **TapscriptProof) tlv.Record {
 func CommitmentProofTapSiblingPreimageRecord(
 	preimage **commitment.TapscriptPreimage) tlv.Record {
 
-	sizeFunc := func() uint64 {
-		var buf bytes.Buffer
-		err := commitment.TapscriptPreimageEncoder(
-			&buf, preimage, &[8]byte{},
-		)
-		if err != nil {
-			panic(err)
-		}
-		return uint64(len(buf.Bytes()))
-	}
-	return tlv.MakeDynamicRecord(
-		CommitmentProofTapSiblingPreimageType, preimage, sizeFunc,
+	return asset.EncodeOnceRecord(
+		CommitmentProofTapSiblingPreimageType,
+		preimage,
 		commitment.TapscriptPreimageEncoder,
 		commitment.TapscriptPreimageDecoder,
 	)
@@ -328,39 +256,19 @@ func CommitmentProofTapSiblingPreimageRecord(
 func CommitmentProofSTXOProofsRecord(
 	stxoProofs *map[asset.SerializedKey]commitment.Proof) tlv.Record {
 
-	sizeFunc := func() uint64 {
-		var buf bytes.Buffer
-		err := CommitmentProofsEncoder(
-			&buf, stxoProofs, &[8]byte{},
-		)
-		if err != nil {
-			panic(err)
-		}
-		return uint64(len(buf.Bytes()))
-	}
-	return tlv.MakeDynamicRecord(
-		CommitmentProofSTXOProofsType, stxoProofs, sizeFunc,
-		CommitmentProofsEncoder,
-		CommitmentProofsDecoder,
+	return asset.EncodeOnceRecord(
+		CommitmentProofSTXOProofsType, stxoProofs,
+		CommitmentProofsEncoder, CommitmentProofsDecoder,
 	)
 }
 
 func TapscriptProofTapPreimage1Record(
 	preimage **commitment.TapscriptPreimage) tlv.Record {
 
-	sizeFunc := func() uint64 {
-		var buf bytes.Buffer
-		err := commitment.TapscriptPreimageEncoder(
-			&buf, preimage, &[8]byte{},
-		)
-		if err != nil {
-			panic(err)
-		}
-		return uint64(len(buf.Bytes()))
-	}
-	return tlv.MakeDynamicRecord(
-		TapscriptProofTapPreimage1, preimage,
-		sizeFunc, commitment.TapscriptPreimageEncoder,
+	return asset.EncodeOnceRecord(
+		TapscriptProofTapPreimage1,
+		preimage,
+		commitment.TapscriptPreimageEncoder,
 		commitment.TapscriptPreimageDecoder,
 	)
 }
@@ -368,19 +276,10 @@ func TapscriptProofTapPreimage1Record(
 func TapscriptProofTapPreimage2Record(
 	preimage **commitment.TapscriptPreimage) tlv.Record {
 
-	sizeFunc := func() uint64 {
-		var buf bytes.Buffer
-		err := commitment.TapscriptPreimageEncoder(
-			&buf, preimage, &[8]byte{},
-		)
-		if err != nil {
-			panic(err)
-		}
-		return uint64(len(buf.Bytes()))
-	}
-	return tlv.MakeDynamicRecord(
-		TapscriptProofTapPreimage2, preimage,
-		sizeFunc, commitment.TapscriptPreimageEncoder,
+	return asset.EncodeOnceRecord(
+		TapscriptProofTapPreimage2,
+		preimage,
+		commitment.TapscriptPreimageEncoder,
 		commitment.TapscriptPreimageDecoder,
 	)
 }
@@ -392,17 +291,8 @@ func TapscriptProofBip86Record(bip86 *bool) tlv.Record {
 }
 
 func MetaRevealRecord(reveal **MetaReveal) tlv.Record {
-	sizeFunc := func() uint64 {
-		var buf bytes.Buffer
-		err := MetaRevealEncoder(&buf, reveal, &[8]byte{})
-		if err != nil {
-			panic(err)
-		}
-		return uint64(len(buf.Bytes()))
-	}
-	return tlv.MakeDynamicRecord(
-		MetaRevealType, reveal, sizeFunc, MetaRevealEncoder,
-		MetaRevealDecoder,
+	return asset.EncodeOnceRecord(
+		MetaRevealType, reveal, MetaRevealEncoder, MetaRevealDecoder,
 	)
 }
 
@@ -534,17 +424,9 @@ func GroupKeyRevealRecord(reveal *asset.GroupKeyReveal) tlv.Record {
 }
 
 func AltLeavesRecord(leaves *[]asset.AltLeaf[asset.Asset]) tlv.Record {
-	sizeFunc := func() uint64 {
-		var buf bytes.Buffer
-		err := asset.AltLeavesEncoder(&buf, leaves, &[8]byte{})
-		if err != nil {
-			panic(err)
-		}
-		return uint64(len(buf.Bytes()))
-	}
-	return tlv.MakeDynamicRecord(
-		AltLeavesType, leaves, sizeFunc, asset.AltLeavesEncoder,
-		asset.AltLeavesDecoder,
+	return asset.EncodeOnceRecord(
+		AltLeavesType, leaves,
+		asset.AltLeavesEncoder, asset.AltLeavesDecoder,
 	)
 }
 
@@ -577,17 +459,9 @@ func FragmentOutPointRecord(prevOut *wire.OutPoint) tlv.Record {
 }
 
 func FragmentOutputsRecord(outputs *map[asset.ID]SendOutput) tlv.Record {
-	sizeFunc := func() uint64 {
-		var buf bytes.Buffer
-		err := SendOutputsEncoder(&buf, outputs, &[8]byte{})
-		if err != nil {
-			panic(err)
-		}
-		return uint64(len(buf.Bytes()))
-	}
-	return tlv.MakeDynamicRecord(
-		SendFragmentOutputsType, outputs, sizeFunc, SendOutputsEncoder,
-		SendOutputsDecoder,
+	return asset.EncodeOnceRecord(
+		SendFragmentOutputsType, outputs,
+		SendOutputsEncoder, SendOutputsDecoder,
 	)
 }
 

--- a/tapchannel/auf_leaf_signer_test.go
+++ b/tapchannel/auf_leaf_signer_test.go
@@ -251,7 +251,7 @@ var _ VirtualPacketSigner = (*mockVirtualSigner)(nil)
 
 // randProof returns a random proof that contains all information required for
 // it to be successfully serialized.
-func randProof(t *testing.T) proof.Proof {
+func randProof(t testing.TB) proof.Proof {
 	oddTxBlockHex, err := os.ReadFile(oddTxBlockHexFileName)
 	require.NoError(t, err)
 

--- a/tapchannel/commitment_bench_test.go
+++ b/tapchannel/commitment_bench_test.go
@@ -1,0 +1,41 @@
+package tapchannel
+
+import (
+	"bytes"
+	"testing"
+
+	cmsg "github.com/lightninglabs/taproot-assets/tapchannelmsg"
+	"github.com/lightningnetwork/lnd/input"
+	"github.com/lightningnetwork/lnd/lnwallet"
+)
+
+// BenchmarkCommitmentBlob measures encoding a commitment blob that carries
+// asset proofs for a balance output and several HTLC outputs, which is done
+// on every commitment update.
+func BenchmarkCommitmentBlob(b *testing.B) {
+	const numHtlcs = 10
+
+	p := randProof(b)
+	newOutput := func() *cmsg.AssetOutput {
+		return cmsg.NewAssetOutput(p.Asset.ID(), p.Asset.Amount, p)
+	}
+
+	outgoing := make(map[input.HtlcIndex][]*cmsg.AssetOutput, numHtlcs)
+	for i := range numHtlcs {
+		outgoing[input.HtlcIndex(i)] = []*cmsg.AssetOutput{newOutput()}
+	}
+	com := cmsg.NewCommitment(
+		[]*cmsg.AssetOutput{newOutput()}, nil, outgoing, nil,
+		lnwallet.CommitAuxLeaves{}, false,
+	)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		var buf bytes.Buffer
+		if err := com.Encode(&buf); err != nil {
+			b.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
(Fable's summary follows.)

A TLV stream asks every record for its size before encoding it. The size functions of our nested records serialized the value into a scratch buffer to measure it, and the encoder then serialized it again. Since those values are TLV streams themselves, the doubling compounded at every level of nesting: the innermost tree proof of a proof was compressed and encoded about sixteen times per Proof.Encode.

Add asset.EncodeOnceRecord, a dynamic record that encodes its value on the first request and serves both the size and the encoder from the result, and use it for the nested records in proof, commitment and address. The encoding is byte for byte unchanged.

Proof.Encode drops from 67us to 9us and from 605 to 211 allocations.  Encoding a commitment blob with eleven proof-carrying outputs drops from 22.7ms to 2.4ms. Decoding constructs the same records and now pays about 30 extra small allocations per proof, with no measurable change in time.

