### PR TITLE
itest: wait for wallet sync before draining node UTXOs

### DIFF
--- a/itest/utils.go
+++ b/itest/utils.go
@@ -254,6 +254,12 @@ func SetNodeUTXOs(t *harnessTest, wallet *node.HarnessNode,
 
 	minerAddr := t.lndHarness.Miner().NewMinerAddress()
 
+	// The send-all below only spends confirmed outputs, and the wallet
+	// counts confirmations against its own synced height rather than the
+	// chain notifier's. Make sure it has caught up first, or coins that
+	// were confirmed in the most recent block are invisible to the sweep.
+	t.lndHarness.WaitForBlockchainSync(wallet)
+
 	// Drain any funds held by the node.
 	wallet.RPC.SendCoins(&lnrpc.SendCoinsRequest{
 		Addr:        minerAddr.EncodeAddress(),


### PR DESCRIPTION
Fixes a flake observed in [this CI job](https://github.com/lightninglabs/taproot-assets/actions/runs/34592580869/job/103242088492?pr=2299). Fable's summary follows:

> SetNodeUTXOs starts by sweeping every coin in the node's wallet to the miner with a send-all SendCoins, which only spends outputs the wallet considers confirmed. The wallet counts confirmations against its own synced height, and it processes blocks independently of the chain notifier that the rest of the harness waits on.
> 
> At the end of testFeeEstimation the deferred ResetNodeWallet runs this drain a few tens of milliseconds after the block that confirmed the final transfer, and by then the wallet's only remaining coin is that transfer's change. If the wallet has not yet applied the block, the sweep finds no inputs and lnd fails the call with
> 
>   insufficient input to create sweep tx: input_sum=0 BTC, ...
> 
> Wait for the wallet to report itself synced before draining, which closes the window.